### PR TITLE
fix(compilation): preserve applyTo lists for hidden tool placement

### DIFF
--- a/.apm/instructions/architecture.instructions.md
+++ b/.apm/instructions/architecture.instructions.md
@@ -67,6 +67,7 @@ semicolon-delimited, and specific to the file(s) that own the fact.
 | JetBrains Copilot MCP config path | adapters/client/intellij.py | `src/apm_cli/adapters/client/intellij.py` |
 | Marketplace tag-pattern validation and expansion | marketplace/tag_pattern.py | `src/apm_cli/marketplace/tag_pattern.py` |
 | Local marketplace package-version manifest precedence | marketplace/version_check.py (_read_local_version) | `src/apm_cli/marketplace/version_check.py` |
+| applyTo normalization and hidden-tool placement | utils/patterns.py (normalize_apply_to); compilation/context_optimizer.py (ContextOptimizer) | `src/apm_cli/utils/patterns.py`; `src/apm_cli/compilation/context_optimizer.py` |
 <!-- /canonical-owner-table -->
 
 Host + credential resolution includes public github.com anonymous-first ordering.

--- a/.github/instructions/architecture.instructions.md
+++ b/.github/instructions/architecture.instructions.md
@@ -67,6 +67,7 @@ semicolon-delimited, and specific to the file(s) that own the fact.
 | JetBrains Copilot MCP config path | adapters/client/intellij.py | `src/apm_cli/adapters/client/intellij.py` |
 | Marketplace tag-pattern validation and expansion | marketplace/tag_pattern.py | `src/apm_cli/marketplace/tag_pattern.py` |
 | Local marketplace package-version manifest precedence | marketplace/version_check.py (_read_local_version) | `src/apm_cli/marketplace/version_check.py` |
+| applyTo normalization and hidden-tool placement | utils/patterns.py (normalize_apply_to); compilation/context_optimizer.py (ContextOptimizer) | `src/apm_cli/utils/patterns.py`; `src/apm_cli/compilation/context_optimizer.py` |
 <!-- /canonical-owner-table -->
 
 Host + credential resolution includes public github.com anonymous-first ordering.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- YAML-list `applyTo` entries now preserve every pattern during compilation
