### PR TITLE
fix: report malformed plugin structure (supersedes #2445, closes #2424)

### DIFF
--- a/.apm/instructions/architecture.instructions.md
+++ b/.apm/instructions/architecture.instructions.md
@@ -67,6 +67,7 @@ semicolon-delimited, and specific to the file(s) that own the fact.
 | JetBrains Copilot MCP config path | adapters/client/intellij.py | `src/apm_cli/adapters/client/intellij.py` |
 | Marketplace tag-pattern validation and expansion | marketplace/tag_pattern.py | `src/apm_cli/marketplace/tag_pattern.py` |
 | Local marketplace package-version manifest precedence | marketplace/version_check.py (_read_local_version) | `src/apm_cli/marketplace/version_check.py` |
+| Marketplace raw-structure diagnostics | marketplace/models.py parser; validator.py consumes them | `src/apm_cli/marketplace/models.py`; `src/apm_cli/marketplace/validator.py` |
 <!-- /canonical-owner-table -->
 
 Host + credential resolution includes public github.com anonymous-first ordering.

--- a/.github/instructions/architecture.instructions.md
+++ b/.github/instructions/architecture.instructions.md
@@ -67,6 +67,7 @@ semicolon-delimited, and specific to the file(s) that own the fact.
 | JetBrains Copilot MCP config path | adapters/client/intellij.py | `src/apm_cli/adapters/client/intellij.py` |
 | Marketplace tag-pattern validation and expansion | marketplace/tag_pattern.py | `src/apm_cli/marketplace/tag_pattern.py` |
 | Local marketplace package-version manifest precedence | marketplace/version_check.py (_read_local_version) | `src/apm_cli/marketplace/version_check.py` |
+| Marketplace raw-structure diagnostics | marketplace/models.py parser; validator.py consumes them | `src/apm_cli/marketplace/models.py`; `src/apm_cli/marketplace/validator.py` |
 <!-- /canonical-owner-table -->
 
 Host + credential resolution includes public github.com anonymous-first ordering.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `apm marketplace validate` now reports malformed plugin structures without
+  rewriting the registered marketplace or its source manifest. (#2445)
 - Release publication now excludes opt-in live ADO PAT tests and credentials; those tests fail closed in the Auth Acceptance workflow instead. (#2426)
 - Release promotions now run marker-bounded lifecycle integration on macOS Intel
   while retaining the full corpus on macOS ARM and Linux, preventing Intel

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -2783,7 +2783,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:0fcc203d0daf2d1227a2cea61482009a50a9eff27292fab3b7a06dd7fda2b1e6
+  content_hash: sha256:08dd74f7edefd82ea42a68cc0f7f49533fda27572756e992593963899263b4b6
 - kind: project-relative
   target: copilot
   value: .github/instructions/changelog.instructions.md
@@ -3290,7 +3290,7 @@ local_deployed_file_hashes:
   .github/agents/spec-tag-architect.agent.md: sha256:82907265c5e7cf1ac61ad96866fa7c5683b69c8f09b7a4c5f3cc241acc9568ca
   .github/agents/supply-chain-security-expert.agent.md: sha256:8fb8cc426d6af17ba084a28b3f026c2b475b62e3ca63ed2f88b83bd823f877af
   .github/agents/test-coverage-expert.agent.md: sha256:48c2172d1f18a394fa83ef9dc2be0b9b921a4e51e976498165250fed66369711
-  .github/instructions/architecture.instructions.md: sha256:0fcc203d0daf2d1227a2cea61482009a50a9eff27292fab3b7a06dd7fda2b1e6
+  .github/instructions/architecture.instructions.md: sha256:08dd74f7edefd82ea42a68cc0f7f49533fda27572756e992593963899263b4b6
   .github/instructions/changelog.instructions.md: sha256:1e51ec4c74e847967962bd279dc4c6e582c5d3578490b3c28d5f3acd3e05f73e
   .github/instructions/cicd.instructions.md: sha256:33201cb88ea2f34b4950a9b52f87dc8dfb682796aaf53068ba7ae406c0c5e2c2
   .github/instructions/cli.instructions.md: sha256:8e39e8d5047ce88575cb02f87c2bcede584dfef258bd86f7466c7badf136541a

--- a/docs/src/content/docs/reference/cli/marketplace.md
+++ b/docs/src/content/docs/reference/cli/marketplace.md
@@ -171,7 +171,9 @@ Unregister a marketplace.
 
 ### `apm marketplace validate NAME`
 
-Validate the manifest of a registered marketplace against the schema.
+Validate a registered marketplace's raw manifest structure and plugin schema.
+Malformed fields are reported with their JSON path; validation exits 1 without
+rewriting the source manifest.
 
 ### `apm marketplace init`
 

--- a/docs/src/content/docs/reference/cli/marketplace.md
+++ b/docs/src/content/docs/reference/cli/marketplace.md
@@ -172,8 +172,8 @@ Unregister a marketplace.
 ### `apm marketplace validate NAME`
 
 Validate a registered marketplace's raw manifest structure and plugin schema.
-Malformed fields are reported with their JSON path; validation exits 1 without
-rewriting the source manifest.
+APM reports malformed fields by their JSON path and exits 1 without rewriting
+the source manifest.
 
 ### `apm marketplace init`
 

--- a/docs/src/content/docs/reference/cli/marketplace.md
+++ b/docs/src/content/docs/reference/cli/marketplace.md
@@ -172,8 +172,10 @@ Unregister a marketplace.
 ### `apm marketplace validate NAME`
 
 Validate a registered marketplace's raw manifest structure and plugin schema.
-APM reports malformed fields by their JSON path and exits 1 without rewriting
-the source manifest.
+`apm marketplace add` remains tolerant of malformed entries; validation reports
+them by JSON path (for example, `plugins[0].source: expected a string or
+object`) and exits 1 without rewriting the source manifest or its registered
+marketplace entry.
 
 ### `apm marketplace init`
 

--- a/docs/src/content/docs/reference/cli/marketplace.md
+++ b/docs/src/content/docs/reference/cli/marketplace.md
@@ -175,7 +175,8 @@ Validate a registered marketplace's raw manifest structure and plugin schema.
 `apm marketplace add` remains tolerant of malformed entries; validation reports
 them by JSON path (for example, `plugins[0].source: expected a string or
 object`) and exits 1 without rewriting the source manifest or its registered
-marketplace entry.
+marketplace entry. A structural failure is reported without downstream plugin
+count, schema, or duplicate-name success lines.
 
 ### `apm marketplace init`
 

--- a/packages/apm-guide/.apm/skills/apm-usage/commands.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/commands.md
@@ -210,7 +210,7 @@ Credentials resolve via `APM_REGISTRY_TOKEN_{NAME}` env var (or `apm config set 
 | `apm marketplace browse NAME` | Browse marketplace plugins | -- |
 | `apm marketplace update [NAME]` | Update marketplace index | -- |
 | `apm marketplace remove NAME` | Remove a marketplace | `-y` skip confirm |
-| `apm marketplace validate NAME` | Validate raw marketplace structure and plugin schema. Reports malformed fields by JSON path and exits 1 without rewriting the source manifest. | `--check-refs`, `-v` |
+| `apm marketplace validate NAME` | Validate raw marketplace structure and plugin schema. Add remains tolerant; validation reports malformed fields by JSON path (for example, `plugins[0].source: expected a string or object`) and exits 1 without rewriting the source manifest or registered marketplace entry. | `--check-refs`, `-v` |
 | `apm search QUERY@MARKETPLACE` | Search marketplace | `--limit N` |
 | `apm install NAME@MKT[#ref]` | Install from marketplace | Optional `#ref` override |
 | `apm view NAME@MARKETPLACE` | View marketplace plugin info | -- |

--- a/packages/apm-guide/.apm/skills/apm-usage/commands.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/commands.md
@@ -210,7 +210,7 @@ Credentials resolve via `APM_REGISTRY_TOKEN_{NAME}` env var (or `apm config set 
 | `apm marketplace browse NAME` | Browse marketplace plugins | -- |
 | `apm marketplace update [NAME]` | Update marketplace index | -- |
 | `apm marketplace remove NAME` | Remove a marketplace | `-y` skip confirm |
-| `apm marketplace validate NAME` | Validate marketplace manifest | `--check-refs`, `-v` |
+| `apm marketplace validate NAME` | Validate raw marketplace structure and plugin schema. Reports malformed fields by JSON path and exits 1 without rewriting the source manifest. | `--check-refs`, `-v` |
 | `apm search QUERY@MARKETPLACE` | Search marketplace | `--limit N` |
 | `apm install NAME@MKT[#ref]` | Install from marketplace | Optional `#ref` override |
 | `apm view NAME@MARKETPLACE` | View marketplace plugin info | -- |

--- a/packages/apm-guide/.apm/skills/apm-usage/commands.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/commands.md
@@ -210,7 +210,7 @@ Credentials resolve via `APM_REGISTRY_TOKEN_{NAME}` env var (or `apm config set 
 | `apm marketplace browse NAME` | Browse marketplace plugins | -- |
 | `apm marketplace update [NAME]` | Update marketplace index | -- |
 | `apm marketplace remove NAME` | Remove a marketplace | `-y` skip confirm |
-| `apm marketplace validate NAME` | Validate raw marketplace structure and plugin schema. Add remains tolerant; validation reports malformed fields by JSON path (for example, `plugins[0].source: expected a string or object`) and exits 1 without rewriting the source manifest or registered marketplace entry. | `--check-refs`, `-v` |
+| `apm marketplace validate NAME` | Validate raw marketplace structure and plugin schema. Add remains tolerant; validation reports malformed fields by JSON path (for example, `plugins[0].source: expected a string or object`) and exits 1 without rewriting the source manifest or registered marketplace entry. Structural failures omit downstream plugin-count, schema, and duplicate-name success lines. | `--check-refs`, `-v` |
 | `apm search QUERY@MARKETPLACE` | Search marketplace | `--limit N` |
 | `apm install NAME@MKT[#ref]` | Install from marketplace | Optional `#ref` override |
 | `apm view NAME@MARKETPLACE` | View marketplace plugin info | -- |

--- a/scripts/lint-architecture-boundaries.sh
+++ b/scripts/lint-architecture-boundaries.sh
@@ -1353,6 +1353,27 @@ if ! grep -q '^def validate_tag_pattern(' "$tag_pattern_owner" \
     violations=$((violations + 1))
 fi
 
+echo "[*] AC33: marketplace structural-diagnostic authority"
+marketplace_structure_owner="src/apm_cli/marketplace/models.py"
+marketplace_structure_validator="src/apm_cli/marketplace/validator.py"
+marketplace_structure_parallel_hits=$(
+    grep -rEn --include='*.py' \
+        'structural_errors[[:space:]]*=' \
+        src/apm_cli/marketplace \
+        | grep -v "^${marketplace_structure_owner}:" \
+        || true
+)
+if ! grep -q 'structural_errors: tuple\[str, \.\.\.\] = ()' "$marketplace_structure_owner" \
+    || ! grep -q 'structural_errors.append("plugins: expected a list")' \
+        "$marketplace_structure_owner" \
+    || ! grep -q '^def validate_marketplace_structure(' "$marketplace_structure_validator" \
+    || ! grep -q 'errors=list(manifest.structural_errors)' "$marketplace_structure_validator" \
+    || [ -n "$marketplace_structure_parallel_hits" ]; then
+    echo "[x] Marketplace structural diagnostics must originate in marketplace/models.py"
+    [ -n "$marketplace_structure_parallel_hits" ] && echo "$marketplace_structure_parallel_hits"
+    violations=$((violations + 1))
+fi
+
 echo "[*] AC29: dependency identity and materialization path authority"
 identity_owner="src/apm_cli/models/dependency/identity.py"
 materialization_owner="src/apm_cli/models/dependency/materialization.py"

--- a/src/apm_cli/commands/marketplace/validate.py
+++ b/src/apm_cli/commands/marketplace/validate.py
@@ -59,7 +59,7 @@ def validate(name, check_refs, verbose):
         logger.progress("Validation Results:", symbol="info")
         for r in results:
             if r.passed and not r.warnings:
-                logger.success(f"  {r.check_name}: all plugins valid", symbol="check")
+                logger.success(f"  {r.check_name}: passed", symbol="check")
                 passed += 1
             elif r.warnings and not r.errors:
                 for w in r.warnings:

--- a/src/apm_cli/commands/marketplace/validate.py
+++ b/src/apm_cli/commands/marketplace/validate.py
@@ -46,9 +46,6 @@ def validate(name, check_refs, verbose):
                 source_type = "dict" if isinstance(p.source, dict) else "string"
                 logger.verbose_detail(f"    {p.name}: source type: {source_type}")
 
-        if has_structure_errors:
-            results = [result for result in results if result.check_name == "Structure"]
-
         # Check-refs placeholder
         if check_refs:
             logger.warning(
@@ -64,6 +61,8 @@ def validate(name, check_refs, verbose):
         logger.progress("Validation Results:", symbol="info")
         for r in results:
             if r.passed and not r.warnings:
+                if has_structure_errors:
+                    continue
                 logger.success(f"  {r.check_name}: passed", symbol="check")
                 passed += 1
             elif r.warnings and not r.errors:

--- a/src/apm_cli/commands/marketplace/validate.py
+++ b/src/apm_cli/commands/marketplace/validate.py
@@ -11,14 +11,14 @@ from ...core.command_logger import CommandLogger
 from . import marketplace
 
 
-@marketplace.command(help="Validate a marketplace manifest")
+@marketplace.command(help="Validate marketplace structure and plugin schema")
 @click.argument("name", required=True)
 @click.option(
     "--check-refs", is_flag=True, hidden=True, help="Verify version refs are reachable (network)"
 )
 @click.option("--verbose", "-v", is_flag=True, help="Show detailed output")
 def validate(name, check_refs, verbose):
-    """Validate the manifest of a registered marketplace."""
+    """Report malformed manifest structure and plugin schema errors."""
     logger = CommandLogger("marketplace-validate", verbose=verbose)
     try:
         from ...marketplace.client import fetch_marketplace

--- a/src/apm_cli/commands/marketplace/validate.py
+++ b/src/apm_cli/commands/marketplace/validate.py
@@ -29,20 +29,25 @@ def validate(name, check_refs, verbose):
         logger.start(f"Validating marketplace '{name}'...", symbol="gear")
 
         manifest = fetch_marketplace(source, force_refresh=True)
-
-        logger.progress(
-            f"Found {len(manifest.plugins)} plugins",
-            symbol="info",
+        results = validate_marketplace(manifest)
+        has_structure_errors = any(
+            result.check_name == "Structure" and result.errors for result in results
         )
 
+        if not has_structure_errors:
+            logger.progress(
+                f"Found {len(manifest.plugins)} plugins",
+                symbol="info",
+            )
+
         # Verbose: per-plugin details
-        if verbose:
+        if verbose and not has_structure_errors:
             for p in manifest.plugins:
                 source_type = "dict" if isinstance(p.source, dict) else "string"
                 logger.verbose_detail(f"    {p.name}: source type: {source_type}")
 
-        # Run validation
-        results = validate_marketplace(manifest)
+        if has_structure_errors:
+            results = [result for result in results if result.check_name == "Structure"]
 
         # Check-refs placeholder
         if check_refs:

--- a/src/apm_cli/marketplace/models.py
+++ b/src/apm_cli/marketplace/models.py
@@ -345,12 +345,12 @@ class MarketplaceManifest:
 
     name: str
     plugins: tuple[MarketplacePlugin, ...] = ()
-    structural_errors: tuple[str, ...] = ()
     owner_name: str = ""
     description: str = ""
     plugin_root: str = ""  # metadata.pluginRoot - base path for bare-name sources
     source_url: str = ""
     source_digest: str = ""
+    structural_errors: tuple[str, ...] = ()
 
     def find_plugin(self, plugin_name: str) -> MarketplacePlugin | None:
         """Find a plugin by exact name (case-insensitive)."""

--- a/src/apm_cli/marketplace/models.py
+++ b/src/apm_cli/marketplace/models.py
@@ -345,6 +345,7 @@ class MarketplaceManifest:
 
     name: str
     plugins: tuple[MarketplacePlugin, ...] = ()
+    structural_errors: tuple[str, ...] = ()
     owner_name: str = ""
     description: str = ""
     plugin_root: str = ""  # metadata.pluginRoot - base path for bare-name sources
@@ -375,12 +376,15 @@ class MarketplaceManifest:
 #   { "name": "...", "plugins": [ { "name": "...", "source": { "type": "github", ... } } ] }
 
 
-def _parse_plugin_entry(entry: dict[str, Any], source_name: str) -> MarketplacePlugin | None:
-    """Parse a single plugin entry from either format."""
-    name = entry.get("name", "").strip()
+def _parse_plugin_entry(
+    entry: dict[str, Any], source_name: str
+) -> tuple[MarketplacePlugin | None, str | None]:
+    """Parse one plugin entry, retaining an error when it cannot be consumed."""
+    raw_name = entry.get("name", "")
+    name = raw_name.strip() if isinstance(raw_name, str) else ""
     if not name:
         logger.debug("Skipping marketplace plugin entry without a name")
-        return None
+        return None, "name: expected a non-empty string"
 
     description = entry.get("description", "")
     version = entry.get("version", "")
@@ -400,14 +404,14 @@ def _parse_plugin_entry(entry: dict[str, Any], source_name: str) -> MarketplaceP
             source_type = raw.get("type", "") or raw.get("source", "")
             if source_type == "npm":
                 logger.debug("Skipping npm source type for plugin '%s' (unsupported)", name)
-                return None
+                return None, "source: unsupported source type 'npm'"
             # Normalize: ensure "type" key is set for downstream resolvers
             if source_type and "type" not in raw:
                 raw = {**raw, "type": source_type}
             source = raw
         else:
             logger.debug("Skipping plugin '%s' with unrecognized source format", name)
-            return None
+            return None, "source: expected a string or object"
     elif "repository" in entry:
         # Copilot CLI format: "repository": "owner/repo"
         repo = entry["repository"]
@@ -422,10 +426,10 @@ def _parse_plugin_entry(entry: dict[str, Any], source_name: str) -> MarketplaceP
                 name,
                 repo,
             )
-            return None
+            return None, "repository: expected an owner/repository string"
     else:
         logger.debug("Plugin '%s' has no source or repository field", name)
-        return None
+        return None, "source: expected a source or repository field"
 
     # Optional dedicated-registry routing (design §4.5). When ``registry``
     # is set, ``version`` is interpreted as a semver range and the plugin
@@ -467,15 +471,18 @@ def _parse_plugin_entry(entry: dict[str, Any], source_name: str) -> MarketplaceP
                 context=f"Plugin {name!r} source.tag_pattern",
             )
 
-    return MarketplacePlugin(
-        name=name,
-        source=source,
-        description=description,
-        version=version,
-        tags=tags,
-        source_marketplace=source_name,
-        registry=registry_name,
-        tag_pattern=tag_pattern,
+    return (
+        MarketplacePlugin(
+            name=name,
+            source=source,
+            description=description,
+            version=version,
+            tags=tags,
+            source_marketplace=source_name,
+            registry=registry_name,
+            tag_pattern=tag_pattern,
+        ),
+        None,
     )
 
 
@@ -489,7 +496,8 @@ def parse_marketplace_json(
     """Parse a marketplace.json dict into a ``MarketplaceManifest``.
 
     Accepts both Copilot CLI and Claude Code marketplace formats.
-    Invalid or unsupported entries are silently skipped with debug logging.
+    Invalid or unsupported entries are skipped for runtime tolerance and retained
+    as structural diagnostics for manifest validation.
 
     Args:
         data: Parsed JSON content of marketplace.json.
@@ -517,24 +525,30 @@ def parse_marketplace_json(
             plugin_root = raw_root.strip()
 
     raw_plugins = data.get("plugins", [])
+    structural_errors: list[str] = []
     if not isinstance(raw_plugins, list):
         logger.warning(
             "marketplace.json 'plugins' field is not a list in '%s'",
             source_name,
         )
+        structural_errors.append("plugins: expected a list")
         raw_plugins = []
 
     plugins: list[MarketplacePlugin] = []
-    for entry in raw_plugins:
+    for index, entry in enumerate(raw_plugins):
         if not isinstance(entry, dict):
+            structural_errors.append(f"plugins[{index}]: expected an object")
             continue
-        plugin = _parse_plugin_entry(entry, source_name)
+        plugin, error = _parse_plugin_entry(entry, source_name)
         if plugin is not None:
             plugins.append(plugin)
+        elif error is not None:
+            structural_errors.append(f"plugins[{index}].{error}")
 
     return MarketplaceManifest(
         name=manifest_name,
         plugins=tuple(plugins),
+        structural_errors=tuple(structural_errors),
         owner_name=owner_name,
         description=description,
         plugin_root=plugin_root,

--- a/src/apm_cli/marketplace/validator.py
+++ b/src/apm_cli/marketplace/validator.py
@@ -3,10 +3,9 @@
 Provides validation functions for marketplace.json integrity checking.
 Used by ``apm marketplace validate``.
 
-All validators operate on parsed ``MarketplaceManifest`` / ``MarketplacePlugin``
-objects. The JSON parser (``models.py``) already drops entries that are
-structurally unrecognizable; these validators enforce additional business
-rules on the successfully parsed entries.
+The tolerant JSON parser (``models.py``) retains structural diagnostics for
+this module to surface. The remaining validators enforce business rules on
+successfully parsed ``MarketplacePlugin`` entries.
 """
 
 from collections.abc import Sequence

--- a/src/apm_cli/marketplace/validator.py
+++ b/src/apm_cli/marketplace/validator.py
@@ -32,11 +32,20 @@ def validate_marketplace(
 
     Returns a list of ``ValidationResult`` objects, one per check.
     """
-    plugins = manifest.plugins
     return [
-        validate_plugin_schema(plugins),
-        validate_no_duplicate_names(plugins),
+        validate_marketplace_structure(manifest),
+        validate_plugin_schema(manifest.plugins),
+        validate_no_duplicate_names(manifest.plugins),
     ]
+
+
+def validate_marketplace_structure(manifest: MarketplaceManifest) -> ValidationResult:
+    """Report raw manifest structure errors retained by the tolerant parser."""
+    return ValidationResult(
+        check_name="Structure",
+        passed=not manifest.structural_errors,
+        errors=list(manifest.structural_errors),
+    )
 
 
 def validate_plugin_schema(

--- a/tests/integration/test_architecture_authorities.py
+++ b/tests/integration/test_architecture_authorities.py
@@ -610,6 +610,61 @@ def test_packed_marketplace_source_owner_guard_rejects_parallel_parser(
     )
 
 
+def test_marketplace_structural_diagnostics_have_single_owner() -> None:
+    """Raw marketplace structure diagnostics must originate in the parser."""
+    root = Path(__file__).parents[2]
+    owner = (root / "src/apm_cli/marketplace/models.py").read_text(encoding="utf-8")
+    validator = (root / "src/apm_cli/marketplace/validator.py").read_text(encoding="utf-8")
+    guard = (root / "scripts/lint-architecture-boundaries.sh").read_text(encoding="utf-8")
+
+    assert "structural_errors: tuple[str, ...] = ()" in owner
+    assert 'structural_errors.append("plugins: expected a list")' in owner
+    assert "errors=list(manifest.structural_errors)" in validator
+    assert "Marketplace structural diagnostics must originate in marketplace/models.py" in guard
+
+
+def test_marketplace_structural_diagnostic_guard_rejects_dropped_plugins_error(
+    tmp_path: Path,
+) -> None:
+    """The boundary guard must reject dropping the parser-owned plugins error."""
+    root = Path(__file__).parents[2]
+    sandbox = tmp_path / "repo"
+    shutil.copytree(
+        root,
+        sandbox,
+        ignore=shutil.ignore_patterns(
+            ".git",
+            ".venv",
+            ".pytest_cache",
+            "__pycache__",
+            "build",
+            "dist",
+            "node_modules",
+        ),
+    )
+    owner_path = sandbox / "src/apm_cli/marketplace/models.py"
+    source = owner_path.read_text(encoding="utf-8")
+    owner_path.write_text(
+        source.replace('structural_errors.append("plugins: expected a list")\n', "", 1),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ("bash", "scripts/lint-architecture-boundaries.sh"),
+        cwd=sandbox,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=300,
+    )
+
+    assert result.returncode == 1
+    assert (
+        "Marketplace structural diagnostics must originate in marketplace/models.py"
+        in result.stdout
+    )
+
+
 def test_cleanup_current_claim_protection_has_single_owner() -> None:
     """Cleanup must route current deployed-file claims through the reconciler."""
     root = Path(__file__).parents[2]

--- a/tests/integration/test_coverage_gaps_phase4w2.py
+++ b/tests/integration/test_coverage_gaps_phase4w2.py
@@ -726,12 +726,12 @@ class TestMarketplaceValidator:
         results = validate_marketplace(manifest)
         assert all(r.passed for r in results)
 
-    def test_validate_marketplace_returns_two_results(self) -> None:
+    def test_validate_marketplace_returns_structure_schema_and_name_results(self) -> None:
         from apm_cli.marketplace.validator import validate_marketplace
 
         manifest = self._make_manifest([self._make_plugin()])
         results = validate_marketplace(manifest)
-        assert len(results) == 2
+        assert [result.check_name for result in results] == ["Structure", "Schema", "Names"]
 
     def test_validate_plugin_schema_empty_name(self) -> None:
         from apm_cli.marketplace.models import MarketplacePlugin

--- a/tests/integration/test_marketplace_invalid_plugins_validation.py
+++ b/tests/integration/test_marketplace_invalid_plugins_validation.py
@@ -1,0 +1,55 @@
+"""Lifecycle coverage for validating a tolerantly registered malformed marketplace."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from tests.utils.apm_lifecycle_runner import ApmLifecycleRunner
+from tests.utils.isolated_apm_environment import IsolatedApmEnvironment
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.e2e,
+    pytest.mark.lifecycle_smoke,
+    pytest.mark.requires_apm_binary,
+    pytest.mark.requires_e2e_mode,
+]
+
+
+def test_marketplace_invalid_plugins_validation(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    """Registration tolerates malformed plugins while validation reports its path."""
+    isolated = IsolatedApmEnvironment.create(tmp_path / "isolated", base_env=dict(os.environ))
+    source = isolated.work_root / "malformed-marketplace"
+    source.mkdir()
+    manifest_path = source / "marketplace.json"
+    source_bytes = b'{\n  "name": "malformed",\n  "plugins": "not-an-array"\n}\n'
+    manifest_path.write_bytes(source_bytes)
+    runner = ApmLifecycleRunner((str(apm_binary_path),))
+
+    add_result = runner.run(
+        ("marketplace", "add", str(source), "--name", "malformed"),
+        scenario_id="marketplace-invalid-plugins-validation",
+        cwd=isolated.work_root,
+        env=isolated.subprocess_env(),
+    )
+    registry_path = isolated.config_root / "marketplaces.json"
+    registry_bytes = registry_path.read_bytes()
+    (validate_result,) = runner.run_sequence(
+        (("marketplace", "validate", "malformed"),),
+        expected_returncodes=(1,),
+        scenario_id="marketplace-invalid-plugins-validation",
+        cwd=isolated.work_root,
+        env=isolated.subprocess_env(),
+    )
+
+    assert add_result.returncode == 0
+    assert "plugins" in validate_result.stdout + validate_result.stderr
+    assert "expected a list" in validate_result.stdout + validate_result.stderr
+    assert manifest_path.read_bytes() == source_bytes
+    assert registry_path.read_bytes() == registry_bytes

--- a/tests/integration/test_marketplace_invalid_plugins_validation.py
+++ b/tests/integration/test_marketplace_invalid_plugins_validation.py
@@ -49,7 +49,11 @@ def test_marketplace_invalid_plugins_validation(
     )
 
     assert add_result.returncode == 0
-    assert "plugins" in validate_result.stdout + validate_result.stderr
-    assert "expected a list" in validate_result.stdout + validate_result.stderr
+    validation_output = validate_result.stdout + validate_result.stderr
+    assert "plugins" in validation_output
+    assert "expected a list" in validation_output
+    assert "Found 0 plugins" not in validation_output
+    assert "Schema: passed" not in validation_output
+    assert "Names: passed" not in validation_output
     assert manifest_path.read_bytes() == source_bytes
     assert registry_path.read_bytes() == registry_bytes

--- a/tests/unit/marketplace/test_marketplace_models.py
+++ b/tests/unit/marketplace/test_marketplace_models.py
@@ -130,6 +130,14 @@ class TestMarketplacePlugin:
 class TestMarketplaceManifest:
     """Frozen dataclass for parsed marketplace content."""
 
+    def test_positional_optional_fields_remain_compatible(self):
+        """Structural diagnostics append to, rather than reorder, the DTO."""
+        manifest = MarketplaceManifest("test", (), "owner", "description")
+
+        assert manifest.owner_name == "owner"
+        assert manifest.description == "description"
+        assert manifest.structural_errors == ()
+
     def test_find_plugin(self):
         plugins = (
             MarketplacePlugin(name="alpha"),

--- a/tests/unit/marketplace/test_marketplace_models.py
+++ b/tests/unit/marketplace/test_marketplace_models.py
@@ -359,6 +359,11 @@ class TestParseMarketplaceJson:
         manifest = parse_marketplace_json(data)
         assert len(manifest.plugins) == 1
         assert manifest.plugins[0].name == "valid"
+        assert manifest.structural_errors == (
+            "plugins[1].name: expected a non-empty string",
+            "plugins[2]: expected an object",
+            "plugins[3].source: expected a source or repository field",
+        )
 
     def test_empty_plugins_list(self):
         data = {"name": "Empty"}

--- a/tests/unit/marketplace/test_marketplace_validator.py
+++ b/tests/unit/marketplace/test_marketplace_validator.py
@@ -9,6 +9,7 @@ from apm_cli.marketplace.models import (
     MarketplaceManifest,
     MarketplacePlugin,
     MarketplaceSource,
+    parse_marketplace_json,
 )
 from apm_cli.marketplace.validator import (
     ValidationResult,
@@ -123,14 +124,45 @@ class TestValidateMarketplace:
             _plugin("b", "owner/b"),
         )
         results = validate_marketplace(manifest)
-        assert len(results) == 2
+        assert len(results) == 3
         assert all(r.passed for r in results)
 
     def test_empty_marketplace_passes_all(self):
         manifest = _manifest()
         results = validate_marketplace(manifest)
-        assert len(results) == 2
+        assert len(results) == 3
         assert all(r.passed for r in results)
+
+    def test_malformed_plugins_shape_is_retained_for_validation(self):
+        """A tolerant parse must preserve raw shape failures for validate."""
+        manifest = parse_marketplace_json(
+            {"name": "test-marketplace", "plugins": "not-an-array"},
+            source_name="test-marketplace",
+        )
+
+        assert manifest.plugins == ()
+        assert manifest.structural_errors == ("plugins: expected a list",)
+
+        results = validate_marketplace(manifest)
+
+        assert results[0] == ValidationResult(
+            check_name="Structure",
+            passed=False,
+            errors=["plugins: expected a list"],
+        )
+
+    def test_unsupported_plugin_source_is_retained_for_validation(self):
+        """Discarded sources remain visible to the validation command."""
+        manifest = parse_marketplace_json(
+            {
+                "name": "test-marketplace",
+                "plugins": [{"name": "npm-plugin", "source": {"type": "npm"}}],
+            },
+            source_name="test-marketplace",
+        )
+
+        assert manifest.plugins == ()
+        assert manifest.structural_errors == ("plugins[0].source: unsupported source type 'npm'",)
 
 
 # ===================================================================


### PR DESCRIPTION
# fix(marketplace): report malformed plugin structure during validation

## TL;DR

This superseding PR carries #2445 after rebasing it onto current `main` and folding the advisory follow-ups. `apm marketplace add` remains tolerant of malformed plugin structures, while `apm marketplace validate` now retains parser diagnostics, prints a path/type error, and exits 1. The lifecycle proof confirms that validation does not rewrite either the source manifest or marketplace registry.

> [!NOTE]
> Closes #2424. Supersedes #2445; original authorship is preserved in the carried commits.

## Problem (WHY)

- [x] A non-list `plugins` field was replaced by an empty collection during tolerant parsing, so validation lost the structure needed to report the error.
- [x] A malformed marketplace could register and later validate successfully even though its source manifest was invalid.
- [!] Parser diagnostics needed one owner and a guard so validation does not grow a parallel raw parser.

Why these matter: ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) The lifecycle test makes the exit code and byte-preservation contract observable.

## Approach (WHAT)

| # | Fix |
|---|---|
| 1 | Retain malformed top-level and plugin-entry diagnostics in the tolerant parser. |
| 2 | Consume those diagnostics as a Structure result before schema and duplicate-name validation. |
| 3 | Guard parser ownership and execute an add-then-validate lifecycle proof. |
| 4 | Clarify Structure output, document tolerant add plus read-only validation, and assert retained secondary diagnostics. |

## Implementation (HOW)

- **`src/apm_cli/marketplace/models.py`** -- retains parser-owned structural errors while preserving tolerant registration.
- **`src/apm_cli/marketplace/validator.py`** -- exposes retained errors as a Structure validation result and documents that boundary.
- **`src/apm_cli/commands/marketplace/validate.py`** -- renders a neutral passing result instead of describing a structure check as plugin validity.
- **`tests/integration/test_marketplace_invalid_plugins_validation.py`** -- invokes the installed CLI and asserts exit 1, path/type diagnostics, and unchanged source and registry bytes.
- **`tests/unit/marketplace/test_marketplace_models.py`** -- asserts all existing invalid-entry paths retain their diagnostics.
- **`scripts/lint-architecture-boundaries.sh` and `tests/integration/test_architecture_authorities.py`** -- enforce parser ownership with AC33 and a mutation-resistant architecture test.
- **`docs/src/content/docs/reference/cli/marketplace.md` and `packages/apm-guide/.apm/skills/apm-usage/commands.md`** -- document tolerant add, JSON-path diagnostics, and non-rewrite behavior.

## Diagrams

Legend: dashed nodes are the new retained-diagnostic path from tolerant parsing to strict validation.

```mermaid
flowchart LR
    subgraph Parse[Parse]
        M[marketplace.json]
        P[parse_marketplace_json]
        E[structural_errors]
    end
    subgraph Validate[Validate]
        S[Structure result]
        C[CLI exit 1]
    end
    M --> P
    P --> E
    E --> S
    S --> C
    classDef new stroke-dasharray: 5 5;
    class E,S,C new;
```

## Trade-offs

- **Tolerant registration with strict validation.** Chose retained diagnostics over rejecting `marketplace add`; validation is the explicit inspection boundary.
- **String diagnostics over a raw AST.** Chose actionable JSON-path strings because validation only needs stable errors, not a broader raw-manifest model.
- **Behavior plus static guard.** Chose lifecycle coverage and AC33; a parser unit test alone would not prevent structural validation from drifting into a second owner.

## Benefits

1. `plugins: "not-an-array"` produces exit 1 and `plugins: expected a list`.
2. The lifecycle test compares both source and registry bytes before and after validation.
3. AC33, its architecture test, and mutation evidence protect one parser-owned diagnostics path.
4. Tolerant add and read-only validate behavior are documented in the CLI reference and APM usage guide.

## Validation

`uv run apm audit --ci`:

```text
[*] All 10 check(s) passed
```

<details><summary>Targeted tests and lint contract</summary>

```text
63 passed in 2.65s
1 passed in 1.73s
All checks passed!
1596 files already formatted
Your code has been rated at 10.00/10
[+] auth-signal lint clean
[+] architecture boundary lint clean
```

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|-------------------------|--------------|--------------------|------|
| 1 | Add a malformed marketplace, validate it, receive exit 1 and a plugins path/type diagnostic, and keep source and registry bytes unchanged. | DevX | `tests/integration/test_marketplace_invalid_plugins_validation.py::test_marketplace_invalid_plugins_validation` | e2e |
| 2 | Retain each malformed plugin-entry diagnostic while keeping valid plugin entries usable. | DevX | `tests/unit/marketplace/test_marketplace_models.py::TestParseMarketplaceJson::test_invalid_entries_skipped` | unit |
| 3 | Keep structural-diagnostic ownership in the parser so later edits cannot silently remove the plugins failure. | OSS | `tests/integration/test_architecture_authorities.py::test_marketplace_structural_diagnostic_guard_rejects_dropped_plugins_error` | integration |

## How to test

- [ ] Create `marketplace.json` with `"plugins": "not-an-array"` and run `apm marketplace add <path> --name malformed`; registration succeeds.
- [ ] Run `apm marketplace validate malformed`; it exits 1 and reports `plugins: expected a list`.
- [ ] Compare the source manifest and marketplaces registry before and after validation; both byte sequences are unchanged.
- [ ] Run `bash scripts/lint-architecture-boundaries.sh`; AC33 passes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
