### PR TITLE
fix(marketplace): validate malformed plugin structure

### DIFF
--- a/.apm/instructions/architecture.instructions.md
+++ b/.apm/instructions/architecture.instructions.md
@@ -67,6 +67,7 @@ semicolon-delimited, and specific to the file(s) that own the fact.
 | Dependency CLI identifier parsing + uninstall selection | models/dependency/selection.py (via DependencyReference) | `src/apm_cli/models/dependency/selection.py` |
 | JetBrains Copilot MCP config path | adapters/client/intellij.py | `src/apm_cli/adapters/client/intellij.py` |
 | Marketplace tag-pattern validation and expansion | marketplace/tag_pattern.py | `src/apm_cli/marketplace/tag_pattern.py` |
+| Marketplace raw-structure diagnostics | marketplace/models.py parser; validator.py consumes them | `src/apm_cli/marketplace/models.py`; `src/apm_cli/marketplace/validator.py` |
 <!-- /canonical-owner-table -->
 
 Host + credential resolution includes public github.com anonymous-first ordering.

--- a/.github/instructions/architecture.instructions.md
+++ b/.github/instructions/architecture.instructions.md
@@ -67,6 +67,7 @@ semicolon-delimited, and specific to the file(s) that own the fact.
 | Dependency CLI identifier parsing + uninstall selection | models/dependency/selection.py (via DependencyReference) | `src/apm_cli/models/dependency/selection.py` |
 | JetBrains Copilot MCP config path | adapters/client/intellij.py | `src/apm_cli/adapters/client/intellij.py` |
 | Marketplace tag-pattern validation and expansion | marketplace/tag_pattern.py | `src/apm_cli/marketplace/tag_pattern.py` |
+| Marketplace raw-structure diagnostics | marketplace/models.py parser; validator.py consumes them | `src/apm_cli/marketplace/models.py`; `src/apm_cli/marketplace/validator.py` |
 <!-- /canonical-owner-table -->
 
 Host + credential resolution includes public github.com anonymous-first ordering.

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -2783,7 +2783,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:18bbdeaf073d7e15a6bdc836d1079ad5c199b4f05aa1db8ac6f724ae8fc08260
+  content_hash: sha256:03a05395329144234c73fc44414fcbaada866f2ca9643f764e900b7621af793c
 - kind: project-relative
   target: copilot
   value: .github/instructions/changelog.instructions.md
@@ -3290,7 +3290,7 @@ local_deployed_file_hashes:
   .github/agents/spec-tag-architect.agent.md: sha256:82907265c5e7cf1ac61ad96866fa7c5683b69c8f09b7a4c5f3cc241acc9568ca
   .github/agents/supply-chain-security-expert.agent.md: sha256:8fb8cc426d6af17ba084a28b3f026c2b475b62e3ca63ed2f88b83bd823f877af
   .github/agents/test-coverage-expert.agent.md: sha256:48c2172d1f18a394fa83ef9dc2be0b9b921a4e51e976498165250fed66369711
-  .github/instructions/architecture.instructions.md: sha256:18bbdeaf073d7e15a6bdc836d1079ad5c199b4f05aa1db8ac6f724ae8fc08260
+  .github/instructions/architecture.instructions.md: sha256:03a05395329144234c73fc44414fcbaada866f2ca9643f764e900b7621af793c
   .github/instructions/changelog.instructions.md: sha256:1e51ec4c74e847967962bd279dc4c6e582c5d3578490b3c28d5f3acd3e05f73e
   .github/instructions/cicd.instructions.md: sha256:33201cb88ea2f34b4950a9b52f87dc8dfb682796aaf53068ba7ae406c0c5e2c2
   .github/instructions/cli.instructions.md: sha256:8e39e8d5047ce88575cb02f87c2bcede584dfef258bd86f7466c7badf136541a

--- a/docs/src/content/docs/reference/cli/marketplace.md
+++ b/docs/src/content/docs/reference/cli/marketplace.md
@@ -171,7 +171,9 @@ Unregister a marketplace.
 
 ### `apm marketplace validate NAME`
 
-Validate the manifest of a registered marketplace against the schema.
+Validate a registered marketplace's raw manifest structure and plugin schema.
+Malformed fields are reported with their JSON path; validation exits 1 without
+rewriting the source manifest.
 
 ### `apm marketplace init`
 