+  and target-native instruction conversion, including explicitly targeted
+  supported hidden tool roots. (#2441)
 - Release publication now excludes opt-in live ADO PAT tests and credentials; those tests fail closed in the Auth Acceptance workflow instead. (#2426)
 - Release promotions now run marker-bounded lifecycle integration on macOS Intel
   while retaining the full corpus on macOS ARM and Linux, preventing Intel

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -2783,7 +2783,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:0fcc203d0daf2d1227a2cea61482009a50a9eff27292fab3b7a06dd7fda2b1e6
+  content_hash: sha256:eb72e42f5e943941eb148f05b52d6ac6506301f27cde39acf80583b77fc7f030
 - kind: project-relative
   target: copilot
   value: .github/instructions/changelog.instructions.md
@@ -3290,7 +3290,7 @@ local_deployed_file_hashes:
   .github/agents/spec-tag-architect.agent.md: sha256:82907265c5e7cf1ac61ad96866fa7c5683b69c8f09b7a4c5f3cc241acc9568ca
   .github/agents/supply-chain-security-expert.agent.md: sha256:8fb8cc426d6af17ba084a28b3f026c2b475b62e3ca63ed2f88b83bd823f877af
   .github/agents/test-coverage-expert.agent.md: sha256:48c2172d1f18a394fa83ef9dc2be0b9b921a4e51e976498165250fed66369711
-  .github/instructions/architecture.instructions.md: sha256:0fcc203d0daf2d1227a2cea61482009a50a9eff27292fab3b7a06dd7fda2b1e6
+  .github/instructions/architecture.instructions.md: sha256:eb72e42f5e943941eb148f05b52d6ac6506301f27cde39acf80583b77fc7f030
   .github/instructions/changelog.instructions.md: sha256:1e51ec4c74e847967962bd279dc4c6e582c5d3578490b3c28d5f3acd3e05f73e
   .github/instructions/cicd.instructions.md: sha256:33201cb88ea2f34b4950a9b52f87dc8dfb682796aaf53068ba7ae406c0c5e2c2
   .github/instructions/cli.instructions.md: sha256:8e39e8d5047ce88575cb02f87c2bcede584dfef258bd86f7466c7badf136541a

--- a/docs/src/content/docs/producer/author-primitives/instructions-and-agents.md
+++ b/docs/src/content/docs/producer/author-primitives/instructions-and-agents.md
@@ -72,8 +72,9 @@ applyTo:
 
 When a YAML sequence contains multiple patterns, APM normalizes every
 non-null entry into the same comma-separated OR expression used by the
-placement compiler and target converters. The comma-separated scalar remains
-useful when you want that exact source syntax preserved for Copilot.
+placement compiler and target converters. Use a comma-separated scalar only
+when you want Copilot output to use that scalar syntax; YAML sequences remain
+verbatim in Copilot output.
 
 ```markdown
 ---
@@ -86,6 +87,10 @@ On Copilot the comma-list is preserved verbatim (Copilot splits it
 natively). On Claude, Cursor, Windsurf, Kiro, and Antigravity the list is
 expanded to a YAML array under `paths:` / `globs:` /
 `fileMatchPattern:`.
+
+During distributed compilation, an explicitly scoped pattern may match files
+under supported top-level harness directories such as `.github` or `.opencode`.
+Other hidden directories remain excluded.
 
 ### Body conventions
 

--- a/docs/src/content/docs/producer/author-primitives/instructions-and-agents.md
+++ b/docs/src/content/docs/producer/author-primitives/instructions-and-agents.md
@@ -71,11 +71,10 @@ applyTo:
 ```
 
 When a YAML sequence contains multiple patterns, APM normalizes every
-non-null entry into the same comma-separated OR expression used by distributed
-placement. Target installers preserve source frontmatter, so prefer the scalar
-form for portable direct target output; use a sequence when its source
-readability matters. To match a literal comma in a filename, escape it as
-`\,`.
+non-null entry into the same comma-separated OR expression used by
+[distributed compilation](../compile/) and target-native installation. Use a
+sequence when its source readability matters. To match a literal comma in a
+filename, escape it as `\,`.
 
 ```markdown
 ---

--- a/docs/src/content/docs/producer/author-primitives/instructions-and-agents.md
+++ b/docs/src/content/docs/producer/author-primitives/instructions-and-agents.md
@@ -71,10 +71,11 @@ applyTo:
 ```
 
 When a YAML sequence contains multiple patterns, APM normalizes every
-non-null entry into the same comma-separated OR expression used by the
-placement compiler and target converters. Use a comma-separated scalar only
-when you want Copilot output to use that scalar syntax; YAML sequences remain
-verbatim in Copilot output.
+non-null entry into the same comma-separated OR expression used by distributed
+placement. Target installers preserve source frontmatter, so prefer the scalar
+form for portable direct target output; use a sequence when its source
+readability matters. To match a literal comma in a filename, escape it as
+`\,`.
 
 ```markdown
 ---
@@ -84,13 +85,13 @@ applyTo: "**/*.{css,scss},**/*.tsx"
 ```
 
 On Copilot the comma-list is preserved verbatim (Copilot splits it
-natively). On Claude, Cursor, Windsurf, Kiro, and Antigravity the list is
-expanded to a YAML array under `paths:` / `globs:` /
-`fileMatchPattern:`.
+natively). Other targets use their own native instruction format; the target
+matrix below records the generated shape.
 
 During distributed compilation, an explicitly scoped pattern may match files
-under supported top-level harness directories such as `.github` or `.opencode`.
-Other hidden directories remain excluded.
+under supported top-level harness directories: `.agents`, `.apm`, `.claude`,
+`.codex`, `.cursor`, `.gemini`, `.github`, `.kiro`, `.opencode`, and
+`.windsurf`. Other hidden directories remain excluded.
 
 ### Body conventions
 

--- a/docs/src/content/docs/producer/author-primitives/instructions-and-agents.md
+++ b/docs/src/content/docs/producer/author-primitives/instructions-and-agents.md
@@ -72,7 +72,7 @@ applyTo:
 
 When a YAML sequence contains multiple patterns, APM normalizes every
 non-null entry into the same comma-separated OR expression used by
-[distributed compilation](../compile/) and target-native installation. Use a
+[distributed compilation](../../compile/) and target-native installation. Use a
 sequence when its source readability matters. To match a literal comma in a
 filename, escape it as `\,`.
 

--- a/docs/src/content/docs/producer/author-primitives/instructions-and-agents.md
+++ b/docs/src/content/docs/producer/author-primitives/instructions-and-agents.md
@@ -70,10 +70,10 @@ applyTo:
   - "**/*.py"
 ```
 
-When a YAML sequence contains multiple patterns, APM preserves the full
-sequence for targets whose native rule format supports multiple globs.
-Prefer the comma-separated string form when you want identical output
-across every target.
+When a YAML sequence contains multiple patterns, APM normalizes every
+non-null entry into the same comma-separated OR expression used by the
+placement compiler and target converters. The comma-separated scalar remains
+useful when you want that exact source syntax preserved for Copilot.
 
 ```markdown
 ---

--- a/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
@@ -306,11 +306,10 @@ way to specify multiple patterns, as it is portably expanded into target-specifi
 YAML arrays/lists (under `paths:` / `globs:` / `fileMatchPattern:`) across
 Claude, Cursor, Windsurf, Kiro, and Antigravity.
 
-A YAML sequence (e.g., `applyTo: ['**/*.py', '**/tests/**/*.py']`) may work
-for some targets, but it is not portable: some converters ignore sequences or
-treat them as a string, while others (like Antigravity and Kiro) parse and
-expand them. For maximum portability, use a comma-separated string for multiple
-globs.
+A YAML sequence (e.g., `applyTo: ['**/*.py', '**/tests/**/*.py']`) is
+normalized to the same comma-separated OR expression. Every non-null sequence
+entry is preserved for placement and target conversion. Use the scalar form
+when you need the source file itself to retain comma-separated syntax.
 
 Commas inside brace alternation (`**/*.{css,scss}`) are part of the glob
 and are NOT separators -- only top-level commas split the list. On Copilot

--- a/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
@@ -309,11 +309,16 @@ Claude, Cursor, Windsurf, Kiro, and Antigravity.
 A YAML sequence (e.g., `applyTo: ['**/*.py', '**/tests/**/*.py']`) is
 normalized to the same comma-separated OR expression. Every non-null sequence
 entry is preserved for placement and target conversion. Use the scalar form
-when you need the source file itself to retain comma-separated syntax.
+only when you want Copilot output to use comma-separated scalar syntax; YAML
+sequences remain verbatim in Copilot output.
 
 Commas inside brace alternation (`**/*.{css,scss}`) are part of the glob
 and are NOT separators -- only top-level commas split the list. On Copilot
 the value is preserved verbatim.
+
+During distributed compilation, explicitly scoped patterns may match files in
+supported top-level harness directories such as `.github` or `.opencode`.
+Other hidden directories remain excluded.
 
 ### 2. Agent (`*.agent.md`)
 

--- a/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
@@ -308,8 +308,7 @@ Claude, Cursor, Windsurf, Kiro, and Antigravity.
 
 A YAML sequence (e.g., `applyTo: ['**/*.py', '**/tests/**/*.py']`) is
 normalized to the same comma-separated OR expression for distributed
-placement. Target installers preserve source frontmatter, so prefer the scalar
-form for portable direct target output; use a sequence when its source
+placement and target-native installation. Use a sequence when its source
 readability matters. To match a literal comma in a filename, escape it as
 `\,`.
 

--- a/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
@@ -307,18 +307,20 @@ YAML arrays/lists (under `paths:` / `globs:` / `fileMatchPattern:`) across
 Claude, Cursor, Windsurf, Kiro, and Antigravity.
 
 A YAML sequence (e.g., `applyTo: ['**/*.py', '**/tests/**/*.py']`) is
-normalized to the same comma-separated OR expression. Every non-null sequence
-entry is preserved for placement and target conversion. Use the scalar form
-only when you want Copilot output to use comma-separated scalar syntax; YAML
-sequences remain verbatim in Copilot output.
+normalized to the same comma-separated OR expression for distributed
+placement. Target installers preserve source frontmatter, so prefer the scalar
+form for portable direct target output; use a sequence when its source
+readability matters. To match a literal comma in a filename, escape it as
+`\,`.
 
 Commas inside brace alternation (`**/*.{css,scss}`) are part of the glob
 and are NOT separators -- only top-level commas split the list. On Copilot
 the value is preserved verbatim.
 
 During distributed compilation, explicitly scoped patterns may match files in
-supported top-level harness directories such as `.github` or `.opencode`.
-Other hidden directories remain excluded.
+supported top-level harness directories: `.agents`, `.apm`, `.claude`,
+`.codex`, `.cursor`, `.gemini`, `.github`, `.kiro`, `.opencode`, and
+`.windsurf`. Other hidden directories remain excluded.
 
 ### 2. Agent (`*.agent.md`)
 

--- a/scripts/lint-architecture-boundaries.sh
+++ b/scripts/lint-architecture-boundaries.sh
@@ -1433,6 +1433,28 @@ if [ "$(grep -Ec '^def _read_local_version\(|^def _read_plugin_json_version\(' \
     violations=$((violations + 1))
 fi
 
+echo "[*] AC31: applyTo normalization and hidden-tool placement authority"
+apply_to_owner="src/apm_cli/utils/patterns.py"
+apply_to_normalizer_defs=$(grep -rEc --include='*.py' \
+    '^def _?normalize_apply_to\(' src/apm_cli \
+    | awk -F: '{sum += $2} END {print sum + 0}')
+apply_to_parser="src/apm_cli/primitives/parser.py"
+hidden_tool_placement_owner="src/apm_cli/compilation/context_optimizer.py"
+hidden_tool_tree_defs=$(grep -rEc --include='*.py' \
+    '^PLACEMENT_HIDDEN_TOOL_TREES[[:space:]]*=' src/apm_cli \
+    | awk -F: '{sum += $2} END {print sum + 0}')
+if [ "$apply_to_normalizer_defs" -ne 1 ] \
+    || ! grep -q '^def normalize_apply_to(' "$apply_to_owner" \
+    || ! grep -q 'from apm_cli.utils.patterns import normalize_apply_to' "$apply_to_parser" \
+    || grep -Eq '^def _?normalize_apply_to\(' "$apply_to_parser" \
+    || ! grep -q 'normalize_apply_to(metadata.get("applyTo"), default="")' "$apply_to_parser" \
+    || [ "$hidden_tool_tree_defs" -ne 1 ] \
+    || ! grep -q '^PLACEMENT_HIDDEN_TOOL_TREES = frozenset(' "$hidden_tool_placement_owner" \
+    || ! grep -q 'not self._is_supported_hidden_tool_root(path)' "$hidden_tool_placement_owner"; then
+    echo "[x] applyTo normalization must use utils/patterns.py and hidden placement ContextOptimizer"
+    violations=$((violations + 1))
+fi
+
 if [ "$violations" -gt 0 ]; then
     echo "[x] $violations architecture boundary rule(s) failed"
     exit 1

--- a/src/apm_cli/compilation/context_optimizer.py
+++ b/src/apm_cli/compilation/context_optimizer.py
@@ -46,6 +46,23 @@ DEFAULT_EXCLUDED_DIRNAMES = frozenset(
     }
 )
 
+# Hidden roots owned by supported agent tools. Placement may examine these
+# trees when an applyTo pattern explicitly targets their non-hidden contents.
+PLACEMENT_HIDDEN_TOOL_TREES = frozenset(
+    {
+        ".agents",
+        ".apm",
+        ".claude",
+        ".codex",
+        ".cursor",
+        ".gemini",
+        ".github",
+        ".kiro",
+        ".opencode",
+        ".windsurf",
+    }
+)
+
 
 @dataclass
 class DirectoryAnalysis:
@@ -204,10 +221,12 @@ class ContextOptimizer:
         if self._file_list_cache is None:
             self._file_list_cache = []
             for root, dirs, files in os.walk(self.base_dir):
-                # Skip hidden and excluded directories for performance
-                # Sort to guarantee deterministic traversal order across filesystems
+                current_path = Path(root)
+                if self._contains_unsupported_hidden_directory(current_path):
+                    dirs[:] = []
+                    continue
                 dirs[:] = sorted(
-                    d for d in dirs if not d.startswith(".") and d not in DEFAULT_EXCLUDED_DIRNAMES
+                    d for d in dirs if not self._should_exclude_subdir(current_path / d)
                 )
                 for file in sorted(files):
                     if not file.startswith("."):
@@ -472,8 +491,10 @@ class ContextOptimizer:
             except ValueError:
                 depth = 0
 
-            # Skip hidden directories and common ignore patterns
-            if any(part.startswith(".") for part in current_path.parts[len(self.base_dir.parts) :]):
+            # Only supported agent-tool roots participate in placement. Other
+            # hidden paths (including nested caches) stay pruned.
+            if self._contains_unsupported_hidden_directory(current_path):
+                dirs[:] = []
                 continue
 
             # Default hardcoded exclusions  -- match on exact path components
@@ -530,11 +551,30 @@ class ContextOptimizer:
         if dir_name in DEFAULT_EXCLUDED_DIRNAMES:
             return True
 
-        # Skip hidden directories
-        if dir_name.startswith("."):  # noqa: SIM103
-            return True
+        # Supported agent-tool roots contain valid applyTo targets. Other
+        # hidden directories remain excluded from placement traversal.
+        return dir_name.startswith(".") and not self._is_supported_hidden_tool_root(path)
 
-        return False
+    def _is_supported_hidden_tool_root(self, path: Path) -> bool:
+        """Return whether ``path`` is a supported top-level hidden tool tree."""
+        try:
+            relative_path = path.resolve().relative_to(self.base_dir.resolve())
+        except (OSError, ValueError):
+            return False
+        return (
+            len(relative_path.parts) == 1 and relative_path.parts[0] in PLACEMENT_HIDDEN_TOOL_TREES
+        )
+
+    def _contains_unsupported_hidden_directory(self, path: Path) -> bool:
+        """Return whether ``path`` enters a hidden tree outside the supported roots."""
+        try:
+            relative_parts = path.resolve().relative_to(self.base_dir.resolve()).parts
+        except (OSError, ValueError):
+            return True
+        return any(
+            part.startswith(".") and not (index == 0 and part in PLACEMENT_HIDDEN_TOOL_TREES)
+            for index, part in enumerate(relative_parts)
+        )
 
     def _should_exclude_path(self, path: Path) -> bool:
         """Check if a path matches any exclusion pattern.

--- a/src/apm_cli/compilation/context_optimizer.py
+++ b/src/apm_cli/compilation/context_optimizer.py
@@ -262,6 +262,8 @@ class ContextOptimizer:
         self._optimization_decisions.clear()
         self._warnings.clear()
         self._errors.clear()
+        # Shared file discovery runs once per compile batch, so traverse the
+        # union of roots explicitly targeted by its instructions.
         self._placement_hidden_tool_trees = self._targeted_hidden_tool_roots(instructions)
         self._file_list_cache = None
         self._glob_cache.clear()
@@ -495,7 +497,7 @@ class ContextOptimizer:
 
             # Only supported agent-tool roots participate in placement. Other
             # hidden paths (including nested caches) stay pruned.
-            if self._contains_unsupported_hidden_directory(current_path):
+            if self._contains_unsupported_hidden_directory(current_path, relative_path):
                 dirs[:] = []
                 continue
 
@@ -567,14 +569,19 @@ class ContextOptimizer:
             and relative_path.parts[0] in self._placement_hidden_tool_trees
         )
 
-    def _contains_unsupported_hidden_directory(self, path: Path) -> bool:
+    def _contains_unsupported_hidden_directory(
+        self, path: Path, relative_path: Path | None = None
+    ) -> bool:
         """Return whether ``path`` enters a hidden tree not targeted this run."""
-        relative_path = self._relative_path(path)
+        relative_path = relative_path or self._relative_path(path)
         if relative_path is None:
             return True
-        return any(
-            part.startswith(".") and not (index == 0 and part in self._placement_hidden_tool_trees)
-            for index, part in enumerate(relative_path.parts)
+        # os.walk reaches a nested directory only after _should_exclude_subdir
+        # admitted its parent, so the top-level component is sufficient here.
+        return bool(
+            relative_path.parts
+            and relative_path.parts[0].startswith(".")
+            and relative_path.parts[0] not in self._placement_hidden_tool_trees
         )
 
     def _targeted_hidden_tool_roots(
@@ -589,7 +596,9 @@ class ContextOptimizer:
         targeted_roots: builtins.set[str] = set()
         for instruction in instructions:
             for pattern in parse_apply_to(instruction.apply_to):
-                targeted_roots.update(PLACEMENT_HIDDEN_TOOL_TREES.intersection(pattern.split("/")))
+                targeted_roots.update(
+                    PLACEMENT_HIDDEN_TOOL_TREES.intersection(pattern.replace("\\", "/").split("/"))
+                )
         return frozenset(targeted_roots)
 
     def _relative_path(self, path: Path) -> Path | None:
@@ -765,7 +774,11 @@ class ContextOptimizer:
             # Skip if it's a wildcard
             if "*" not in first_part and first_part:
                 intended_dir = self.base_dir / first_part
-                if intended_dir.exists() and intended_dir.is_dir():
+                if (
+                    intended_dir.exists()
+                    and intended_dir.is_dir()
+                    and not self._should_exclude_subdir(intended_dir)
+                ):
                     return intended_dir
 
         return None

--- a/src/apm_cli/compilation/context_optimizer.py
+++ b/src/apm_cli/compilation/context_optimizer.py
@@ -152,6 +152,7 @@ class ContextOptimizer:
         self._glob_cache: builtins.dict[str, builtins.list[str]] = {}
         self._glob_set_cache: builtins.dict[str, builtins.set[Path]] = {}
         self._file_list_cache: builtins.list[Path] | None = None
+        self._placement_hidden_tool_trees: frozenset[str] = frozenset()
         self._inheritance_cache: builtins.dict[Path, builtins.list[Path]] = {}  # (#171)
         self._timing_enabled = False
         self._phase_timings: builtins.dict[str, float] = {}
@@ -261,6 +262,10 @@ class ContextOptimizer:
         self._optimization_decisions.clear()
         self._warnings.clear()
         self._errors.clear()
+        self._placement_hidden_tool_trees = self._targeted_hidden_tool_roots(instructions)
+        self._file_list_cache = None
+        self._glob_cache.clear()
+        self._glob_set_cache.clear()
 
         # Phase 1: Analyze project structure
         self._time_phase("Project Analysis", self._analyze_project_structure)
@@ -485,11 +490,8 @@ class ContextOptimizer:
             visited_dirs.add(current_path)
 
             # Calculate depth for analysis
-            try:
-                relative_path = current_path.resolve().relative_to(self.base_dir.resolve())
-                depth = len(relative_path.parts)
-            except ValueError:
-                depth = 0
+            relative_path = self._relative_path(current_path)
+            depth = len(relative_path.parts) if relative_path is not None else 0
 
             # Only supported agent-tool roots participate in placement. Other
             # hidden paths (including nested caches) stay pruned.
@@ -551,30 +553,49 @@ class ContextOptimizer:
         if dir_name in DEFAULT_EXCLUDED_DIRNAMES:
             return True
 
-        # Supported agent-tool roots contain valid applyTo targets. Other
-        # hidden directories remain excluded from placement traversal.
+        # Only roots named by this compile's applyTo expressions participate.
+        # Every other hidden directory remains excluded from placement traversal.
         return dir_name.startswith(".") and not self._is_supported_hidden_tool_root(path)
 
     def _is_supported_hidden_tool_root(self, path: Path) -> bool:
-        """Return whether ``path`` is a supported top-level hidden tool tree."""
-        try:
-            relative_path = path.resolve().relative_to(self.base_dir.resolve())
-        except (OSError, ValueError):
+        """Return whether ``path`` is a top-level hidden root targeted this run."""
+        relative_path = self._relative_path(path)
+        if relative_path is None:
             return False
         return (
-            len(relative_path.parts) == 1 and relative_path.parts[0] in PLACEMENT_HIDDEN_TOOL_TREES
+            len(relative_path.parts) == 1
+            and relative_path.parts[0] in self._placement_hidden_tool_trees
         )
 
     def _contains_unsupported_hidden_directory(self, path: Path) -> bool:
-        """Return whether ``path`` enters a hidden tree outside the supported roots."""
-        try:
-            relative_parts = path.resolve().relative_to(self.base_dir.resolve()).parts
-        except (OSError, ValueError):
+        """Return whether ``path`` enters a hidden tree not targeted this run."""
+        relative_path = self._relative_path(path)
+        if relative_path is None:
             return True
         return any(
-            part.startswith(".") and not (index == 0 and part in PLACEMENT_HIDDEN_TOOL_TREES)
-            for index, part in enumerate(relative_parts)
+            part.startswith(".") and not (index == 0 and part in self._placement_hidden_tool_trees)
+            for index, part in enumerate(relative_path.parts)
         )
+
+    def _targeted_hidden_tool_roots(
+        self, instructions: builtins.list[Instruction]
+    ) -> frozenset[str]:
+        """Return supported top-level hidden roots named by applyTo patterns."""
+        targeted_roots = {
+            root
+            for instruction in instructions
+            for pattern in parse_apply_to(instruction.apply_to)
+            for root in PLACEMENT_HIDDEN_TOOL_TREES
+            if root in pattern.split("/")
+        }
+        return frozenset(targeted_roots)
+
+    def _relative_path(self, path: Path) -> Path | None:
+        """Return a lexical base-relative path without per-directory resolution."""
+        try:
+            return path.relative_to(self.base_dir)
+        except ValueError:
+            return None
 
     def _should_exclude_path(self, path: Path) -> bool:
         """Check if a path matches any exclusion pattern.

--- a/src/apm_cli/compilation/context_optimizer.py
+++ b/src/apm_cli/compilation/context_optimizer.py
@@ -580,18 +580,20 @@ class ContextOptimizer:
     def _targeted_hidden_tool_roots(
         self, instructions: builtins.list[Instruction]
     ) -> frozenset[str]:
-        """Return supported top-level hidden roots named by applyTo patterns."""
-        targeted_roots = {
-            root
-            for instruction in instructions
-            for pattern in parse_apply_to(instruction.apply_to)
-            for root in PLACEMENT_HIDDEN_TOOL_TREES
-            if root in pattern.split("/")
-        }
+        """Return supported top-level hidden roots named by applyTo patterns.
+
+        A pattern can name the root after a wildcard (for example,
+        ``**/.apm/**/*.md``), but traversal still admits only the top-level
+        root through :meth:`_is_supported_hidden_tool_root`.
+        """
+        targeted_roots: builtins.set[str] = set()
+        for instruction in instructions:
+            for pattern in parse_apply_to(instruction.apply_to):
+                targeted_roots.update(PLACEMENT_HIDDEN_TOOL_TREES.intersection(pattern.split("/")))
         return frozenset(targeted_roots)
 
     def _relative_path(self, path: Path) -> Path | None:
-        """Return a lexical base-relative path without per-directory resolution."""
+        """Return a lexical path for a directory discovered under ``base_dir``."""
         try:
             return path.relative_to(self.base_dir)
         except ValueError:

--- a/src/apm_cli/integration/instruction_integrator.py
+++ b/src/apm_cli/integration/instruction_integrator.py
@@ -19,7 +19,7 @@ from apm_cli.utils.atomic_io import normalize_crlf_to_lf, write_text_lf
 from apm_cli.utils.console import _rich_echo
 from apm_cli.utils.path_security import ensure_path_within
 from apm_cli.utils.paths import portable_relpath
-from apm_cli.utils.patterns import parse_apply_to, yaml_double_quote
+from apm_cli.utils.patterns import normalize_apply_to, parse_apply_to, yaml_double_quote
 
 if TYPE_CHECKING:
     from apm_cli.integration.targets import TargetProfile
@@ -48,6 +48,17 @@ class InstructionIntegrator(BaseIntegrator):
         "kiro_steering": "_convert_to_kiro_steering",
         "antigravity_rules": "_convert_to_antigravity_rules",
     }
