### PR TITLE
fix(release): decouple live ADO acceptance

### DIFF
--- a/.apm/instructions/cicd.instructions.md
+++ b/.apm/instructions/cicd.instructions.md
@@ -42,9 +42,9 @@ integration suite runs only at merge time via GitHub Merge Queue
      to `.github/workflows/**`.
 4. **`build-release.yml`** - `push` to main, tags, schedule, `workflow_dispatch`
    - **Linux + Windows** run combined `build-and-test` (unit tests + binary build in one job). Unit tests run on every push for platform-regression signal; **smoke tests are gated to tag/schedule/dispatch only** (promotion boundaries) to avoid duplicating `ci-integration.yml`'s merge-time smoke and to cut redundant codex-binary downloads.
-   - **macOS Intel** uses `build-and-validate-macos-intel` (root node, runs own unit tests - no dependency on `build-and-test`). Builds the binary on every push for early regression feedback; tag/schedule/dispatch promotion runs add marker-bounded `lifecycle_smoke` integration coverage and isolated release validation.
-   - **macOS ARM** uses `build-and-validate-macos-arm` (root node, tag/schedule/dispatch only - ARM runners are extremely scarce with 2-4h+ queue waits). Promotion runs retain the unfiltered integration corpus and isolated release validation.
-   - Secrets always available. Full 5-platform binary output (linux x86_64/arm64, darwin x86_64/arm64, windows x86_64).
+   - **macOS Intel** uses `build-and-validate-macos-intel` (root node, runs own unit tests - no dependency on `build-and-test`). Builds the binary on every push for early regression feedback; tag/schedule/dispatch promotion runs add marker-bounded `lifecycle_smoke and not live` integration coverage and isolated release validation.
+   - **macOS ARM** uses `build-and-validate-macos-arm` (root node, tag/schedule/dispatch only - ARM runners are extremely scarce with 2-4h+ queue waits). Promotion runs retain the full non-live integration corpus and isolated release validation.
+   - Publication jobs do not receive `ADO_APM_PAT`; live ADO PAT acceptance is an explicit `ado_pat_e2e` mode in `auth-acceptance.yml`. Full 5-platform binary output (linux x86_64/arm64, darwin x86_64/arm64, windows x86_64).
 5. **`ci-runtime.yml`** - nightly schedule, manual dispatch, path-filtered push
    - **Linux x86_64 only**. Live inference smoke tests (`apm run`) isolated from release pipeline.
    - Uses `GH_MODELS_PAT` for GitHub Models API access.
@@ -82,8 +82,9 @@ integration suite runs only at merge time via GitHub Merge Queue
 - **Merge queue workflow**: ci.yml (Tier 1 against tentative merge ref) + ci-integration.yml (Tier 2: build -> smoke-test -> integration-tests -> release-validation). Queue auto-merges on success; ejects on failure.
 - **Push/Release workflow (Linux + Windows)**: build-and-test -> integration-tests -> release-validation -> create-release -> publish-pypi (gh-aw-compat runs in parallel, informational)
 - **Homebrew distribution**: `microsoft/homebrew-apm` polls the latest public APM release and updates its formula with its own `GITHUB_TOKEN`; this workflow must not send a cross-repository dispatch or hold a tap credential.
-- **Push/Release workflow (macOS Intel)**: build-and-validate-macos-intel (root node: unit tests + build always + conditional `lifecycle_smoke` integration/release-validation) -> create-release
-- **Push/Release workflow (macOS ARM)**: build-and-validate-macos-arm (root node, tag/schedule/dispatch only; full integration corpus and all phases run) -> create-release
+- **Push/Release workflow (macOS Intel)**: build-and-validate-macos-intel (root node: unit tests + build always + conditional `lifecycle_smoke and not live` integration/release-validation) -> create-release
+- **Push/Release workflow (macOS ARM)**: build-and-validate-macos-arm (root node, tag/schedule/dispatch only; full non-live integration corpus and all phases run) -> create-release
+- **Live ADO PAT acceptance**: manual `auth-acceptance.yml` dispatch with `ado_pat_e2e: true` -> exact `live and requires_ado_pat` marker intersection. Invalid credentials fail with production auth diagnostics but do not block publication.
 - **Tag Triggers**: Only `v*.*.*` tags trigger full release pipeline
 - **Artifact Retention**: 30 days for debugging failed releases
 - **Cross-workflow artifacts**: ci-integration.yml builds the binary inline (no cross-workflow artifact transfer); build-release.yml jobs share artifacts within the same workflow run.
@@ -110,8 +111,8 @@ integration suite runs only at merge time via GitHub Merge Queue
 - **macOS as root nodes**: macOS consolidated jobs run their own unit tests and start immediately - no dependency on Linux/Windows test completion.
 - **Native uv caching**: `setup-uv` action with `enable-cache: true` replaces manual `actions/cache@v3` blocks.
 - **Targeted setup-node usage**: Node.js is only installed in `ci-runtime.yml`, macOS consolidated jobs, and integration-tests/release-validation phases (for `apm runtime setup copilot` -> npm install).
-- **macOS runner consolidation**: Each macOS arch has a single consolidated job (build + integration + release-validation). Intel (`build-and-validate-macos-intel`) runs on every push since Intel runners are plentiful and uses marker-bounded lifecycle integration coverage for promotions. ARM (`build-and-validate-macos-arm`) is gated to tag/schedule/dispatch only since ARM runners are extremely scarce (2-4h+ queue waits) and remains the full-corpus macOS authority. This avoids serial re-queuing of runners across multiple jobs and redundant full-corpus replay on Intel.
-- **Unit tests skip macOS**: Python unit tests are platform-agnostic; Linux + Windows coverage is sufficient. macOS-specific validation (binary build, focused Intel integration, full ARM integration, and release validation) still runs via the consolidated jobs.
+- **macOS runner consolidation**: Each macOS arch has a single consolidated job (build + integration + release-validation). Intel (`build-and-validate-macos-intel`) runs on every push since Intel runners are plentiful and uses marker-bounded non-live lifecycle integration coverage for promotions. ARM (`build-and-validate-macos-arm`) is gated to tag/schedule/dispatch only since ARM runners are extremely scarce (2-4h+ queue waits) and remains the full non-live corpus macOS authority. This avoids serial re-queuing of runners across multiple jobs and redundant corpus replay on Intel.
+- **Unit tests skip macOS**: Python unit tests are platform-agnostic; Linux + Windows coverage is sufficient. macOS-specific validation (binary build, focused Intel integration, full non-live ARM integration, and release validation) still runs via the consolidated jobs.
 - **Tier 2 runs once per merged PR**, not per WIP push, since it triggers on `merge_group` only. Saves the bulk of integration minutes that the previous per-push flow burned.
 - UPX compression when available (reduces binary size ~50%)
 - Python optimization level 2 in PyInstaller

--- a/.github/instructions/cicd.instructions.md
+++ b/.github/instructions/cicd.instructions.md
@@ -42,9 +42,9 @@ integration suite runs only at merge time via GitHub Merge Queue
      to `.github/workflows/**`.
 4. **`build-release.yml`** - `push` to main, tags, schedule, `workflow_dispatch`
    - **Linux + Windows** run combined `build-and-test` (unit tests + binary build in one job). Unit tests run on every push for platform-regression signal; **smoke tests are gated to tag/schedule/dispatch only** (promotion boundaries) to avoid duplicating `ci-integration.yml`'s merge-time smoke and to cut redundant codex-binary downloads.