--- a/packages/apm-guide/.apm/skills/apm-usage/commands.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/commands.md
@@ -210,7 +210,7 @@ Credentials resolve via `APM_REGISTRY_TOKEN_{NAME}` env var (or `apm config set 
 | `apm marketplace browse NAME` | Browse marketplace plugins | -- |
 | `apm marketplace update [NAME]` | Update marketplace index | -- |
 | `apm marketplace remove NAME` | Remove a marketplace | `-y` skip confirm |
-| `apm marketplace validate NAME` | Validate marketplace manifest | `--check-refs`, `-v` |
+| `apm marketplace validate NAME` | Validate raw marketplace structure and plugin schema. Reports malformed fields by JSON path and exits 1 without rewriting the source manifest. | `--check-refs`, `-v` |
 | `apm search QUERY@MARKETPLACE` | Search marketplace | `--limit N` |
 | `apm install NAME@MKT[#ref]` | Install from marketplace | Optional `#ref` override |
 | `apm view NAME@MARKETPLACE` | View marketplace plugin info | -- |

--- a/scripts/lint-architecture-boundaries.sh
+++ b/scripts/lint-architecture-boundaries.sh
@@ -1353,6 +1353,27 @@ if ! grep -q '^def validate_tag_pattern(' "$tag_pattern_owner" \
     violations=$((violations + 1))
 fi
 
+echo "[*] AC33: marketplace structural-diagnostic authority"
+marketplace_structure_owner="src/apm_cli/marketplace/models.py"
+marketplace_structure_validator="src/apm_cli/marketplace/validator.py"
+marketplace_structure_parallel_hits=$(
+    grep -rEn --include='*.py' \
+        'structural_errors[[:space:]]*=' \
+        src/apm_cli/marketplace \
+        | grep -v "^${marketplace_structure_owner}:" \
+        || true
+)
+if ! grep -q 'structural_errors: tuple\[str, \.\.\.\] = ()' "$marketplace_structure_owner" \
+    || ! grep -q 'structural_errors.append("plugins: expected a list")' \
+        "$marketplace_structure_owner" \
+    || ! grep -q '^def validate_marketplace_structure(' "$marketplace_structure_validator" \
+    || ! grep -q 'errors=list(manifest.structural_errors)' "$marketplace_structure_validator" \
+    || [ -n "$marketplace_structure_parallel_hits" ]; then
+    echo "[x] Marketplace structural diagnostics must originate in marketplace/models.py"
+    [ -n "$marketplace_structure_parallel_hits" ] && echo "$marketplace_structure_parallel_hits"
+    violations=$((violations + 1))
+fi
+
 echo "[*] AC29: dependency identity and materialization path authority"
 identity_owner="src/apm_cli/models/dependency/identity.py"
 materialization_owner="src/apm_cli/models/dependency/materialization.py"

--- a/src/apm_cli/marketplace/models.py
+++ b/src/apm_cli/marketplace/models.py
@@ -345,6 +345,7 @@ class MarketplaceManifest:
 
     name: str
     plugins: tuple[MarketplacePlugin, ...] = ()
+    structural_errors: tuple[str, ...] = ()
     owner_name: str = ""
     description: str = ""
     plugin_root: str = ""  # metadata.pluginRoot - base path for bare-name sources
@@ -375,12 +376,15 @@ class MarketplaceManifest:
 #   { "name": "...", "plugins": [ { "name": "...", "source": { "type": "github", ... } } ] }
 
 
-def _parse_plugin_entry(entry: dict[str, Any], source_name: str) -> MarketplacePlugin | None:
-    """Parse a single plugin entry from either format."""
-    name = entry.get("name", "").strip()
+def _parse_plugin_entry(
+    entry: dict[str, Any], source_name: str
+) -> tuple[MarketplacePlugin | None, str | None]:
+    """Parse one plugin entry, retaining an error when it cannot be consumed."""
+    raw_name = entry.get("name", "")
+    name = raw_name.strip() if isinstance(raw_name, str) else ""
     if not name:
         logger.debug("Skipping marketplace plugin entry without a name")
-        return None
+        return None, "name: expected a non-empty string"
 
     description = entry.get("description", "")
     version = entry.get("version", "")
@@ -400,14 +404,14 @@ def _parse_plugin_entry(entry: dict[str, Any], source_name: str) -> MarketplaceP
             source_type = raw.get("type", "") or raw.get("source", "")
             if source_type == "npm":
                 logger.debug("Skipping npm source type for plugin '%s' (unsupported)", name)
-                return None
+                return None, "source: unsupported source type 'npm'"
             # Normalize: ensure "type" key is set for downstream resolvers
             if source_type and "type" not in raw:
                 raw = {**raw, "type": source_type}
             source = raw
         else:
             logger.debug("Skipping plugin '%s' with unrecognized source format", name)
-            return None
+            return None, "source: expected a string or object"
     elif "repository" in entry:
         # Copilot CLI format: "repository": "owner/repo"
         repo = entry["repository"]
@@ -422,10 +426,10 @@ def _parse_plugin_entry(entry: dict[str, Any], source_name: str) -> MarketplaceP
                 name,
                 repo,
             )
-            return None
+            return None, "repository: expected an owner/repository string"
     else:
         logger.debug("Plugin '%s' has no source or repository field", name)
-        return None
+        return None, "source: expected a source or repository field"
 
     # Optional dedicated-registry routing (design §4.5). When ``registry``
     # is set, ``version`` is interpreted as a semver range and the plugin
@@ -467,15 +471,18 @@ def _parse_plugin_entry(entry: dict[str, Any], source_name: str) -> MarketplaceP
                 context=f"Plugin {name!r} source.tag_pattern",
             )
 