+
+    @staticmethod
+    def _normalize_frontmatter_apply_to(frontmatter: str) -> str:
+        """Return canonical applyTo text from a bounded YAML frontmatter block."""
+        from apm_cli.utils.yaml_io import load_yaml_str
+
+        try:
+            metadata = load_yaml_str(frontmatter) or {}
+        except Exception:
+            return ""
+        return normalize_apply_to(metadata.get("applyTo"), default="")
 
     def find_instruction_files(self, package_path: Path) -> list[Path]:
         """Find all .instructions.md files in a package.
@@ -488,12 +499,11 @@ class InstructionIntegrator(BaseIntegrator):
         if fm_match:
             fm_block = fm_match.group(1)
             body = content[fm_match.end() :]
+            apply_to = InstructionIntegrator._normalize_frontmatter_apply_to(fm_block)
 
             for line in fm_block.splitlines():
                 line_stripped = line.strip()
-                if line_stripped.startswith("applyTo:"):
-                    apply_to = line_stripped[len("applyTo:") :].strip().strip("'\"")
-                elif line_stripped.startswith("description:"):
+                if line_stripped.startswith("description:"):
                     description = line_stripped[len("description:") :].strip().strip("'\"")
 
         # Generate description from first content sentence if missing
@@ -580,8 +590,6 @@ class InstructionIntegrator(BaseIntegrator):
 
         Ref: https://docs.windsurf.com/windsurf/cascade/memories
         """
