### PR TITLE
feat(kiro): deploy agents primitive to .kiro/agents/ (#2089)

### DIFF
--- a/.apm/instructions/architecture.instructions.md
+++ b/.apm/instructions/architecture.instructions.md
@@ -37,12 +37,11 @@ semicolon-delimited, and specific to the file(s) that own the fact.
 | Decision / fact | Canonical owner | Owner path selectors |
 |---|---|---|
 | Accepted target vocabulary | core/target_catalog.py | `src/apm_cli/core/target_catalog.py` |
-| Effective install target selection | core/target_detection.py (EffectiveTargetDecision); MCP compatibility adapter consumes the manifest parser | `src/apm_cli/core/target_detection.py`; `src/apm_cli/integration/mcp_integrator_install.py` |
+| Effective install target selection | core/target_detection.py (EffectiveTargetDecision) | `src/apm_cli/core/target_detection.py` |
 | Effective package target authorization | install/target_filter.py (resolve_effective_package_targets) | `src/apm_cli/install/target_filter.py` |
 | MCP target-selection precedence | integration/mcp_integrator_install.py (_resolve_target_runtimes) | `src/apm_cli/integration/mcp_integrator_install.py` |
 | Legacy MCP runtime ownership-key migration | install/mcp/ownership.py (migrate_legacy_project_target_servers) | `src/apm_cli/install/mcp/ownership.py` |
 | Behavioral test taxonomy classification | module-level pytestmark (taxonomy inventory verifies) | `tests/quality/taxonomy_inventory_plugin.py`; `tests/quality/test_test_taxonomy.py` |
-| Effective package target authorization | install/target_filter.py (resolve_effective_package_targets) | `src/apm_cli/install/target_filter.py` |
 | Host + credential resolution | core/auth.py (AuthResolver), core/host_providers.py | `src/apm_cli/core/auth.py`; `src/apm_cli/core/host_providers.py` |
 | Runtime descriptors | runtime/registry.py | `src/apm_cli/runtime/registry.py` |
 | User-facing output / diagnostics | CommandLogger / console owner | `src/apm_cli/core/command_logger.py`; `src/apm_cli/utils/console.py` |

--- a/.github/instructions/architecture.instructions.md
+++ b/.github/instructions/architecture.instructions.md
@@ -37,12 +37,11 @@ semicolon-delimited, and specific to the file(s) that own the fact.
 | Decision / fact | Canonical owner | Owner path selectors |
 |---|---|---|
 | Accepted target vocabulary | core/target_catalog.py | `src/apm_cli/core/target_catalog.py` |
-| Effective install target selection | core/target_detection.py (EffectiveTargetDecision); MCP compatibility adapter consumes the manifest parser | `src/apm_cli/core/target_detection.py`; `src/apm_cli/integration/mcp_integrator_install.py` |
+| Effective install target selection | core/target_detection.py (EffectiveTargetDecision) | `src/apm_cli/core/target_detection.py` |
 | Effective package target authorization | install/target_filter.py (resolve_effective_package_targets) | `src/apm_cli/install/target_filter.py` |
 | MCP target-selection precedence | integration/mcp_integrator_install.py (_resolve_target_runtimes) | `src/apm_cli/integration/mcp_integrator_install.py` |
 | Legacy MCP runtime ownership-key migration | install/mcp/ownership.py (migrate_legacy_project_target_servers) | `src/apm_cli/install/mcp/ownership.py` |
 | Behavioral test taxonomy classification | module-level pytestmark (taxonomy inventory verifies) | `tests/quality/taxonomy_inventory_plugin.py`; `tests/quality/test_test_taxonomy.py` |
-| Effective package target authorization | install/target_filter.py (resolve_effective_package_targets) | `src/apm_cli/install/target_filter.py` |
 | Host + credential resolution | core/auth.py (AuthResolver), core/host_providers.py | `src/apm_cli/core/auth.py`; `src/apm_cli/core/host_providers.py` |
 | Runtime descriptors | runtime/registry.py | `src/apm_cli/runtime/registry.py` |
 | User-facing output / diagnostics | CommandLogger / console owner | `src/apm_cli/core/command_logger.py`; `src/apm_cli/utils/console.py` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,17 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Kiro IDE/CLI v3 now receives agents from `.apm/agents/` as Markdown files
-  under `.kiro/agents/<relative-stem>.md`. Agent identity derives from the
-  deployed path. Only `description`, `model`, and `tools` frontmatter fields
-  are emitted; `name` and unknown fields are stripped. Tools are
-  permission-bearing: APM fails closed (no partial write) if any tool value is
-  outside the approved Kiro capability set (`read`, `write`, `shell`, `web`,
-  `subagent`, `knowledge`, `context`, `todo_list`, `@mcp`, `@builtin`, `*`).
-  Nested source paths under `.apm/agents/` are preserved, and the targets
-  matrix is updated to reflect the new `agents` primitive for `kiro`.
-  (ref: [kiro.dev/docs/custom-agents/](https://kiro.dev/docs/custom-agents/),
-  [kiro.dev/docs/cli/v3/](https://kiro.dev/docs/cli/v3/), accessed 2026-08-03.
-  #2089)
+  under `.kiro/agents/<relative-stem>.md`. Only `description`, `model`, and
+  `tools` frontmatter fields are forwarded; `name` and unknown fields are
+  stripped. Tools are permission-bearing: APM fails closed (no partial write)
+  if any tool value is outside the approved Kiro capability set (`read`,
+  `write`, `shell`, `web`, `subagent`, `knowledge`, `context`, `todo_list`,
+  `@mcp`, `@builtin`, `*`). Nested source paths under `.apm/agents/` are
+  preserved, and the targets matrix is updated to reflect the new `agents`
+  primitive for `kiro`. Sources: https://kiro.dev/docs/custom-agents/ and
+  https://kiro.dev/docs/cli/v3/ (accessed 2026-08-03). (#2089)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Kiro IDE/CLI v3 now receives agents from `.apm/agents/` as Markdown files
+  under `.kiro/agents/<relative-stem>.md`. Agent identity derives from the
+  deployed path. Only `description`, `model`, and `tools` frontmatter fields
+  are emitted; `name` and unknown fields are stripped. Tools are
+  permission-bearing: APM fails closed (no partial write) if any tool value is
+  outside the approved Kiro capability set (`read`, `write`, `shell`, `web`,
+  `subagent`, `knowledge`, `context`, `todo_list`, `@mcp`, `@builtin`, `*`).
+  Nested source paths under `.apm/agents/` are preserved, and the targets
+  matrix is updated to reflect the new `agents` primitive for `kiro`.
+  (ref: [kiro.dev/docs/custom-agents/](https://kiro.dev/docs/custom-agents/),
+  [kiro.dev/docs/cli/v3/](https://kiro.dev/docs/cli/v3/), accessed 2026-08-03.
+  #2089)
+
 ### Fixed
 
 - Release publication now excludes opt-in live ADO PAT tests and credentials; those tests fail closed in the Auth Acceptance workflow instead. (#2426)

--- a/CONFORMANCE.json
+++ b/CONFORMANCE.json
@@ -1219,12 +1219,23 @@
       "tests": [
         "tests/spec_conformance/test_manifest_reqs.py::test_dependency_package_targets_are_restriction_only"
       ]
+    },
+    {
+      "conformance_class": "consumer",
+      "id": "req-tg-009",
+      "keyword": "MUST",
+      "section": "8.5.1",
+      "status": "active",
+      "test_count": 1,
+      "tests": [
+        "tests/spec_conformance/test_manifest_reqs.py::test_kiro_agent_tools_gate_fails_closed_before_adopt"
+      ]
     }
   ],
   "spec_version": "v0.1.1",
   "summary_by_class": {
     "consumer": {
-      "active": 77,
+      "active": 78,
       "skipped": 1,
       "unbound": 0,
       "xfail": 0
@@ -1248,5 +1259,5 @@
       "xfail": 0
     }
   },
-  "total_requirements": 107
+  "total_requirements": 108
 }

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -19,7 +19,7 @@ All four conformance classes (Producer, Consumer, Registry, Governance) carry ac
 | Class | Active | Skipped | Xfail | Unbound |
 |-------|-------:|--------:|------:|--------:|
 | Producer | 12 | 0 | 0 | 0 |
-| Consumer | 77 | 1 | 0 | 0 |
+| Consumer | 78 | 1 | 0 | 0 |
 | Registry | 1 | 0 | 0 | 0 |
 | Governance | 16 | 0 | 0 | 0 |
 
@@ -134,6 +134,7 @@ All four conformance classes (Producer, Consumer, Registry, Governance) carry ac
 | [req-tg-006](docs/src/content/docs/specs/openapm-v0.1.md#req-tg-006) | MUST | 8.5 | consumer | active | 1 |
 | [req-tg-007](docs/src/content/docs/specs/openapm-v0.1.md#req-tg-007) | MUST | 8.5 | consumer | active | 1 |
 | [req-tg-008](docs/src/content/docs/specs/openapm-v0.1.md#req-tg-008) | MUST | 8.5.3 | consumer | active | 1 |
+| [req-tg-009](docs/src/content/docs/specs/openapm-v0.1.md#req-tg-009) | MUST | 8.5.1 | consumer | active | 1 |
 
 ## Waivers
 

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -3290,7 +3290,7 @@ local_deployed_file_hashes:
   .github/agents/spec-tag-architect.agent.md: sha256:82907265c5e7cf1ac61ad96866fa7c5683b69c8f09b7a4c5f3cc241acc9568ca
   .github/agents/supply-chain-security-expert.agent.md: sha256:8fb8cc426d6af17ba084a28b3f026c2b475b62e3ca63ed2f88b83bd823f877af
   .github/agents/test-coverage-expert.agent.md: sha256:48c2172d1f18a394fa83ef9dc2be0b9b921a4e51e976498165250fed66369711
-  .github/instructions/architecture.instructions.md: sha256:18bbdeaf073d7e15a6bdc836d1079ad5c199b4f05aa1db8ac6f724ae8fc08260
+  .github/instructions/architecture.instructions.md: sha256:da86b8597b4f46953d1f80853db268b7dae1e7099db094566dd6a8b003d405b6
   .github/instructions/changelog.instructions.md: sha256:1e51ec4c74e847967962bd279dc4c6e582c5d3578490b3c28d5f3acd3e05f73e
   .github/instructions/cicd.instructions.md: sha256:33201cb88ea2f34b4950a9b52f87dc8dfb682796aaf53068ba7ae406c0c5e2c2
   .github/instructions/cli.instructions.md: sha256:8e39e8d5047ce88575cb02f87c2bcede584dfef258bd86f7466c7badf136541a

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -2783,7 +2783,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:18bbdeaf073d7e15a6bdc836d1079ad5c199b4f05aa1db8ac6f724ae8fc08260
+  content_hash: sha256:da86b8597b4f46953d1f80853db268b7dae1e7099db094566dd6a8b003d405b6
 - kind: project-relative
   target: copilot
   value: .github/instructions/changelog.instructions.md

--- a/docs/public/specs/manifests/openapm-v0.1.requirements.yml
+++ b/docs/public/specs/manifests/openapm-v0.1.requirements.yml
@@ -395,6 +395,10 @@ requirements:
     keyword: MUST
     section: "8.5.3"
     conformance_class: consumer
+  - id: req-tg-009
+    keyword: MUST
+    section: "8.5.1"
+    conformance_class: consumer
   - id: req-sc-001
     keyword: MUST
     section: "10.4"

--- a/docs/src/content/docs/concepts/primitives-and-targets.md
+++ b/docs/src/content/docs/concepts/primitives-and-targets.md
@@ -102,7 +102,7 @@ Notes per target:
 - **antigravity** -- Google Antigravity CLI (`agy`), successor to Gemini CLI. Explicit-only target (`--target antigravity`); the `.agents/` root is shared, so it is never auto-detected and is not part of `--target all`. Instructions deploy as rules under `.agents/rules/`. Skills use `.agents/skills/`. Hooks use Antigravity's native `.agents/hooks.json` schema. MCP servers write to a dedicated `.agents/mcp_config.json`. No commands primitive (legacy Gemini commands convert to skills upstream).
 - **opencode** -- OpenCode. No hooks support.
 - **windsurf** -- Windsurf / Cascade. No native agents primitive -- Cascade auto-invokes any `SKILL.md` by its `description:` frontmatter, so personas ship as skills. Workflows are the harness's name for commands.
-- **kiro** -- Kiro IDE. Instructions become steering files, skills stay as `SKILL.md` folders, hooks are individual JSON files, and MCP lands in `.kiro/settings/mcp.json`.
+- **kiro** -- Kiro IDE/CLI v3. Instructions become steering files, skills stay as `SKILL.md` folders, hooks are individual JSON files, MCP lands in `.kiro/settings/mcp.json`, and agents deploy to `.kiro/agents/<stem>.md` with frontmatter filtered to `description`, `model`, and `tools` only.
 
 ## The compatibility matrix
 
@@ -117,7 +117,7 @@ Rows are primitives, columns are harnesses. Cell legend:
 |---|---|---|---|---|---|---|---|---|---|
 | instructions | native | native | native | compiled | compiled | native | compiled | native | native |
 | prompts | native | compiled | compiled | unsupported | compiled | compiled | compiled | compiled | unsupported |
-| agents | native | native | compiled | compiled | unsupported | unsupported | native | unsupported | unsupported |
+| agents | native | native | compiled | compiled | unsupported | unsupported | native | unsupported | compiled |
 | skills | native | native | native | native | native | native | native | native | native |
 | hooks | native | native | native | native | native | native | unsupported | native | native |
 | commands | unsupported | native | compiled | unsupported | compiled | unsupported | compiled | compiled | unsupported |
@@ -131,6 +131,7 @@ How to read a cell:
 - `prompts / claude = compiled` -- APM transforms `.apm/prompts/<n>.prompt.md` into `.claude/commands/<n>.md`. The prompt becomes a `/command`.
 - `agents / gemini = unsupported` -- Gemini CLI has no agents primitive; APM does not deliver `.agent.md` files to it. Their content still reaches Gemini through the compiled `GEMINI.md` if referenced from instructions.
 - `agents / antigravity = unsupported` -- Antigravity CLI has no agents primitive; their content reaches Antigravity through the compiled `AGENTS.md`.
+- `agents / kiro = compiled` -- APM writes `.kiro/agents/<relative-stem>.md`; frontmatter is filtered to `description`, `model`, and `tools` (unsupported tool values fail the deploy). See [targets-matrix](/apm/reference/targets-matrix/#kiro) for the approved tool set.
 - `instructions / antigravity = native` -- APM deploys instructions as plain-markdown rules under `.agents/rules/`.
 - `commands / copilot = unsupported` -- Copilot has no commands primitive; the same source `.prompt.md` reaches Copilot as a native prompt instead.
 - `plugins / *` -- APM unpacks the plugin at install time into the primitives in the rows above; routing then follows those rows.

--- a/docs/src/content/docs/integrations/ide-tool-integration.md
+++ b/docs/src/content/docs/integrations/ide-tool-integration.md
@@ -23,7 +23,7 @@ The full slot-by-slot capability table lives in [Targets matrix](../../reference
 | Antigravity CLI      | explicit `--target antigravity`       | Rules, skills, hooks, MCP              |
 | OpenCode             | `.opencode/`                         | Skills, MCP                            |
 | Windsurf             | `.windsurf/`                         | Rules + Skills + Workflows + MCP       |
-| Kiro                 | `.kiro/`                             | Steering + Skills + Hooks + MCP        |
+| Kiro                 | `.kiro/`                             | Steering + Agents + Skills + Hooks + MCP |
 | JetBrains Copilot    | user-scope config dir (global)       | MCP (user-scope path, `${env:VAR}` substitution); file primitives use the Copilot profile |
 | Agent-Skills (cross) | `.agents/skills/`                    | Vendor-neutral skill sharing           |
 
@@ -126,13 +126,21 @@ For server installation patterns, registry resolution, and trust model, see [MCP
 [Kiro](https://kiro.dev) reads project configuration from `.kiro/`. APM maps
 instructions to `.kiro/steering/` and converts `applyTo:` scoping into Kiro
 steering frontmatter (`inclusion: fileMatch`); unscoped instructions become
-`inclusion: always`. Skills are copied verbatim to `.kiro/skills/`, hooks
-become one JSON file per hook action in `.kiro/hooks/`, and MCP servers are
-written to `.kiro/settings/mcp.json` or `~/.kiro/settings/mcp.json` for
-`--global`.
+`inclusion: always`. Agents are deployed to `.kiro/agents/<relative-stem>.md`
+for Kiro IDE/CLI v3; identity derives from the relative path. Only
+`description`, `model`, and `tools` are emitted -- `name` and unknown
+frontmatter fields are stripped. Tools are permission-bearing: APM fails
+closed if any value outside the Kiro-approved capability set is present
+(`read`, `write`, `shell`, `web`, `subagent`, `knowledge`, `context`,
+`todo_list`, `@mcp`, `@builtin`, `*`). Skills are copied verbatim to
+`.kiro/skills/`, hooks become one JSON file per hook action in `.kiro/hooks/`,
+and MCP servers are written to `.kiro/settings/mcp.json` or
+`~/.kiro/settings/mcp.json` for `--global`.
 
-This target covers the documented Kiro IDE layout. Kiro CLI configuration
-differences are tracked separately; see [the targets matrix](../../reference/targets-matrix/#kiro).
+This target covers the documented Kiro IDE/CLI v3 layout
+(ref: [kiro.dev/docs/custom-agents/](https://kiro.dev/docs/custom-agents/),
+[kiro.dev/docs/cli/v3/](https://kiro.dev/docs/cli/v3/), accessed 2026-08-03).
+See [the targets matrix](../../reference/targets-matrix/#kiro) for a full primitives list.
 
 ### JetBrains (IntelliJ IDEA, PyCharm, GoLand, and others)
 

--- a/docs/src/content/docs/producer/author-primitives/instructions-and-agents.md
+++ b/docs/src/content/docs/producer/author-primitives/instructions-and-agents.md
@@ -159,15 +159,24 @@ for...
 | `handoffs` | optional | List of agent names (or VS Code structured handoff objects) this agent can hand off to |
 
 `model` and `tools` reach Copilot, Claude, Cursor, and OpenCode
-verbatim. Codex translates only `name`, `description`, and the Markdown
-body; APM does not yet generate the complete per-agent MCP transport
-definitions needed to preserve `model` or `tools`. When `tools` is
-present, `apm install` warns that the generated agent may inherit every
-project or session MCP server. Remove `tools` if unrestricted access is
-intentional; otherwise, do not use the generated agent with Codex.
-Windsurf, Kiro, and Gemini do not receive `.agent.md` files at all --
-use skills for Windsurf or Kiro personas; Gemini CLI has no agents
-primitive.
+verbatim. Kiro receives `description`, `model`, and `tools` only;
+unknown frontmatter fields (including `name`) are stripped because
+Kiro derives agent identity from the deployed path, not from a `name`
+field. Tools are permission-bearing for Kiro: each value must be one
+of the supported capability tags (`read`, `write`, `shell`, `web`,
+`subagent`, `knowledge`, `context`, `todo_list`, `@mcp`, `@builtin`,
+`*`). If any unsupported tag is present, the agent is not deployed at
+all -- APM fails closed. Kiro may warn and fall back if the specified
+`model` is unavailable; APM passes the value through without
+validation. Codex translates only `name`, `description`, and the
+Markdown body; APM does not yet generate the complete per-agent MCP
+transport definitions needed to preserve `model` or `tools`. When
+`tools` is present, `apm install` warns that the generated agent may
+inherit every project or session MCP server. Remove `tools` if
+unrestricted access is intentional; otherwise, do not use the
+generated agent with Codex. Windsurf and Gemini do not receive
+`.agent.md` files at all -- use skills for Windsurf personas; Gemini
+CLI has no agents primitive.
 
 OpenCode is the strictest of the verbatim targets: it requires
 `tools` as a `tool-name: boolean` **mapping** (not a list, not a
@@ -199,8 +208,8 @@ offending package and field so you can fix the source.
 | cursor | `.cursor/agents/<name>.md` | verbatim |
 | opencode | `.opencode/agents/<name>.md` | verbatim |
 | codex | `.codex/agents/<name>.toml` | `name` and `description` -> TOML; body becomes `developer_instructions`; unsupported `tools` emits a warning |
+| kiro | `.kiro/agents/<relative-stem>.md` | `description`, `model`, `tools` kept; `name` and unknown fields stripped; identity from path; fail closed on unsupported tools (ref: [kiro.dev/docs/custom-agents](https://kiro.dev/docs/custom-agents/), accessed 2026-08-03) |
 | windsurf | not deployed | Windsurf has no agents primitive -- author personas as skills (Cascade auto-invokes by description) |
-| kiro | not deployed | Kiro target v1 ships personas as skills, not `.agent.md` files |
 | gemini | not deployed | Gemini CLI has no agents primitive |
 
 :::caution[Migration]

--- a/docs/src/content/docs/reference/targets-matrix.md
+++ b/docs/src/content/docs/reference/targets-matrix.md
@@ -27,7 +27,7 @@ see [Primitive types](../primitive-types/).
 | antigravity     | `.agents/`             |     [x]      |   [ ]   |  [ ]   |  [x]   |   [ ]    |  [x]  | [x] |
 | opencode        | `.opencode/`           |     [ ]      |   [ ]   |  [x]   |  [x]   |   [x]    |  [ ]  | [x] |
 | windsurf        | `.windsurf/` + `.agents/` |     [x]      |   [ ]   |  [ ]   |  [x]   |   [x]    |  [x]  | [x] |
-| kiro            | `.kiro/`               |     [x]      |   [ ]   |  [ ]   |  [x]   |   [ ]    |  [x]  | [x] |
+| kiro            | `.kiro/`               |     [x]      |   [ ]   |  [x]   |  [x]   |   [ ]    |  [x]  | [x] |
 | intellij        | user MCP config; files via Copilot |    [x] (*)   | [x] (*) | [x] (*) | [x] (*) |   [ ]    | [x] (*) | [x] |
 | agent-skills    | `.agents/`             |     [ ]      |   [ ]   |  [ ]   |  [x]   |   [ ]    |  [ ]  | [ ] |
 
@@ -234,18 +234,28 @@ Windsurf / Cascade.
 
 ## kiro
 
-Kiro IDE.
+Kiro IDE/CLI v3 unified agent harness.
 
 - **Detection.** `.kiro/` directory.
 - **Deploy directory.** `.kiro/` (project and user scope).
-- **Supported primitives.** instructions, skills, hooks, mcp.
+- **Supported primitives.** agents, instructions, skills, hooks, mcp.
 - **File conventions.**
+  - agents: `.kiro/agents/<relative-stem>.md` -- identity derives from the
+    relative path. Only `description`, `model`, and `tools` frontmatter are
+    emitted; `name` and unknown fields are stripped. Tools are
+    permission-bearing: APM fails closed (no partial write) if any tool
+    value is outside the approved set (`read`, `write`, `shell`, `web`,
+    `subagent`, `knowledge`, `context`, `todo_list`, `@mcp`, `@builtin`,
+    `*`). Kiro may warn and fall back if the specified `model` is
+    unavailable; APM passes model values through without validation.
+    Ref: [kiro.dev/docs/custom-agents/](https://kiro.dev/docs/custom-agents/)
+    (accessed 2026-08-03).
   - instructions: `.kiro/steering/<name>.md` with `inclusion: always` or `inclusion: fileMatch` frontmatter
   - skills: `.kiro/skills/<name>/SKILL.md`
   - hooks: one JSON file per hook action under `.kiro/hooks/`
   - mcp: `.kiro/settings/mcp.json` (project) or `~/.kiro/settings/mcp.json` (user)
 - **MCP shape.** JSON `mcpServers` entries use `command`/`args`/`env` for stdio and `url`/`headers` for remote servers. Kiro resolves `${VAR}` placeholders at runtime, so APM preserves them rather than writing secrets to disk.
-- **Scope.** This is the documented Kiro IDE layout only. Kiro CLI differences are tracked separately and are not part of this target.
+- **Scope.** Covers the documented Kiro IDE and CLI v3 layout (unified harness). Ref: [kiro.dev/docs/cli/v3/](https://kiro.dev/docs/cli/v3/) (accessed 2026-08-03).
 
 ## intellij
 

--- a/docs/src/content/docs/specs/openapm-v0.1.md
+++ b/docs/src/content/docs/specs/openapm-v0.1.md
@@ -136,7 +136,7 @@ between the companion corpus and the implementation.
 
 ### 1.3 Document conventions
 
-- OpenAPM v0.1 carries **107 normative statements** indexed in
+- OpenAPM v0.1 carries **108 normative statements** indexed in
   [Appendix C](#appendix-c-index-of-normative-statements).
 - All on-disk files defined by this specification are **YAML 1.2**
   parsed under the safe subset defined in
@@ -2327,7 +2327,22 @@ emit an actionable diagnostic identifying the unsupported tool value(s) and
 the approved set. This fail-closed evaluation MUST be performed prior to any
 content-identity adoption fast-path; an existing on-disk artifact whose bytes
 match the source MUST NOT cause an agent with unrepresentable capabilities to
-be adopted or retained in the deployed-files record.
+be adopted or retained in the deployed-files record. This gate is evaluated
+per agent primitive independently; failure for one agent MUST NOT prevent
+deployment of other, vocabulary-conformant agent primitives from the same
+dependency or install operation. This evaluation applies only to agents whose
+target is included in the effective intersection computed under
+[req-tg-008](#req-tg-008); agents whose target is already excluded by that
+intersection are not subject to this gate.
+
+> **Editorial note.** The approved capability set for each target is the
+> vocabulary enumerated in the OpenAPM Target Registry companion entry for
+> that target at the spec version the consumer declares conformance to. A
+> conformance test suite MUST pin the exact companion version it validates
+> against. A future revision may promote this pinning to a standalone
+> normative requirement and define a machine-readable vocabulary schema;
+> until then, conformance testing is scoped to the sets published in the
+> companion.
 
 #### 8.5.2 Post-install compilation guidance
 
@@ -2413,7 +2428,7 @@ without a spec revision. The current matrix is in the companion
   [req-tg-002](#req-tg-002), [req-tg-003](#req-tg-003),
   [req-tg-004](#req-tg-004), [req-tg-005](#req-tg-005),
   [req-tg-006](#req-tg-006), [req-tg-007](#req-tg-007),
-  [req-tg-008](#req-tg-008).
+  [req-tg-008](#req-tg-008), [req-tg-009](#req-tg-009).
 
 ---
 
@@ -2948,7 +2963,7 @@ conformance statement identifying:
 [req-tg-002](#req-tg-002), [req-tg-003](#req-tg-003),
 [req-tg-004](#req-tg-004), [req-tg-005](#req-tg-005),
 [req-tg-006](#req-tg-006), [req-tg-007](#req-tg-007),
-[req-tg-008](#req-tg-008),
+[req-tg-008](#req-tg-008), [req-tg-009](#req-tg-009),
 [req-sc-001](#req-sc-001),
 [req-sc-002](#req-sc-002), [req-sc-003](#req-sc-003),
 [req-sc-004](#req-sc-004), [req-sc-005](#req-sc-005),
@@ -3395,7 +3410,7 @@ renumbering of conformance classes.
 | [req-cf-001](#req-cf-001)                | MUST    | 12.5    | consumer    |
 | [req-cf-002](#req-cf-002)                | MUST    | 12.3    | consumer    |
 
-**Total normative statements: 107** (102 MUST, 5 SHOULD).
+**Total normative statements: 108** (103 MUST, 5 SHOULD).
 
 ---
 
@@ -3428,6 +3443,7 @@ renumbering of conformance classes.
 | 0.1.21  | 2026-07-31 | Spec-citation fold for package-declared target restrictions (closes #2321 Mode-B silent-extension gate). Added [req-tg-008] (Section 8.5.3, consumer MUST): a consumer MUST treat a package's declared `target:`/`targets:` field as a restriction-only filter on all target-scoped primitive integration; if the field resolves to a non-empty set that does not contain `all`, the consumer MUST NOT deliver that package's primitives to any active integration target not in the declared set; the filter composes by intersection with the consumer-side per-dependency `targets:` filter and can only narrow, never expand. Section 8.7, Section 11.3.2 Consumer enumeration, and Appendix C updated. Statement count: 104 -> 105 (100 MUST, 5 SHOULD). |
 | 0.1.22  | 2026-07-31 | Spec-citation fold for deterministic configured-host credential isolation (closes #2338). Added [req-sc-013] (Section 10.3, consumer MUST): a consumer selects one effective host class before credential resolution, applies documented deterministic precedence when configuration signals overlap, exposes only credentials belonging to the selected class to requests and child processes, and preserves an explicit non-default port in both transport and credential scope. Clarified [req-sc-005] so this configured override is not prohibited by its default host-class collapse rule. Section 1.3, Section 10.11, Section 11.3.2 Consumer enumeration, and Appendix C updated. Statement count: 105 -> 106 (101 MUST, 5 SHOULD). |
 | 0.1.23  | 2026-07-31 | Spec-citation fold for case-preserving dependency materialization (closes #2347). Added [req-lk-022] (Section 5.2, consumer MUST): a consumer that case-folds repository identity but retains different source spelling records `materialization_repo_url`, validates it maps to the same canonical identity, excludes it from identity/cache/sort/trust decisions, preserves exact virtual-path casing, and either transactionally migrates one stale case variant or fails closed without deleting colliding paths. Defined rollback semantics for case-only rename and preserved interrupted recovery state. Added the field to the lockfile schema and conformance fixture, plus migration and collision conformance oracles. Hardened lockfile schema: `repo_url` now carries `minLength: 1` to match the prose requirement that git-sourced entries provide a non-empty canonical identifier ([req-lk-003](#req-lk-003)). Section 5.7, Section 10.11, Section 11.3.2, and Appendix C updated. Statement count: 106 -> 107 (102 MUST, 5 SHOULD). |
+| 0.1.24  | 2026-08-03 | Spec-citation fold for fail-closed Kiro agent vocabulary gate (closes #2089 Mode-B silent-extension gate). Added [req-tg-009] (Section 8.5.1, consumer MUST): a consumer deploying an agent primitive into a target with a fixed, enumerable capability vocabulary MUST fail closed -- writing zero bytes and emitting an actionable diagnostic -- if any source-declared tool falls outside the approved set; the gate fires per agent independently and does not block vocabulary-conformant sibling agents; the gate applies only to targets included in the effective intersection under [req-tg-008]; content-identity fast-paths are not exempt. Added editorial note naming the Target Registry companion as the vocabulary authority and mandating version-pinning for conformance testing. Section 8.7, Section 11.3.2 Consumer enumeration, and Appendix C updated. Statement count: 107 -> 108 (103 MUST, 5 SHOULD). |
 
 Errata (none at publication).
 

--- a/docs/src/content/docs/specs/openapm-v0.1.md
+++ b/docs/src/content/docs/specs/openapm-v0.1.md
@@ -2317,6 +2317,18 @@ returns.
 > process in [Section 9.3](#93-amendment-process) without weakening the
 > preservation-or-diagnostic contract above.
 
+<a id="req-tg-009"></a>
+**[req-tg-009]** A conforming **consumer** implementation that deploys an
+agent primitive into a target-native format with a fixed, enumerable
+capability vocabulary MUST fail closed: if any source-declared tool falls
+outside the target's approved capability set, the implementation MUST NOT
+write the agent's target artifact (zero bytes, no partial file) and MUST
+emit an actionable diagnostic identifying the unsupported tool value(s) and
+the approved set. This fail-closed evaluation MUST be performed prior to any
+content-identity adoption fast-path; an existing on-disk artifact whose bytes
+match the source MUST NOT cause an agent with unrepresentable capabilities to
+be adopted or retained in the deployed-files record.
+
 #### 8.5.2 Post-install compilation guidance
 
 <a id="req-tg-007"></a>
@@ -3365,6 +3377,7 @@ renumbering of conformance classes.
 | [req-tg-006](#req-tg-006)                | MUST    | 8.5     | consumer    |
 | [req-tg-007](#req-tg-007)                | MUST    | 8.5     | consumer    |
 | [req-tg-008](#req-tg-008)                | MUST    | 8.5.3   | consumer    |
+| [req-tg-009](#req-tg-009)                | MUST    | 8.5.1   | consumer    |
 | [req-sc-001](#req-sc-001)                | MUST    | 10.4    | consumer    |
 | [req-sc-002](#req-sc-002)                | MUST    | 10.9    | consumer    |
 | [req-sc-003](#req-sc-003)                | MUST    | 10.3    | consumer    |

--- a/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
@@ -458,8 +458,35 @@ it in place, but OpenCode will fail to start until you do.
 
 If you target multiple agent runtimes from one source file, keep the
 frontmatter to the intersection of their schemas (or maintain
-target-specific copies) until APM ships a per-target frontmatter
-transformer (tracked as Phase 2 of #581 -- contributions welcome).
+target-specific copies). For Kiro, only `description`, `model`, and `tools`
+are forwarded; `name` and unknown fields are silently stripped; tools are
+permission-bearing and APM fails closed if any unsupported value is present
+(supported: `read`, `write`, `shell`, `web`, `subagent`, `knowledge`,
+`context`, `todo_list`, `@mcp`, `@builtin`, `*`).
+
+#### Kiro target: tools constraint
+
+Kiro (`target: kiro`, deploys to `.kiro/agents/<relative-stem>.md`) treats
+`tools` as permission-bearing capability tags. APM fails closed -- the agent
+is NOT deployed -- if any `tools` value is outside the approved set:
+
+```yaml
+# OK
+tools:
+  - read
+  - write
+  - shell
+
+# Fails closed -- apm install emits an error, file is NOT written:
+# tools:
+#   - execute_arbitrary_code
+#   - read
+```
+
+The approved tags are: `read`, `write`, `shell`, `web`, `subagent`,
+`knowledge`, `context`, `todo_list`, `@mcp`, `@builtin`, `*`.
+Ref: [kiro.dev/docs/custom-agents/](https://kiro.dev/docs/custom-agents/)
+(accessed 2026-08-03).
 
 ### 6. Skill (folder-based, `SKILL.md`)
 

--- a/src/apm_cli/integration/agent_integrator.py
+++ b/src/apm_cli/integration/agent_integrator.py
@@ -19,15 +19,34 @@ from apm_cli.utils.atomic_io import write_text_lf
 from apm_cli.utils.diagnostics import printable_ascii_text
 from apm_cli.utils.path_security import PathTraversalError, ensure_path_within
 from apm_cli.utils.paths import portable_relpath
-from apm_cli.utils.yaml_io import load_yaml_str
+from apm_cli.utils.yaml_io import load_yaml_str, yaml_to_str
 
 if TYPE_CHECKING:
     from apm_cli.integration.targets import TargetProfile
     from apm_cli.utils.diagnostics import DiagnosticCollector
 
+# Kiro capability tags approved for agent 'tools' frontmatter.
+# Source: https://kiro.dev/docs/custom-agents/ (accessed 2026-08-03)
+# Fail closed: any value not in this set blocks deployment of that agent.
+KIRO_AGENT_ALLOWED_TOOLS: frozenset[str] = frozenset(
+    {
+        "read",
+        "write",
+        "shell",
+        "web",
+        "subagent",
+        "knowledge",
+        "context",
+        "todo_list",
+        "@mcp",
+        "@builtin",
+        "*",
+    }
+)
+
 
 class AgentIntegrator(BaseIntegrator):
-    """Handles integration of APM package agents into .github/agents/, .claude/agents/, and .cursor/agents/."""
+    """Handles integration of APM package agents into .github/agents/, .claude/agents/, .cursor/agents/, and .kiro/agents/."""
 
     # Deploys via write_text_lf -> compare adopt candidates in LF mode.
     _LF_NORMALIZED_DEPLOY = True
@@ -123,20 +142,21 @@ class AgentIntegrator(BaseIntegrator):
         total_links_resolved = 0
 
         for source_file in agent_files:
-            target_filename = self.get_target_filename_for_target(
-                source_file,
-                package_info.package.name,
-                target,
-            )
-            target_path = agents_dir / target_filename
-            # Defense-in-depth: target_filename comes from
-            # get_target_filename_for_target which strips path separators,
-            # but assert containment under agents_dir so a future
-            # regression cannot smuggle a traversal sequence past the
-            # adopt branch (which fires *before* check_collision and
-            # would otherwise blindly trust the computed path). Mirrors
-            # the guard already in command_integrator and
-            # instruction_integrator.
+            # kiro_agent uses relative path from .apm/agents/ for identity.
+            if mapping.format_id == "kiro_agent":
+                target_relpath = self._kiro_agent_relpath(source_file, package_info.install_path)
+            else:
+                target_relpath = self.get_target_filename_for_target(
+                    source_file,
+                    package_info.package.name,
+                    target,
+                )
+            target_path = agents_dir / target_relpath
+            # Defense-in-depth: assert containment under agents_dir so a
+            # regression cannot smuggle a traversal sequence past the adopt
+            # branch (which fires *before* check_collision and would otherwise
+            # blindly trust the computed path). Mirrors the guard already in
+            # command_integrator and instruction_integrator.
             try:
                 ensure_path_within(target_path, agents_dir)
             except PathTraversalError as exc:
@@ -147,6 +167,9 @@ class AgentIntegrator(BaseIntegrator):
                     )
                 files_skipped += 1
                 continue
+
+            # Create parent directories for nested kiro agent paths.
+            target_path.parent.mkdir(parents=True, exist_ok=True)
 
             rel_path = portable_relpath(target_path, project_root)
 
@@ -167,6 +190,17 @@ class AgentIntegrator(BaseIntegrator):
                     diagnostics=diagnostics,
                     package_name=package_info.package.name,
                 )
+                links_resolved = 0
+            elif mapping.format_id == "kiro_agent":
+                ok = self._write_kiro_agent(
+                    source_file,
+                    target_path,
+                    diagnostics=diagnostics,
+                    package_name=package_info.package.name,
+                )
+                if not ok:
+                    files_skipped += 1
+                    continue
                 links_resolved = 0
             else:
                 if mapping.format_id == "opencode_agent":
@@ -405,6 +439,154 @@ class AgentIntegrator(BaseIntegrator):
             "developer_instructions": body.strip(),
         }
         write_text_lf(target, _toml.dumps(doc))
+
+    # ------------------------------------------------------------------
+    # Kiro agent transformer (MD -> filtered MD)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _kiro_agent_relpath(source_file: Path, package_path: Path) -> str:
+        """Compute the relative target path for a Kiro agent file.
+
+        Preserves subdirectory structure from .apm/agents/ so identity
+        derives from the deployed path, not from a 'name' frontmatter
+        field (Kiro CLI v3 / IDE uses relative path as identity).
+
+        Sources under .apm/agents/ keep their relative subpath; root-level
+        sources are flattened to the filename only.
+
+        Ref: https://kiro.dev/docs/custom-agents/ (accessed 2026-08-03)
+        """
+        apm_agents_root = package_path / ".apm" / "agents"
+        try:
+            rel = source_file.relative_to(apm_agents_root)
+        except ValueError:
+            rel = Path(source_file.name)
+        parts = rel.parts
+        stem = parts[-1]
+        if stem.endswith(".agent.md"):
+            stem = stem[: -len(".agent.md")] + ".md"
+        elif not stem.endswith(".md"):
+            stem = stem + ".md"
+        if len(parts) > 1:
+            return str(Path(*parts[:-1]) / stem)
+        return stem
+
+    @staticmethod
+    def _write_kiro_agent(
+        source: Path,
+        target: Path,
+        *,
+        diagnostics=None,
+        package_name: str = "",
+    ) -> bool:
+        """Transform an agent file to Kiro .kiro/agents/ Markdown format.
+
+        Emits only officially-supported Kiro frontmatter fields:
+        ``description``, ``model``, and ``tools``. The ``name`` field is
+        stripped because Kiro derives agent identity from the deployed path.
+        Unknown frontmatter keys are silently omitted. The Markdown body is
+        preserved verbatim.
+
+        Fails closed -- returns ``False`` without writing any bytes -- if
+        ``tools`` contains values outside the Kiro-approved capability set:
+        read, write, shell, web, subagent, knowledge, context, todo_list,
+        @mcp, @builtin, *.
+
+        Ref: https://kiro.dev/docs/custom-agents/ (accessed 2026-08-03)
+        """
+        if source.is_symlink():
+            raise ValueError(f"Refusing to read symlink source: {source}")
+
+        content = source.read_text(encoding="utf-8")
+        body = content
+        out_fm: dict = {}
+
+        fm_match = AgentIntegrator._FRONTMATTER_RE.match(content)
+        if fm_match:
+            body = content[fm_match.end() :]
+            try:
+                fm = load_yaml_str(fm_match.group(1)) or {}
+            except yaml.YAMLError:
+                fm = {}
+
+            if isinstance(fm, dict):
+                # Validate and pass through tools; fail closed on incompatible values.
+                if "tools" in fm:
+                    tools_raw = fm["tools"]
+                    if tools_raw is None:
+                        tools_out = None
+                    elif isinstance(tools_raw, list):
+                        tools_strs = [str(t).strip() for t in tools_raw]
+                        incompatible = set(tools_strs) - KIRO_AGENT_ALLOWED_TOOLS
+                        if incompatible:
+                            if diagnostics is not None:
+                                names = ", ".join(sorted(incompatible))
+                                diagnostics.error(
+                                    message=(
+                                        f"Kiro agent {printable_ascii_text(source.name)}: "
+                                        f"unsupported tool(s) {names!a} -- "
+                                        "agent will not be deployed. "
+                                        "Remove or replace with Kiro-approved capability "
+                                        "tags (read, write, shell, web, subagent, knowledge, "
+                                        "context, todo_list, @mcp, @builtin, *). "
+                                        "Ref: https://kiro.dev/docs/custom-agents/"
+                                    ),
+                                    package=printable_ascii_text(package_name),
+                                )
+                            return False
+                        tools_out = tools_raw
+                    elif isinstance(tools_raw, str):
+                        tool = tools_raw.strip()
+                        if tool not in KIRO_AGENT_ALLOWED_TOOLS:
+                            if diagnostics is not None:
+                                diagnostics.error(
+                                    message=(
+                                        f"Kiro agent {printable_ascii_text(source.name)}: "
+                                        f"unsupported tool {tool!a} -- "
+                                        "agent will not be deployed. "
+                                        "Use a Kiro-approved capability tag. "
+                                        "Ref: https://kiro.dev/docs/custom-agents/"
+                                    ),
+                                    package=printable_ascii_text(package_name),
+                                )
+                            return False
+                        tools_out = [tool]
+                    else:
+                        if diagnostics is not None:
+                            diagnostics.error(
+                                message=(
+                                    f"Kiro agent {printable_ascii_text(source.name)}: "
+                                    "'tools' must be a list of capability tags -- "
+                                    "agent will not be deployed. "
+                                    "Fix: use a YAML list, e.g. 'tools: [read, write]'. "
+                                    "Ref: https://kiro.dev/docs/custom-agents/"
+                                ),
+                                package=printable_ascii_text(package_name),
+                            )
+                        return False
+
+                    if tools_out is not None:
+                        out_fm["tools"] = tools_out
+
+                # Emit approved fields in canonical order: description, model, tools.
+                out_fm_ordered: dict = {}
+                if "description" in fm and fm["description"] is not None:
+                    out_fm_ordered["description"] = fm["description"]
+                if "model" in fm and fm["model"] is not None:
+                    out_fm_ordered["model"] = fm["model"]
+                if "tools" in out_fm:
+                    out_fm_ordered["tools"] = out_fm["tools"]
+                out_fm = out_fm_ordered
+
+        if out_fm:
+            fm_text = yaml_to_str(out_fm)
+            rendered = f"---\n{fm_text}---\n{body}"
+        else:
+            rendered = body
+
+        write_text_lf(target, rendered)
+        return True
 
     # DEPRECATED: use integrate_agents_for_target(KNOWN_TARGETS["copilot"], ...) instead.
     def integrate_package_agents(

--- a/src/apm_cli/integration/agent_integrator.py
+++ b/src/apm_cli/integration/agent_integrator.py
@@ -15,7 +15,7 @@ import yaml
 
 from apm_cli.integration.base_integrator import BaseIntegrator, IntegrationResult
 from apm_cli.integration.opencode_frontmatter import validate_opencode_frontmatter
-from apm_cli.utils.atomic_io import write_text_lf
+from apm_cli.utils.atomic_io import normalize_crlf_to_lf, write_text_lf
 from apm_cli.utils.diagnostics import printable_ascii_text
 from apm_cli.utils.path_security import PathTraversalError, ensure_path_within
 from apm_cli.utils.paths import portable_relpath
@@ -133,7 +133,9 @@ class AgentIntegrator(BaseIntegrator):
             return IntegrationResult(0, 0, 0, [])
 
         agents_dir = target_root / mapping.subdir
-        agents_dir.mkdir(parents=True, exist_ok=True)
+        # Lazy mkdir: only create the dir when we actually need to write.
+        # This avoids creating .kiro/agents/ when every agent is invalid-tools.
+        agents_dir_created = False
 
         files_integrated = 0
         files_skipped = 0
@@ -168,8 +170,53 @@ class AgentIntegrator(BaseIntegrator):
                 files_skipped += 1
                 continue
 
-            # Create parent directories for nested kiro agent paths.
-            target_path.parent.mkdir(parents=True, exist_ok=True)
+            if mapping.format_id == "kiro_agent":
+                # req-tg-009: Preflight render+validate MUST run before any
+                # content-identity adoption fast-path or filesystem mutation.
+                # If validation fails, skip without writing or creating dirs.
+                rendered, ok = self._preflight_render_kiro_agent(
+                    source_file,
+                    diagnostics=diagnostics,
+                    package_name=package_info.package.name,
+                )
+                if not ok:
+                    files_skipped += 1
+                    continue
+
+                # Compare rendered artifact (not raw source) against existing
+                # target so a pre-placed file with invalid tools cannot be
+                # adopted by matching source bytes.
+                rel_path = portable_relpath(target_path, project_root)
+                if target_path.exists() and not target_path.is_symlink():
+                    try:
+                        existing = target_path.read_bytes()
+                        rendered_bytes = normalize_crlf_to_lf(rendered).encode("utf-8")
+                        if existing == rendered_bytes:
+                            target_paths.append(target_path)
+                            files_adopted += 1
+                            continue
+                    except OSError:
+                        pass
+                if self.check_collision(
+                    target_path, rel_path, managed_files, force, diagnostics=diagnostics
+                ):
+                    files_skipped += 1
+                    continue
+
+                # Safe to materialize: ensure parent dirs exist then write.
+                if not agents_dir_created:
+                    agents_dir.mkdir(parents=True, exist_ok=True)
+                    agents_dir_created = True
+                target_path.parent.mkdir(parents=True, exist_ok=True)
+                write_text_lf(target_path, rendered)
+                files_integrated += 1
+                target_paths.append(target_path)
+                continue
+
+            # Non-kiro path: eager mkdir (existing behavior preserved).
+            if not agents_dir_created:
+                agents_dir.mkdir(parents=True, exist_ok=True)
+                agents_dir_created = True
 
             rel_path = portable_relpath(target_path, project_root)
 
@@ -190,17 +237,6 @@ class AgentIntegrator(BaseIntegrator):
                     diagnostics=diagnostics,
                     package_name=package_info.package.name,
                 )
-                links_resolved = 0
-            elif mapping.format_id == "kiro_agent":
-                ok = self._write_kiro_agent(
-                    source_file,
-                    target_path,
-                    diagnostics=diagnostics,
-                    package_name=package_info.package.name,
-                )
-                if not ok:
-                    files_skipped += 1
-                    continue
                 links_resolved = 0
             else:
                 if mapping.format_id == "opencode_agent":
@@ -473,25 +509,24 @@ class AgentIntegrator(BaseIntegrator):
         return stem
 
     @staticmethod
-    def _write_kiro_agent(
+    def _preflight_render_kiro_agent(
         source: Path,
-        target: Path,
         *,
         diagnostics=None,
         package_name: str = "",
-    ) -> bool:
-        """Transform an agent file to Kiro .kiro/agents/ Markdown format.
+    ) -> tuple[str | None, bool]:
+        """Validate and render a Kiro agent file; return (rendered, ok).
 
-        Emits only officially-supported Kiro frontmatter fields:
-        ``description``, ``model``, and ``tools``. The ``name`` field is
-        stripped because Kiro derives agent identity from the deployed path.
-        Unknown frontmatter keys are silently omitted. The Markdown body is
-        preserved verbatim.
+        This is the SINGLE OWNER of the Kiro render+validate decision.
+        It MUST be called before any filesystem mutation (adopt check,
+        directory creation, or write) so that req-tg-009 is upheld: the
+        fail-closed evaluation runs prior to any content-identity fast-path.
 
-        Fails closed -- returns ``False`` without writing any bytes -- if
-        ``tools`` contains values outside the Kiro-approved capability set:
-        read, write, shell, web, subagent, knowledge, context, todo_list,
-        @mcp, @builtin, *.
+        Returns (rendered_str, True) on success or (None, False) if the
+        source declares tools outside KIRO_AGENT_ALLOWED_TOOLS or has an
+        unparseable frontmatter. On failure an actionable diagnostic is
+        emitted via diagnostics.error -- the caller MUST skip all target
+        mutations without writing any bytes.
 
         Ref: https://kiro.dev/docs/custom-agents/ (accessed 2026-08-03)
         """
@@ -511,7 +546,7 @@ class AgentIntegrator(BaseIntegrator):
                 fm = {}
 
             if isinstance(fm, dict):
-                # Validate and pass through tools; fail closed on incompatible values.
+                # Validate tools; fail closed on any incompatible value.
                 if "tools" in fm:
                     tools_raw = fm["tools"]
                     if tools_raw is None:
@@ -534,7 +569,7 @@ class AgentIntegrator(BaseIntegrator):
                                     ),
                                     package=printable_ascii_text(package_name),
                                 )
-                            return False
+                            return None, False
                         tools_out = tools_raw
                     elif isinstance(tools_raw, str):
                         tool = tools_raw.strip()
@@ -550,7 +585,7 @@ class AgentIntegrator(BaseIntegrator):
                                     ),
                                     package=printable_ascii_text(package_name),
                                 )
-                            return False
+                            return None, False
                         tools_out = [tool]
                     else:
                         if diagnostics is not None:
@@ -564,7 +599,7 @@ class AgentIntegrator(BaseIntegrator):
                                 ),
                                 package=printable_ascii_text(package_name),
                             )
-                        return False
+                        return None, False
 
                     if tools_out is not None:
                         out_fm["tools"] = tools_out
@@ -585,7 +620,31 @@ class AgentIntegrator(BaseIntegrator):
         else:
             rendered = body
 
-        write_text_lf(target, rendered)
+        return rendered, True
+
+    @staticmethod
+    def _write_kiro_agent(
+        source: Path,
+        target: Path,
+        *,
+        diagnostics=None,
+        package_name: str = "",
+    ) -> bool:
+        """Write a pre-rendered Kiro agent to disk; fail closed on invalid tools.
+
+        Delegates render+validate to _preflight_render_kiro_agent (the single
+        owner). Writes only when validation passes. Callers in the integration
+        loop should prefer calling _preflight_render_kiro_agent directly so
+        the rendered content can be reused for the adopt comparison.
+
+        Ref: https://kiro.dev/docs/custom-agents/ (accessed 2026-08-03)
+        """
+        rendered, ok = AgentIntegrator._preflight_render_kiro_agent(
+            source, diagnostics=diagnostics, package_name=package_name
+        )
+        if not ok:
+            return False
+        write_text_lf(target, rendered)  # type: ignore[arg-type]
         return True
 
     # DEPRECATED: use integrate_agents_for_target(KNOWN_TARGETS["copilot"], ...) instead.

--- a/src/apm_cli/integration/agent_integrator.py
+++ b/src/apm_cli/integration/agent_integrator.py
@@ -570,7 +570,7 @@ class AgentIntegrator(BaseIntegrator):
                                     package=printable_ascii_text(package_name),
                                 )
                             return None, False
-                        tools_out = tools_raw
+                        tools_out = tools_strs
                     elif isinstance(tools_raw, str):
                         tool = tools_raw.strip()
                         if tool not in KIRO_AGENT_ALLOWED_TOOLS:

--- a/src/apm_cli/integration/targets.py
+++ b/src/apm_cli/integration/targets.py
@@ -589,12 +589,14 @@ KNOWN_TARGETS: dict[str, TargetProfile] = {
         unsupported_user_primitives=("instructions",),
         hooks_config_display=".cursor/hooks.json",
     ),
-    # Kiro IDE -- spec-driven development editor.
+    # Kiro IDE/CLI v3 -- spec-driven development editor.
+    # Agents are Markdown files under .kiro/agents/; identity derives from
+    # the relative path (no redundant 'name' frontmatter field).
     # Steering files use Kiro frontmatter under .kiro/steering/.
     # Skills use the open Agent Skills SKILL.md layout under .kiro/skills/.
     # Hooks are individual JSON files under .kiro/hooks/.
     # MCP config lives at .kiro/settings/mcp.json and ~/.kiro/settings/mcp.json.
-    # Kiro CLI config divergence is intentionally out of scope for this v1 target.
+    # Ref: https://kiro.dev/docs/custom-agents/ (accessed 2026-08-03)
     # Ref: https://kiro.dev/docs/steering/
     # Ref: https://kiro.dev/docs/skills/
     # Ref: https://kiro.dev/docs/hooks/
@@ -602,6 +604,7 @@ KNOWN_TARGETS: dict[str, TargetProfile] = {
         capability=TARGET_CAPABILITIES["kiro"],
         root_dir=".kiro",
         primitives={
+            "agents": PrimitiveMapping("agents", ".md", "kiro_agent"),
             "instructions": PrimitiveMapping(
                 "steering",
                 ".md",

--- a/tests/integration/test_kiro_agent_lifecycle.py
+++ b/tests/integration/test_kiro_agent_lifecycle.py
@@ -1,0 +1,405 @@
+"""Kiro agent lifecycle integration tests (#2089).
+
+Exercises the full CLI install/reinstall/update/uninstall cycle for agents
+deployed to .kiro/agents/ through the packaged CLI binary and real filesystem
+effects. Mirrors the established pattern from test_primitive_target_covering_array.py.
+
+Failure modes covered:
+- compatible agent deploys with only description/model/tools (frontmatter filtering)
+- nested relative identity (.apm/agents/subdir/X.agent.md -> .kiro/agents/subdir/X.md)
+- idempotent reinstall (no spurious rewrites)
+- update replacement (v1 source -> v2 deployed bytes)
+- stale removal (uninstall prunes all .kiro/agents/ records)
+- coexistence with steering and hooks under .kiro/
+- incompatible-tools fail-closed (no partial agent write, no agents dir created)
+- adopt-ordering regression (req-tg-009): byte-identical-source pre-seeded target
+  with invalid tools MUST NOT be adopted; must remain skipped
+
+Official source: https://kiro.dev/docs/custom-agents/ (accessed 2026-08-03)
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from apm_cli.deps.lockfile import LockFile
+from tests.utils.apm_lifecycle_runner import ApmLifecycleRunner, CommandResult
+from tests.utils.isolated_apm_environment import IsolatedApmEnvironment
+from tests.utils.local_git_repository import LocalGitRepositoryFactory
+from tests.utils.local_package import LocalPackage, LocalPackageFactory
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.e2e,
+    pytest.mark.requires_e2e_mode,
+    pytest.mark.requires_apm_binary,
+]
+
+_SCENARIO_TIMEOUT_SECONDS = 300.0
+_REMOTE_PREFIX = "https://gitlab.example.invalid/apm-lifecycle"
+
+
+def _run(
+    runner: ApmLifecycleRunner,
+    args: tuple[str, ...],
+    *,
+    scenario_id: str,
+    cwd: Path,
+    environment: dict[str, str],
+) -> CommandResult:
+    result = runner.run(args, scenario_id=scenario_id, cwd=cwd, env=environment)
+    assert result.returncode == 0, (
+        f"{scenario_id} failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    return result
+
+
+def _run_expect_failure(
+    runner: ApmLifecycleRunner,
+    args: tuple[str, ...],
+    *,
+    scenario_id: str,
+    cwd: Path,
+    environment: dict[str, str],
+) -> CommandResult:
+    result = runner.run(args, scenario_id=scenario_id, cwd=cwd, env=environment)
+    assert result.returncode != 0, (
+        f"{scenario_id} unexpectedly succeeded\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    return result
+
+
+def _install_args(targets: tuple[str, ...]) -> tuple[str, ...]:
+    return ("install", "--target", ",".join(targets), "--no-policy", "--parallel-downloads", "0")
+
+
+def _create_kiro_project(factory: LocalPackageFactory, name: str) -> LocalPackage:
+    """Create a consumer project pre-seeded with a .kiro/ directory."""
+    project = factory.create(name)
+    (project.root / ".kiro").mkdir(exist_ok=True)
+    return project
+
+
+def _deployed_records(project_root: Path) -> tuple:
+    lock = LockFile.read(project_root / "apm.lock.yaml")
+    if lock is None:
+        return ()
+    return tuple(sorted(lock.deployment_ledger.records.items()))
+
+
+def _kiro_agents_path(project_root: Path) -> Path:
+    return project_root / ".kiro" / "agents"
+
+
+def test_kiro_agent_compatible_deploy_and_reinstall(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    """Compatible agent deploys to .kiro/agents/ with filtered frontmatter; reinstall is idempotent."""
+    isolated = IsolatedApmEnvironment.create(tmp_path / "compatible", base_env=dict(os.environ))
+    environment = isolated.subprocess_env()
+    runner = ApmLifecycleRunner(
+        (str(apm_binary_path),),
+        scenario_timeout_seconds=_SCENARIO_TIMEOUT_SECONDS,
+    )
+
+    source_factory = LocalPackageFactory(isolated.package_root)
+    pkg_name = "fixture-kiro-agent-compat"
+    source = source_factory.create(pkg_name, targets=("kiro",))
+    agent_content = (
+        "---\n"
+        "name: my-agent\n"
+        "description: A compatible Kiro agent\n"
+        "model: claude-3-5-sonnet-20241022\n"
+        "tools:\n"
+        "- read\n"
+        "- write\n"
+        "color: blue\n"
+        "---\n\n"
+        "# Compatible agent\n\nYou are a helpful agent.\n"
+    )
+    source_factory.add_agent(source, "compatible", agent_content)
+
+    repositories = LocalGitRepositoryFactory(isolated.repository_root, env=environment)
+    repo = repositories.create(pkg_name, source_tree=source.root)
+    rev = repositories.commit(repo, message="seed kiro agent lifecycle")
+    remote = f"{_REMOTE_PREFIX}/{pkg_name}.git"
+    repositories.install_url_rewrite(repo, remote)
+
+    project_factory = LocalPackageFactory(isolated.work_root)
+    project = project_factory.create(
+        f"consumer-{pkg_name}",
+        dependencies=({"git": remote, "type": "gitlab", "ref": rev.sha, "alias": pkg_name},),
+        targets=("kiro",),
+    )
+    (project.root / ".kiro").mkdir(exist_ok=True)
+    cwd = project.root
+
+    _run(
+        runner,
+        _install_args(("kiro",)),
+        scenario_id="compat-install",
+        cwd=cwd,
+        environment=environment,
+    )
+
+    agents_dir = _kiro_agents_path(project.root)
+    deployed = agents_dir / "compatible.md"
+    assert deployed.exists(), "Expected .kiro/agents/compatible.md to exist"
+    content = deployed.read_text(encoding="utf-8")
+    assert "description: A compatible Kiro agent" in content
+    assert "model: claude-3-5-sonnet-20241022" in content
+    assert "- read" in content
+    assert "- write" in content
+    assert "name:" not in content, "'name' must be stripped for Kiro identity"
+    assert "color:" not in content, "'color' must be stripped (unknown field)"
+    assert "# Compatible agent" in content
+
+    records_after_install = _deployed_records(project.root)
+    assert any("kiro" in str(r) for r in records_after_install), (
+        "Expected kiro agent in deployment ledger"
+    )
+
+    # Reinstall must be idempotent.
+    _run(
+        runner,
+        _install_args(("kiro",)),
+        scenario_id="compat-reinstall",
+        cwd=cwd,
+        environment=environment,
+    )
+    content_after_reinstall = deployed.read_text(encoding="utf-8")
+    assert content_after_reinstall == content, "Reinstall changed agent content unexpectedly"
+
+
+def test_kiro_agent_nested_path_identity(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    """Nested .apm/agents/subdir/name.agent.md deploys to .kiro/agents/subdir/name.md."""
+    isolated = IsolatedApmEnvironment.create(tmp_path / "nested", base_env=dict(os.environ))
+    environment = isolated.subprocess_env()
+    runner = ApmLifecycleRunner(
+        (str(apm_binary_path),),
+        scenario_timeout_seconds=_SCENARIO_TIMEOUT_SECONDS,
+    )
+
+    source_factory = LocalPackageFactory(isolated.package_root)
+    pkg_name = "fixture-kiro-agent-nested"
+    source = source_factory.create(pkg_name, targets=("kiro",))
+
+    # Add nested agent manually (LocalPackageFactory.add_agent is flat)
+    nested_dir = source.root / ".apm" / "agents" / "team"
+    nested_dir.mkdir(parents=True, exist_ok=True)
+    (nested_dir / "architect.agent.md").write_text(
+        "---\ndescription: Team architect\ntools:\n- read\n---\n\n# Architect\n",
+        encoding="utf-8",
+    )
+
+    repositories = LocalGitRepositoryFactory(isolated.repository_root, env=environment)
+    repo = repositories.create(pkg_name, source_tree=source.root)
+    rev = repositories.commit(repo, message="seed nested kiro agent")
+    remote = f"{_REMOTE_PREFIX}/{pkg_name}.git"
+    repositories.install_url_rewrite(repo, remote)
+
+    project_factory = LocalPackageFactory(isolated.work_root)
+    project = project_factory.create(
+        f"consumer-{pkg_name}",
+        dependencies=({"git": remote, "type": "gitlab", "ref": rev.sha, "alias": pkg_name},),
+        targets=("kiro",),
+    )
+    (project.root / ".kiro").mkdir(exist_ok=True)
+    cwd = project.root
+
+    _run(
+        runner,
+        _install_args(("kiro",)),
+        scenario_id="nested-install",
+        cwd=cwd,
+        environment=environment,
+    )
+
+    deployed = project.root / ".kiro" / "agents" / "team" / "architect.md"
+    assert deployed.exists(), "Expected nested agent at .kiro/agents/team/architect.md"
+    content = deployed.read_text(encoding="utf-8")
+    assert "description: Team architect" in content
+    assert "# Architect" in content
+
+
+def test_kiro_agent_stale_removal(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    """Uninstall removes all .kiro/agents/ records from the deployment ledger."""
+    isolated = IsolatedApmEnvironment.create(tmp_path / "stale", base_env=dict(os.environ))
+    environment = isolated.subprocess_env()
+    runner = ApmLifecycleRunner(
+        (str(apm_binary_path),),
+        scenario_timeout_seconds=_SCENARIO_TIMEOUT_SECONDS,
+    )
+
+    source_factory = LocalPackageFactory(isolated.package_root)
+    pkg_name = "fixture-kiro-agent-stale"
+    source = source_factory.create(pkg_name, targets=("kiro",))
+    source_factory.add_agent(
+        source, "reviewer", "---\ndescription: Reviewer\ntools:\n- read\n---\n\n# Reviewer\n"
+    )
+
+    repositories = LocalGitRepositoryFactory(isolated.repository_root, env=environment)
+    repo = repositories.create(pkg_name, source_tree=source.root)
+    rev = repositories.commit(repo, message="seed kiro stale test")
+    remote = f"{_REMOTE_PREFIX}/{pkg_name}.git"
+    repositories.install_url_rewrite(repo, remote)
+
+    project_factory = LocalPackageFactory(isolated.work_root)
+    project = project_factory.create(
+        f"consumer-{pkg_name}",
+        dependencies=({"git": remote, "type": "gitlab", "ref": rev.sha, "alias": pkg_name},),
+        targets=("kiro",),
+    )
+    (project.root / ".kiro").mkdir(exist_ok=True)
+    cwd = project.root
+
+    _run(
+        runner,
+        _install_args(("kiro",)),
+        scenario_id="stale-install",
+        cwd=cwd,
+        environment=environment,
+    )
+    deployed = project.root / ".kiro" / "agents" / "reviewer.md"
+    assert deployed.exists()
+
+    _run(
+        runner,
+        ("uninstall", remote),
+        scenario_id="stale-uninstall",
+        cwd=cwd,
+        environment=environment,
+    )
+    assert not deployed.exists(), "Uninstall must remove .kiro/agents/reviewer.md"
+    records_after = _deployed_records(project.root)
+    kiro_agent_records = [r for r in records_after if "kiro/agents" in str(r)]
+    assert not kiro_agent_records, "No kiro agent records should remain after uninstall"
+
+
+def test_kiro_agent_coexistence_with_steering_and_hooks(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    """Agents coexist with steering and hooks under .kiro/ without cross-clobbering."""
+    isolated = IsolatedApmEnvironment.create(tmp_path / "coexist", base_env=dict(os.environ))
+    environment = isolated.subprocess_env()
+    runner = ApmLifecycleRunner(
+        (str(apm_binary_path),),
+        scenario_timeout_seconds=_SCENARIO_TIMEOUT_SECONDS,
+    )
+
+    source_factory = LocalPackageFactory(isolated.package_root)
+    pkg_name = "fixture-kiro-agent-coexist"
+    source = source_factory.create(pkg_name, targets=("kiro",))
+
+    source_factory.add_agent(
+        source, "helper", "---\ndescription: Helper agent\ntools:\n- read\n---\n\n# Helper\n"
+    )
+    source_factory.add_instruction(
+        source,
+        "global",
+        "---\napplyTo: '**'\ndescription: Global rules\n---\n\n# Rules\n",
+    )
+    source_factory.add_hook(
+        source,
+        "pre-tool",
+        {"hooks": {"PreToolUse": [{"hooks": [{"type": "command", "command": "echo coexist"}]}]}},
+    )
+
+    repositories = LocalGitRepositoryFactory(isolated.repository_root, env=environment)
+    repo = repositories.create(pkg_name, source_tree=source.root)
+    rev = repositories.commit(repo, message="seed kiro coexistence test")
+    remote = f"{_REMOTE_PREFIX}/{pkg_name}.git"
+    repositories.install_url_rewrite(repo, remote)
+
+    project_factory = LocalPackageFactory(isolated.work_root)
+    project = project_factory.create(
+        f"consumer-{pkg_name}",
+        dependencies=({"git": remote, "type": "gitlab", "ref": rev.sha, "alias": pkg_name},),
+        targets=("kiro",),
+    )
+    (project.root / ".kiro").mkdir(exist_ok=True)
+    cwd = project.root
+
+    _run(
+        runner,
+        _install_args(("kiro",)),
+        scenario_id="coexist-install",
+        cwd=cwd,
+        environment=environment,
+    )
+
+    assert (project.root / ".kiro" / "agents" / "helper.md").exists()
+    assert (project.root / ".kiro" / "steering").is_dir()
+    assert (project.root / ".kiro" / "hooks").is_dir()
+
+
+def test_kiro_agent_incompatible_tools_fail_closed(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    """Agent with incompatible tools is not deployed; no partial write; no agents dir created."""
+    isolated = IsolatedApmEnvironment.create(tmp_path / "incompatible", base_env=dict(os.environ))
+    environment = isolated.subprocess_env()
+    runner = ApmLifecycleRunner(
+        (str(apm_binary_path),),
+        scenario_timeout_seconds=_SCENARIO_TIMEOUT_SECONDS,
+    )
+
+    source_factory = LocalPackageFactory(isolated.package_root)
+    pkg_name = "fixture-kiro-agent-incompat"
+    source = source_factory.create(pkg_name, targets=("kiro",))
+    bad_agent_content = (
+        "---\n"
+        "description: Agent with bad tools\n"
+        "tools:\n"
+        "- read\n"
+        "- execute_arbitrary_code\n"
+        "---\n\n"
+        "# Bad agent\n"
+    )
+    source_factory.add_agent(source, "badtools", bad_agent_content)
+
+    repositories = LocalGitRepositoryFactory(isolated.repository_root, env=environment)
+    repo = repositories.create(pkg_name, source_tree=source.root)
+    rev = repositories.commit(repo, message="seed kiro incompatible-tools test")
+    remote = f"{_REMOTE_PREFIX}/{pkg_name}.git"
+    repositories.install_url_rewrite(repo, remote)
+
+    project_factory = LocalPackageFactory(isolated.work_root)
+    project = project_factory.create(
+        f"consumer-{pkg_name}",
+        dependencies=({"git": remote, "type": "gitlab", "ref": rev.sha, "alias": pkg_name},),
+        targets=("kiro",),
+    )
+    (project.root / ".kiro").mkdir(exist_ok=True)
+    cwd = project.root
+
+    result = runner.run(
+        _install_args(("kiro",)),
+        scenario_id="incompat-install",
+        cwd=cwd,
+        env=environment,
+    )
+    # APM may exit 0 (fail-per-agent, not fatal) but must not write the agent.
+    agents_dir = project.root / ".kiro" / "agents"
+    assert not (agents_dir / "badtools.md").exists(), (
+        "Incompatible agent MUST NOT be deployed (fail closed, no partial write)"
+    )
+    combined_output = result.stdout + result.stderr
+    assert "execute_arbitrary_code" in combined_output, (
+        "Error diagnostic must name the unsupported tool"
+    )
+    assert "badtools" in combined_output or "Kiro" in combined_output, (
+        "Error diagnostic must identify the agent or target"
+    )

--- a/tests/integration/test_kiro_agent_lifecycle.py
+++ b/tests/integration/test_kiro_agent_lifecycle.py
@@ -403,3 +403,161 @@ def test_kiro_agent_incompatible_tools_fail_closed(
     assert "badtools" in combined_output or "Kiro" in combined_output, (
         "Error diagnostic must identify the agent or target"
     )
+
+
+def test_kiro_agent_update_replacement(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    """Source revision change replaces deployed agent bytes at .kiro/agents/.
+
+    Workflow:
+    1. Install v1 of the agent (marker 'v1-marker' in body).
+    2. Commit v2 to the same repo (marker 'v2-marker' in body).
+    3. Update consumer apm.yml ref to v2 SHA.
+    4. Reinstall -- deployed agent MUST contain 'v2-marker' and NOT 'v1-marker'.
+    """
+    from apm_cli.utils.yaml_io import dump_yaml, load_yaml
+
+    isolated = IsolatedApmEnvironment.create(tmp_path / "update", base_env=dict(os.environ))
+    environment = isolated.subprocess_env()
+    runner = ApmLifecycleRunner(
+        (str(apm_binary_path),),
+        scenario_timeout_seconds=_SCENARIO_TIMEOUT_SECONDS,
+    )
+
+    source_factory = LocalPackageFactory(isolated.package_root)
+    pkg_name = "fixture-kiro-agent-update"
+    source = source_factory.create(pkg_name, targets=("kiro",))
+
+    # v1 agent content
+    v1_content = (
+        "---\ndescription: Updatable agent v1\ntools:\n- read\n---\n\n# Agent v1\n\nv1-marker\n"
+    )
+    source_factory.add_agent(source, "updatable", v1_content)
+
+    repositories = LocalGitRepositoryFactory(isolated.repository_root, env=environment)
+    repo = repositories.create(pkg_name, source_tree=source.root)
+    rev1 = repositories.commit(repo, message="kiro agent v1")
+    remote = f"{_REMOTE_PREFIX}/{pkg_name}.git"
+    repositories.install_url_rewrite(repo, remote)
+
+    project_factory = LocalPackageFactory(isolated.work_root)
+    project = project_factory.create(
+        f"consumer-{pkg_name}",
+        dependencies=({"git": remote, "type": "gitlab", "ref": rev1.sha, "alias": pkg_name},),
+        targets=("kiro",),
+    )
+    (project.root / ".kiro").mkdir(exist_ok=True)
+    cwd = project.root
+
+    # Install v1.
+    _run(
+        runner,
+        _install_args(("kiro",)),
+        scenario_id="update-install-v1",
+        cwd=cwd,
+        environment=environment,
+    )
+    deployed = project.root / ".kiro" / "agents" / "updatable.md"
+    assert deployed.exists(), "v1 agent must be deployed"
+    v1_bytes = deployed.read_text(encoding="utf-8")
+    assert "v1-marker" in v1_bytes, "deployed agent must contain v1 marker"
+
+    # Commit v2: update source agent in the repo worktree.
+    v2_content = (
+        "---\ndescription: Updatable agent v2\ntools:\n- read\n- write\n---\n\n"
+        "# Agent v2\n\nv2-marker\n"
+    )
+    agent_src = repo.worktree / ".apm" / "agents" / "updatable.agent.md"
+    agent_src.write_text(v2_content, encoding="utf-8")
+    rev2 = repositories.commit(repo, message="kiro agent v2")
+
+    # Update consumer apm.yml to reference v2 SHA.
+    manifest = load_yaml(project.manifest_path)
+    assert isinstance(manifest, dict)
+    for dep in manifest.get("dependencies", {}).get("apm", []):
+        if isinstance(dep, dict) and dep.get("alias") == pkg_name:
+            dep["ref"] = rev2.sha
+    dump_yaml(manifest, project.manifest_path)
+
+    # Reinstall with updated ref.
+    _run(
+        runner,
+        ("install", "--target", "kiro", "--no-policy", "--parallel-downloads", "0"),
+        scenario_id="update-install-v2",
+        cwd=cwd,
+        environment=environment,
+    )
+    v2_bytes = deployed.read_text(encoding="utf-8")
+    assert "v2-marker" in v2_bytes, "deployed agent must contain v2 marker after update"
+    assert "v1-marker" not in v2_bytes, "v1 marker must be gone after update"
+    assert "description: Updatable agent v2" in v2_bytes
+
+
+def test_kiro_target_autodetection(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    """Kiro is autodetected via .kiro/ when no explicit --target is passed.
+
+    Verifies KNOWN_TARGETS['kiro'].detect_by_dir = True is honored by the CLI.
+    Consumer apm.yml declares no targets; the presence of .kiro/ in the project
+    root drives target selection, and the package declares targets: [kiro].
+    The agent is deployed without any --target flag.
+
+    Canonical path: resolve_targets() -> detect_signals() sees .kiro/ ->
+    returns ['kiro'] -> intersects with package targets: ['kiro'] ->
+    agent integrator deploys to .kiro/agents/.
+    """
+
+    isolated = IsolatedApmEnvironment.create(tmp_path / "autodetect", base_env=dict(os.environ))
+    environment = isolated.subprocess_env()
+    runner = ApmLifecycleRunner(
+        (str(apm_binary_path),),
+        scenario_timeout_seconds=_SCENARIO_TIMEOUT_SECONDS,
+    )
+
+    source_factory = LocalPackageFactory(isolated.package_root)
+    pkg_name = "fixture-kiro-agent-autodetect"
+    source = source_factory.create(pkg_name, targets=("kiro",))
+    source_factory.add_agent(
+        source,
+        "autodetected",
+        "---\ndescription: Autodetected agent\ntools:\n- read\n---\n\n# Auto\n",
+    )
+
+    repositories = LocalGitRepositoryFactory(isolated.repository_root, env=environment)
+    repo = repositories.create(pkg_name, source_tree=source.root)
+    rev = repositories.commit(repo, message="seed kiro autodetect test")
+    remote = f"{_REMOTE_PREFIX}/{pkg_name}.git"
+    repositories.install_url_rewrite(repo, remote)
+
+    project_factory = LocalPackageFactory(isolated.work_root)
+    # Consumer project: NO explicit targets declaration.
+    project = project_factory.create(
+        f"consumer-{pkg_name}",
+        dependencies=({"git": remote, "type": "gitlab", "ref": rev.sha, "alias": pkg_name},),
+        targets=(),  # <-- no explicit targets: relies on autodetection
+    )
+
+    # Seed .kiro/ to trigger autodetection -- the signal detect_by_dir checks.
+    (project.root / ".kiro").mkdir(exist_ok=True)
+    cwd = project.root
+
+    # Run install with NO --target flag.
+    _run(
+        runner,
+        ("install", "--no-policy", "--parallel-downloads", "0"),
+        scenario_id="autodetect-install",
+        cwd=cwd,
+        environment=environment,
+    )
+
+    deployed = project.root / ".kiro" / "agents" / "autodetected.md"
+    assert deployed.exists(), (
+        ".kiro/ autodetection must route the kiro agent to .kiro/agents/ "
+        "without an explicit --target flag"
+    )
+    content = deployed.read_text(encoding="utf-8")
+    assert "description: Autodetected agent" in content

--- a/tests/integration/test_primitive_target_covering_array.py
+++ b/tests/integration/test_primitive_target_covering_array.py
@@ -68,6 +68,7 @@ _ROWS = (
         narrow_targets=("claude",),
     ),
     _Row("kiro-hook-user", ("hooks",), ("kiro",), True),
+    _Row("kiro-agent-project", ("agents",), ("kiro",), False),
     _Row("opencode-skill-user", ("skills",), ("opencode",), True),
     _Row(
         "copilot-app-unavailable",

--- a/tests/spec_conformance/test_manifest_reqs.py
+++ b/tests/spec_conformance/test_manifest_reqs.py
@@ -722,7 +722,7 @@ def test_dependency_package_targets_are_restriction_only() -> None:
         "MUST be rejected before target-scoped",
         "MUST be reconciled under",
         "[req-lk-021](#req-lk-021)",
-        "[req-tg-008](#req-tg-008),\n[req-sc-001](#req-sc-001),",
+        "[req-tg-008](#req-tg-008), [req-tg-009](#req-tg-009),\n[req-sc-001](#req-sc-001),",
     )
 
 

--- a/tests/spec_conformance/test_manifest_reqs.py
+++ b/tests/spec_conformance/test_manifest_reqs.py
@@ -726,6 +726,87 @@ def test_dependency_package_targets_are_restriction_only() -> None:
     )
 
 
+@pytest.mark.req("req-tg-009")
+def test_kiro_agent_tools_gate_fails_closed_before_adopt(tmp_path: Path) -> None:
+    """Fail-closed evaluation precedes any content-identity adoption fast-path.
+
+    req-tg-009: An agent with tools outside the target's approved capability
+    set MUST NOT be written or adopted -- even when the on-disk target has
+    byte-identical content to the source.
+    """
+    from datetime import datetime
+
+    from apm_cli.integration.agent_integrator import AgentIntegrator
+    from apm_cli.integration.targets import KNOWN_TARGETS
+    from apm_cli.models.apm_package import (
+        APMPackage,
+        GitReferenceType,
+        PackageInfo,
+        ResolvedReference,
+    )
+    from apm_cli.utils.diagnostics import CATEGORY_ERROR, DiagnosticCollector
+
+    project_root = tmp_path
+    (project_root / ".kiro").mkdir()
+
+    package_dir = tmp_path / "pkg"
+    apm_agents = package_dir / ".apm" / "agents"
+    apm_agents.mkdir(parents=True)
+    # Source agent with an unsupported tool.
+    bad_source = apm_agents / "hacked.agent.md"
+    bad_content = "---\ntools:\n- read\n- execute_arbitrary_code\n---\n\n# Hacked\n"
+    bad_source.write_text(bad_content, encoding="utf-8")
+
+    # Pre-place a target with byte-identical content to the source.
+    kiro_agents = project_root / ".kiro" / "agents"
+    kiro_agents.mkdir(parents=True)
+    target_path = kiro_agents / "hacked.md"
+    target_path.write_text(bad_content, encoding="utf-8")
+
+    package = APMPackage(
+        name="test-pkg",
+        version="1.0.0",
+        package_path=package_dir,
+        source="github.com/test/test-pkg",
+    )
+    resolved_ref = ResolvedReference(
+        original_ref="main",
+        ref_type=GitReferenceType.BRANCH,
+        resolved_commit="abc123",
+        ref_name="main",
+    )
+    pi = PackageInfo(
+        package=package,
+        install_path=package_dir,
+        resolved_reference=resolved_ref,
+        installed_at=datetime.now().isoformat(),
+    )
+
+    diagnostics = DiagnosticCollector()
+    result = AgentIntegrator().integrate_agents_for_target(
+        KNOWN_TARGETS["kiro"],
+        pi,
+        project_root,
+        managed_files={".kiro/agents/hacked.md"},
+        diagnostics=diagnostics,
+    )
+
+    # The invalid agent must be skipped, never adopted.
+    assert result.files_integrated == 0
+    assert result.files_adopted == 0
+    assert target_path not in result.target_paths
+    errors = [d for d in diagnostics._diagnostics if d.category == CATEGORY_ERROR]
+    assert errors, "Expected an error diagnostic for incompatible tools"
+    assert "execute_arbitrary_code" in errors[0].message
+
+    assert_spec_contains(
+        "MUST fail closed: if any source-declared tool falls",
+        "MUST NOT\nwrite the agent's target artifact (zero bytes, no partial file)",
+        "MUST\nemit an actionable diagnostic identifying the unsupported tool value(s)",
+        "MUST be performed prior to any\ncontent-identity adoption fast-path",
+    )
+
+
 # --- req-cf-001..002 --------------------------------------------------
 
 

--- a/tests/unit/core/test_target_catalog.py
+++ b/tests/unit/core/test_target_catalog.py
@@ -146,6 +146,7 @@ def test_current_native_profiles_are_characterized() -> None:
         "kiro": (
             ".kiro",
             {
+                "agents": ("agents", ".md", "kiro_agent", None, False),
                 "instructions": ("steering", ".md", "kiro_steering", None, True),
                 "skills": ("skills", "/SKILL.md", "skill_standard", None, False),
                 "hooks": ("hooks", ".json", "kiro_hooks", None, False),

--- a/tests/unit/integration/test_data_driven_dispatch.py
+++ b/tests/unit/integration/test_data_driven_dispatch.py
@@ -309,6 +309,7 @@ class TestExhaustivenessChecks:
             "agents_github",  # was agents_copilot, aliased
             "agents_claude",
             "agents_cursor",
+            "agents_kiro",
             "agents_opencode",
             "agents_codex",
             # NOTE: windsurf no longer exposes an 'agents' primitive

--- a/tests/unit/integration/test_kiro_target.py
+++ b/tests/unit/integration/test_kiro_target.py
@@ -1,4 +1,4 @@
-"""Acceptance tests for the Kiro target profile and transforms (#702)."""
+"""Acceptance tests for the Kiro target profile and transforms (#702, #2089)."""
 
 from __future__ import annotations
 
@@ -7,6 +7,7 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
+from apm_cli.integration.agent_integrator import KIRO_AGENT_ALLOWED_TOOLS, AgentIntegrator
 from apm_cli.integration.hook_integrator import HookIntegrator
 from apm_cli.integration.instruction_integrator import InstructionIntegrator
 from apm_cli.integration.skill_integrator import SkillIntegrator
@@ -18,6 +19,7 @@ from apm_cli.models.apm_package import (
     PackageType,
     ResolvedReference,
 )
+from apm_cli.utils.diagnostics import DiagnosticCollector
 
 
 def _make_package_info(
@@ -64,7 +66,13 @@ def test_kiro_target_profile_matches_ratified_layout() -> None:
     assert target.detect_by_dir is True
     assert target.user_supported is True
     assert target.user_root_dir == ".kiro"
-    assert set(target.primitives) == {"instructions", "skills", "hooks"}
+    assert set(target.primitives) == {"agents", "instructions", "skills", "hooks"}
+
+    agents = target.primitives["agents"]
+    assert agents.subdir == "agents"
+    assert agents.extension == ".md"
+    assert agents.format_id == "kiro_agent"
+    assert agents.output_compare is False
 
     instructions = target.primitives["instructions"]
     assert instructions.subdir == "steering"
@@ -362,3 +370,355 @@ def test_kiro_hooks_skip_when_project_has_no_kiro_dir(tmp_path: Path) -> None:
 
     assert result.files_integrated == 0
     assert not (tmp_path / ".kiro").exists()
+
+
+# ---------------------------------------------------------------------------
+# Kiro agents (#2089) - .kiro/agents/<relative-stem>.md
+# ---------------------------------------------------------------------------
+
+
+def test_kiro_agents_deploy_plain_body_no_frontmatter(tmp_path: Path) -> None:
+    """Agent with no frontmatter: body preserved verbatim as .md."""
+    (tmp_path / ".kiro").mkdir()
+    package_dir = tmp_path / "pkg"
+    apm_agents = package_dir / ".apm" / "agents"
+    apm_agents.mkdir(parents=True)
+    (apm_agents / "reviewer.agent.md").write_text(
+        "# Reviewer\n\nYou review code.\n",
+        encoding="utf-8",
+    )
+
+    result = AgentIntegrator().integrate_agents_for_target(
+        KNOWN_TARGETS["kiro"],
+        _make_package_info(package_dir),
+        tmp_path,
+    )
+
+    assert result.files_integrated == 1
+    target = tmp_path / ".kiro" / "agents" / "reviewer.md"
+    assert target.exists()
+    assert target.read_text(encoding="utf-8") == "# Reviewer\n\nYou review code.\n"
+
+
+def test_kiro_agents_preserve_description_model_tools(tmp_path: Path) -> None:
+    """description, model, and tools are preserved in the target frontmatter."""
+    (tmp_path / ".kiro").mkdir()
+    package_dir = tmp_path / "pkg"
+    apm_agents = package_dir / ".apm" / "agents"
+    apm_agents.mkdir(parents=True)
+    (apm_agents / "helper.agent.md").write_text(
+        "---\n"
+        "description: My helpful agent\n"
+        "model: claude-3-5-sonnet-20241022\n"
+        "tools:\n"
+        "- read\n"
+        "- write\n"
+        "---\n\n"
+        "# Helper\n\nHelp the user.\n",
+        encoding="utf-8",
+    )
+
+    result = AgentIntegrator().integrate_agents_for_target(
+        KNOWN_TARGETS["kiro"],
+        _make_package_info(package_dir),
+        tmp_path,
+    )
+
+    assert result.files_integrated == 1
+    target = tmp_path / ".kiro" / "agents" / "helper.md"
+    content = target.read_text(encoding="utf-8")
+    assert "description: My helpful agent" in content
+    assert "model: claude-3-5-sonnet-20241022" in content
+    assert "- read" in content
+    assert "- write" in content
+    assert "# Helper" in content
+    assert "Help the user." in content
+
+
+def test_kiro_agents_strip_name_and_unknown_frontmatter(tmp_path: Path) -> None:
+    """name and unknown fields are stripped; only description/model/tools kept."""
+    (tmp_path / ".kiro").mkdir()
+    package_dir = tmp_path / "pkg"
+    apm_agents = package_dir / ".apm" / "agents"
+    apm_agents.mkdir(parents=True)
+    (apm_agents / "specialist.agent.md").write_text(
+        "---\n"
+        "name: specialist\n"
+        "description: A specialist agent\n"
+        "color: blue\n"
+        "someunknown: ignored\n"
+        "tools:\n"
+        "- shell\n"
+        "---\n\n"
+        "Specialist body.\n",
+        encoding="utf-8",
+    )
+
+    result = AgentIntegrator().integrate_agents_for_target(
+        KNOWN_TARGETS["kiro"],
+        _make_package_info(package_dir),
+        tmp_path,
+    )
+
+    assert result.files_integrated == 1
+    target = tmp_path / ".kiro" / "agents" / "specialist.md"
+    content = target.read_text(encoding="utf-8")
+    assert "name:" not in content
+    assert "color:" not in content
+    assert "someunknown:" not in content
+    assert "description: A specialist agent" in content
+    assert "- shell" in content
+    assert "Specialist body." in content
+
+
+def test_kiro_agents_nested_path_identity_derivation(tmp_path: Path) -> None:
+    """Nested path in .apm/agents/ is preserved under .kiro/agents/."""
+    (tmp_path / ".kiro").mkdir()
+    package_dir = tmp_path / "pkg"
+    nested = package_dir / ".apm" / "agents" / "team"
+    nested.mkdir(parents=True)
+    (nested / "architect.agent.md").write_text(
+        "---\ndescription: Team architect\n---\n\n# Architect\n",
+        encoding="utf-8",
+    )
+
+    result = AgentIntegrator().integrate_agents_for_target(
+        KNOWN_TARGETS["kiro"],
+        _make_package_info(package_dir),
+        tmp_path,
+    )
+
+    assert result.files_integrated == 1
+    target = tmp_path / ".kiro" / "agents" / "team" / "architect.md"
+    assert target.exists()
+    content = target.read_text(encoding="utf-8")
+    assert "description: Team architect" in content
+    assert "# Architect" in content
+
+
+def test_kiro_agents_fail_closed_incompatible_tools(tmp_path: Path) -> None:
+    """Agent with incompatible tools is not deployed and emits an error."""
+    (tmp_path / ".kiro").mkdir()
+    package_dir = tmp_path / "pkg"
+    apm_agents = package_dir / ".apm" / "agents"
+    apm_agents.mkdir(parents=True)
+    (apm_agents / "badtools.agent.md").write_text(
+        "---\n"
+        "description: Agent with bad tools\n"
+        "tools:\n"
+        "- read\n"
+        "- execute_arbitrary_code\n"
+        "---\n\n"
+        "# Bad Tools Agent\n",
+        encoding="utf-8",
+    )
+
+    diagnostics = DiagnosticCollector()
+    result = AgentIntegrator().integrate_agents_for_target(
+        KNOWN_TARGETS["kiro"],
+        _make_package_info(package_dir),
+        tmp_path,
+        diagnostics=diagnostics,
+    )
+
+    # Agent must not be deployed (fail closed)
+    assert result.files_integrated == 0
+    assert not (tmp_path / ".kiro" / "agents" / "badtools.md").exists()
+    # Error diagnostic must name the unsupported tool
+    errors = [d for d in diagnostics._diagnostics if d.category == "error"]
+    assert errors, "Expected an error diagnostic for incompatible tools"
+    assert "execute_arbitrary_code" in errors[0].message
+
+
+def test_kiro_agents_no_partial_write_on_incompatible_tools(tmp_path: Path) -> None:
+    """Fail closed: no partial agent file written when tools are invalid."""
+    (tmp_path / ".kiro").mkdir()
+    package_dir = tmp_path / "pkg"
+    apm_agents = package_dir / ".apm" / "agents"
+    apm_agents.mkdir(parents=True)
+    (apm_agents / "partial.agent.md").write_text(
+        "---\ntools:\n- read\n- INVALID_TOOL\n---\n\nBody.\n",
+        encoding="utf-8",
+    )
+
+    AgentIntegrator().integrate_agents_for_target(
+        KNOWN_TARGETS["kiro"],
+        _make_package_info(package_dir),
+        tmp_path,
+    )
+
+    assert not (tmp_path / ".kiro" / "agents" / "partial.md").exists()
+
+
+def test_kiro_agents_all_approved_tools_pass(tmp_path: Path) -> None:
+    """Every value in KIRO_AGENT_ALLOWED_TOOLS is accepted without error."""
+    (tmp_path / ".kiro").mkdir()
+    package_dir = tmp_path / "pkg"
+    apm_agents = package_dir / ".apm" / "agents"
+    apm_agents.mkdir(parents=True)
+    tools_list = sorted(KIRO_AGENT_ALLOWED_TOOLS - {"*"})
+    tools_yaml = "\n".join(f"- {t}" for t in tools_list)
+    (apm_agents / "alltools.agent.md").write_text(
+        f"---\ndescription: All tools\ntools:\n{tools_yaml}\n---\n\nBody.\n",
+        encoding="utf-8",
+    )
+
+    diagnostics = DiagnosticCollector()
+    result = AgentIntegrator().integrate_agents_for_target(
+        KNOWN_TARGETS["kiro"],
+        _make_package_info(package_dir),
+        tmp_path,
+        diagnostics=diagnostics,
+    )
+
+    assert result.files_integrated == 1
+    errors = [d for d in diagnostics._diagnostics if d.category == "error"]
+    assert not errors
+
+
+def test_kiro_agents_wildcard_tool_passes(tmp_path: Path) -> None:
+    """The '*' wildcard tool is accepted."""
+    (tmp_path / ".kiro").mkdir()
+    package_dir = tmp_path / "pkg"
+    apm_agents = package_dir / ".apm" / "agents"
+    apm_agents.mkdir(parents=True)
+    (apm_agents / "fullaccess.agent.md").write_text(
+        "---\ntools:\n- '*'\n---\n\nBody.\n",
+        encoding="utf-8",
+    )
+
+    result = AgentIntegrator().integrate_agents_for_target(
+        KNOWN_TARGETS["kiro"],
+        _make_package_info(package_dir),
+        tmp_path,
+    )
+
+    assert result.files_integrated == 1
+    assert (tmp_path / ".kiro" / "agents" / "fullaccess.md").exists()
+
+
+def test_kiro_agents_skip_when_no_kiro_dir(tmp_path: Path) -> None:
+    """Agent integration is skipped when .kiro/ does not exist."""
+    package_dir = tmp_path / "pkg"
+    apm_agents = package_dir / ".apm" / "agents"
+    apm_agents.mkdir(parents=True)
+    (apm_agents / "agent.agent.md").write_text("# Agent\n", encoding="utf-8")
+
+    result = AgentIntegrator().integrate_agents_for_target(
+        KNOWN_TARGETS["kiro"],
+        _make_package_info(package_dir),
+        tmp_path,
+    )
+
+    assert result.files_integrated == 0
+    assert not (tmp_path / ".kiro").exists()
+
+
+def test_kiro_agents_idempotent_second_deploy(tmp_path: Path) -> None:
+    """Second deploy with the same source produces identical output."""
+    (tmp_path / ".kiro").mkdir()
+    package_dir = tmp_path / "pkg"
+    apm_agents = package_dir / ".apm" / "agents"
+    apm_agents.mkdir(parents=True)
+    (apm_agents / "worker.agent.md").write_text(
+        "---\ndescription: Worker\ntools:\n- read\n---\n\n# Worker\n",
+        encoding="utf-8",
+    )
+
+    integrator = AgentIntegrator()
+    pi = _make_package_info(package_dir)
+
+    result1 = integrator.integrate_agents_for_target(KNOWN_TARGETS["kiro"], pi, tmp_path)
+    assert result1.files_integrated == 1
+    first_content = (tmp_path / ".kiro" / "agents" / "worker.md").read_text(encoding="utf-8")
+
+    # Second deploy (simulate managed_files from lockfile)
+    managed = {".kiro/agents/worker.md"}
+    integrator.integrate_agents_for_target(
+        KNOWN_TARGETS["kiro"], pi, tmp_path, managed_files=managed
+    )
+    second_content = (tmp_path / ".kiro" / "agents" / "worker.md").read_text(encoding="utf-8")
+
+    assert first_content == second_content
+
+
+def test_kiro_agents_update_replaces_stale_file(tmp_path: Path) -> None:
+    """Updated source replaces the stale deployed agent."""
+    (tmp_path / ".kiro").mkdir()
+    package_dir = tmp_path / "pkg"
+    apm_agents = package_dir / ".apm" / "agents"
+    apm_agents.mkdir(parents=True)
+    agent_src = apm_agents / "evolving.agent.md"
+    agent_src.write_text("---\ndescription: v1\n---\n\n# v1\n", encoding="utf-8")
+
+    integrator = AgentIntegrator()
+    pi = _make_package_info(package_dir)
+    target = tmp_path / ".kiro" / "agents" / "evolving.md"
+
+    integrator.integrate_agents_for_target(KNOWN_TARGETS["kiro"], pi, tmp_path)
+    assert "v1" in target.read_text(encoding="utf-8")
+
+    agent_src.write_text("---\ndescription: v2\n---\n\n# v2\n", encoding="utf-8")
+    managed = {".kiro/agents/evolving.md"}
+    integrator.integrate_agents_for_target(
+        KNOWN_TARGETS["kiro"], pi, tmp_path, managed_files=managed
+    )
+    assert "v2" in target.read_text(encoding="utf-8")
+    assert "v1" not in target.read_text(encoding="utf-8")
+
+
+def test_kiro_agents_coexist_with_hooks_and_steering(tmp_path: Path) -> None:
+    """Kiro agents coexist with steering and hooks under .kiro/."""
+    kiro_dir = tmp_path / ".kiro"
+    kiro_dir.mkdir()
+    (kiro_dir / "steering").mkdir()
+    (kiro_dir / "steering" / "global.md").write_text(
+        "---\ninclusion: always\n---\n\nGlobal rules.\n",
+        encoding="utf-8",
+    )
+
+    package_dir = tmp_path / "pkg"
+    apm_agents = package_dir / ".apm" / "agents"
+    apm_agents.mkdir(parents=True)
+    (apm_agents / "helper.agent.md").write_text(
+        "---\ndescription: Helper\n---\n\n# Helper\n",
+        encoding="utf-8",
+    )
+
+    result = AgentIntegrator().integrate_agents_for_target(
+        KNOWN_TARGETS["kiro"],
+        _make_package_info(package_dir),
+        tmp_path,
+    )
+
+    assert result.files_integrated == 1
+    assert (tmp_path / ".kiro" / "agents" / "helper.md").exists()
+    # Existing steering file is untouched
+    assert (tmp_path / ".kiro" / "steering" / "global.md").exists()
+
+
+def test_kiro_agents_sync_removes_managed_file(tmp_path: Path) -> None:
+    """sync_for_target removes APM-managed Kiro agent files."""
+    from apm_cli.models.apm_package import APMPackage
+
+    (tmp_path / ".kiro" / "agents").mkdir(parents=True)
+    managed_agent = tmp_path / ".kiro" / "agents" / "obsolete.md"
+    managed_agent.write_text("---\ndescription: Old\n---\n\n# Old\n", encoding="utf-8")
+
+    pkg = APMPackage(
+        name="test-pkg",
+        version="1.0.0",
+        package_path=tmp_path,
+        source="github.com/test/test-pkg",
+    )
+    managed_files = {".kiro/agents/obsolete.md"}
+
+    result = AgentIntegrator().sync_for_target(
+        KNOWN_TARGETS["kiro"],
+        pkg,
+        tmp_path,
+        managed_files=managed_files,
+    )
+
+    assert result["files_removed"] == 1
+    assert not managed_agent.exists()

--- a/tests/unit/integration/test_kiro_target.py
+++ b/tests/unit/integration/test_kiro_target.py
@@ -19,7 +19,7 @@ from apm_cli.models.apm_package import (
     PackageType,
     ResolvedReference,
 )
-from apm_cli.utils.diagnostics import DiagnosticCollector
+from apm_cli.utils.diagnostics import CATEGORY_ERROR, DiagnosticCollector
 
 
 def _make_package_info(
@@ -525,7 +525,7 @@ def test_kiro_agents_fail_closed_incompatible_tools(tmp_path: Path) -> None:
     assert result.files_integrated == 0
     assert not (tmp_path / ".kiro" / "agents" / "badtools.md").exists()
     # Error diagnostic must name the unsupported tool
-    errors = [d for d in diagnostics._diagnostics if d.category == "error"]
+    errors = diagnostics.by_category().get("error", [])
     assert errors, "Expected an error diagnostic for incompatible tools"
     assert "execute_arbitrary_code" in errors[0].message
 
@@ -572,7 +572,7 @@ def test_kiro_agents_all_approved_tools_pass(tmp_path: Path) -> None:
     )
 
     assert result.files_integrated == 1
-    errors = [d for d in diagnostics._diagnostics if d.category == "error"]
+    errors = diagnostics.by_category().get("error", [])
     assert not errors
 
 
@@ -731,8 +731,6 @@ def test_kiro_agents_preflight_before_adopt_bypass(tmp_path: Path) -> None:
     an unsupported tool). The adopt fast-path MUST NOT fire; the agent must
     remain in files_skipped and not appear in target_paths.
     """
-    from apm_cli.utils.diagnostics import CATEGORY_ERROR
-
     (tmp_path / ".kiro").mkdir()
     package_dir = tmp_path / "pkg"
     apm_agents = package_dir / ".apm" / "agents"
@@ -758,7 +756,7 @@ def test_kiro_agents_preflight_before_adopt_bypass(tmp_path: Path) -> None:
     assert result.files_integrated == 0
     assert result.files_adopted == 0
     assert preset_target not in result.target_paths
-    errors = [d for d in diagnostics._diagnostics if d.category == CATEGORY_ERROR]
+    errors = diagnostics.by_category().get(CATEGORY_ERROR, [])
     assert errors, "Expected diagnostics.error for incompatible tools even in adopt path"
     assert "BANNED_TOOL" in errors[0].message
 
@@ -782,3 +780,105 @@ def test_kiro_agents_no_agents_dir_created_for_all_invalid(tmp_path: Path) -> No
 
     # The .kiro/agents/ directory must NOT be created.
     assert not (tmp_path / ".kiro" / "agents").exists()
+
+
+def test_kiro_agents_tools_whitespace_stripped_in_output(tmp_path: Path) -> None:
+    """Whitespace around tool values must be stripped in deployed frontmatter.
+
+    Regression for the normalization gap: validation stripped leading/trailing
+    whitespace before checking the allowlist, but the original (unstripped)
+    values were written to disk.  After the fix, the deployed file must contain
+    the stripped values, not the source values with surrounding whitespace.
+    """
+    (tmp_path / ".kiro").mkdir()
+    package_dir = tmp_path / "pkg"
+    apm_agents = package_dir / ".apm" / "agents"
+    apm_agents.mkdir(parents=True)
+    # Source agent with whitespace-padded tool values.
+    (apm_agents / "ws.agent.md").write_text(
+        "---\ndescription: WS test\ntools:\n- ' read '\n- ' write '\n---\n\nBody.\n",
+        encoding="utf-8",
+    )
+
+    result = AgentIntegrator().integrate_agents_for_target(
+        KNOWN_TARGETS["kiro"],
+        _make_package_info(package_dir),
+        tmp_path,
+    )
+
+    assert result.files_integrated == 1, "Agent with whitespace-padded tools should deploy"
+    deployed = (tmp_path / ".kiro" / "agents" / "ws.md").read_text(encoding="utf-8")
+    # Stripped values must be in the deployed file, not the original padded ones.
+    assert "read" in deployed
+    assert "write" in deployed
+    # The raw padded values must not appear verbatim in the output.
+    assert " read " not in deployed
+    assert " write " not in deployed
+
+
+def test_kiro_agents_stale_managed_file_removed_when_tools_become_incompatible(
+    tmp_path: Path,
+) -> None:
+    """Stale APM-managed Kiro agent is removed when its tools become incompatible.
+
+    Regression: if a source agent was previously deployed with valid tools and
+    its source is later updated to declare incompatible tools, the fail-closed
+    gate blocks the new deployment.  The stale deployed file must be removed
+    through the normal sync reconcile when the agent is no longer in the new
+    target_paths list and the caller passes the managed set.
+
+    This test validates the unit contract: integrate_agents_for_target with
+    incompatible tools skips the agent and does NOT add it to target_paths,
+    leaving the reconcile caller free to remove the stale path.
+    """
+    from apm_cli.models.apm_package import APMPackage
+
+    (tmp_path / ".kiro" / "agents").mkdir(parents=True)
+    stale_path = tmp_path / ".kiro" / "agents" / "prev.md"
+    stale_path.write_text("---\ndescription: Old valid\n---\n\n# Old\n", encoding="utf-8")
+
+    package_dir = tmp_path / "pkg"
+    apm_agents = package_dir / ".apm" / "agents"
+    apm_agents.mkdir(parents=True)
+    # Source now has incompatible tools.
+    (apm_agents / "prev.agent.md").write_text(
+        "---\ndescription: Now bad\ntools:\n- EVIL_TOOL\n---\n\n# Bad\n",
+        encoding="utf-8",
+    )
+
+    diagnostics = DiagnosticCollector()
+    result = AgentIntegrator().integrate_agents_for_target(
+        KNOWN_TARGETS["kiro"],
+        _make_package_info(package_dir),
+        tmp_path,
+        managed_files={".kiro/agents/prev.md"},
+        diagnostics=diagnostics,
+    )
+
+    # The new integration must skip the agent (incompatible tools).
+    assert result.files_integrated == 0
+    assert result.files_skipped == 1
+    # The stale path must NOT appear in target_paths; the caller can remove it.
+    assert stale_path not in result.target_paths
+    errors = diagnostics.by_category().get(CATEGORY_ERROR, [])
+    assert errors, "Incompatible tools must produce an error diagnostic"
+    assert "EVIL_TOOL" in errors[0].message
+
+    # Reconcile: simulate what the install service does -- remove stale managed files
+    # that no longer appear in target_paths.
+    pkg = APMPackage(
+        name="test-pkg",
+        version="1.0.0",
+        package_path=tmp_path,
+        source="github.com/test/test-pkg",
+    )
+    sync_result = AgentIntegrator().sync_for_target(
+        KNOWN_TARGETS["kiro"],
+        pkg,
+        tmp_path,
+        managed_files={".kiro/agents/prev.md"},
+    )
+    assert sync_result["files_removed"] == 1, (
+        "sync_for_target must remove the stale APM-managed file"
+    )
+    assert not stale_path.exists(), "Stale managed Kiro agent must be removed after sync"

--- a/tests/unit/integration/test_kiro_target.py
+++ b/tests/unit/integration/test_kiro_target.py
@@ -722,3 +722,63 @@ def test_kiro_agents_sync_removes_managed_file(tmp_path: Path) -> None:
 
     assert result["files_removed"] == 1
     assert not managed_agent.exists()
+
+
+def test_kiro_agents_preflight_before_adopt_bypass(tmp_path: Path) -> None:
+    """reg-tg-009 regression: invalid-tools agent is not adopted via byte-match.
+
+    Pre-place a .kiro/agents/X.md whose bytes match the source (which has
+    an unsupported tool). The adopt fast-path MUST NOT fire; the agent must
+    remain in files_skipped and not appear in target_paths.
+    """
+    from apm_cli.utils.diagnostics import CATEGORY_ERROR
+
+    (tmp_path / ".kiro").mkdir()
+    package_dir = tmp_path / "pkg"
+    apm_agents = package_dir / ".apm" / "agents"
+    apm_agents.mkdir(parents=True)
+    bad_src_content = "---\ntools:\n- read\n- BANNED_TOOL\n---\n\n# Agent\n"
+    (apm_agents / "agent.agent.md").write_text(bad_src_content, encoding="utf-8")
+
+    # Pre-seed target with the SAME bytes as source (the bypass scenario).
+    kiro_agents = tmp_path / ".kiro" / "agents"
+    kiro_agents.mkdir(parents=True)
+    preset_target = kiro_agents / "agent.md"
+    preset_target.write_text(bad_src_content, encoding="utf-8")
+
+    diagnostics = DiagnosticCollector()
+    result = AgentIntegrator().integrate_agents_for_target(
+        KNOWN_TARGETS["kiro"],
+        _make_package_info(package_dir),
+        tmp_path,
+        managed_files={".kiro/agents/agent.md"},
+        diagnostics=diagnostics,
+    )
+
+    assert result.files_integrated == 0
+    assert result.files_adopted == 0
+    assert preset_target not in result.target_paths
+    errors = [d for d in diagnostics._diagnostics if d.category == CATEGORY_ERROR]
+    assert errors, "Expected diagnostics.error for incompatible tools even in adopt path"
+    assert "BANNED_TOOL" in errors[0].message
+
+
+def test_kiro_agents_no_agents_dir_created_for_all_invalid(tmp_path: Path) -> None:
+    """No .kiro/agents/ directory is created when the only agent has invalid tools."""
+    (tmp_path / ".kiro").mkdir()
+    package_dir = tmp_path / "pkg"
+    apm_agents = package_dir / ".apm" / "agents"
+    apm_agents.mkdir(parents=True)
+    (apm_agents / "bad.agent.md").write_text(
+        "---\ntools:\n- INVALID\n---\n\nBad agent.\n",
+        encoding="utf-8",
+    )
+
+    AgentIntegrator().integrate_agents_for_target(
+        KNOWN_TARGETS["kiro"],
+        _make_package_info(package_dir),
+        tmp_path,
+    )
+
+    # The .kiro/agents/ directory must NOT be created.
+    assert not (tmp_path / ".kiro" / "agents").exists()

--- a/tests/unit/test_shepherd_owner_touch_gate.py
+++ b/tests/unit/test_shepherd_owner_touch_gate.py
@@ -482,9 +482,7 @@ def test_cross_row_duplicate_selector_fails_closed(
 
     result = _gate(repo, "detect", base, head)
 
-    assert result.returncode != 0, (
-        "detect must fail closed when two rows share a selector"
-    )
+    assert result.returncode != 0, "detect must fail closed when two rows share a selector"
     assert "duplicate canonical owner selector" in result.stderr, (
         f"Expected 'duplicate canonical owner selector' in stderr, got: {result.stderr!r}"
     )

--- a/tests/unit/test_shepherd_owner_touch_gate.py
+++ b/tests/unit/test_shepherd_owner_touch_gate.py
@@ -438,6 +438,59 @@ def test_unknown_completion_status_fails_closed(
 
 
 # ---------------------------------------------------------------------------
+# Cross-row duplicate selector regression (architecture integrity gate)
+#
+# The canonical owner table must have a unique selector per row; a selector
+# that appears in two DISTINCT rows is an ambiguous ownership claim that the
+# gate must reject fail-closed.  This test constructs that exact scenario
+# -- two rows with different decisions but the same path selector -- and
+# asserts that the gate emits the exact diagnostic text
+# "duplicate canonical owner selector".
+# ---------------------------------------------------------------------------
+
+
+def _table_with_cross_row_dup(selector: str = OWNER_PATH) -> str:
+    """Return a canonical table with TWO distinct rows sharing one selector."""
+    return (
+        "# Architecture\n\n"
+        "<!-- canonical-owner-table:v1 -->\n"
+        "| Decision / fact | Canonical owner | Owner path selectors |\n"
+        "|---|---|---|\n"
+        f"| First distinct decision | `owner-a` | `{selector}` |\n"
+        f"| Second distinct decision | `owner-b` | `{selector}` |\n"
+        "<!-- /canonical-owner-table -->\n"
+    )
+
+
+def test_cross_row_duplicate_selector_fails_closed(
+    owner_repo: tuple[Path, str],
+) -> None:
+    """Two distinct rows sharing a selector MUST be rejected fail-closed.
+
+    Regression for the architecture instruction integrity rule: every row
+    in the canonical owner table must carry a unique set of path selectors.
+    A selector shared across two different decision rows is ambiguous
+    (neither row is the unambiguous canonical owner) and MUST produce
+    fail-closed output containing 'duplicate canonical owner selector'.
+    """
+    repo, base = owner_repo
+
+    # Overwrite the owner table with two rows that share OWNER_PATH.
+    _write(repo, OWNER_TABLE, _table_with_cross_row_dup(OWNER_PATH))
+    _write(repo, OWNER_PATH, 'FACT = "dup"\n')
+    head = _commit(repo, "introduce cross-row duplicate selector")
+
+    result = _gate(repo, "detect", base, head)
+
+    assert result.returncode != 0, (
+        "detect must fail closed when two rows share a selector"
+    )
+    assert "duplicate canonical owner selector" in result.stderr, (
+        f"Expected 'duplicate canonical owner selector' in stderr, got: {result.stderr!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Windows bare-argv git resolution regression (microsoft/apm#2233)
 #
 # subprocess.run(["git", ...]) does not reliably resolve on Windows with


### PR DESCRIPTION
## feat(kiro): deploy agents primitive to .kiro/agents/ + req-tg-009 (#2089)

## TL;DR

APM now compiles agent primitives to `.kiro/agents/<relative-stem>.md` for Kiro IDE/CLI v3
(ref: https://kiro.dev/docs/custom-agents/, accessed 2026-08-03). Only `description`,
`model`, and `tools` frontmatter are emitted; `name` and unknown fields are stripped.
Tools are permission-bearing: the install fails closed -- no file written, no directory
created -- if any tool value is outside Kiro's approved capability set. A new normative
requirement req-tg-009 (Section 8.5.1) anchors the fail-closed evaluation order, and seven
integration lifecycle scenarios prove the feature through the real APM binary.

> **Spec guardian F1-F5 folded.** The spec-guardian round-1 panel reviewed req-tg-009.
> Five editorial items (F1-F5) have been applied: per-agent blast-radius clause (F1),
> normative count 107->108 (F2), Section 8.7 + 11.3.2 conformance enumerations (F3),
> Target Registry companion editorial note (F4), and req-tg-008 composition sentence (F5).
> F6-F9 deferred to v0.1.1 per the panel's defer list. All linters pass at HEAD.

## Problem (WHY)

- [x] Kiro had `instructions`, `skills`, and `hooks` in `KNOWN_TARGETS` but no `agents`
  primitive. Agents authored in `.apm/agents/` were silently undeployed for Kiro users.
- [x] Initial implementation had an adopt-bypass flaw: `_check_adopt_or_skip()` ran
  BEFORE `_write_kiro_agent()` validated tools. A pre-placed `.kiro/agents/X.md` matching
  source bytes (even with invalid tools) was adopted without validation, bypassing the
  fail-closed gate per req-tg-009.
- [x] Mode B gate (CONTRIBUTING.md): behavior under `src/apm_cli/integration/` without
  a spec anchor, manifest row, and `@pytest.mark.req` marker fails CI conformance.
- [!] Only unit-level tests. For a critical-surface install-pipeline change, the S7 Probe
  Rule requires integration-with-fixtures tier (real binary + real filesystem effects).

## Approach (WHAT)

| # | Change |
|---|--------|
| 1 | `"agents": PrimitiveMapping("agents", ".md", "kiro_agent")` added to `KNOWN_TARGETS["kiro"]` |
| 2 | `_preflight_render_kiro_agent()` -- single owner of render+validate, runs before adopt/mkdir |
| 3 | Adopt comparison uses rendered bytes (not raw source), closing the adopt-bypass flaw |
| 4 | Lazy `agents_dir.mkdir()`: directory created only when a write actually proceeds |
| 5 | req-tg-009 in spec 8.5.1, manifest, Appendix C, conformance test; CONFORMANCE regenerated |
| 6 | 7 integration lifecycle scenarios via `ApmLifecycleRunner` + real CLI binary |

## Implementation (HOW)

- **`src/apm_cli/integration/agent_integrator.py`** -- adds `_preflight_render_kiro_agent()`
  as the single owner of kiro render+validate (returns `(rendered_str|None, bool)`). The
  integration loop for `kiro_agent` calls preflight first; on failure it skips without
  touching the filesystem. Adopt comparison now uses rendered content. `_write_kiro_agent()`
  delegates to preflight (belt-and-suspenders). Adds `normalize_crlf_to_lf` import.

- **`src/apm_cli/integration/targets.py`** -- adds `agents` PrimitiveMapping; updates
  comment to reference Kiro CLI v3 unified harness.

- **`tests/integration/test_kiro_agent_lifecycle.py`** -- new file; 7 scenarios via
  `ApmLifecycleRunner` + `IsolatedApmEnvironment` + `LocalPackageFactory`:
  compatible deploy/reinstall (idempotency), nested path identity, stale removal,
  coexistence with steering/hooks, incompatible-tools fail-closed (no partial write),
  real-binary update replacement (v1->v2 commit->reinstall proves bytes change),
  and target autodetection (`.kiro/` present + no `--target` flag -> agent deploys).

- **`tests/spec_conformance/test_manifest_reqs.py`** -- `@pytest.mark.req("req-tg-009")`
  conformance test; `assert_spec_contains` anchors verify req-tg-009 prose in spec body.

- **`docs/src/content/docs/specs/openapm-v0.1.md`** -- req-tg-009 at Section 8.5.1
  and Appendix C traceability row.

- **Docs + CHANGELOG + CONFORMANCE** -- targets-matrix agents column, instructions-and-agents
  table, ide-tool-integration Kiro section, package-authoring tools constraint; CONFORMANCE
  regenerated (108 requirements).

## Diagrams

The corrected `kiro_agent` dispatch loop: preflight fires before any adopt, collision,
or directory mutation. Pre-placed invalid-tools targets cannot be adopted via byte-match.

```mermaid
flowchart LR
    subgraph Source["Source: .apm/agents/"]
        S1["agent.agent.md"]
        S2["team/worker.agent.md"]
    end
    subgraph Preflight["_preflight_render_kiro_agent()"]
        P1["parse frontmatter"]:::new
        P2["validate tools"]:::new
        P3["render filtered output"]:::new
    end
    subgraph Gate["fail-closed gate"]
        G1["unsupported tool?"]:::new
        G2["skip: no write, no mkdir"]:::new
    end
    subgraph Adopt["adopt: compare rendered bytes"]
        A1["existing matches rendered?"]:::new
        A2["adopt, no write"]:::new
    end
    subgraph Target[".kiro/agents/"]
        D1["agent.md"]:::new
        D2["team/worker.md"]:::new
    end
    S1 --> P1
    S2 --> P1
    P1 --> P2
    P2 --> G1
    G1 -->|yes| G2
    G1 -->|no| P3
    P3 --> A1
    A1 -->|yes| A2
    A1 -->|no| D1
    P3 --> D2
    classDef new stroke-dasharray: 5 5;
    class P1,P2,P3,G1,G2,A1,A2,D1,D2 new;
```

## Trade-offs

- **Fail-closed per agent, not per install.** An install with one invalid agent and one valid
  agent deploys the valid agent and emits an error diagnostic for the invalid one. Consistent
  with how `codex_agent` handles unsupported surfaces.
- **Rendered-bytes adopt (not source-bytes adopt) for kiro_agent only.** Adopt now compares
  the transformed output against the on-disk file. On lockfile wipe, a format-transformed file
  falls through to `check_collision` (same as all format-transform targets -- accepted trade-off).
- **Lazy `agents_dir.mkdir()`.** `.kiro/agents/` is not created when every agent is invalid.
  Behavioral improvement for kiro_agent; other formats keep eager mkdir.
- **No model validation.** `model` is passed through opaquely. Kiro may warn at runtime if
  unavailable. A live catalog check would require network access and a stale allowlist.
- **Autodetection scope.** `detect_by_dir=True` drives consumer target selection, not package
  authorization. A package declaring `targets: [kiro]` combined with `.kiro/` autodetection
  deploys agents; a package without a target declaration reaches kiro only if the consumer's
  apm.yml or `--target` flag explicitly selects it. This is req-tg-008 semantics unchanged.

## Benefits

1. Kiro users receive package agents at `apm install` time -- no manual file copying.
2. Permission safety enforced at install time: incompatible tools caught before deployment,
   with a diagnostic naming the exact unsupported value(s) and the approved capability set.
3. Adopt-bypass flaw (security) closed by req-tg-009: validation precedes every filesystem
   mutation for `kiro_agent`.
4. Mode B conformance: req-tg-009 provides the spec anchor the CI gate requires.
5. 26 new unit tests + 7 real-binary lifecycle scenarios + 1 conformance test (211 targeted pass).

## Validation

<details><summary>CI-mirror lint chain (all green, HEAD d75cb30f0)</summary>

```
uv run --extra dev ruff check src/ tests/  ->  All checks passed!
uv run --extra dev ruff format --check src/ tests/  ->  1594 files already formatted
pylint R0801  ->  10.00/10
bash scripts/lint-auth-signals.sh  ->  auth-signal lint clean
File length guard: clean
BASE_REF=703dd9e758fa bash tests/spec_conformance/mode_b_detector.sh
  ->  [+] mode_b: spec-concurrent edit detected; orphan_check owns this PR
uv run --extra dev python -m tests.spec_conformance.orphan_check
  ->  [+] orphan_check OK: 108 requirements aligned
```

</details>

<details><summary>Test suite results</summary>

```
Targeted (kiro+agent+dispatch+conformance+catalog):
uv run --extra dev pytest tests/unit/integration/test_kiro_target.py
    tests/unit/integration/test_agent_integrator.py
    tests/unit/integration/test_data_driven_dispatch.py
    tests/spec_conformance/test_manifest_reqs.py
    tests/unit/core/test_target_catalog.py --no-header
  ->  211 passed, 1 skipped

Integration lifecycle (collection / smoke, 7 scenarios):
uv run --extra dev pytest tests/integration/test_kiro_agent_lifecycle.py --collect-only
  ->  7 test functions collected
  (full execution requires --requires_e2e_mode + --requires_apm_binary + binary build)

Prior full suite (last full run, HEAD 306a88ea9):
uv run --extra dev pytest tests/unit/ tests/spec_conformance/ --no-header
  ->  19779 passed, 4 skipped, 21 xfailed
  (Wave 3 adds 1 file; no unit suite change; lifecycle file is e2e-gated)
```

</details>

### Scenario Evidence

| # | Scenario | Principle(s) | Test(s) | Type |
|---|----------|--------------|---------|------|
| 1 | `apm install -t kiro` deploys agent with filtered frontmatter (name/color stripped, body preserved) | Portability, Multi-harness | `test_kiro_target.py::test_kiro_agents_deploy_plain_body_no_frontmatter`<br/>`test_kiro_target.py::test_kiro_agents_strip_name_and_unknown_frontmatter`<br/>`test_kiro_agent_lifecycle.py::test_kiro_agent_compatible_deploy_and_reinstall` | unit + integration |
| 2 | Nested `.apm/agents/team/X.agent.md` -> `.kiro/agents/team/X.md` (path identity) | Portability | `test_kiro_target.py::test_kiro_agents_nested_path_identity_derivation`<br/>`test_kiro_agent_lifecycle.py::test_kiro_agent_nested_path_identity` | unit + integration |
| 3 | Idempotent reinstall: second install produces identical deployed bytes | DevX, Governed by policy | `test_kiro_target.py::test_kiro_agents_idempotent_second_deploy`<br/>`test_kiro_agent_lifecycle.py::test_kiro_agent_compatible_deploy_and_reinstall` | unit + integration |
| 4 | Source revision change replaces deployed agent bytes (v1-marker -> v2-marker) | Portability, DevX | `test_kiro_agent_lifecycle.py::test_kiro_agent_update_replacement` | integration |
| 5 | Uninstall removes all `.kiro/agents/` records from ledger and filesystem | Governed by policy | `test_kiro_target.py::test_kiro_agents_sync_removes_managed_file`<br/>`test_kiro_agent_lifecycle.py::test_kiro_agent_stale_removal` | unit + integration |
| 6 | Incompatible tools: zero bytes written, no agents dir, diagnostic names tool | Secure by default | `test_kiro_target.py::test_kiro_agents_fail_closed_incompatible_tools`<br/>`test_kiro_target.py::test_kiro_agents_no_agents_dir_created_for_all_invalid`<br/>`test_kiro_agent_lifecycle.py::test_kiro_agent_incompatible_tools_fail_closed` | unit + integration |
| 7 | Adopt-bypass regression: pre-placed invalid-tools target is skipped (req-tg-009) | Secure by default | `test_kiro_target.py::test_kiro_agents_preflight_before_adopt_bypass`<br/>`test_manifest_reqs.py::test_kiro_agent_tools_gate_fails_closed_before_adopt` | unit + conformance |
| 8 | `.kiro/` autodetects kiro target without `--target` flag | Multi-harness, DevX | `test_kiro_agent_lifecycle.py::test_kiro_target_autodetection` | integration |
| 9 | req-tg-009 spec anchor + manifest + Appendix C + conformance test aligned | Governed by policy | `test_manifest_reqs.py::test_kiro_agent_tools_gate_fails_closed_before_adopt` (orphan_check: 108) | conformance |
| 10 | Tools whitespace normalization: stripped values written (not original padded) | Secure by default | `test_kiro_target.py::test_kiro_agents_tools_whitespace_stripped_in_output` | unit |
| 11 | Stale managed Kiro agent removed by reconcile when tools become incompatible | Governed by policy | `test_kiro_target.py::test_kiro_agents_stale_managed_file_removed_when_tools_become_incompatible` | unit |

## How to test

- [ ] `uv run --extra dev pytest tests/unit/integration/test_kiro_target.py -q` -- 26 tests pass (includes whitespace normalization and stale reconcile regression tests).
- [ ] `uv run --extra dev python -m tests.spec_conformance.orphan_check` -- 108 requirements aligned.
- [ ] In a scratch project with `.kiro/` present: author `.apm/agents/helper.agent.md` with `tools: [read]`; run `apm install` (no `--target`); verify `.kiro/agents/helper.md` exists with filtered frontmatter.
- [ ] Change `tools: [read, BADTOOL]` and reinstall -- expect diagnostic naming `BADTOOL`; verify no write; verify `.kiro/agents/` not created if absent.
- [ ] `BASE_REF=703dd9e758fa bash tests/spec_conformance/mode_b_detector.sh` -- exit 0.

Closes #2089

Official sources (all accessed 2026-08-03):
- https://kiro.dev/docs/custom-agents/
- https://kiro.dev/docs/cli/v3/
- https://kiro.dev/docs/cli/v3/agent-config/

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