-    return MarketplacePlugin(
-        name=name,
-        source=source,
-        description=description,
-        version=version,
-        tags=tags,
-        source_marketplace=source_name,
-        registry=registry_name,
-        tag_pattern=tag_pattern,
+    return (
+        MarketplacePlugin(
+            name=name,
+            source=source,
+            description=description,
+            version=version,
+            tags=tags,
+            source_marketplace=source_name,
+            registry=registry_name,
+            tag_pattern=tag_pattern,
+        ),
+        None,
     )
 
 
@@ -489,7 +496,8 @@ def parse_marketplace_json(
     """Parse a marketplace.json dict into a ``MarketplaceManifest``.
 
     Accepts both Copilot CLI and Claude Code marketplace formats.
-    Invalid or unsupported entries are silently skipped with debug logging.
+    Invalid or unsupported entries are skipped for runtime tolerance and retained
+    as structural diagnostics for manifest validation.
 
     Args:
         data: Parsed JSON content of marketplace.json.
@@ -517,24 +525,30 @@ def parse_marketplace_json(
             plugin_root = raw_root.strip()
 
     raw_plugins = data.get("plugins", [])
+    structural_errors: list[str] = []
     if not isinstance(raw_plugins, list):
         logger.warning(
             "marketplace.json 'plugins' field is not a list in '%s'",
             source_name,
         )
+        structural_errors.append("plugins: expected a list")
         raw_plugins = []
 
     plugins: list[MarketplacePlugin] = []
-    for entry in raw_plugins:
+    for index, entry in enumerate(raw_plugins):
         if not isinstance(entry, dict):
+            structural_errors.append(f"plugins[{index}]: expected an object")
             continue
-        plugin = _parse_plugin_entry(entry, source_name)
+        plugin, error = _parse_plugin_entry(entry, source_name)
         if plugin is not None:
             plugins.append(plugin)
+        elif error is not None:
+            structural_errors.append(f"plugins[{index}].{error}")
 
     return MarketplaceManifest(
         name=manifest_name,
         plugins=tuple(plugins),
+        structural_errors=tuple(structural_errors),
         owner_name=owner_name,
         description=description,
         plugin_root=plugin_root,

--- a/src/apm_cli/marketplace/validator.py
+++ b/src/apm_cli/marketplace/validator.py
@@ -32,11 +32,20 @@ def validate_marketplace(
 
     Returns a list of ``ValidationResult`` objects, one per check.
     """
-    plugins = manifest.plugins
     return [
-        validate_plugin_schema(plugins),
-        validate_no_duplicate_names(plugins),
+        validate_marketplace_structure(manifest),
+        validate_plugin_schema(manifest.plugins),
+        validate_no_duplicate_names(manifest.plugins),
     ]
+
+
+def validate_marketplace_structure(manifest: MarketplaceManifest) -> ValidationResult:
+    """Report raw manifest structure errors retained by the tolerant parser."""
+    return ValidationResult(
+        check_name="Structure",
+        passed=not manifest.structural_errors,
+        errors=list(manifest.structural_errors),
+    )
 
 
 def validate_plugin_schema(

--- a/tests/integration/test_architecture_authorities.py
+++ b/tests/integration/test_architecture_authorities.py
@@ -553,6 +553,61 @@ def test_packed_marketplace_source_owner_guard_rejects_parallel_parser(
     )
 
 
+def test_marketplace_structural_diagnostics_have_single_owner() -> None:
+    """Raw marketplace structure diagnostics must originate in the parser."""
+    root = Path(__file__).parents[2]
+    owner = (root / "src/apm_cli/marketplace/models.py").read_text(encoding="utf-8")
+    validator = (root / "src/apm_cli/marketplace/validator.py").read_text(encoding="utf-8")
+    guard = (root / "scripts/lint-architecture-boundaries.sh").read_text(encoding="utf-8")
+
+    assert "structural_errors: tuple[str, ...] = ()" in owner
+    assert 'structural_errors.append("plugins: expected a list")' in owner
+    assert "errors=list(manifest.structural_errors)" in validator
+    assert "Marketplace structural diagnostics must originate in marketplace/models.py" in guard
+
+
+def test_marketplace_structural_diagnostic_guard_rejects_dropped_plugins_error(
+    tmp_path: Path,
+) -> None:
+    """The boundary guard must reject dropping the parser-owned plugins error."""
+    root = Path(__file__).parents[2]
+    sandbox = tmp_path / "repo"
+    shutil.copytree(
+        root,
+        sandbox,
+        ignore=shutil.ignore_patterns(
+            ".git",
+            ".venv",
+            ".pytest_cache",
+            "__pycache__",
+            "build",
+            "dist",
+            "node_modules",
+        ),
+    )
+    owner_path = sandbox / "src/apm_cli/marketplace/models.py"
+    source = owner_path.read_text(encoding="utf-8")
+    owner_path.write_text(
+        source.replace('structural_errors.append("plugins: expected a list")\n', "", 1),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ("bash", "scripts/lint-architecture-boundaries.sh"),
+        cwd=sandbox,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=300,
+    )
+
+    assert result.returncode == 1
+    assert (
+        "Marketplace structural diagnostics must originate in marketplace/models.py"
+        in result.stdout
+    )
+
+
 def test_cleanup_current_claim_protection_has_single_owner() -> None:
     """Cleanup must route current deployed-file claims through the reconciler."""
     root = Path(__file__).parents[2]

--- a/tests/integration/test_marketplace_invalid_plugins_validation.py
+++ b/tests/integration/test_marketplace_invalid_plugins_validation.py
@@ -1,0 +1,55 @@
+"""Lifecycle coverage for validating a tolerantly registered malformed marketplace."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from tests.utils.apm_lifecycle_runner import ApmLifecycleRunner
+from tests.utils.isolated_apm_environment import IsolatedApmEnvironment
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.e2e,
+    pytest.mark.lifecycle_smoke,
+    pytest.mark.requires_apm_binary,
+    pytest.mark.requires_e2e_mode,
+]
+
+
+def test_marketplace_invalid_plugins_validation(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    """Registration tolerates malformed plugins while validation reports its path."""
+    isolated = IsolatedApmEnvironment.create(tmp_path / "isolated", base_env=dict(os.environ))
+    source = isolated.work_root / "malformed-marketplace"
+    source.mkdir()
+    manifest_path = source / "marketplace.json"
+    source_bytes = b'{\n  "name": "malformed",\n  "plugins": "not-an-array"\n}\n'
+    manifest_path.write_bytes(source_bytes)
+    runner = ApmLifecycleRunner((str(apm_binary_path),))
+
+    add_result = runner.run(
+        ("marketplace", "add", str(source), "--name", "malformed"),
+        scenario_id="marketplace-invalid-plugins-validation",
+        cwd=isolated.work_root,
+        env=isolated.subprocess_env(),
+    )
+    registry_path = isolated.config_root / "marketplaces.json"
+    registry_bytes = registry_path.read_bytes()
+    (validate_result,) = runner.run_sequence(
+        (("marketplace", "validate", "malformed"),),
+        expected_returncodes=(1,),
+        scenario_id="marketplace-invalid-plugins-validation",
+        cwd=isolated.work_root,
+        env=isolated.subprocess_env(),
+    )
+
+    assert add_result.returncode == 0
+    assert "plugins" in validate_result.stdout + validate_result.stderr
+    assert "expected a list" in validate_result.stdout + validate_result.stderr
+    assert manifest_path.read_bytes() == source_bytes
+    assert registry_path.read_bytes() == registry_bytes

--- a/tests/unit/marketplace/test_marketplace_validator.py
+++ b/tests/unit/marketplace/test_marketplace_validator.py
@@ -9,6 +9,7 @@ from apm_cli.marketplace.models import (
     MarketplaceManifest,
     MarketplacePlugin,
     MarketplaceSource,
+    parse_marketplace_json,
 )
 from apm_cli.marketplace.validator import (
     ValidationResult,
@@ -123,14 +124,45 @@ class TestValidateMarketplace:
             _plugin("b", "owner/b"),
         )
         results = validate_marketplace(manifest)
-        assert len(results) == 2
+        assert len(results) == 3
         assert all(r.passed for r in results)
 
     def test_empty_marketplace_passes_all(self):
         manifest = _manifest()
         results = validate_marketplace(manifest)
-        assert len(results) == 2
+        assert len(results) == 3
         assert all(r.passed for r in results)
+
+    def test_malformed_plugins_shape_is_retained_for_validation(self):
+        """A tolerant parse must preserve raw shape failures for validate."""
+        manifest = parse_marketplace_json(
+            {"name": "test-marketplace", "plugins": "not-an-array"},
+            source_name="test-marketplace",
+        )
+
+        assert manifest.plugins == ()
+        assert manifest.structural_errors == ("plugins: expected a list",)
+
+        results = validate_marketplace(manifest)
+
+        assert results[0] == ValidationResult(
+            check_name="Structure",
+            passed=False,
+            errors=["plugins: expected a list"],
+        )
+
+    def test_unsupported_plugin_source_is_retained_for_validation(self):
+        """Discarded sources remain visible to the validation command."""
+        manifest = parse_marketplace_json(
+            {
+                "name": "test-marketplace",
+                "plugins": [{"name": "npm-plugin", "source": {"type": "npm"}}],
+            },
+            source_name="test-marketplace",
+        )
+
+        assert manifest.plugins == ()
+        assert manifest.structural_errors == ("plugins[0].source: unsupported source type 'npm'",)
 
 
 # ===================================================================


### PR DESCRIPTION
fix(marketplace): report malformed plugin structure during validation

## TL;DR

`apm marketplace add` remains tolerant of malformed marketplace manifests, but `apm marketplace validate` now retains and reports the discarded structure errors. This closes #2424: a non-list `plugins` field now exits 1 with the `plugins` path and expected list type, without rewriting either the source manifest or marketplace registry. Parser-owned diagnostics, a boundary guard, unit coverage, and an end-to-end lifecycle test make the behavior explicit.

> [!NOTE]
> Closes #2424. Registration remains permissive; validation is the explicit failure boundary.

## Problem (WHY)

- [x] The tolerant parser replaced a non-list `plugins` value with an empty list, so the validation command no longer had the malformed shape to report.
- [x] A malformed marketplace could be added and subsequently validate successfully, despite the source manifest containing an invalid `plugins` field.
- [!] Parser and validator responsibilities needed a durable ownership boundary so structural diagnostics do not drift into a second parser.

Why these matter: ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) The lifecycle test makes the CLI's failure exit and byte-preservation promise directly observable.

## Approach (WHAT)

| # | Fix |
|---|---|
| 1 | Retain malformed top-level and plugin-entry diagnostics while continuing tolerant plugin parsing. |
| 2 | Surface retained diagnostics as a `Structure` validation result before schema and duplicate-name checks. |
| 3 | Guard parser ownership statically and exercise the add-then-validate lifecycle against a real CLI binary. |
| 4 | Document path-addressed failures and the non-rewrite contract in the CLI reference and APM usage guide. |

## Implementation (HOW)

| Area | Files | Change |
|---|---|---|
| Parser and validation | `src/apm_cli/marketplace/models.py`, `src/apm_cli/marketplace/validator.py` | `MarketplaceManifest` carries parser-owned `structural_errors`; validation consumes them as the new `Structure` result without changing registration tolerance. |
| Regression coverage | `tests/unit/marketplace/test_marketplace_validator.py` | Covers non-list `plugins` and unsupported `npm` source retention, and updates the valid-manifest result shape. |
| Lifecycle proof | `tests/integration/test_marketplace_invalid_plugins_validation.py` | Adds a malformed local marketplace, validates it with expected exit code 1, checks the path/type diagnostic, and proves source plus registry bytes are unchanged. |
| Architecture enforcement | `scripts/lint-architecture-boundaries.sh`, `tests/integration/test_architecture_authorities.py` | Adds AC33 and a mutation-proof test that the guard rejects removal of the parser's `plugins` diagnostic. |
| Ownership artifacts | `.apm/instructions/architecture.instructions.md`, `.github/instructions/architecture.instructions.md`, `apm.lock.yaml` | Records the canonical owner, synchronizes the deployed instruction, and refreshes both deployment-ledger hashes. |
| User guidance | `docs/src/content/docs/reference/cli/marketplace.md`, `packages/apm-guide/.apm/skills/apm-usage/commands.md` | Documents JSON-path structural failures and the source-manifest non-rewrite behavior. |

## Diagrams

Legend: the dashed nodes are the new diagnostic path that preserves malformed input through parsing and makes validation fail without mutating the registered source.

```mermaid
flowchart LR
    subgraph Parse[Parse]
        M[marketplace.json]
        P[parse_marketplace_json]
        E[structural_errors]
    end
    subgraph Validate[Validate]
        S[Structure result]
        C[CLI exit 1]
    end
    M --> P
    P --> E
    E --> S
    S --> C
    classDef new stroke-dasharray: 5 5;
    class E,S,C new;
```

## Trade-offs

- **Tolerant registration with strict validation.** Chose retained diagnostics over rejecting `marketplace add`; rejected hard parse failure because registration has existing permissive behavior and validation is the explicit inspection command.
- **String diagnostics over a new raw AST.** Chose path-addressed error strings because the validator only needs stable actionable messages; rejected a broader raw-manifest model to keep the fix bounded.
- **Static ownership guard plus behavior test.** Chose both AC33 and lifecycle coverage; rejected relying on a parser unit test alone because future changes could silently relocate or drop the diagnostic.

## Benefits

1. A marketplace with `"plugins": "not-an-array"` now yields exit code 1 and `plugins: expected a list` during validation.
2. The lifecycle test verifies two byte-preservation boundaries: the source `marketplace.json` and registry file remain unchanged after validation.
3. One parser-owned diagnostics field is enforced by AC33 and a mutation test, preventing duplicate structural parsers.
4. The deployed instruction and both lockfile hash records are synchronized, so `apm audit --ci` reports no drift.

## Validation

`uv run apm audit --ci`:

```
[*] All 10 check(s) passed
```

<details><summary>Targeted tests and CI-mirror lint</summary>

```
25 passed, 96 deselected in 144.08s
All checks passed!
1594 files already formatted
Your code has been rated at 10.00/10
[+] auth-signal lint clean
[+] architecture boundary lint clean
```

The lifecycle test was run with `APM_E2E_TESTS=1` and `APM_BINARY_PATH="$PWD/.venv/bin/apm"`.
</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|---|---|---|---|
| 1 | Add a malformed marketplace, then validate it and receive a nonzero result naming the bad `plugins` field and expected list type. | DevX (pragmatic as npm) | `tests/integration/test_marketplace_invalid_plugins_validation.py::test_marketplace_invalid_plugins_validation` (regression-trap for #2424) | e2e |
| 2 | Parse a malformed marketplace without blocking registration, while retaining its structure failure for the validation command. | DevX (pragmatic as npm) | `tests/unit/marketplace/test_marketplace_validator.py::TestValidateMarketplace::test_malformed_plugins_shape_is_retained_for_validation` | unit |
| 3 | Keep structural diagnostic ownership in the parser so a future edit cannot remove the `plugins` failure silently. | OSS / community-driven | `tests/integration/test_architecture_authorities.py::test_marketplace_structural_diagnostic_guard_rejects_dropped_plugins_error` | integration |

## How to test

- [ ] Create a local `marketplace.json` with `"plugins": "not-an-array"` and add it with `apm marketplace add <path> --name malformed`; expect success.
- [ ] Run `apm marketplace validate malformed`; expect exit code 1 and output containing `plugins: expected a list`.
- [ ] Compare the source manifest bytes before and after validation; expect no change.
- [ ] Run `bash scripts/lint-architecture-boundaries.sh`; expect AC33 and the full boundary lint to pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