-        from ..utils.yaml_io import load_yaml_str
-
         body = content
         apply_to = ""
 
@@ -590,11 +598,7 @@ class InstructionIntegrator(BaseIntegrator):
         fm_match = re.match(r"^---\s*\n(.*?)\n---\s*\n?", content, re.DOTALL)
         if fm_match:
             body = content[fm_match.end() :]
-            try:
-                fm = load_yaml_str(fm_match.group(1)) or {}
-            except Exception:
-                fm = {}
-            apply_to = str(fm.get("applyTo", "")).strip()
+            apply_to = InstructionIntegrator._normalize_frontmatter_apply_to(fm_match.group(1))
 
         # Build Windsurf rules frontmatter
         parts = ["---"]
@@ -698,11 +702,7 @@ class InstructionIntegrator(BaseIntegrator):
         if fm_match:
             fm_block = fm_match.group(1)
             body = content[fm_match.end() :]
-
-            for line in fm_block.splitlines():
-                line_stripped = line.strip()
-                if line_stripped.startswith("applyTo:"):
-                    apply_to = line_stripped[len("applyTo:") :].strip().strip("'\"")
+            apply_to = InstructionIntegrator._normalize_frontmatter_apply_to(fm_block)
 
         # Build Claude rules frontmatter (only when path-scoped)
         globs = parse_apply_to(apply_to)

--- a/src/apm_cli/primitives/parser.py
+++ b/src/apm_cli/primitives/parser.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+from apm_cli.utils.patterns import normalize_apply_to
 from apm_cli.utils.yaml_io import load_frontmatter
 
 from .models import Chatmode, Context, Instruction, Primitive, Skill
@@ -92,33 +93,6 @@ def parse_primitive_file(file_path: str | Path, source: str = None) -> Primitive
         raise ValueError(f"Failed to parse primitive file {file_path}: {e}")  # noqa: B904
 
 