-   - **macOS Intel** uses `build-and-validate-macos-intel` (root node, runs own unit tests - no dependency on `build-and-test`). Builds the binary on every push for early regression feedback; tag/schedule/dispatch promotion runs add marker-bounded `lifecycle_smoke` integration coverage and isolated release validation.
-   - **macOS ARM** uses `build-and-validate-macos-arm` (root node, tag/schedule/dispatch only - ARM runners are extremely scarce with 2-4h+ queue waits). Promotion runs retain the unfiltered integration corpus and isolated release validation.
-   - Secrets always available. Full 5-platform binary output (linux x86_64/arm64, darwin x86_64/arm64, windows x86_64).
+   - **macOS Intel** uses `build-and-validate-macos-intel` (root node, runs own unit tests - no dependency on `build-and-test`). Builds the binary on every push for early regression feedback; tag/schedule/dispatch promotion runs add marker-bounded `lifecycle_smoke and not live` integration coverage and isolated release validation.
+   - **macOS ARM** uses `build-and-validate-macos-arm` (root node, tag/schedule/dispatch only - ARM runners are extremely scarce with 2-4h+ queue waits). Promotion runs retain the full non-live integration corpus and isolated release validation.
+   - Publication jobs do not receive `ADO_APM_PAT`; live ADO PAT acceptance is an explicit `ado_pat_e2e` mode in `auth-acceptance.yml`. Full 5-platform binary output (linux x86_64/arm64, darwin x86_64/arm64, windows x86_64).
 5. **`ci-runtime.yml`** - nightly schedule, manual dispatch, path-filtered push
    - **Linux x86_64 only**. Live inference smoke tests (`apm run`) isolated from release pipeline.
    - Uses `GH_MODELS_PAT` for GitHub Models API access.
@@ -82,8 +82,9 @@ integration suite runs only at merge time via GitHub Merge Queue
 - **Merge queue workflow**: ci.yml (Tier 1 against tentative merge ref) + ci-integration.yml (Tier 2: build -> smoke-test -> integration-tests -> release-validation). Queue auto-merges on success; ejects on failure.
 - **Push/Release workflow (Linux + Windows)**: build-and-test -> integration-tests -> release-validation -> create-release -> publish-pypi (gh-aw-compat runs in parallel, informational)
 - **Homebrew distribution**: `microsoft/homebrew-apm` polls the latest public APM release and updates its formula with its own `GITHUB_TOKEN`; this workflow must not send a cross-repository dispatch or hold a tap credential.
-- **Push/Release workflow (macOS Intel)**: build-and-validate-macos-intel (root node: unit tests + build always + conditional `lifecycle_smoke` integration/release-validation) -> create-release
-- **Push/Release workflow (macOS ARM)**: build-and-validate-macos-arm (root node, tag/schedule/dispatch only; full integration corpus and all phases run) -> create-release
+- **Push/Release workflow (macOS Intel)**: build-and-validate-macos-intel (root node: unit tests + build always + conditional `lifecycle_smoke and not live` integration/release-validation) -> create-release
+- **Push/Release workflow (macOS ARM)**: build-and-validate-macos-arm (root node, tag/schedule/dispatch only; full non-live integration corpus and all phases run) -> create-release
+- **Live ADO PAT acceptance**: manual `auth-acceptance.yml` dispatch with `ado_pat_e2e: true` -> exact `live and requires_ado_pat` marker intersection. Invalid credentials fail with production auth diagnostics but do not block publication.
 - **Tag Triggers**: Only `v*.*.*` tags trigger full release pipeline
 - **Artifact Retention**: 30 days for debugging failed releases
 - **Cross-workflow artifacts**: ci-integration.yml builds the binary inline (no cross-workflow artifact transfer); build-release.yml jobs share artifacts within the same workflow run.
@@ -110,8 +111,8 @@ integration suite runs only at merge time via GitHub Merge Queue
 - **macOS as root nodes**: macOS consolidated jobs run their own unit tests and start immediately - no dependency on Linux/Windows test completion.
 - **Native uv caching**: `setup-uv` action with `enable-cache: true` replaces manual `actions/cache@v3` blocks.
 - **Targeted setup-node usage**: Node.js is only installed in `ci-runtime.yml`, macOS consolidated jobs, and integration-tests/release-validation phases (for `apm runtime setup copilot` -> npm install).
-- **macOS runner consolidation**: Each macOS arch has a single consolidated job (build + integration + release-validation). Intel (`build-and-validate-macos-intel`) runs on every push since Intel runners are plentiful and uses marker-bounded lifecycle integration coverage for promotions. ARM (`build-and-validate-macos-arm`) is gated to tag/schedule/dispatch only since ARM runners are extremely scarce (2-4h+ queue waits) and remains the full-corpus macOS authority. This avoids serial re-queuing of runners across multiple jobs and redundant full-corpus replay on Intel.
-- **Unit tests skip macOS**: Python unit tests are platform-agnostic; Linux + Windows coverage is sufficient. macOS-specific validation (binary build, focused Intel integration, full ARM integration, and release validation) still runs via the consolidated jobs.
+- **macOS runner consolidation**: Each macOS arch has a single consolidated job (build + integration + release-validation). Intel (`build-and-validate-macos-intel`) runs on every push since Intel runners are plentiful and uses marker-bounded non-live lifecycle integration coverage for promotions. ARM (`build-and-validate-macos-arm`) is gated to tag/schedule/dispatch only since ARM runners are extremely scarce (2-4h+ queue waits) and remains the full non-live corpus macOS authority. This avoids serial re-queuing of runners across multiple jobs and redundant corpus replay on Intel.
+- **Unit tests skip macOS**: Python unit tests are platform-agnostic; Linux + Windows coverage is sufficient. macOS-specific validation (binary build, focused Intel integration, full non-live ARM integration, and release validation) still runs via the consolidated jobs.
 - **Tier 2 runs once per merged PR**, not per WIP push, since it triggers on `merge_group` only. Saves the bulk of integration minutes that the previous per-push flow burned.
 - UPX compression when available (reduces binary size ~50%)
 - Python optimization level 2 in PyInstaller

--- a/.github/workflows/auth-acceptance.yml
+++ b/.github/workflows/auth-acceptance.yml
@@ -26,8 +26,12 @@ on:
         description: 'GHE Cloud test repo (org/repo@host, optional)'
         required: false
       ado_repo:
-        description: 'Azure DevOps test repo (dev.azure.com/org/project/_git/repo, optional)'
+        description: 'ADO package fixture with gdpr-assessment.prompt.md and Copilot instructions'
         required: false
+      ado_pat_e2e:
+        description: 'Run live ADO PAT integration tests (requires ado_repo and AUTH_TEST_ADO_APM_PAT)'
+        type: boolean
+        default: false
       git_url_repo:
         description: 'Private repo for git: URL object format (owner/repo, optional)'
         required: false
@@ -80,13 +84,13 @@ jobs:
           AUTH_TEST_PRIVATE_REPO_2: ${{ inputs.private_repo_2 }}
           AUTH_TEST_EMU_REPO: ${{ inputs.emu_repo }}
           AUTH_TEST_GHE_REPO: ${{ inputs.ghe_repo }}
-          AUTH_TEST_ADO_REPO: ${{ inputs.ado_repo }}
+          AUTH_TEST_ADO_REPO: ${{ inputs.ado_pat_e2e && inputs.ado_repo || '' }}
           AUTH_TEST_GIT_URL_REPO: ${{ inputs.git_url_repo }}
           AUTH_TEST_GIT_URL_PUBLIC_REPO: ${{ inputs.git_url_public_repo }}
           GITHUB_APM_PAT: ${{ secrets.AUTH_TEST_GITHUB_APM_PAT }}
           GITHUB_TOKEN: ${{ secrets.AUTH_TEST_GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.AUTH_TEST_GH_TOKEN }}
-          ADO_APM_PAT: ${{ secrets.AUTH_TEST_ADO_APM_PAT }}
+          ADO_APM_PAT: ${{ inputs.ado_pat_e2e && secrets.AUTH_TEST_ADO_APM_PAT || '' }}
           GITHUB_APM_PAT_MCAPS_MICROSOFT: ${{ secrets.AUTH_TEST_GITHUB_APM_PAT_MCAPS_MICROSOFT }}
           GITHUB_APM_PAT_DEVEXPGBB: ${{ secrets.AUTH_TEST_GITHUB_APM_PAT_DEVEXPGBB }}
         run: |
@@ -95,6 +99,24 @@ jobs:
           else
             ./scripts/test-auth-acceptance.sh
           fi