-def _normalize_apply_to(value: object, default: str = "") -> str:
-    """Normalize an applyTo frontmatter value to a string.
-
-    YAML allows list-valued applyTo (e.g. ``applyTo: ['**/*.py']``).
-    The rest of the compilation pipeline expects a plain string and treats
-    apply_to as a single glob pattern -- it has no mechanism to split a
-    comma-joined multi-pattern string back into individual globs.
-
-    When a list is encountered, only the first non-null element is used.
-    Multi-pattern support (``list[str]`` migration across all consumers)
-    is tracked separately.
-
-    Args:
-        value: The raw value returned by the YAML parser (str, list, or None).
-        default: Fallback when value is None or an empty list.
-
-    Returns:
-        str: Normalized glob pattern string.
-    """
-    if isinstance(value, list):
-        non_null = [str(v) for v in value if v is not None]
-        return non_null[0] if non_null else default
-    if value is None:
-        return default
-    return str(value)
-
-
 def _parse_chatmode(
     name: str,
     file_path: Path,
@@ -139,7 +113,7 @@ def _parse_chatmode(
         Chatmode: Parsed chatmode primitive.
     """
     raw_apply_to = metadata.get("applyTo")
-    normalized_apply_to = _normalize_apply_to(raw_apply_to, default="") or None
+    normalized_apply_to = normalize_apply_to(raw_apply_to, default="") or None
     raw_handoffs = metadata.get("handoffs")
     handoffs: list[str | dict] | None = None
     if isinstance(raw_handoffs, list):
@@ -183,7 +157,7 @@ def _parse_instruction(
         name=name,
         file_path=file_path,
         description=metadata.get("description", ""),
-        apply_to=_normalize_apply_to(metadata.get("applyTo"), default=""),
+        apply_to=normalize_apply_to(metadata.get("applyTo"), default=""),
         content=content,
         author=metadata.get("author"),
         version=metadata.get("version"),

--- a/src/apm_cli/utils/patterns.py
+++ b/src/apm_cli/utils/patterns.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 class _ApplyToPattern(str):
     """A parsed pattern that remembers an escaped top-level comma."""
 
+    _escaped_top_level_comma: bool
+
     def __new__(cls, value: str, escaped_top_level_comma: bool):
         instance = super().__new__(cls, value)
         instance._escaped_top_level_comma = escaped_top_level_comma

--- a/src/apm_cli/utils/patterns.py
+++ b/src/apm_cli/utils/patterns.py
@@ -55,6 +55,21 @@ def yaml_double_quote(value: str) -> str:
     return f'"{escaped}"'
 
 
+def normalize_apply_to(value: object, default: str = "") -> str:
+    """Normalize scalar or YAML-list ``applyTo`` values into one OR expression.
+
+    Compilation stores ``applyTo`` as a string. YAML sequences therefore use
+    the documented top-level-comma representation consumed by
+    :func:`parse_apply_to`, preserving every non-null list entry.
+    """
+    if isinstance(value, list):
+        patterns = [str(pattern) for pattern in value if pattern is not None]
+        return ",".join(patterns) if patterns else default
+    if value is None:
+        return default
+    return str(value)
+
+
 def parse_apply_to(value: str | None) -> list[str]:
     """Split a primitive ``applyTo`` value into individual glob patterns.
 

--- a/src/apm_cli/utils/patterns.py
+++ b/src/apm_cli/utils/patterns.py
@@ -7,6 +7,10 @@ parse so converters and the placement optimizer behave consistently.
 
 from __future__ import annotations
 
+_APPLY_TO_ESCAPE = "\\"
+_APPLY_TO_SEPARATOR = ","
+_ESCAPABLE_APPLY_TO_CHARS = frozenset({_APPLY_TO_SEPARATOR, _APPLY_TO_ESCAPE})
+
 
 class _ApplyToPattern(str):
     """A parsed pattern that remembers an escaped top-level comma."""
@@ -39,7 +43,11 @@ def has_top_level_comma(pattern: str) -> bool:
     index = 0
     while index < len(pattern):
         ch = pattern[index]
-        if ch == "\\" and index + 1 < len(pattern) and pattern[index + 1] in {",", "\\"}:
+        if (
+            ch == _APPLY_TO_ESCAPE
+            and index + 1 < len(pattern)
+            and pattern[index + 1] in _ESCAPABLE_APPLY_TO_CHARS
+        ):
             index += 2
             continue
         if ch == "{":
@@ -47,7 +55,7 @@ def has_top_level_comma(pattern: str) -> bool:
         elif ch == "}":
             if depth > 0:
                 depth -= 1
-        elif ch == "," and depth == 0:
+        elif ch == _APPLY_TO_SEPARATOR and depth == 0:
             return True
         index += 1
     return False
@@ -105,8 +113,8 @@ def _escape_apply_to_segment(pattern: str) -> str:
     escaped: list[str] = []
     depth = 0
     for char in pattern:
-        if char == "\\":
-            escaped.append("\\\\")
+        if char == _APPLY_TO_ESCAPE:
+            escaped.append(_APPLY_TO_ESCAPE * 2)
         elif char == "{":
             depth += 1
             escaped.append(char)
@@ -114,8 +122,8 @@ def _escape_apply_to_segment(pattern: str) -> str:
             if depth > 0:
                 depth -= 1
             escaped.append(char)
-        elif char == "," and depth == 0:
-            escaped.append("\\,")
+        elif char == _APPLY_TO_SEPARATOR and depth == 0:
+            escaped.append(_APPLY_TO_ESCAPE + _APPLY_TO_SEPARATOR)
         else:
             escaped.append(char)
     return "".join(escaped)
@@ -148,9 +156,15 @@ def parse_apply_to(value: str | None) -> list[str]:
     index = 0
     while index < len(value):
         char = value[index]
-        if char == "\\" and index + 1 < len(value) and value[index + 1] in {",", "\\"}:
+        if (
+            char == _APPLY_TO_ESCAPE
+            and index + 1 < len(value)
+            and value[index + 1] in _ESCAPABLE_APPLY_TO_CHARS
+        ):
             current.append(value[index + 1])
-            escaped_top_level_comma = escaped_top_level_comma or value[index + 1] == ","
+            escaped_top_level_comma = (
+                escaped_top_level_comma or value[index + 1] == _APPLY_TO_SEPARATOR
+            )
             index += 2
             continue
         if char == "{":
@@ -160,7 +174,7 @@ def parse_apply_to(value: str | None) -> list[str]:
             if depth > 0:
                 depth -= 1
             current.append(char)
-        elif char == "," and depth == 0:
+        elif char == _APPLY_TO_SEPARATOR and depth == 0:
             append_current()
             current = []
             escaped_top_level_comma = False

--- a/src/apm_cli/utils/patterns.py
+++ b/src/apm_cli/utils/patterns.py
@@ -8,6 +8,19 @@ parse so converters and the placement optimizer behave consistently.
 from __future__ import annotations
 
 
+class _ApplyToPattern(str):
+    """A parsed pattern that remembers an escaped top-level comma."""
+
+    def __new__(cls, value: str, escaped_top_level_comma: bool):
+        instance = super().__new__(cls, value)
+        instance._escaped_top_level_comma = escaped_top_level_comma
+        return instance
+
+    def strip(self, chars: str | None = None) -> _ApplyToPattern:
+        """Preserve comma-boundary metadata while trimming a pattern."""
+        return type(self)(super().strip(chars), self._escaped_top_level_comma)
+
+
 def has_top_level_comma(pattern: str) -> bool:
     """Return True if ``pattern`` contains a comma outside any ``{...}`` group.
 
@@ -17,8 +30,16 @@ def has_top_level_comma(pattern: str) -> bool:
     placement optimizer and the integrators both consume this so the
     semantics of ``parse_apply_to`` and its callers stay in lock-step.
     """
+    if getattr(pattern, "_escaped_top_level_comma", False):
+        return False
+
     depth = 0
-    for ch in pattern:
+    index = 0
+    while index < len(pattern):
+        ch = pattern[index]
+        if ch == "\\" and index + 1 < len(pattern) and pattern[index + 1] in {",", "\\"}:
+            index += 2
+            continue
         if ch == "{":
             depth += 1
         elif ch == "}":
@@ -26,6 +47,7 @@ def has_top_level_comma(pattern: str) -> bool:
                 depth -= 1
         elif ch == "," and depth == 0:
             return True
+        index += 1
     return False
 
 
@@ -63,11 +85,38 @@ def normalize_apply_to(value: object, default: str = "") -> str:
     :func:`parse_apply_to`, preserving every non-null list entry.
     """
     if isinstance(value, list):
-        patterns = [str(pattern) for pattern in value if pattern is not None]
+        patterns = []
+        for pattern in value:
+            if pattern is None:
+                continue
+            normalized = str(pattern).strip()
+            if normalized:
+                patterns.append(_escape_apply_to_segment(normalized))
         return ",".join(patterns) if patterns else default
     if value is None:
         return default
     return str(value)
+
+
+def _escape_apply_to_segment(pattern: str) -> str:
+    """Encode one YAML-list pattern so top-level commas retain their boundary."""
+    escaped: list[str] = []
+    depth = 0
+    for char in pattern:
+        if char == "\\":
+            escaped.append("\\\\")
+        elif char == "{":
+            depth += 1
+            escaped.append(char)
+        elif char == "}":
+            if depth > 0:
+                depth -= 1
+            escaped.append(char)
+        elif char == "," and depth == 0:
+            escaped.append("\\,")
+        else:
+            escaped.append(char)
+    return "".join(escaped)
 
 
 def parse_apply_to(value: str | None) -> list[str]:
@@ -86,10 +135,22 @@ def parse_apply_to(value: str | None) -> list[str]:
     """
     if not value:
         return []
-    segments: list[str] = []
+    segments: list[_ApplyToPattern] = []
     depth = 0
     current: list[str] = []
-    for char in value:
+    escaped_top_level_comma = False
+
+    def append_current() -> None:
+        segments.append(_ApplyToPattern("".join(current), escaped_top_level_comma))
+
+    index = 0
+    while index < len(value):
+        char = value[index]
+        if char == "\\" and index + 1 < len(value) and value[index + 1] in {",", "\\"}:
+            current.append(value[index + 1])
+            escaped_top_level_comma = escaped_top_level_comma or value[index + 1] == ","
+            index += 2
+            continue
         if char == "{":
             depth += 1
             current.append(char)
@@ -98,9 +159,11 @@ def parse_apply_to(value: str | None) -> list[str]:
                 depth -= 1
             current.append(char)
         elif char == "," and depth == 0:
-            segments.append("".join(current))
+            append_current()
             current = []
+            escaped_top_level_comma = False
         else:
             current.append(char)
-    segments.append("".join(current))
+        index += 1
+    append_current()
     return [segment for segment in (s.strip() for s in segments) if segment]

--- a/tests/integration/test_apply_to_hidden_targeting_lifecycle.py
+++ b/tests/integration/test_apply_to_hidden_targeting_lifecycle.py
@@ -1,0 +1,90 @@
+"""Lifecycle coverage for YAML-list applyTo placement in hidden tool trees."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from tests.utils.apm_lifecycle_runner import ApmLifecycleRunner
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.lifecycle_smoke,
+    pytest.mark.requires_e2e_mode,
+    pytest.mark.requires_apm_binary,
+]
+
+_SCENARIO_ID = "apply-to-hidden-directory-placement"
+_PATTERNS = (
+    ".opencode/**/*.md",
+    ".github/**/*.md",
+    "**/.apm/**/*.md",
+)
+
+
+def _write_project(project: Path) -> None:
+    """Create one project whose rule targets supported hidden tool trees."""
+    (project / "apm.yml").write_text(
+        "name: hidden-targeting\nversion: 0.1.0\n",
+        encoding="utf-8",
+    )
+    instructions = project / ".apm" / "instructions"
+    instructions.mkdir(parents=True)
+    (instructions / "hidden-tool-rule.instructions.md").write_text(
+        "---\n"
+        "description: Hidden tool tree conventions\n"
+        "applyTo:\n"
+        + "".join(f"  - '{pattern}'\n" for pattern in _PATTERNS)
+        + "---\n\n# Hidden tool conventions\n\nKeep tool metadata consistent.\n",
+        encoding="utf-8",
+    )
+    for relative_path in (
+        ".opencode/project.md",
+        ".github/contributing.md",
+        ".apm/context/project.md",
+    ):
+        path = project / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("target\n", encoding="utf-8")
+
+
+def test_apply_to_hidden_directory_placement_is_idempotent(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    """Two OpenCode compiles preserve list patterns and avoid fallback placement."""
+    project = tmp_path / "hidden-targeting"
+    project.mkdir()
+    _write_project(project)
+    runner = ApmLifecycleRunner((str(apm_binary_path),))
+
+    first = runner.run(
+        ("compile", "--target", "opencode"),
+        scenario_id=_SCENARIO_ID,
+        cwd=project,
+        env=dict(os.environ),
+    )
+    assert first.returncode == 0, first.stderr or first.stdout
+    generated = project / "AGENTS.md"
+    assert generated.is_file(), (
+        "matching hidden files must produce a distributed placement\n"
+        f"stdout:\n{first.stdout}\nstderr:\n{first.stderr}"
+    )
+    first_bytes = generated.read_bytes()
+    assert first_bytes
+    second = runner.run(
+        ("compile", "--target", "opencode"),
+        scenario_id=_SCENARIO_ID,
+        cwd=project,
+        env=dict(os.environ),
+    )
+    assert second.returncode == 0, second.stderr or second.stdout
+    assert generated.read_bytes() == first_bytes
+    source = (project / ".apm" / "instructions" / "hidden-tool-rule.instructions.md").read_text(
+        encoding="utf-8"
+    )
+    assert all(f"  - '{pattern}'" in source for pattern in _PATTERNS)
+    combined_output = "\n".join(f"{result.stdout}\n{result.stderr}" for result in (first, second))
+    assert "matched no files" not in combined_output

--- a/tests/integration/test_apply_to_hidden_targeting_lifecycle.py
+++ b/tests/integration/test_apply_to_hidden_targeting_lifecycle.py
@@ -18,7 +18,7 @@ pytestmark = [
 
 _SCENARIO_ID = "apply-to-hidden-directory-placement"
 _PATTERNS = (
-    ".opencode/**/*.md",
+    ".opencode/**/project,guide.md",
     ".github/**/*.md",
     "**/.apm/**/*.md",
 )
@@ -41,7 +41,7 @@ def _write_project(project: Path) -> None:
         encoding="utf-8",
     )
     for relative_path in (
-        ".opencode/project.md",
+        ".opencode/project,guide.md",
         ".github/contributing.md",
         ".apm/context/project.md",
     ):

--- a/tests/integration/test_architecture_apply_to_patterns.py
+++ b/tests/integration/test_architecture_apply_to_patterns.py
@@ -1,0 +1,71 @@
+"""Architecture guardrails for applyTo normalization and placement."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def test_apply_to_normalization_and_hidden_placement_have_canonical_owners() -> None:
+    """Parser and placement must route through their declared shared owners."""
+    root = Path(__file__).parents[2]
+    patterns = (root / "src/apm_cli/utils/patterns.py").read_text(encoding="utf-8")
+    parser = (root / "src/apm_cli/primitives/parser.py").read_text(encoding="utf-8")
+    optimizer = (root / "src/apm_cli/compilation/context_optimizer.py").read_text(encoding="utf-8")
+    owner_table = (root / ".github/instructions/architecture.instructions.md").read_text(
+        encoding="utf-8"
+    )
+    guard = (root / "scripts/lint-architecture-boundaries.sh").read_text(encoding="utf-8")
+
+    assert patterns.count("def normalize_apply_to(") == 1
+    assert "from apm_cli.utils.patterns import normalize_apply_to" in parser
+    assert "def _normalize_apply_to(" not in parser
+    assert "PLACEMENT_HIDDEN_TOOL_TREES = frozenset(" in optimizer
+    assert "not self._is_supported_hidden_tool_root(path)" in optimizer
+    assert "| applyTo normalization and hidden-tool placement |" in owner_table
+    assert (
+        "applyTo normalization must use utils/patterns.py and hidden placement ContextOptimizer"
+        in guard
+    )
+
+
+def test_apply_to_owner_guard_rejects_a_parser_normalizer(tmp_path: Path) -> None:
+    """AC31 rejects restoring parser-local applyTo normalization."""
+    root = Path(__file__).parents[2]
+    sandbox = tmp_path / "repo"
+    shutil.copytree(
+        root,
+        sandbox,
+        ignore=shutil.ignore_patterns(
+            ".git",
+            ".venv",
+            ".pytest_cache",
+            "__pycache__",
+            "build",
+            "dist",
+            "node_modules",
+        ),
+    )
+    parser = sandbox / "src/apm_cli/primitives/parser.py"
+    parser.write_text(
+        parser.read_text(encoding="utf-8")
+        + '\n\ndef normalize_apply_to(value: object, default: str = "") -> str:\n'
+        + "    return default\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ("bash", "scripts/lint-architecture-boundaries.sh"),
+        cwd=sandbox,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=300,
+    )
+
+    assert result.returncode == 1
+    assert (
+        "applyTo normalization must use utils/patterns.py and hidden placement ContextOptimizer"
+        in (result.stdout)
+    )

--- a/tests/integration/test_architecture_apply_to_patterns.py
+++ b/tests/integration/test_architecture_apply_to_patterns.py
@@ -6,6 +6,10 @@ import shutil
 import subprocess
 from pathlib import Path
 
+import pytest
+
+pytestmark = pytest.mark.component
+
 
 def test_apply_to_normalization_and_hidden_placement_have_canonical_owners() -> None:
     """Parser and placement must route through their declared shared owners."""

--- a/tests/integration/test_architecture_apply_to_patterns.py
+++ b/tests/integration/test_architecture_apply_to_patterns.py
@@ -22,6 +22,8 @@ def test_apply_to_normalization_and_hidden_placement_have_canonical_owners() -> 
     assert "from apm_cli.utils.patterns import normalize_apply_to" in parser
     assert "def _normalize_apply_to(" not in parser
     assert "PLACEMENT_HIDDEN_TOOL_TREES = frozenset(" in optimizer
+    assert "def _targeted_hidden_tool_roots(" in optimizer
+    assert "self._placement_hidden_tool_trees" in optimizer
     assert "not self._is_supported_hidden_tool_root(path)" in optimizer
     assert "| applyTo normalization and hidden-tool placement |" in owner_table
     assert (

--- a/tests/unit/compilation/test_context_optimizer.py
+++ b/tests/unit/compilation/test_context_optimizer.py
@@ -1016,6 +1016,44 @@ class TestApplyToCommaInOptimizer:
         assert placement
         assert not any("matched no files" in warning for warning in opt._warnings)
 
+    def test_generic_patterns_do_not_scan_hidden_tool_trees(self, comma_project):
+        """Hidden tool trees require an applyTo segment that names their root."""
+        (comma_project / ".github").mkdir()
+        (comma_project / ".github" / "guide.md").touch()
+        generic = Instruction(
+            name="generic-rule",
+            file_path=Path("generic-rule.instructions.md"),
+            description="generic rule",
+            apply_to="**/*.md",
+            content="rules",
+            source="local",
+        )
+
+        opt = ContextOptimizer(str(comma_project))
+        opt.optimize_instruction_placement([generic])
+
+        assert (comma_project / ".github").resolve() not in opt._directory_cache
+
+    def test_literal_comma_list_pattern_matches_hidden_tool_tree(self, comma_project):
+        """YAML-list literal commas remain one pattern during hidden placement."""
+        target = comma_project / ".opencode"
+        target.mkdir()
+        (target / "guide,example.md").touch()
+        instruction = Instruction(
+            name="literal-comma-rule",
+            file_path=Path("literal-comma-rule.instructions.md"),
+            description="literal comma rule",
+            apply_to=r".opencode/**/guide\,example.md,**/*.nope",
+            content="rules",
+            source="local",
+        )
+
+        opt = ContextOptimizer(str(comma_project))
+        placement = opt.optimize_instruction_placement([instruction])
+
+        assert placement
+        assert not any("matched no files" in warning for warning in opt._warnings)
+
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/unit/compilation/test_context_optimizer.py
+++ b/tests/unit/compilation/test_context_optimizer.py
@@ -1034,6 +1034,43 @@ class TestApplyToCommaInOptimizer:
 
         assert (comma_project / ".github").resolve() not in opt._directory_cache
 
+    def test_unsupported_hidden_root_does_not_receive_fallback_placement(self, comma_project):
+        """A no-match pattern cannot write generated rules into .git."""
+        (comma_project / ".git").mkdir()
+        instruction = Instruction(
+            name="git-rule",
+            file_path=Path("git-rule.instructions.md"),
+            description="git rule",
+            apply_to=".git/**/*.md",
+            content="rules",
+            source="local",
+        )
+
+        placement = ContextOptimizer(str(comma_project)).optimize_instruction_placement(
+            [instruction]
+        )
+
+        assert (comma_project / ".git") not in placement
+
+    def test_backslash_hidden_root_pattern_is_recognized(self, comma_project):
+        """Windows-authored applyTo paths still admit their targeted root."""
+        target = comma_project / ".opencode"
+        target.mkdir()
+        (target / "guide.md").touch()
+        instruction = Instruction(
+            name="windows-hidden-rule",
+            file_path=Path("windows-hidden-rule.instructions.md"),
+            description="windows hidden rule",
+            apply_to=r".opencode\**\*.md",
+            content="rules",
+            source="local",
+        )
+
+        optimizer = ContextOptimizer(str(comma_project))
+        optimizer.optimize_instruction_placement([instruction])
+
+        assert target.resolve() in optimizer._directory_cache
+
     def test_literal_comma_list_pattern_matches_hidden_tool_tree(self, comma_project):
         """YAML-list literal commas remain one pattern during hidden placement."""
         target = comma_project / ".opencode"

--- a/tests/unit/compilation/test_context_optimizer.py
+++ b/tests/unit/compilation/test_context_optimizer.py
@@ -984,6 +984,38 @@ class TestApplyToCommaInOptimizer:
         assert placement
         assert not any("matched no files" in w for w in opt._warnings)
 
+    def test_yaml_list_expression_matches_supported_hidden_tool_trees(self, comma_project):
+        """Hidden tool trees remain available to explicitly scoped applyTo patterns."""
+        (comma_project / ".opencode").mkdir()
+        (comma_project / ".github").mkdir()
+        (comma_project / ".apm" / "context").mkdir(parents=True)
+        (comma_project / ".git").mkdir()
+        (comma_project / ".opencode" / "guide.md").touch()
+        (comma_project / ".github" / "guide.md").touch()
+        (comma_project / ".apm" / "context" / "guide.md").touch()
+        (comma_project / ".git" / "ignored.md").touch()
+        expression = ".opencode/**/*.md,.github/**/*.md,**/.apm/**/*.md"
+        opt = ContextOptimizer(str(comma_project))
+        instruction = Instruction(
+            name="hidden-tool-rule",
+            file_path=Path("hidden-tool-rule.instructions.md"),
+            description="hidden tool rule",
+            apply_to=expression,
+            content="rules",
+            source="local",
+        )
+
+        placement = opt.optimize_instruction_placement([instruction])
+
+        assert opt._find_matching_directories(expression) == {
+            (comma_project / ".opencode").resolve(),
+            (comma_project / ".github").resolve(),
+            (comma_project / ".apm" / "context").resolve(),
+        }
+        assert all(".git" not in path.parts for path in opt._directory_cache)
+        assert placement
+        assert not any("matched no files" in warning for warning in opt._warnings)
+
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/unit/compilation/test_context_optimizer.py
+++ b/tests/unit/compilation/test_context_optimizer.py
@@ -1034,6 +1034,29 @@ class TestApplyToCommaInOptimizer:
 
         assert (comma_project / ".github").resolve() not in opt._directory_cache
 
+    def test_nested_hidden_directories_stay_pruned_inside_supported_tool_tree(self, comma_project):
+        """A permitted tool root does not admit nested hidden directories."""
+        allowed = comma_project / ".apm" / "context"
+        hidden = comma_project / ".apm" / ".cache"
+        allowed.mkdir(parents=True)
+        hidden.mkdir()
+        (allowed / "guide.md").touch()
+        (hidden / "secret.md").touch()
+        opt = ContextOptimizer(str(comma_project))
+        instruction = Instruction(
+            name="apm-rule",
+            file_path=Path("apm-rule.instructions.md"),
+            description="apm rule",
+            apply_to="**/.apm/**/*.md",
+            content="rules",
+            source="local",
+        )
+
+        opt.optimize_instruction_placement([instruction])
+
+        assert allowed.resolve() in opt._directory_cache
+        assert hidden.resolve() not in opt._directory_cache
+
     def test_unsupported_hidden_root_does_not_receive_fallback_placement(self, comma_project):
         """A no-match pattern cannot write generated rules into .git."""
         (comma_project / ".git").mkdir()

--- a/tests/unit/integration/test_instruction_integrator.py
+++ b/tests/unit/integration/test_instruction_integrator.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from pathlib import Path
 from unittest.mock import Mock
 
-import pytest  # noqa: F401
+import pytest
 
 from apm_cli.integration.base_integrator import IntegrationResult
 from apm_cli.integration.instruction_integrator import InstructionIntegrator
@@ -1310,6 +1310,23 @@ class TestApplyToCommaSplitting:
     """Verify all three converters split comma-separated applyTo globs."""
 
     # ---- Claude ----
+
+    @pytest.mark.parametrize(
+        ("converter", "target_key"),
+        [
+            ("_convert_to_claude_rules", "paths:"),
+            ("_convert_to_cursor_rules", "globs:"),
+            ("_convert_to_windsurf_rules", "globs:"),
+        ],
+    )
+    def test_yaml_list_emits_all_globs(self, converter, target_key):
+        """YAML-list applyTo inputs keep every path-scoping rule."""
+        content = "---\napplyTo:\n  - '**/*.py'\n  - '**/*.pyi'\n---\n\n# Rules"
+        result = getattr(InstructionIntegrator, converter)(content)
+
+        assert target_key in result
+        assert '  - "**/*.py"' in result
+        assert '  - "**/*.pyi"' in result
 
     def test_claude_comma_list_emits_yaml_list(self):
         content = "---\napplyTo: '**/src/**,**/api/**,**/services/**'\n---\n\n# Rules"

--- a/tests/unit/primitives/test_primitives.py
+++ b/tests/unit/primitives/test_primitives.py
@@ -727,20 +727,15 @@ class TestListValuedFrontmatterNormalization(unittest.TestCase):
         self.assertIsInstance(primitive.apply_to, str)
         self.assertIn("**/*.py", primitive.apply_to)
 
-    def test_apply_to_multi_element_list_uses_first_element(self):
-        """applyTo with multiple patterns uses only the first element.
-
-        Downstream glob consumers treat apply_to as a single pattern string;
-        comma-joining multiple patterns produces a string no consumer can split.
-        Multi-pattern support is tracked separately.
-        """
+    def test_apply_to_multi_element_list_preserves_all_patterns(self):
+        """A YAML applyTo list becomes the canonical comma-separated OR expression."""
         path = self._write(
             "multi.instructions.md",
             "---\ndescription: Test\napplyTo:\n  - '**/*.py'\n  - '**/*.ts'\n---\n\n# c\n",
         )
         primitive = parse_primitive_file(path)
         self.assertIsInstance(primitive, Instruction)
-        self.assertEqual(primitive.apply_to, "**/*.py")
+        self.assertEqual(primitive.apply_to, "**/*.py,**/*.ts")
 
     def test_apply_to_string_unchanged(self):
         """Scalar applyTo strings pass through unchanged."""

--- a/tests/unit/utils/test_patterns.py
+++ b/tests/unit/utils/test_patterns.py
@@ -1,6 +1,11 @@
 """Tests for the applyTo pattern parser."""
 
-from apm_cli.utils.patterns import has_top_level_comma, parse_apply_to, yaml_double_quote
+from apm_cli.utils.patterns import (
+    has_top_level_comma,
+    normalize_apply_to,
+    parse_apply_to,
+    yaml_double_quote,
+)
 
 
 class TestParseApplyTo:
@@ -56,6 +61,12 @@ class TestParseApplyTo:
             "**/*.py",
         ]
 
+    def test_escaped_comma_is_not_split(self):
+        assert parse_apply_to(r"src/foo\,bar/*.py,**/*.pyi") == [
+            "src/foo,bar/*.py",
+            "**/*.pyi",
+        ]
+
 
 class TestHasTopLevelComma:
     """Unit tests for has_top_level_comma()."""
@@ -78,6 +89,23 @@ class TestHasTopLevelComma:
 
     def test_empty(self):
         assert has_top_level_comma("") is False
+
+    def test_escaped_comma_is_not_top_level(self):
+        assert has_top_level_comma(r"src/foo\,bar/*.py") is False
+
+
+class TestNormalizeApplyTo:
+    """Unit tests for YAML-list applyTo normalization."""
+
+    def test_list_trims_entries_and_discards_empty_values(self):
+        normalized = normalize_apply_to(["  **/*.py  ", None, "", "  ", "**/*.md"])
+
+        assert normalized == "**/*.py,**/*.md"
+
+    def test_list_literal_comma_preserves_pattern_boundary(self):
+        normalized = normalize_apply_to(["src/foo,bar/*.py", "**/*.pyi"])
+
+        assert parse_apply_to(normalized) == ["src/foo,bar/*.py", "**/*.pyi"]
 
 
 class TestYamlDoubleQuote:


### PR DESCRIPTION
# fix(compilation): preserve applyTo lists for hidden tool placement

## TL;DR

Fixes #2353 by preserving every YAML-list `applyTo` entry as the documented comma-separated OR expression and by allowing explicitly targeted files in supported hidden tool roots to participate in placement analysis. `apm compile --target opencode` now finds `.opencode`, `.github`, and `.apm` targets without falling back when those are the only matches. A two-run lifecycle smoke test proves the generated bytes remain unchanged.

> [!NOTE]
> This PR closes #2353 and confines hidden-directory traversal to named top-level agent-tool roots; `.git`, caches, excluded directories, and nested hidden directories remain pruned.

## Problem (WHY)

- [x] [#2353](https://github.com/microsoft/apm/issues/2353) reports that a comma-separated `applyTo` expression reached placement as zero matches and triggered fallback placement.
- [x] The primitive parser retained only the first non-null YAML-list entry, losing the remaining user-declared match scopes before compilation.
- [x] Placement traversal excluded all hidden directories, so valid targets in supported agent-tool roots could not affect placement.
- [!] Parser, matcher, and placement code need one declared ownership boundary rather than independent normalization rules.

Why these matter: the issue's expected behavior is OR matching for each declared glob. The repair is grounded in ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) and protects the concrete shared structure described by ["agents pattern-match well against concrete structures"](https://agentskills.io/skill-creation/best-practices).

## Approach (WHAT)

| # | Fix (and why, if non-obvious) |
|---|---|
| 1 | Normalize scalar and YAML-list `applyTo` values once in `utils/patterns.py`; list entries become the existing top-level-comma OR representation. |
| 2 | Let `ContextOptimizer` traverse only supported top-level hidden agent-tool roots, while retaining every existing exclusion for other hidden and generated paths. |
| 3 | Lock the ownership boundary with AC31 plus regression, lifecycle, and mutation-style tests. |
| 4 | Document the now-portable YAML sequence behavior for primitive authors. |

## Implementation (HOW)

- **`src/apm_cli/utils/patterns.py`** -- adds the canonical `normalize_apply_to()` owner, which preserves every non-null sequence element without changing scalar behavior.
- **`src/apm_cli/primitives/parser.py`** -- removes parser-local normalization and consumes the shared owner for instruction and chatmode parsing.
- **`src/apm_cli/compilation/context_optimizer.py`** -- introduces a finite supported-root allowlist for placement traversal and rejects nested or unrelated hidden directories.
- **`tests/unit/primitives/test_primitives.py`** -- changes the list-valued regression trap to require both patterns in the effective expression.
- **`tests/unit/compilation/test_context_optimizer.py`** -- proves an OR expression matches supported hidden roots while `.git` remains excluded.
- **`tests/integration/test_apply_to_hidden_targeting_lifecycle.py`** -- runs `apm compile --target opencode` twice and asserts output-byte idempotence, preserved source patterns, and no fallback warning.
- **`tests/integration/test_architecture_apply_to_patterns.py`** -- asserts the two canonical owners and mutation-proves that AC31 rejects a restored parser-local normalizer.
- **`.github/instructions/architecture.instructions.md`** -- records the normalization and placement ownership pair in the canonical-owner table.
- **`scripts/lint-architecture-boundaries.sh`** -- adds AC31 so duplicate normalizers or a missing placement allowlist fail the architecture gate.
- **`docs/src/content/docs/producer/author-primitives/instructions-and-agents.md`** -- explains that every non-null YAML sequence entry participates in the common OR expression.
- **`packages/apm-guide/.apm/skills/apm-usage/package-authoring.md`** -- aligns package-authoring guidance with the runtime behavior.

## Diagrams

Legend: the dashed nodes are the new canonical normalization and supported-root traversal decisions; follow the OR expression from parsed frontmatter into placement matching.

```mermaid
flowchart LR
    subgraph Parse[Primitive parsing]
        F[applyTo scalar or YAML list]
        N[normalize_apply_to]
    end
    subgraph Placement[Context placement]
        P[parse_apply_to OR patterns]
        H[Supported hidden roots]
        M[Matched directories]
    end
    subgraph Output[OpenCode compile]
        G[Generated AGENTS.md]
    end
    F --> N
    N --> P
    P --> H
    H --> M
    M --> G
    classDef new stroke-dasharray: 5 5;
    class N,H new;
```

## Trade-offs

- **Finite hidden-root allowlist.** Chose named top-level agent-tool roots; rejected opening every dot-directory because `.git`, caches, and unrelated hidden state must remain outside placement analysis.
- **Comma-separated internal representation.** Chose the already-supported top-level-comma form; rejected a broad `list[str]` migration because existing converters and matchers already consume this representation.
- **Static boundary gate.** Chose AC31 and a mutation-style test; rejected relying on convention alone because duplicate normalizers would silently reintroduce divergent semantics.
- **No CHANGELOG entry.** This focused bug fix follows the existing unreleased release workflow rather than adding an unrelated release-note decision in this PR.

## Benefits

1. All non-null YAML-list `applyTo` entries are observable in the effective matcher instead of only the first entry.
2. Three supported hidden-root pattern forms are covered: `.opencode`, `.github`, and recursive `.apm` paths.
3. Two consecutive OpenCode compiles produce byte-identical generated output in the lifecycle smoke scenario.
4. The architecture lint rejects both duplicate normalization ownership and missing hidden-placement ownership signals.

## Validation

`APM_E2E_TESTS=1 uv run --extra dev pytest tests/unit/primitives/test_primitives.py tests/unit/compilation/test_context_optimizer.py tests/integration/test_apply_to_hidden_targeting_lifecycle.py tests/integration/test_architecture_apply_to_patterns.py -q`:

```
93 passed in 75.06s (0:01:15)
```

<details><summary>Canonical lint and architecture gates</summary>

`uv run --extra dev ruff check src/ tests/ && uv run --extra dev ruff format --check src/ tests/ && uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/ && bash scripts/lint-auth-signals.sh && bash scripts/lint-architecture-boundaries.sh`:

```
All checks passed!
1595 files already formatted
Your code has been rated at 10.00/10
[+] auth-signal lint clean
[*] AC31: applyTo normalization and hidden-tool placement authority
[+] architecture boundary lint clean
```

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|---|---|---|---|
| 1 | An author can use a YAML `applyTo` list and every declared glob is honored during compile placement. | Portability by manifest, OSS / community-driven | `tests/unit/primitives/test_primitives.py::TestListValuedFrontmatterNormalization::test_apply_to_multi_element_list_preserves_all_patterns` (regression-trap for #2353) | unit |
| 2 | An author targeting supported hidden tool trees gets a placement from matching files rather than a fallback. | Multi-harness support, DevX (pragmatic as npm) | `tests/unit/compilation/test_context_optimizer.py::TestApplyToCommaInOptimizer::test_yaml_list_expression_matches_supported_hidden_tool_trees` | unit |
| 3 | Running `apm compile --target opencode` twice for hidden-tree rules succeeds, preserves source patterns, emits no fallback warning, and leaves generated bytes unchanged. | Multi-harness support, DevX (pragmatic as npm) | `tests/integration/test_apply_to_hidden_targeting_lifecycle.py::test_apply_to_hidden_directory_placement_is_idempotent` | e2e |

## How to test

- [ ] Create `.apm/instructions/rule.instructions.md` with YAML-list `applyTo` entries for `.opencode/**/*.md`, `.github/**/*.md`, and `**/.apm/**/*.md`; add matching files under those roots.
- [ ] Run `apm compile --target opencode`; expect success and no `matched no files` fallback warning.
- [ ] Read the generated `AGENTS.md`; expect the rule to be placed through the normal matching path.
- [ ] Run the same compile command again; expect the generated file bytes to be unchanged.
- [ ] Run `bash scripts/lint-architecture-boundaries.sh`; expect AC31 to report clean ownership.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