+
+      - name: Run live ADO PAT integration acceptance
+        if: ${{ inputs.ado_pat_e2e == true }}
+        env:
+          APM_BINARY_PATH: .venv/bin/apm
+          APM_TEST_ADO_REPO: ${{ inputs.ado_repo }}
+          ADO_APM_PAT: ${{ secrets.AUTH_TEST_ADO_APM_PAT }}
+        run: |
+          if [ -z "$APM_TEST_ADO_REPO" ]; then
+            echo "::error::ado_repo is required when ado_pat_e2e is enabled"
+            exit 1
+          fi
+          if [ -z "$ADO_APM_PAT" ]; then
+            echo "::error::AUTH_TEST_ADO_APM_PAT is not configured in the auth-acceptance environment"
+            exit 1
+          fi
+          uv run pytest tests/integration/ \
+            -m "live and requires_ado_pat" -v --tb=short
 
   # ADO AAD bearer-token tests (#852).
   #

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -219,11 +219,11 @@ jobs:
         env:
           APM_E2E_TESTS: "1"
           GITHUB_APM_PAT: ${{ secrets.GH_CLI_PAT }}
-          ADO_APM_PAT: ${{ secrets.ADO_APM_PAT }}
           # Intel validates the promoted lifecycle subset against its native
-          # binary. ARM and Linux retain the unfiltered integration corpus.
+          # binary. Live credential acceptance belongs to auth-acceptance.yml.
           # loadgroup preserves HOME-mutating test serialization.
-          PYTEST_EXTRA_ARGS: "-m=lifecycle_smoke -n 4 --dist loadgroup"
+          PYTEST_MARK_EXPR: "lifecycle_smoke and not live"
+          PYTEST_EXTRA_ARGS: "-n 4 --dist loadgroup"
         run: |
           chmod +x scripts/test-integration.sh
           uv run ./scripts/test-integration.sh
@@ -250,7 +250,6 @@ jobs:
         env:
           APM_E2E_TESTS: "1"
           GITHUB_APM_PAT: ${{ secrets.GH_CLI_PAT }}
-          ADO_APM_PAT: ${{ secrets.ADO_APM_PAT }}
         run: |
           cd /tmp/apm-isolated-test
           chmod +x test-release-validation.sh
@@ -334,11 +333,12 @@ jobs:
         env:
           APM_E2E_TESTS: "1"
           GITHUB_APM_PAT: ${{ secrets.GH_CLI_PAT }}
-          ADO_APM_PAT: ${{ secrets.ADO_APM_PAT }}
           # Scarce ARM runners force the full suite onto one runner, so
-          # parallelise in-process with xdist. --dist loadgroup honors the
+          # parallelise the non-live corpus in-process with xdist.
+          # --dist loadgroup honors the
           # home_env xdist_group markers that keep HOME-mutating tests
           # serialized on a single worker.
+          PYTEST_MARK_EXPR: "not live"
           PYTEST_EXTRA_ARGS: "-n 4 --dist loadgroup"
         run: |
           chmod +x scripts/test-integration.sh
@@ -364,7 +364,6 @@ jobs:
         env:
           APM_E2E_TESTS: "1"
           GITHUB_APM_PAT: ${{ secrets.GH_CLI_PAT }}
-          ADO_APM_PAT: ${{ secrets.ADO_APM_PAT }}
         run: |
           cd /tmp/apm-isolated-test
           chmod +x test-release-validation.sh
@@ -432,10 +431,10 @@ jobs:
         env:
           APM_E2E_TESTS: "1"
           GITHUB_APM_PAT: ${{ secrets.GH_CLI_PAT }}    # Primary: APM module access
-          ADO_APM_PAT: ${{ secrets.ADO_APM_PAT }}      # Azure DevOps module access
-          # The tag gate runs the full corpus on one runner. Four workers stay
+          # The tag gate runs the non-live corpus on one runner. Four workers stay
           # below the merge gate's aggregate width while loadgroup preserves
           # xdist_group serialization for HOME-mutating tests.
+          PYTEST_MARK_EXPR: "not live"
           PYTEST_EXTRA_ARGS: "-n 4 --dist loadgroup"
         run: |
           chmod +x scripts/test-integration.sh
@@ -448,7 +447,6 @@ jobs:
         env:
           APM_E2E_TESTS: "1"
           GITHUB_APM_PAT: ${{ secrets.GH_CLI_PAT }}
-          ADO_APM_PAT: ${{ secrets.ADO_APM_PAT }}
         run: |
           uv run pwsh scripts/windows/test-integration.ps1 -SkipBuild
         timeout-minutes: 20
@@ -536,7 +534,6 @@ jobs:
         env:
           APM_E2E_TESTS: "1"
           GITHUB_APM_PAT: ${{ secrets.GH_CLI_PAT }}
-          ADO_APM_PAT: ${{ secrets.ADO_APM_PAT }}
         run: |
           cd /tmp/apm-isolated-test
           chmod +x scripts/test-release-validation.sh
@@ -549,7 +546,6 @@ jobs:
         env:
           APM_E2E_TESTS: "1"
           GITHUB_APM_PAT: ${{ secrets.GH_CLI_PAT }}
-          ADO_APM_PAT: ${{ secrets.ADO_APM_PAT }}
         run: |
           cd D:\apm-isolated-test
           .\scripts\windows\test-release-validation.ps1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Release publication now excludes opt-in live ADO PAT tests and credentials;
-  those tests fail closed in the Auth Acceptance workflow instead.
+  those tests fail closed in the Auth Acceptance workflow instead. (#2426)
 - Release promotions now run marker-bounded lifecycle integration on macOS Intel
   while retaining the full corpus on macOS ARM and Linux, preventing Intel
   runner capacity timeouts. (#2423)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Release publication now excludes opt-in live ADO PAT tests and credentials;
-  those tests fail closed in the Auth Acceptance workflow instead. (#2426)
+- Release publication now excludes opt-in live ADO PAT tests and credentials; those tests fail closed in the Auth Acceptance workflow instead. (#2426)
 - Release promotions now run marker-bounded lifecycle integration on macOS Intel
   while retaining the full corpus on macOS ARM and Linux, preventing Intel
   runner capacity timeouts. (#2423)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Release publication now excludes opt-in live ADO PAT tests and credentials;
+  those tests fail closed in the Auth Acceptance workflow instead.
 - Release promotions now run marker-bounded lifecycle integration on macOS Intel
   while retaining the full corpus on macOS ARM and Linux, preventing Intel
   runner capacity timeouts. (#2423)

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -2801,7 +2801,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:60466b074de6bcc8a682ddb8ba938d8f76eb3dd76013812ad6e1bd3c729c5152
+  content_hash: sha256:33201cb88ea2f34b4950a9b52f87dc8dfb682796aaf53068ba7ae406c0c5e2c2
 - kind: project-relative
   target: copilot
   value: .github/instructions/cli.instructions.md
@@ -3292,7 +3292,7 @@ local_deployed_file_hashes:
   .github/agents/test-coverage-expert.agent.md: sha256:48c2172d1f18a394fa83ef9dc2be0b9b921a4e51e976498165250fed66369711
   .github/instructions/architecture.instructions.md: sha256:18bbdeaf073d7e15a6bdc836d1079ad5c199b4f05aa1db8ac6f724ae8fc08260
   .github/instructions/changelog.instructions.md: sha256:1e51ec4c74e847967962bd279dc4c6e582c5d3578490b3c28d5f3acd3e05f73e
-  .github/instructions/cicd.instructions.md: sha256:60466b074de6bcc8a682ddb8ba938d8f76eb3dd76013812ad6e1bd3c729c5152
+  .github/instructions/cicd.instructions.md: sha256:33201cb88ea2f34b4950a9b52f87dc8dfb682796aaf53068ba7ae406c0c5e2c2
   .github/instructions/cli.instructions.md: sha256:8e39e8d5047ce88575cb02f87c2bcede584dfef258bd86f7466c7badf136541a
   .github/instructions/doc-sync.instructions.md: sha256:bb3816254f8df6bffc6faacd556871f36903e9d7f348982f1e2de0339384c696
   .github/instructions/encoding.instructions.md: sha256:93db7377dc896f6efecf2c5d8c5d89255a555562f468d034d64c42edd5cf46d5

--- a/docs/src/content/docs/contributing/integration-testing.md
+++ b/docs/src/content/docs/contributing/integration-testing.md
@@ -81,7 +81,7 @@ what the test family you want actually requires.
 | `requires_runtime_codex` | The `codex` runtime installed under `~/.apm/runtimes/` | `apm runtime setup codex` |
 | `requires_runtime_copilot` | The GitHub Copilot CLI runtime installed under `~/.apm/runtimes/` | `apm runtime setup copilot` |
 | `requires_runtime_llm` | The `llm` runtime installed under `~/.apm/runtimes/` | `apm runtime setup llm` |
-| `live` | Tests that hit real GitHub repos via cloning; deselected by default | Override the deselect: `pytest -m live tests/integration -v` |
+| `live` | Tests that hit real third-party repositories; deselected by default | Override the deselect: `pytest -m live tests/integration -v` |
 
 Without any of those env vars or runtimes a `pytest tests/integration`
 invocation is silent rather than red: every test is collected and
@@ -304,6 +304,22 @@ marker registry described above. New integration tests dropped into
 `requires_*` marker and the registry will skip the test when its
 precondition is missing.
 
+Release promotion sets `PYTEST_MARK_EXPR="not live"`, so an expiring
+third-party credential cannot block publication. Live ADO PAT coverage is
+owned by the **Auth Acceptance Tests** workflow: dispatch it with
+`ado_pat_e2e: true` and an `ado_repo` acceptance fixture. That workflow
+selects `live and requires_ado_pat`, requires
+`AUTH_TEST_ADO_APM_PAT`, and fails with the normal actionable auth
+diagnostic when the PAT is rejected.
+
+Run the same focused acceptance locally with:
+
+```bash
+APM_TEST_ADO_REPO=dev.azure.com/org/project/_git/repo \
+ADO_APM_PAT=... \
+uv run pytest tests/integration/ -m "live and requires_ado_pat" -v
+```
+
 The orchestrator is mainly intended for reproducing the full CI
 environment end-to-end; for local iteration prefer the direct
 `pytest` invocations earlier on this page.
@@ -318,7 +334,7 @@ environment end-to-end; for local iteration prefer the direct
 **On version tag releases:**
 1. Unit tests + Smoke tests
 2. Build binaries (cross-platform)
-3. **E2E golden scenario tests** (using built binaries). Linux and macOS Apple Silicon retain the full integration corpus; macOS Intel runs the marker-bounded `lifecycle_smoke` subset plus native startup and isolated release validation.
+3. **E2E golden scenario tests** (using built binaries). Linux and macOS Apple Silicon retain the full non-live integration corpus; macOS Intel runs the marker-bounded `lifecycle_smoke and not live` subset plus native startup and isolated release validation.
 4. Create GitHub Release
 5. Publish to PyPI 
 
@@ -346,12 +362,14 @@ Runtime setup prefers `GITHUB_TOKEN` for GitHub Models and falls back to `GITHUB
 The workflow ensures quality gates at each step:
 
 1. **build-and-test** jobs - Unit tests plus binary builds
-2. **integration-tests** job - Comprehensive runtime scenarios
+2. **integration-tests** job - Comprehensive non-live runtime scenarios
 3. **release-validation** job - Final shipped-binary validation
 4. **create-release** job - GitHub release creation
 5. **publish-pypi** job - PyPI package publication
 
-Each stage must succeed before proceeding to the next, ensuring only fully validated releases reach users.
+Each publication stage must succeed before proceeding to the next. Live
+third-party credential acceptance remains a failing gate in the opt-in Auth
+Acceptance workflow rather than a dependency of release publication.
 
 The [`microsoft/homebrew-apm`](https://github.com/microsoft/homebrew-apm) tap updates independently: it polls the latest APM release and commits formula updates with its own repository-scoped `GITHUB_TOKEN`. The release pipeline does not hold a cross-repository Homebrew credential.
 
@@ -360,8 +378,8 @@ The [`microsoft/homebrew-apm`](https://github.com/microsoft/homebrew-apm) tap up
 Promotion integration tests run on:
 - **Linux**: ubuntu-24.04 (x86_64), ubuntu-24.04-arm (arm64)
 - **Windows**: windows-latest (x86_64)
-- **macOS Intel**: macos-15-intel (x86_64), with marker-bounded `lifecycle_smoke` integration coverage, native binary startup, and isolated release validation
-- **macOS Apple Silicon**: macos-latest (arm64), with the full integration corpus
+- **macOS Intel**: macos-15-intel (x86_64), with marker-bounded `lifecycle_smoke and not live` integration coverage, native binary startup, and isolated release validation
+- **macOS Apple Silicon**: macos-latest (arm64), with the full non-live integration corpus
 
 **Python Version**: 3.12 (standardized across all environments)
 **Package Manager**: uv (for fast dependency management and virtual environments)

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -363,7 +363,14 @@ run_e2e_tests() {
     # bare "${arr[@]}" on an empty array raises an unbound-variable error.
     # shellcheck disable=SC2206
     extra_args=(${PYTEST_EXTRA_ARGS:-})
-    if pytest tests/integration/ -v --tb=short ${extra_args[@]+"${extra_args[@]}"}; then
+    marker_args=()
+    if [[ -n "${PYTEST_MARK_EXPR:-}" ]]; then
+        marker_args=(-m "$PYTEST_MARK_EXPR")
+        log_info "Pytest marker selection: $PYTEST_MARK_EXPR"
+    fi
+    if pytest tests/integration/ -v --tb=short \
+        ${extra_args[@]+"${extra_args[@]}"} \
+        ${marker_args[@]+"${marker_args[@]}"}; then
         log_success "Integration test suite passed (collected and ran via pytest discovery)"
     else
         log_error "Integration test suite reported failures"

--- a/scripts/windows/test-integration.ps1
+++ b/scripts/windows/test-integration.ps1
@@ -12,7 +12,8 @@
 
 param(
     [switch]$SkipBuild,
-    [switch]$SkipRuntimes
+    [switch]$SkipRuntimes,
+    [switch]$IncludeLiveADO
 )
 
 $ErrorActionPreference = "Stop"
@@ -198,17 +199,20 @@ function Invoke-IntegrationTests {
     }
     Write-Success "APM Dependencies integration tests passed!"
 
-    # Azure DevOps E2E tests (conditional)
-    if ($env:ADO_APM_PAT) {
+    # Azure DevOps E2E tests are live acceptance and require explicit opt-in.
+    if ($IncludeLiveADO -and $env:ADO_APM_PAT) {
         Write-Info "Running Azure DevOps E2E tests..."
-        pytest tests/integration/test_ado_e2e.py -v -s --tb=short
+        pytest tests/integration/test_ado_e2e.py -m "live and requires_ado_pat" -v -s --tb=short
         if ($LASTEXITCODE -ne 0) {
             Write-ErrorText "Azure DevOps E2E tests failed!"
             exit 1
         }
         Write-Success "Azure DevOps E2E tests passed!"
+    } elseif ($IncludeLiveADO) {
+        Write-ErrorText "Live Azure DevOps E2E requested but ADO_APM_PAT is not set"
+        exit 1
     } else {
-        Write-Info "Skipping Azure DevOps E2E tests (ADO_APM_PAT not set)"
+        Write-Info "Skipping live Azure DevOps E2E tests (pass -IncludeLiveADO to opt in)"
     }
 
     # #1212 anti-regression: ADO --update preflight bearer-fallback.

--- a/tests/integration/test_ado_e2e.py
+++ b/tests/integration/test_ado_e2e.py
@@ -1,8 +1,8 @@
 """
 E2E tests for Azure DevOps package support.
 
-These tests require the ADO_APM_PAT environment variable to be set
-and make real network calls to Azure DevOps repositories.
+These opt-in live tests require the ADO_APM_PAT environment variable
+and make real network calls to an Azure DevOps acceptance fixture.
 
 Skip these tests if ADO_APM_PAT is not available.
 """
@@ -12,12 +12,37 @@ import shlex
 import subprocess
 import tempfile  # noqa: F401
 from pathlib import Path
+from urllib.parse import unquote, urlparse
 
 import pytest
 import yaml
 
-# Skip all tests in this module if ADO_APM_PAT is not set
-pytestmark = pytest.mark.requires_ado_pat
+pytestmark = [
+    pytest.mark.live,
+    pytest.mark.requires_ado_pat,
+]
+
+_DEFAULT_ADO_TEST_REPO = "dev.azure.com/dmeppiel-org/market-js-app/_git/compliance-rules"
+_ADO_TEST_REPO = os.environ.get("APM_TEST_ADO_REPO", _DEFAULT_ADO_TEST_REPO).rstrip("/")
+
+
+def _ado_repo_coordinates(repo: str) -> tuple[str, str, str]:
+    """Return the org, project, and repository from an ADO Git URL."""
+    parsed = urlparse(repo if "://" in repo else f"https://{repo}")
+    parts = [unquote(part) for part in parsed.path.split("/") if part]
+    try:
+        git_index = parts.index("_git")
+        if parsed.hostname != "dev.azure.com" or git_index != 2:
+            raise ValueError
+        return parts[0], parts[1], parts[git_index + 1].removesuffix(".git")
+    except (IndexError, ValueError) as error:
+        raise ValueError(
+            "APM_TEST_ADO_REPO must use dev.azure.com/org/project/_git/repo"
+        ) from error
+
+
+ADO_ORG, ADO_PROJECT, ADO_REPO = _ado_repo_coordinates(_ADO_TEST_REPO)
+_ADO_VIRTUAL_PACKAGE = f"{_ADO_TEST_REPO}/gdpr-assessment.prompt.md"
 
 
 def run_apm_command(
@@ -41,7 +66,7 @@ class TestADOInstall:
     """Test installing ADO packages."""
 
     # Test ADO repository - must be accessible with ADO_APM_PAT
-    ADO_TEST_REPO = "dev.azure.com/dmeppiel-org/market-js-app/_git/compliance-rules"
+    ADO_TEST_REPO = _ADO_TEST_REPO
 
     def test_install_ado_package(self, tmp_path, apm_binary_path: Path):
         """Install a real ADO package and verify directory structure."""
@@ -69,8 +94,7 @@ class TestADOInstall:
         apm_modules = project_dir / "apm_modules"
         assert apm_modules.exists(), "apm_modules/ not created"
 
-        # Should be: apm_modules/dmeppiel-org/market-js-app/compliance-rules/
-        expected_path = apm_modules / "dmeppiel-org" / "market-js-app" / "compliance-rules"
+        expected_path = apm_modules / ADO_ORG / ADO_PROJECT / ADO_REPO
         assert expected_path.exists(), f"Expected 3-level path not found: {expected_path}"
 
         # Verify package content
@@ -80,7 +104,7 @@ class TestADOInstall:
 class TestADODepsAndPrune:
     """Test deps list and prune with ADO packages."""
 
-    ADO_TEST_REPO = "dev.azure.com/dmeppiel-org/market-js-app/_git/compliance-rules"
+    ADO_TEST_REPO = _ADO_TEST_REPO
 
     def test_deps_list_shows_correct_path(self, tmp_path, apm_binary_path: Path):
         """deps list should show full 3-level path for ADO packages."""
@@ -107,7 +131,7 @@ class TestADODepsAndPrune:
         assert result.returncode == 0, f"deps list failed: {result.stderr}"
 
         # Should show 3-level path (may be truncated with ...) and azure-devops source
-        assert "dmeppiel-org/market-js-app" in result.stdout
+        assert f"{ADO_ORG}/{ADO_PROJECT}" in result.stdout
         assert "azure-devops" in result.stdout
         assert "orphaned" not in result.stdout.lower()
 
@@ -142,7 +166,7 @@ class TestADODepsAndPrune:
 class TestADOCompile:
     """Test compilation with ADO dependencies."""
 
-    ADO_TEST_REPO = "dev.azure.com/dmeppiel-org/market-js-app/_git/compliance-rules"
+    ADO_TEST_REPO = _ADO_TEST_REPO
 
     def test_compile_generates_agents_md(self, tmp_path, apm_binary_path: Path):
         """Compile should keep ADO Copilot instructions outside AGENTS.md."""
@@ -185,9 +209,7 @@ class TestADOCompile:
 class TestADOVirtualPackage:
     """Test virtual package (single file) installation from ADO."""
 
-    ADO_VIRTUAL_PACKAGE = (
-        "dev.azure.com/dmeppiel-org/market-js-app/_git/compliance-rules/gdpr-assessment.prompt.md"
-    )
+    ADO_VIRTUAL_PACKAGE = _ADO_VIRTUAL_PACKAGE
 
     def test_install_virtual_package(self, tmp_path, apm_binary_path: Path):
         """Install a single file (virtual package) from ADO repo."""
@@ -215,10 +237,7 @@ class TestADOVirtualPackage:
 
         # Verify 3-level virtual package path
         apm_modules = project_dir / "apm_modules"
-        # Virtual package name: compliance-rules-gdpr-assessment
-        expected_path = (
-            apm_modules / "dmeppiel-org" / "market-js-app" / "compliance-rules-gdpr-assessment"
-        )
+        expected_path = apm_modules / ADO_ORG / ADO_PROJECT / f"{ADO_REPO}-gdpr-assessment"
         assert expected_path.exists(), f"Expected virtual package path not found: {expected_path}"
 
     def test_virtual_package_not_orphaned(self, tmp_path, apm_binary_path: Path):
@@ -254,7 +273,7 @@ class TestMixedDependencies:
     """Test mixed GitHub and ADO dependencies."""
 
     GITHUB_PACKAGE = "microsoft/apm-sample-package"
-    ADO_PACKAGE = "dev.azure.com/dmeppiel-org/market-js-app/_git/compliance-rules"
+    ADO_PACKAGE = _ADO_TEST_REPO
 
     def test_mixed_install(self, tmp_path, apm_binary_path: Path):
         """Both GitHub and ADO packages should install correctly."""
@@ -286,7 +305,7 @@ class TestMixedDependencies:
         assert github_path.exists(), f"GitHub package not found: {github_path}"
 
         # ADO: 3-level
-        ado_path = apm_modules / "dmeppiel-org" / "market-js-app" / "compliance-rules"
+        ado_path = apm_modules / ADO_ORG / ADO_PROJECT / ADO_REPO
         assert ado_path.exists(), f"ADO package not found: {ado_path}"
 
     def test_mixed_deps_list(self, tmp_path, apm_binary_path: Path):

--- a/tests/integration/test_ado_e2e.py
+++ b/tests/integration/test_ado_e2e.py
@@ -1,10 +1,9 @@
 """
 E2E tests for Azure DevOps package support.
 
-These opt-in live tests require the ADO_APM_PAT environment variable
-and make real network calls to an Azure DevOps acceptance fixture.
-
-Skip these tests if ADO_APM_PAT is not available.
+These tests require explicit ``-m live`` selection and the ADO_APM_PAT
+environment variable, then make real network calls to an Azure DevOps
+acceptance fixture.
 """
 
 import os

--- a/tests/unit/test_ado_live_workflow_contract.py
+++ b/tests/unit/test_ado_live_workflow_contract.py
@@ -1,0 +1,178 @@
+"""Contracts separating live ADO acceptance from release publication."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.integration import test_ado_e2e
+from tests.workflow_contracts import (
+    assert_exact_command,
+    effective_env,
+    load_workflow,
+    shell_commands,
+    shell_tokens,
+    workflow_job,
+    workflow_step,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "build-release.yml"
+AUTH_WORKFLOW = ROOT / ".github" / "workflows" / "auth-acceptance.yml"
+INTEGRATION_SCRIPT = ROOT / "scripts" / "test-integration.sh"
+LIVE_ADO_SELECTOR = "live and requires_ado_pat"
+RELEASE_INTEGRATION_STEPS = (
+    ("build-and-validate-macos-intel", "Run focused Intel integration tests"),
+    ("build-and-validate-macos-arm", "Run integration tests"),
+    ("integration-tests", "Run integration tests (Unix)"),
+)
+
+
+def _walk_nodes(value: Any) -> list[dict[str, Any]]:
+    """Return every mapping nested under a parsed workflow."""
+    nodes: list[dict[str, Any]] = []
+    if isinstance(value, dict):
+        nodes.append(value)
+        for child in value.values():
+            nodes.extend(_walk_nodes(child))
+    elif isinstance(value, list):
+        for child in value:
+            nodes.extend(_walk_nodes(child))
+    return nodes
+
+
+def _assert_release_excludes_live_ado(workflow: dict[str, Any]) -> None:
+    """Require publication integration to be credential-free and non-live."""
+    for node in _walk_nodes(workflow):
+        env = node.get("env")
+        if isinstance(env, dict):
+            assert "ADO_APM_PAT" not in env
+
+    for job_id, step_name in RELEASE_INTEGRATION_STEPS:
+        job = workflow_job(workflow, job_id)
+        step = workflow_step(job, step_name)
+        marker_expression = effective_env(workflow, job, step).get("PYTEST_MARK_EXPR")
+        assert isinstance(marker_expression, str)
+        assert "not live" in marker_expression
+
+    windows_step = workflow_step(
+        workflow_job(workflow, "integration-tests"),
+        "Run integration tests (Windows)",
+    )
+    assert "-IncludeLiveADO" not in shell_tokens(windows_step)
+
+
+def _assert_auth_acceptance_selects_live_ado(workflow: dict[str, Any]) -> None:
+    """Require opt-in auth acceptance to run the credential-gated live nodes."""
+    dispatch_inputs = workflow["on"]["workflow_dispatch"]["inputs"]
+    assert dispatch_inputs["ado_pat_e2e"] == {
+        "description": (
+            "Run live ADO PAT integration tests (requires ado_repo and AUTH_TEST_ADO_APM_PAT)"
+        ),
+        "type": "boolean",
+        "default": False,
+    }
+
+    job = workflow_job(workflow, "auth-tests")
+    generic_step = workflow_step(job, "Run auth acceptance tests")
+    assert generic_step["env"]["AUTH_TEST_ADO_REPO"] == (
+        "${{ inputs.ado_pat_e2e && inputs.ado_repo || '' }}"
+    )
+    assert generic_step["env"]["ADO_APM_PAT"] == (
+        "${{ inputs.ado_pat_e2e && secrets.AUTH_TEST_ADO_APM_PAT || '' }}"
+    )
+
+    step = workflow_step(job, "Run live ADO PAT integration acceptance")
+    assert step.get("if") == "${{ inputs.ado_pat_e2e == true }}"
+    assert step["env"] == {
+        "APM_BINARY_PATH": ".venv/bin/apm",
+        "APM_TEST_ADO_REPO": "${{ inputs.ado_repo }}",
+        "ADO_APM_PAT": "${{ secrets.AUTH_TEST_ADO_APM_PAT }}",
+    }
+    assert_exact_command(
+        shell_commands(step),
+        [
+            "uv",
+            "run",
+            "pytest",
+            "tests/integration/",
+            "-m",
+            LIVE_ADO_SELECTOR,
+            "-v",
+            "--tb=short",
+        ],
+        label="live ADO auth acceptance step",
+    )
+    run = step["run"]
+    assert "ado_repo is required when ado_pat_e2e is enabled" in run
+    assert "AUTH_TEST_ADO_APM_PAT is not configured" in run
+
+
+def test_ado_e2e_is_live_and_credential_gated() -> None:
+    """The real ADO fixture requires both opt-in scheduling and a PAT."""
+    assert {mark.name for mark in test_ado_e2e.pytestmark} == {
+        "live",
+        "requires_ado_pat",
+    }
+
+
+def test_release_integration_excludes_live_ado_and_its_credential() -> None:
+    """A rejected third-party PAT cannot block publication jobs."""
+    _assert_release_excludes_live_ado(load_workflow(RELEASE_WORKFLOW))
+
+
+def test_integration_script_owns_explicit_marker_selection() -> None:
+    """The shared Unix orchestrator must pass workflow marker expressions safely."""
+    script = INTEGRATION_SCRIPT.read_text(encoding="utf-8")
+    assert 'marker_args=(-m "$PYTEST_MARK_EXPR")' in script
+    assert '${marker_args[@]+"${marker_args[@]}"}' in script
+    assert script.index('${extra_args[@]+"${extra_args[@]}"}') < script.index(
+        '${marker_args[@]+"${marker_args[@]}"}'
+    )
+
+
+def test_auth_acceptance_explicitly_selects_live_ado_nodes() -> None:
+    """The opt-in auth workflow remains the live PAT acceptance owner."""
+    _assert_auth_acceptance_selects_live_ado(load_workflow(AUTH_WORKFLOW))
+
+
+def test_release_ado_secret_mutation_is_rejected() -> None:
+    """Adding the expiring ADO PAT back to publication must fail the contract."""
+    workflow = deepcopy(load_workflow(RELEASE_WORKFLOW))
+    step = workflow_step(
+        workflow_job(workflow, "integration-tests"),
+        "Run integration tests (Unix)",
+    )
+    step["env"]["ADO_APM_PAT"] = "secret"
+
+    with pytest.raises(AssertionError):
+        _assert_release_excludes_live_ado(workflow)
+
+
+def test_release_live_selector_mutation_is_rejected() -> None:
+    """Publication cannot silently regain live external-service nodes."""
+    workflow = deepcopy(load_workflow(RELEASE_WORKFLOW))
+    step = workflow_step(
+        workflow_job(workflow, "build-and-validate-macos-arm"),
+        "Run integration tests",
+    )
+    step["env"]["PYTEST_MARK_EXPR"] = "live"
+
+    with pytest.raises(AssertionError):
+        _assert_release_excludes_live_ado(workflow)
+
+
+def test_auth_acceptance_non_live_selector_mutation_is_rejected() -> None:
+    """Auth acceptance cannot silently stop selecting the live ADO nodes."""
+    workflow = deepcopy(load_workflow(AUTH_WORKFLOW))
+    step = workflow_step(
+        workflow_job(workflow, "auth-tests"),
+        "Run live ADO PAT integration acceptance",
+    )
+    step["run"] = step["run"].replace(LIVE_ADO_SELECTOR, "not live")
+
+    with pytest.raises(AssertionError):
+        _assert_auth_acceptance_selects_live_ado(workflow)

--- a/tests/unit/test_platform_contract_workflow.py
+++ b/tests/unit/test_platform_contract_workflow.py
@@ -121,7 +121,7 @@ def _assert_standalone_integration_timeouts(workflow: dict) -> None:
     assert windows_step.get("timeout-minutes") == 20
 
 
-def _assert_full_corpus_unix_integration_parallelism(workflow: dict) -> None:
+def _assert_non_live_unix_integration_parallelism(workflow: dict) -> None:
     for job_id, step_name in NON_LIVE_UNIX_INTEGRATION_STEPS:
         step = workflow_step(workflow_job(workflow, job_id), step_name)
         assert step["env"].get("PYTEST_MARK_EXPR") == NON_LIVE_MARK_EXPRESSION
@@ -163,7 +163,7 @@ def test_standalone_integration_timeouts_are_platform_specific() -> None:
 
 def test_linux_and_arm_retain_non_live_corpus_grouped_parallelism() -> None:
     """Linux and macOS ARM keep the bounded non-live integration corpus."""
-    _assert_full_corpus_unix_integration_parallelism(_workflow())
+    _assert_non_live_unix_integration_parallelism(_workflow())
 
 
 def test_intel_integration_is_marker_scoped_and_bounded() -> None:
@@ -185,7 +185,7 @@ def test_non_live_unix_serial_integration_mutation_is_rejected(
     del step["env"]["PYTEST_EXTRA_ARGS"]
 
     with pytest.raises(AssertionError):
-        _assert_full_corpus_unix_integration_parallelism(workflow)
+        _assert_non_live_unix_integration_parallelism(workflow)
 
 
 @pytest.mark.parametrize(
@@ -202,7 +202,7 @@ def test_non_live_unix_timeout_mutation_is_rejected(
     step["timeout-minutes"] = 31
 
     with pytest.raises(AssertionError):
-        _assert_full_corpus_unix_integration_parallelism(workflow)
+        _assert_non_live_unix_integration_parallelism(workflow)
 
 
 def test_intel_non_live_corpus_mutation_is_rejected() -> None:
@@ -228,7 +228,7 @@ def test_arm_focused_subset_mutation_is_rejected() -> None:
     step["env"]["PYTEST_MARK_EXPR"] = INTEL_FOCUSED_MARK_EXPRESSION
 
     with pytest.raises(AssertionError):
-        _assert_full_corpus_unix_integration_parallelism(workflow)
+        _assert_non_live_unix_integration_parallelism(workflow)
 
 
 def test_unix_integration_twenty_minute_timeout_mutation_is_rejected() -> None:

--- a/tests/unit/test_platform_contract_workflow.py
+++ b/tests/unit/test_platform_contract_workflow.py
@@ -43,13 +43,14 @@ MACOS_STARTUP_CONTRACTS = (
         "github.event_name == 'workflow_dispatch'",
     ),
 )
-FULL_CORPUS_UNIX_INTEGRATION_STEPS = (
+NON_LIVE_UNIX_INTEGRATION_STEPS = (
     ("integration-tests", "Run integration tests (Unix)"),
     ("build-and-validate-macos-arm", "Run integration tests"),
 )
-FULL_CORPUS_UNIX_PYTEST_ARGS = "-n 4 --dist loadgroup"
+NON_LIVE_UNIX_PYTEST_ARGS = "-n 4 --dist loadgroup"
+NON_LIVE_MARK_EXPRESSION = "not live"
 INTEL_FOCUSED_INTEGRATION_STEP = "Run focused Intel integration tests"
-INTEL_FOCUSED_PYTEST_ARGS = "-m=lifecycle_smoke -n 4 --dist loadgroup"
+INTEL_FOCUSED_MARK_EXPRESSION = "lifecycle_smoke and not live"
 
 
 def _workflow() -> dict:
@@ -121,9 +122,10 @@ def _assert_standalone_integration_timeouts(workflow: dict) -> None:
 
 
 def _assert_full_corpus_unix_integration_parallelism(workflow: dict) -> None:
-    for job_id, step_name in FULL_CORPUS_UNIX_INTEGRATION_STEPS:
+    for job_id, step_name in NON_LIVE_UNIX_INTEGRATION_STEPS:
         step = workflow_step(workflow_job(workflow, job_id), step_name)
-        assert step["env"].get("PYTEST_EXTRA_ARGS") == FULL_CORPUS_UNIX_PYTEST_ARGS
+        assert step["env"].get("PYTEST_MARK_EXPR") == NON_LIVE_MARK_EXPRESSION
+        assert step["env"].get("PYTEST_EXTRA_ARGS") == NON_LIVE_UNIX_PYTEST_ARGS
         assert step.get("timeout-minutes") == 30
 
 
@@ -134,7 +136,8 @@ def _assert_intel_focused_integration(workflow: dict) -> None:
         "github.ref_type == 'tag' || github.event_name == 'schedule' || "
         "github.event_name == 'workflow_dispatch'"
     )
-    assert step["env"].get("PYTEST_EXTRA_ARGS") == INTEL_FOCUSED_PYTEST_ARGS
+    assert step["env"].get("PYTEST_MARK_EXPR") == INTEL_FOCUSED_MARK_EXPRESSION
+    assert step["env"].get("PYTEST_EXTRA_ARGS") == NON_LIVE_UNIX_PYTEST_ARGS
     assert step.get("timeout-minutes") == 30
     assert_exact_command(
         shell_commands(step),
@@ -158,8 +161,8 @@ def test_standalone_integration_timeouts_are_platform_specific() -> None:
     _assert_standalone_integration_timeouts(_workflow())
 
 
-def test_linux_and_arm_retain_full_corpus_grouped_parallelism() -> None:
-    """Linux and macOS ARM keep the unfiltered, bounded integration corpus."""
+def test_linux_and_arm_retain_non_live_corpus_grouped_parallelism() -> None:
+    """Linux and macOS ARM keep the bounded non-live integration corpus."""
     _assert_full_corpus_unix_integration_parallelism(_workflow())
 
 
@@ -170,13 +173,13 @@ def test_intel_integration_is_marker_scoped_and_bounded() -> None:
 
 @pytest.mark.parametrize(
     ("job_id", "step_name"),
-    FULL_CORPUS_UNIX_INTEGRATION_STEPS,
+    NON_LIVE_UNIX_INTEGRATION_STEPS,
 )
-def test_full_corpus_unix_serial_integration_mutation_is_rejected(
+def test_non_live_unix_serial_integration_mutation_is_rejected(
     job_id: str,
     step_name: str,
 ) -> None:
-    """No full-corpus release node can silently regress to the serial path."""
+    """No non-live release node can silently regress to the serial path."""
     workflow = deepcopy(_workflow())
     step = workflow_step(workflow_job(workflow, job_id), step_name)
     del step["env"]["PYTEST_EXTRA_ARGS"]
@@ -187,13 +190,13 @@ def test_full_corpus_unix_serial_integration_mutation_is_rejected(
 
 @pytest.mark.parametrize(
     ("job_id", "step_name"),
-    FULL_CORPUS_UNIX_INTEGRATION_STEPS,
+    NON_LIVE_UNIX_INTEGRATION_STEPS,
 )
-def test_full_corpus_unix_timeout_mutation_is_rejected(
+def test_non_live_unix_timeout_mutation_is_rejected(
     job_id: str,
     step_name: str,
 ) -> None:
-    """Every full-corpus Unix release node remains bounded to 30 minutes."""
+    """Every non-live Unix release node remains bounded to 30 minutes."""
     workflow = deepcopy(_workflow())
     step = workflow_step(workflow_job(workflow, job_id), step_name)
     step["timeout-minutes"] = 31
@@ -202,27 +205,27 @@ def test_full_corpus_unix_timeout_mutation_is_rejected(
         _assert_full_corpus_unix_integration_parallelism(workflow)
 
 
-def test_intel_full_corpus_mutation_is_rejected() -> None:
-    """Intel cannot silently regain the redundant unfiltered corpus."""
+def test_intel_non_live_corpus_mutation_is_rejected() -> None:
+    """Intel cannot silently regain the redundant non-live corpus."""
     workflow = deepcopy(_workflow())
     step = workflow_step(
         workflow_job(workflow, "build-and-validate-macos-intel"),
         INTEL_FOCUSED_INTEGRATION_STEP,
     )
-    step["env"]["PYTEST_EXTRA_ARGS"] = FULL_CORPUS_UNIX_PYTEST_ARGS
+    step["env"]["PYTEST_MARK_EXPR"] = NON_LIVE_MARK_EXPRESSION
 
     with pytest.raises(AssertionError):
         _assert_intel_focused_integration(workflow)
 
 
 def test_arm_focused_subset_mutation_is_rejected() -> None:
-    """ARM remains a full-corpus macOS release authority."""
+    """ARM remains the broad non-live macOS release authority."""
     workflow = deepcopy(_workflow())
     step = workflow_step(
         workflow_job(workflow, "build-and-validate-macos-arm"),
         "Run integration tests",
     )
-    step["env"]["PYTEST_EXTRA_ARGS"] = INTEL_FOCUSED_PYTEST_ARGS
+    step["env"]["PYTEST_MARK_EXPR"] = INTEL_FOCUSED_MARK_EXPRESSION
 
     with pytest.raises(AssertionError):
         _assert_full_corpus_unix_integration_parallelism(workflow)


### PR DESCRIPTION
# fix(release): decouple live ADO acceptance

## TL;DR

Release publication now runs the full non-live integration corpus without receiving `ADO_APM_PAT`, so an expired or revoked third-party credential cannot block GitHub release or PyPI publication. Live ADO PAT coverage remains fail-closed behind an explicit `ado_pat_e2e` dispatch in **Auth Acceptance Tests**, where rejected credentials retain the production diagnostic. Production `AuthResolver` behavior is unchanged.

> [!IMPORTANT]
> This fixes the only failure in release run [30738263533](https://github.com/microsoft/apm/actions/runs/30738263533): live `test_ado_e2e.py` nodes ran because the repository PAT was present, then failed with the existing “Authentication failed for dev.azure.com” diagnostic.

## Problem (WHY)

- [x] `build-release.yml` injected `ADO_APM_PAT` into macOS, Linux, and Windows promotion jobs, making a long-lived third-party secret a transitive dependency of release publication.
- [x] `test_ado_e2e.py` required a PAT but lacked the opt-in `live` scheduling marker, so merely configuring the secret selected real ADO network calls during release integration.
- [x] Windows integration used secret presence as the live-test selector; a stale secret therefore opted the release into a test it could not satisfy.
- [!] The marker taxonomy already documented `live` as deselected by default, but workflow intent was implicit and could be overridden by later pytest arguments.

The fix makes selection deterministic because ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) It also keeps publication and credential acceptance as separate, chainable gates: ["Favor small, chainable primitives over monolithic frameworks."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/)

## Approach (WHAT)

| # | Fix | Principle |
|---:|---|---|
| 1 | Classify real ADO package tests as `live` plus `requires_ado_pat`. | ["Add what the agent lacks, omit what it knows"](https://agentskills.io/skill-creation/best-practices) |
| 2 | Give release jobs an explicit final `not live` selector and remove `ADO_APM_PAT` from every publication step. | ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) |
| 3 | Add an opt-in Auth Acceptance step selecting exactly `live and requires_ado_pat`, with hard failures for missing fixture or secret. | ["Favor small, chainable primitives over monolithic frameworks."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) |
| 4 | Pin marker ownership, credential scope, and mutation failures in workflow contract tests. | ["agents pattern-match well against concrete structures"](https://agentskills.io/skill-creation/best-practices) |

## Implementation (HOW)

| File | Change |
|---|---|
| `.github/workflows/build-release.yml` | Removes every `ADO_APM_PAT` binding and selects `not live` after all extra pytest arguments; Intel keeps the narrower `lifecycle_smoke and not live` intersection. |
| `.github/workflows/auth-acceptance.yml` | Adds the `ado_pat_e2e` opt-in, gates the existing shell scenarios with it, validates required inputs, and runs the exact live ADO marker intersection. |
| `scripts/test-integration.sh` | Adds a safely quoted `PYTEST_MARK_EXPR` channel after `PYTEST_EXTRA_ARGS`, preventing extra arguments from re-enabling live nodes. |
| `scripts/windows/test-integration.ps1` | Replaces secret-presence selection with `-IncludeLiveADO`; opting in without a PAT fails explicitly. |
| `tests/integration/test_ado_e2e.py` | Adds `live`, retains `requires_ado_pat`, and accepts a controlled ADO fixture URL from `APM_TEST_ADO_REPO`. |
| `tests/unit/test_ado_live_workflow_contract.py` | Proves release exclusion, auth-workflow selection, argument precedence, and mutation rejection. |
| `tests/unit/test_platform_contract_workflow.py` | Renames the prior “full corpus” contract to the accurate full non-live corpus and pins each expression. |
| `docs/src/content/docs/contributing/integration-testing.md` | Documents local and workflow opt-in commands plus the publication boundary. |
| `.github/instructions/cicd.instructions.md` | Updates the canonical CI topology and release-flow ownership. |
| `CHANGELOG.md` | Records the release-unblock behavior under **Unreleased / Fixed**. |

## Diagrams

Legend: publication and live acceptance now share test code but have separate selectors, credentials, and outcomes.

```mermaid
sequenceDiagram
    participant R as Release workflow
    participant S as Integration script
    participant P as Pytest
    participant A as Auth Acceptance
    participant D as dev.azure.com

    rect rgb(255, 247, 200)
        Note over R,P: Publication boundary
        R->>S: PYTEST_MARK_EXPR=not live
        S->>P: full non-live integration corpus
        P-->>R: release evidence
    end
    rect rgb(255, 247, 200)
        Note over A,D: Explicit live credential boundary
        A->>P: select live and requires_ado_pat
        P->>D: real fixture request with ADO_APM_PAT
        D-->>P: success or auth rejection
        P-->>A: pass or failing production diagnostic
    end
```

## Trade-offs

- **Explicit selector channel over relying on `pyproject.toml` defaults.** Defaults remain useful locally, but release intent is now visible in the workflow and protected against a later `-m` override.
- **Manual auth acceptance over publication gating.** Live ADO failures still fail their workflow; they no longer strand an otherwise validated release on credential rotation.
- **One controlled fixture contract over generic repositories.** The optional fixture must contain the known prompt and Copilot instructions used by the lifecycle assertions; accepting arbitrary repositories would turn content differences into false auth failures.
- **No production auth changes.** The rejected-PAT diagnostic observed in the failed release remains the behavior under acceptance; this PR changes scheduling and credential scope only.

## Benefits

1. Zero `ADO_APM_PAT` references remain in `build-release.yml`.
2. All three Unix promotion integration paths end with a marker expression containing `not live`.
3. Windows requires an explicit `-IncludeLiveADO` switch instead of secret presence.
4. Auth Acceptance selects exactly `live and requires_ado_pat` and fails before pytest when its fixture or PAT is missing.
5. Seven focused contract tests reject secret, selector, and ownership regressions.

## Validation

`uv run --extra dev pytest tests/unit/test_ado_live_workflow_contract.py tests/unit/test_platform_contract_workflow.py tests/unit/integration/test_integration_wiring_invariants.py -q`:

```text
40 passed in 0.97s
```

<details><summary>Full CI lint mirror</summary>

```text
1. Ruff lint: All checks passed
2. Ruff format check: 1593 files already formatted
3. YAML encoding safety guard: no violations
4. File length guardrail: passed
5. Raw str(relative_to) guard: passed
6. Pylint R0801: 10.00/10
7. Auth-protocol boundary: auth-signal lint clean
8. Architecture authority boundaries: architecture boundary lint clean
```

</details>

`bash -n scripts/test-integration.sh` and PowerShell parser validation:

```text
Bash syntax check passed
PowerShell parser validation passed
```

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---:|---|---|---|---|
| 1 | Publishing a release does not depend on a live ADO PAT | Secure by default, Governed by policy | `tests/unit/test_ado_live_workflow_contract.py::test_release_integration_excludes_live_ado_and_its_credential` (regression trap for release run 30738263533) | unit contract |
| 2 | Opting into live ADO acceptance runs the real PAT-gated nodes and fails on rejected credentials | Secure by default, DevX (pragmatic as npm) | `tests/unit/test_ado_live_workflow_contract.py::test_auth_acceptance_explicitly_selects_live_ado_nodes`<br/>`tests/integration/test_ado_e2e.py` | unit contract + live e2e |
| 3 | Extra pytest arguments cannot silently re-enable live tests during publication | Governed by policy | `tests/unit/test_ado_live_workflow_contract.py::test_integration_script_owns_explicit_marker_selection`<br/>`tests/unit/test_ado_live_workflow_contract.py::test_release_live_selector_mutation_is_rejected` | unit contract |
| 4 | Windows runs live ADO tests only after an explicit operator opt-in | Secure by default, DevX (pragmatic as npm) | `tests/unit/test_ado_live_workflow_contract.py::test_release_integration_excludes_live_ado_and_its_credential` | unit contract |

## How to test

- [ ] Run the focused unit command above; expect `40 passed`.
- [ ] Inspect `build-release.yml`; expect no `ADO_APM_PAT` and `not live` on every Unix promotion integration step.
- [ ] Dispatch **Auth Acceptance Tests** with `ado_pat_e2e: true`, the controlled `ado_repo`, and a valid environment PAT; expect the shell scenarios and live pytest nodes to pass.
- [ ] Repeat with a rejected PAT; expect the workflow to fail with the actionable `dev.azure.com` authentication diagnostic, without affecting release publication.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
