### PR TITLE
refactor(performance): eliminate repeated I/O and lockfile scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   policy cache metadata and diagnostics also omit credentials embedded in
   direct policy URLs. (#2422)
 
+### Performance
+
+- Policy discovery now performs one remote lookup per discovery, compilation
+  uses one project traversal plus in-memory directory indexes, and uninstall
+  pre-indexes lockfile entries for marketplace lookup. (#2472)
+
 ## [0.27.0] - 2026-07-31
 
 ### Added

--- a/src/apm_cli/commands/uninstall/engine.py
+++ b/src/apm_cli/commands/uninstall/engine.py
@@ -469,6 +469,26 @@ def _resolve_marketplace_packages(
 
     resolved: dict[str, str | None] = {}
 
+    # Pre-index lockfile dependencies once for the entire batch.
+    # exact_index[(via, plugin)] = canonical  -- first insertion-order exact match wins.
+    # plugin_index[plugin] = [(via, canonical), ...]  -- insertion-order list for
+    #   provenance-mismatch fallback (first entry whose via != requested marketplace wins).
+    exact_index: dict[tuple[str, str], str] = {}
+    plugin_index: dict[str, list[tuple[str, str]]] = {}
+    if lockfile is not None:
+        for dep in lockfile.dependencies.values():
+            mp = dep.marketplace_plugin_name
+            via = dep.discovered_via
+            if not mp or not via:
+                continue
+            canonical_key = dep.get_unique_key()
+            exact_key = (via, mp)
+            if exact_key not in exact_index:
+                exact_index[exact_key] = canonical_key
+            if mp not in plugin_index:
+                plugin_index[mp] = []
+            plugin_index[mp].append((via, canonical_key))
+
     for package in packages:
         parsed = parse_marketplace_ref(package)
         if parsed is None:
@@ -479,26 +499,17 @@ def _resolve_marketplace_packages(
 
         # Stage 1: Lockfile-first lookup (offline, zero network calls)
         if lockfile is not None:
-            # First pass: exact match (both discovered_via AND marketplace_plugin_name)
-            for dep in lockfile.dependencies.values():
-                if (
-                    dep.discovered_via == marketplace_name
-                    and dep.marketplace_plugin_name == plugin_name
-                ):
-                    canonical = dep.get_unique_key()
-                    break
+            # Exact match: both discovered_via and marketplace_plugin_name match
+            canonical = exact_index.get((marketplace_name, plugin_name))
 
-            # Second pass: plugin_name match with different marketplace (provenance mismatch)
+            # Provenance-mismatch fallback: first same-plugin entry via a different marketplace
             if canonical is None:
-                for dep in lockfile.dependencies.values():
-                    if (
-                        dep.marketplace_plugin_name == plugin_name
-                        and dep.discovered_via != marketplace_name
-                    ):
-                        canonical = dep.get_unique_key()
+                for via, candidate_key in plugin_index.get(plugin_name, []):
+                    if via != marketplace_name:
+                        canonical = candidate_key
                         logger.warning(
                             f"{plugin_name}@{marketplace_name} not found; "
-                            f"package was installed via {dep.discovered_via}. "
+                            f"package was installed via {via}. "
                             f"Proceeding with uninstall of {canonical}."
                         )
                         break

--- a/src/apm_cli/commands/uninstall/engine.py
+++ b/src/apm_cli/commands/uninstall/engine.py
@@ -470,9 +470,9 @@ def _resolve_marketplace_packages(
     resolved: dict[str, str | None] = {}
 
     # Pre-index lockfile dependencies once for the entire batch.
-    # exact_index[(via, plugin)] = canonical  -- first insertion-order exact match wins.
-    # plugin_index[plugin] = [(via, canonical), ...]  -- insertion-order list for
-    #   provenance-mismatch fallback (first entry whose via != requested marketplace wins).
+    # Exact matches preserve the first canonical entry for each provenance pair.
+    # Plugin matches retain every entry in insertion order so fallback can select
+    # the first entry whose provenance differs from the requested marketplace.
     exact_index: dict[tuple[str, str], str] = {}
     plugin_index: dict[str, list[tuple[str, str]]] = {}
     if lockfile is not None:
@@ -483,11 +483,8 @@ def _resolve_marketplace_packages(
                 continue
             canonical_key = dep.get_unique_key()
             exact_key = (via, mp)
-            if exact_key not in exact_index:
-                exact_index[exact_key] = canonical_key
-            if mp not in plugin_index:
-                plugin_index[mp] = []
-            plugin_index[mp].append((via, canonical_key))
+            exact_index.setdefault(exact_key, canonical_key)
+            plugin_index.setdefault(mp, []).append((via, canonical_key))
 
     for package in packages:
         parsed = parse_marketplace_ref(package)

--- a/src/apm_cli/compilation/context_optimizer.py
+++ b/src/apm_cli/compilation/context_optimizer.py
@@ -218,20 +218,18 @@ class ContextOptimizer:
         return results
 
     def _get_all_files(self) -> builtins.list[Path]:
-        """Get cached list of all files in project."""
+        """Get cached list of all files in project.
+
+        Routes through :meth:`_analyze_project_structure` when the cache is
+        empty so the single canonical walk builds both ``_file_list_cache``
+        and ``_directory_cache`` in one pass.  Callers that invoke this method
+        directly (before :meth:`optimize_instruction_placement`) are handled
+        correctly: the walk runs once and the result is reused.  Triggering
+        that walk clears and rebuilds ``_directory_cache`` and
+        ``_pattern_cache`` as part of the canonical analysis lifecycle.
+        """
         if self._file_list_cache is None:
-            self._file_list_cache = []
-            for root, dirs, files in os.walk(self.base_dir):
-                current_path = Path(root)
-                if self._contains_unsupported_hidden_directory(current_path):
-                    dirs[:] = []
-                    continue
-                dirs[:] = sorted(
-                    d for d in dirs if not self._should_exclude_subdir(current_path / d)
-                )
-                for file in sorted(files):
-                    if not file.startswith("."):
-                        self._file_list_cache.append(Path(root) / file)
+            self._analyze_project_structure()
         return self._file_list_cache
 
     def optimize_instruction_placement(
@@ -476,61 +474,72 @@ class ContextOptimizer:
         )
 
     def _analyze_project_structure(self) -> None:
-        """Analyze the project structure and cache results."""
-        self._directory_cache.clear()
-        self._pattern_cache.clear()  # Also clear pattern cache for deterministic behavior
+        """Analyze the project structure; populate both ``_directory_cache`` and ``_file_list_cache``.
 
-        # Track visited directories to prevent infinite loops
-        visited_dirs = set()
+        This is the single canonical ``os.walk`` traversal for the entire
+        optimization pipeline.  Both caches are built in one pass so that
+        :meth:`_get_all_files` (used by :meth:`_cached_glob` / the symlink-safe
+        glob replacement) never needs a separate walk.
+
+        Ordering guarantee: subdirectories are sorted before descent and files
+        are sorted within each directory, so ``_file_list_cache`` is
+        deterministic regardless of OS-level readdir order.
+        """
+        self._directory_cache.clear()
+        self._pattern_cache.clear()
+        self._file_list_cache = []
+
+        visited_dirs: builtins.set[Path] = set()
 
         for root, dirs, files in os.walk(self.base_dir):
             current_path = Path(root)
 
-            # Safety check for infinite loops
+            # Guard against symlink-induced infinite loops.
             if current_path in visited_dirs:
+                dirs[:] = []
                 continue
             visited_dirs.add(current_path)
 
-            # Calculate depth for analysis
             relative_path = self._relative_path(current_path)
             depth = len(relative_path.parts) if relative_path is not None else 0
 
-            # Only supported agent-tool roots participate in placement. Other
-            # hidden paths (including nested caches) stay pruned.
+            # Only supported agent-tool roots participate in placement.  Other
+            # hidden paths (including nested caches) stay pruned entirely.
             if self._contains_unsupported_hidden_directory(current_path, relative_path):
                 dirs[:] = []
                 continue
 
-            # Default hardcoded exclusions  -- match on exact path components
+            # Safety net: skip if a default-excluded component snuck through.
             if any(part in DEFAULT_EXCLUDED_DIRNAMES for part in relative_path.parts):
                 continue
 
-            # Apply configurable exclusion patterns
+            # Skip paths matching configurable exclusion patterns.
             if self._should_exclude_path(current_path):
                 continue
 
-            # Prune subdirectories from os.walk to avoid descending into excluded paths
-            # This significantly improves performance by avoiding expensive traversal
-            # Note: Modifying dirs[:] (slice assignment) is the standard Python idiom
-            # to control which subdirectories os.walk will descend into
-            dirs[:] = [d for d in dirs if not self._should_exclude_subdir(current_path / d)]
+            # Prune and sort subdirectories.  Sorting ensures that
+            # ``_file_list_cache`` has a stable, deterministic order across
+            # platforms (the OS-level readdir order is not guaranteed).
+            dirs[:] = sorted(d for d in dirs if not self._should_exclude_subdir(current_path / d))
 
-            # Analyze files in this directory
-            total_files = len([f for f in files if not f.startswith(".")])
+            # Build the file-list cache (non-hidden files, sorted for stability).
+            for file in sorted(files):
+                if not file.startswith("."):
+                    self._file_list_cache.append(current_path / file)
+
+            # Build the directory cache (only for directories that contain
+            # at least one non-hidden file; empty directories are skipped).
+            total_files = sum(1 for f in files if not f.startswith("."))
             if total_files == 0:
                 continue
 
             analysis = DirectoryAnalysis(
                 directory=current_path, depth=depth, total_files=total_files
             )
-
-            # Analyze file types
             for file in files:
                 if file.startswith("."):
                     continue
-
-                file_path = current_path / file
-                analysis.file_types.add(file_path.suffix)
+                analysis.file_types.add((current_path / file).suffix)
 
             self._directory_cache[current_path] = analysis
 

--- a/src/apm_cli/compilation/context_optimizer.py
+++ b/src/apm_cli/compilation/context_optimizer.py
@@ -273,6 +273,8 @@ class ContextOptimizer:
         self._file_list_cache = None
         self._glob_cache.clear()
         self._glob_set_cache.clear()
+        # Clear before the timed phase; analysis also clears so direct callers
+        # receive the same deterministic rebuild.
         self._files_by_directory.clear()
         self._children_by_directory.clear()
 
@@ -494,6 +496,7 @@ class ContextOptimizer:
         are sorted within each directory, so ``_file_list_cache`` is
         deterministic regardless of OS-level readdir order.
         """
+        # Rebuild from scratch for both direct calls and optimize orchestration.
         self._directory_cache.clear()
         self._pattern_cache.clear()
         self._file_list_cache = []
@@ -522,10 +525,12 @@ class ContextOptimizer:
 
             # Safety net: skip if a default-excluded component snuck through.
             if any(part in DEFAULT_EXCLUDED_DIRNAMES for part in relative_path.parts):
+                dirs[:] = []
                 continue
 
             # Skip paths matching configurable exclusion patterns.
             if self._should_exclude_path(current_path):
+                dirs[:] = []
                 continue
 
             # Prune and sort subdirectories.  Sorting ensures that
@@ -536,9 +541,9 @@ class ContextOptimizer:
             # Populate the children-by-directory index with admitted child dirs.
             self._children_by_directory[current_path] = [current_path / d for d in dirs]
 
-            # Build the project-file cache from os.walk's file entries.  The
-            # matching index retains the old Path.is_file() semantics so
-            # broken symlinks and other non-regular entries cannot match.
+            # project_files preserves os.walk entries for project accounting;
+            # matching_files keeps the old is_file() filter, excluding broken
+            # symlinks and other non-regular entries from pattern matching.
             project_files: builtins.list[Path] = []
             matching_files: builtins.list[Path] = []
             for file in sorted(files):
@@ -549,14 +554,13 @@ class ContextOptimizer:
                     if file_path.is_file():
                         matching_files.append(file_path)
 
-            # Populate the files-by-directory index.
-            self._files_by_directory[current_path] = matching_files
-
             # Build the directory cache (only for directories that contain
             # at least one non-hidden file; empty directories are skipped).
             total_files = len(project_files)
             if total_files == 0:
                 continue
+
+            self._files_by_directory[current_path] = matching_files
 
             analysis = DirectoryAnalysis(
                 directory=current_path, depth=depth, total_files=total_files
@@ -919,8 +923,7 @@ class ContextOptimizer:
 
         matching_dirs: builtins.set[Path] = set()
 
-        # Use the in-memory files-by-directory index populated by the
-        # canonical os.walk, eliminating per-pattern iterdir() calls.
+        # This lookup is entirely in memory; no filesystem error path remains.
         for directory, analysis in sorted(self._directory_cache.items()):
             files = self._files_by_directory.get(directory, [])
 

--- a/src/apm_cli/compilation/context_optimizer.py
+++ b/src/apm_cli/compilation/context_optimizer.py
@@ -157,6 +157,13 @@ class ContextOptimizer:
         self._timing_enabled = False
         self._phase_timings: builtins.dict[str, float] = {}
 
+        # In-memory directory indexes populated by the canonical os.walk
+        # traversal in _analyze_project_structure.  These eliminate per-pattern
+        # and per-candidate Path.iterdir() filesystem calls in
+        # _find_matching_directories and _calculate_inheritance_pollution.
+        self._files_by_directory: builtins.dict[Path, builtins.list[Path]] = {}
+        self._children_by_directory: builtins.dict[Path, builtins.list[Path]] = {}
+
         # Data collection for output formatting
         self._optimization_decisions: builtins.list[OptimizationDecision] = []
         self._warnings: builtins.list[str] = []
@@ -266,6 +273,8 @@ class ContextOptimizer:
         self._file_list_cache = None
         self._glob_cache.clear()
         self._glob_set_cache.clear()
+        self._files_by_directory.clear()
+        self._children_by_directory.clear()
 
         # Phase 1: Analyze project structure
         self._time_phase("Project Analysis", self._analyze_project_structure)
@@ -488,6 +497,8 @@ class ContextOptimizer:
         self._directory_cache.clear()
         self._pattern_cache.clear()
         self._file_list_cache = []
+        self._files_by_directory.clear()
+        self._children_by_directory.clear()
 
         visited_dirs: builtins.set[Path] = set()
 
@@ -522,24 +533,36 @@ class ContextOptimizer:
             # platforms (the OS-level readdir order is not guaranteed).
             dirs[:] = sorted(d for d in dirs if not self._should_exclude_subdir(current_path / d))
 
-            # Build the file-list cache (non-hidden files, sorted for stability).
+            # Populate the children-by-directory index with admitted child dirs.
+            self._children_by_directory[current_path] = [current_path / d for d in dirs]
+
+            # Build the project-file cache from os.walk's file entries.  The
+            # matching index retains the old Path.is_file() semantics so
+            # broken symlinks and other non-regular entries cannot match.
+            project_files: builtins.list[Path] = []
+            matching_files: builtins.list[Path] = []
             for file in sorted(files):
                 if not file.startswith("."):
-                    self._file_list_cache.append(current_path / file)
+                    file_path = current_path / file
+                    self._file_list_cache.append(file_path)
+                    project_files.append(file_path)
+                    if file_path.is_file():
+                        matching_files.append(file_path)
+
+            # Populate the files-by-directory index.
+            self._files_by_directory[current_path] = matching_files
 
             # Build the directory cache (only for directories that contain
             # at least one non-hidden file; empty directories are skipped).
-            total_files = sum(1 for f in files if not f.startswith("."))
+            total_files = len(project_files)
             if total_files == 0:
                 continue
 
             analysis = DirectoryAnalysis(
                 directory=current_path, depth=depth, total_files=total_files
             )
-            for file in files:
-                if file.startswith("."):
-                    continue
-                analysis.file_types.add((current_path / file).suffix)
+            for fp in project_files:
+                analysis.file_types.add(fp.suffix)
 
             self._directory_cache[current_path] = analysis
 
@@ -896,23 +919,19 @@ class ContextOptimizer:
 
         matching_dirs: builtins.set[Path] = set()
 
-        # Use the reliable approach for all patterns
+        # Use the in-memory files-by-directory index populated by the
+        # canonical os.walk, eliminating per-pattern iterdir() calls.
         for directory, analysis in sorted(self._directory_cache.items()):
-            try:
-                files = [
-                    f for f in directory.iterdir() if f.is_file() and not f.name.startswith(".")
-                ]
+            files = self._files_by_directory.get(directory, [])
 
-                match_count = 0
-                for file_path in files:
-                    if self._file_matches_pattern(file_path, pattern):
-                        match_count += 1
-                        matching_dirs.add(directory)
+            match_count = 0
+            for file_path in files:
+                if self._file_matches_pattern(file_path, pattern):
+                    match_count += 1
+                    matching_dirs.add(directory)
 
-                if match_count > 0:
-                    analysis.pattern_matches[pattern] = match_count
-            except (OSError, PermissionError):
-                continue
+            if match_count > 0:
+                analysis.pattern_matches[pattern] = match_count
 
         self._pattern_cache[pattern] = matching_dirs
         return matching_dirs
@@ -929,28 +948,25 @@ class ContextOptimizer:
         """
         pollution_score = 0.0
 
-        # Optimization: Only check direct children instead of all directories
-        # This prevents O(n2) complexity with unlimited depth analysis
-        try:
-            direct_children = [
-                child
-                for child in directory.iterdir()
-                if child.is_dir() and child in self._directory_cache
-            ]
+        # Use the in-memory children-by-directory index populated by the
+        # canonical os.walk, eliminating per-candidate iterdir() calls.
+        # Filter to children present in _directory_cache (i.e. have files).
+        direct_children = [
+            child
+            for child in self._children_by_directory.get(directory, [])
+            if child in self._directory_cache
+        ]
 
-            # Check only direct child directories for pollution
-            for child_dir in direct_children:
-                analysis = self._directory_cache[child_dir]
+        # Check only direct child directories for pollution
+        for child_dir in direct_children:
+            analysis = self._directory_cache[child_dir]
 
-                # If child has no matching files, this creates pollution
-                child_relevance = analysis.get_relevance_score(pattern)
-                if child_relevance == 0.0:
-                    pollution_score += 0.5  # Strong pollution penalty
-                elif child_relevance < 0.1:  # Weak relevance threshold
-                    pollution_score += 0.2  # Weak pollution penalty
-        except (OSError, PermissionError):
-            # Skip directories we can't read
-            pass
+            # If child has no matching files, this creates pollution
+            child_relevance = analysis.get_relevance_score(pattern)
+            if child_relevance == 0.0:
+                pollution_score += 0.5  # Strong pollution penalty
+            elif child_relevance < 0.1:  # Weak relevance threshold
+                pollution_score += 0.2  # Weak pollution penalty
 
         return pollution_score
 

--- a/src/apm_cli/policy/discovery.py
+++ b/src/apm_cli/policy/discovery.py
@@ -863,15 +863,14 @@ def _auto_discover(
        - Found -> return (first match wins)
     5. All candidates exhausted -> outcome="absent"
     """
-    org_and_host = _extract_org_from_git_remote(project_root)
-    if org_and_host is None:
+    identity = _extract_org_host_port_from_git_remote(project_root)
+    if identity is None:
         return PolicyFetchResult(
             error="Could not determine org from git remote",
             outcome="no_git_remote",
         )
 
-    org, host = org_and_host
-    port = _extract_port_from_git_remote(project_root)
+    org, host, port = identity
     candidates = _policy_repo_candidates(host)
     is_ado = is_azure_devops_hostname(host)
 
@@ -971,24 +970,6 @@ def _extract_org_host_port_from_git_remote(
                 return None
         return parsed_identity[0], parsed_identity[1], port
     except (subprocess.TimeoutExpired, FileNotFoundError):
-        return None
-
-
-def _extract_port_from_git_remote(project_root: Path) -> int | None:
-    """Return the explicit HTTPS port from git remote origin."""
-    try:
-        result = subprocess.run(
-            ["git", "remote", "get-url", "origin"],
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            cwd=project_root,
-            timeout=5,
-        )
-        if result.returncode != 0 or "://" not in result.stdout:
-            return None
-        return urlparse(result.stdout.strip()).port
-    except (ValueError, subprocess.TimeoutExpired, FileNotFoundError):
         return None
 
 

--- a/src/apm_cli/policy/discovery.py
+++ b/src/apm_cli/policy/discovery.py
@@ -969,7 +969,7 @@ def _extract_org_host_port_from_git_remote(
             except ValueError:
                 return None
         return parsed_identity[0], parsed_identity[1], port
-    except (subprocess.TimeoutExpired, FileNotFoundError):
+    except (ValueError, subprocess.TimeoutExpired, FileNotFoundError):
         return None
 
 

--- a/tests/integration/test_uninstall_policy_pack_flow.py
+++ b/tests/integration/test_uninstall_policy_pack_flow.py
@@ -1218,7 +1218,7 @@ class TestAutoDiscover:
         from apm_cli.policy.discovery import _auto_discover
 
         with patch(
-            "apm_cli.policy.discovery._extract_org_from_git_remote",
+            "apm_cli.policy.discovery._extract_org_host_port_from_git_remote",
             return_value=None,
         ):
             result = _auto_discover(tmp_path)
@@ -1230,8 +1230,8 @@ class TestAutoDiscover:
         from apm_cli.policy.discovery import _auto_discover
 
         with patch(
-            "apm_cli.policy.discovery._extract_org_from_git_remote",
-            return_value=("contoso", "ghe.corp.com"),
+            "apm_cli.policy.discovery._extract_org_host_port_from_git_remote",
+            return_value=("contoso", "ghe.corp.com", None),
         ):
             with patch(
                 "apm_cli.policy.discovery._fetch_from_repo",

--- a/tests/unit/compilation/test_context_optimizer_iterdir_indexes.py
+++ b/tests/unit/compilation/test_context_optimizer_iterdir_indexes.py
@@ -106,6 +106,22 @@ class TestIndexesPopulatedByCanonicalWalk:
         child_names = [p.name for p in children]
         assert child_names == sorted(child_names)
 
+    def test_empty_directory_absent_from_file_index_but_retained_as_child(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Empty directories stay in the child index but not the file index."""
+        empty_dir = tmp_path / "src/empty"
+        empty_dir.mkdir(parents=True)
+        _touch(tmp_path, "src/app.py")
+
+        optimizer = ContextOptimizer(base_dir=str(tmp_path))
+        optimizer.optimize_instruction_placement([_make_instruction(apply_to="**/*.py")])
+
+        assert empty_dir in optimizer._children_by_directory[tmp_path / "src"]
+        assert empty_dir not in optimizer._files_by_directory
+        assert empty_dir not in optimizer._directory_cache
+
 
 class TestNoIterdirCalls:
     """Optimized paths must not call Path.iterdir()."""

--- a/tests/unit/compilation/test_context_optimizer_iterdir_indexes.py
+++ b/tests/unit/compilation/test_context_optimizer_iterdir_indexes.py
@@ -1,0 +1,476 @@
+"""Regression tests for in-memory directory indexes in ContextOptimizer.
+
+Asserts that ``_files_by_directory`` and ``_children_by_directory`` indexes
+eliminate all ``Path.iterdir()`` calls from ``_find_matching_directories``
+and ``_calculate_inheritance_pollution`` without changing matching-directory
+sets, pollution scores, stable ordering, or cache lifecycle.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from apm_cli.compilation.context_optimizer import ContextOptimizer
+from apm_cli.primitives.models import Instruction
+
+pytestmark = pytest.mark.component
+
+
+def _make_instruction(
+    name: str = "inst",
+    apply_to: str = "**/*.py",
+) -> Instruction:
+    return Instruction(
+        name=name,
+        file_path=Path(f"{name}.instructions.md"),
+        description=f"{name} description",
+        apply_to=apply_to,
+        content=f"{name} content",
+    )
+
+
+def _touch(base: Path, rel: str) -> None:
+    p = base / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.touch()
+
+
+def _symlink_or_skip(link: Path, target: Path, *, target_is_directory: bool = False) -> None:
+    try:
+        link.symlink_to(target, target_is_directory=target_is_directory)
+    except OSError:
+        pytest.skip("symlink creation not supported on this platform")
+
+
+class TestIndexesPopulatedByCanonicalWalk:
+    """_files_by_directory and _children_by_directory built by _analyze_project_structure."""
+
+    def test_files_by_directory_populated(self, tmp_path: Path) -> None:
+        """Each admitted directory has its non-hidden files in the index."""
+        _touch(tmp_path, "src/main.py")
+        _touch(tmp_path, "src/utils.py")
+        _touch(tmp_path, "src/.hidden")
+        _touch(tmp_path, "tests/test_main.py")
+
+        optimizer = ContextOptimizer(base_dir=str(tmp_path))
+        optimizer.optimize_instruction_placement([_make_instruction(apply_to="**/*.py")])
+
+        src_dir = tmp_path / "src"
+        assert src_dir in optimizer._files_by_directory
+        src_files = {p.name for p in optimizer._files_by_directory[src_dir]}
+        assert src_files == {"main.py", "utils.py"}
+        assert ".hidden" not in src_files
+
+    def test_children_by_directory_populated(self, tmp_path: Path) -> None:
+        """Each admitted directory has its admitted child directories in the index."""
+        _touch(tmp_path, "src/core/engine.py")
+        _touch(tmp_path, "src/utils/helpers.py")
+        _touch(tmp_path, "src/app.py")
+
+        optimizer = ContextOptimizer(base_dir=str(tmp_path))
+        optimizer.optimize_instruction_placement([_make_instruction(apply_to="**/*.py")])
+
+        src_dir = tmp_path / "src"
+        assert src_dir in optimizer._children_by_directory
+        child_names = {p.name for p in optimizer._children_by_directory[src_dir]}
+        assert child_names == {"core", "utils"}
+
+    def test_excluded_dirs_absent_from_children_index(self, tmp_path: Path) -> None:
+        """Excluded directories (node_modules, __pycache__) not in children index."""
+        _touch(tmp_path, "src/app.py")
+        _touch(tmp_path, "src/node_modules/pkg/index.js")
+        _touch(tmp_path, "src/__pycache__/mod.pyc")
+
+        optimizer = ContextOptimizer(base_dir=str(tmp_path))
+        optimizer.optimize_instruction_placement([_make_instruction(apply_to="**/*.py")])
+
+        src_dir = tmp_path / "src"
+        child_names = {p.name for p in optimizer._children_by_directory.get(src_dir, [])}
+        assert "node_modules" not in child_names
+        assert "__pycache__" not in child_names
+
+    def test_children_index_sorted_deterministically(self, tmp_path: Path) -> None:
+        """Children are in sorted order matching the walk's subdir sort."""
+        _touch(tmp_path, "z_dir/file.py")
+        _touch(tmp_path, "a_dir/file.py")
+        _touch(tmp_path, "m_dir/file.py")
+        _touch(tmp_path, "root.py")
+
+        optimizer = ContextOptimizer(base_dir=str(tmp_path))
+        optimizer.optimize_instruction_placement([_make_instruction(apply_to="**/*.py")])
+
+        children = optimizer._children_by_directory.get(tmp_path, [])
+        child_names = [p.name for p in children]
+        assert child_names == sorted(child_names)
+
+
+class TestNoIterdirCalls:
+    """Optimized paths must not call Path.iterdir()."""
+
+    def test_find_matching_directories_no_iterdir(self, tmp_path: Path) -> None:
+        """_find_matching_directories does not call Path.iterdir."""
+        _touch(tmp_path, "src/main.py")
+        _touch(tmp_path, "src/utils.py")
+        _touch(tmp_path, "tests/test_main.py")
+        _touch(tmp_path, "docs/guide.md")
+
+        optimizer = ContextOptimizer(base_dir=str(tmp_path))
+        # Trigger analysis so indexes are built
+        optimizer._placement_hidden_tool_trees = frozenset()
+        optimizer._analyze_project_structure()
+
+        iterdir_called = False
+        original_iterdir = Path.iterdir
+
+        def tracking_iterdir(self_path):
+            nonlocal iterdir_called
+            iterdir_called = True
+            return original_iterdir(self_path)
+
+        with patch.object(Path, "iterdir", tracking_iterdir):
+            optimizer._find_matching_directories("**/*.py")
+
+        assert not iterdir_called, (
+            "_find_matching_directories must not call Path.iterdir "
+            "(should use _files_by_directory index)"
+        )
+
+    def test_calculate_inheritance_pollution_no_iterdir(self, tmp_path: Path) -> None:
+        """_calculate_inheritance_pollution does not call Path.iterdir."""
+        _touch(tmp_path, "src/core/engine.py")
+        _touch(tmp_path, "src/utils/helpers.py")
+        _touch(tmp_path, "src/app.py")
+
+        optimizer = ContextOptimizer(base_dir=str(tmp_path))
+        instruction = _make_instruction(apply_to="**/*.py")
+        optimizer.optimize_instruction_placement([instruction])
+
+        iterdir_called = False
+        original_iterdir = Path.iterdir
+
+        def tracking_iterdir(self_path):
+            nonlocal iterdir_called
+            iterdir_called = True
+            return original_iterdir(self_path)
+
+        src_dir = tmp_path / "src"
+        with patch.object(Path, "iterdir", tracking_iterdir):
+            optimizer._calculate_inheritance_pollution(src_dir, "**/*.py")
+
+        assert not iterdir_called, (
+            "_calculate_inheritance_pollution must not call Path.iterdir "
+            "(should use _children_by_directory index)"
+        )
+
+
+class TestMatchingDirectorySetsUnchanged:
+    """Matching-directory sets must be identical to the pre-optimization behavior."""
+
+    def test_matching_dirs_for_recursive_pattern(self, tmp_path: Path) -> None:
+        """Recursive glob pattern finds all directories with matching files."""
+        _touch(tmp_path, "src/main.py")
+        _touch(tmp_path, "src/core/engine.py")
+        _touch(tmp_path, "tests/test_main.py")
+        _touch(tmp_path, "docs/guide.md")
+
+        optimizer = ContextOptimizer(base_dir=str(tmp_path))
+        optimizer._placement_hidden_tool_trees = frozenset()
+        optimizer._analyze_project_structure()
+
+        matching = optimizer._find_matching_directories("**/*.py")
+        expected = {tmp_path / "src", tmp_path / "src/core", tmp_path / "tests"}
+        assert matching == expected
+
+    def test_matching_dirs_for_directory_scoped_pattern(self, tmp_path: Path) -> None:
+        """Directory-scoped pattern finds only the targeted directory."""
+        _touch(tmp_path, "src/main.py")
+        _touch(tmp_path, "src/core/engine.py")
+        _touch(tmp_path, "tests/test_main.py")
+
+        optimizer = ContextOptimizer(base_dir=str(tmp_path))
+        optimizer._placement_hidden_tool_trees = frozenset()
+        optimizer._analyze_project_structure()
+
+        matching = optimizer._find_matching_directories("src/**/*.py")
+        expected = {tmp_path / "src", tmp_path / "src/core"}
+        assert matching == expected
+
+    def test_matching_dirs_for_extension_only_pattern(self, tmp_path: Path) -> None:
+        """Extension-only pattern matches in all directories with that extension."""
+        _touch(tmp_path, "root.md")
+        _touch(tmp_path, "docs/guide.md")
+        _touch(tmp_path, "src/notes.md")
+        _touch(tmp_path, "src/main.py")
+
+        optimizer = ContextOptimizer(base_dir=str(tmp_path))
+        optimizer._placement_hidden_tool_trees = frozenset()
+        optimizer._analyze_project_structure()
+
+        matching = optimizer._find_matching_directories("*.md")
+        expected = {tmp_path, tmp_path / "docs", tmp_path / "src"}
+        assert matching == expected
+
+    def test_matching_dirs_empty_for_no_match(self, tmp_path: Path) -> None:
+        """Pattern with no matching files returns empty set."""
+        _touch(tmp_path, "src/main.py")
+        _touch(tmp_path, "tests/test_main.py")
+
+        optimizer = ContextOptimizer(base_dir=str(tmp_path))
+        optimizer._placement_hidden_tool_trees = frozenset()
+        optimizer._analyze_project_structure()
+
+        matching = optimizer._find_matching_directories("**/*.rs")
+        assert matching == set()
+
+    def test_valid_file_symlink_preserves_matching_behavior(self, tmp_path: Path) -> None:
+        """A symlink to a regular file remains eligible for pattern matching."""
+        _touch(tmp_path, "src/target.py")
+        link = tmp_path / "src/alias.py"
+        _symlink_or_skip(link, tmp_path / "src/target.py")
+
+        optimizer = ContextOptimizer(base_dir=str(tmp_path))
+        optimizer._placement_hidden_tool_trees = frozenset()
+        optimizer._analyze_project_structure()
+
+        assert optimizer._find_matching_directories("*.py") == {tmp_path / "src"}
+        assert set(optimizer._files_by_directory[tmp_path / "src"]) == {
+            link,
+            tmp_path / "src/target.py",
+        }
+
+    def test_broken_file_symlink_does_not_create_match(self, tmp_path: Path) -> None:
+        """A broken file symlink stays in the project cache but cannot match."""
+        _touch(tmp_path, "src/readme.txt")
+        link = tmp_path / "src/broken.py"
+        _symlink_or_skip(link, tmp_path / "missing.py")
+
+        optimizer = ContextOptimizer(base_dir=str(tmp_path))
+        optimizer._placement_hidden_tool_trees = frozenset()
+        optimizer._analyze_project_structure()
+
+        assert link in optimizer._file_list_cache
+        assert link not in optimizer._files_by_directory[tmp_path / "src"]
+        assert optimizer._find_matching_directories("*.py") == set()
+
+    def test_symlinked_directory_does_not_match_or_inflate_pollution(self, tmp_path: Path) -> None:
+        """A directory symlink is indexed as a child but never analyzed twice."""
+        _touch(tmp_path, "src/real/module.py")
+        link = tmp_path / "src/linked"
+        _symlink_or_skip(link, tmp_path / "src/real", target_is_directory=True)
+
+        optimizer = ContextOptimizer(base_dir=str(tmp_path))
+        optimizer.optimize_instruction_placement([_make_instruction(apply_to="**/*.py")])
+
+        assert link in optimizer._children_by_directory[tmp_path / "src"]
+        assert link not in optimizer._directory_cache
+        assert optimizer._find_matching_directories("**/*.py") == {tmp_path / "src/real"}
+        assert optimizer._calculate_inheritance_pollution(
+            tmp_path / "src", "**/*.py"
+        ) == pytest.approx(0.0)
+
+
+class TestPollutionScoresUnchanged:
+    """Pollution scores must be identical to the pre-optimization behavior."""
+
+    def test_pollution_score_with_matching_children(self, tmp_path: Path) -> None:
+        """No pollution when all children match the pattern."""
+        _touch(tmp_path, "src/core/engine.py")
+        _touch(tmp_path, "src/utils/helpers.py")
+        _touch(tmp_path, "src/app.py")
+
+        optimizer = ContextOptimizer(base_dir=str(tmp_path))
+        instruction = _make_instruction(apply_to="**/*.py")
+        optimizer.optimize_instruction_placement([instruction])
+
+        src_dir = tmp_path / "src"
+        score = optimizer._calculate_inheritance_pollution(src_dir, "**/*.py")
+        # All children have .py files, so no pollution
+        assert score == 0.0
+
+    def test_pollution_score_with_non_matching_children(self, tmp_path: Path) -> None:
+        """Pollution when children have no matching files."""
+        _touch(tmp_path, "src/core/engine.py")
+        _touch(tmp_path, "src/assets/logo.png")
+        _touch(tmp_path, "src/app.py")
+
+        optimizer = ContextOptimizer(base_dir=str(tmp_path))
+        instruction = _make_instruction(apply_to="**/*.py")
+        optimizer.optimize_instruction_placement([instruction])
+
+        src_dir = tmp_path / "src"
+        score = optimizer._calculate_inheritance_pollution(src_dir, "**/*.py")
+        # assets/ has no .py files -> pollution penalty 0.5
+        assert score == 0.5
+
+    def test_pollution_score_multiple_non_matching_children(self, tmp_path: Path) -> None:
+        """Multiple non-matching children accumulate pollution."""
+        _touch(tmp_path, "src/core/engine.py")
+        _touch(tmp_path, "src/assets/logo.png")
+        _touch(tmp_path, "src/static/style.css")
+        _touch(tmp_path, "src/app.py")
+
+        optimizer = ContextOptimizer(base_dir=str(tmp_path))
+        instruction = _make_instruction(apply_to="**/*.py")
+        optimizer.optimize_instruction_placement([instruction])
+
+        src_dir = tmp_path / "src"
+        score = optimizer._calculate_inheritance_pollution(src_dir, "**/*.py")
+        # assets/ and static/ have no .py files -> 0.5 + 0.5 = 1.0
+        assert score == 1.0
+
+    def test_pollution_score_leaf_directory(self, tmp_path: Path) -> None:
+        """Leaf directory (no children) has zero pollution."""
+        _touch(tmp_path, "src/core/engine.py")
+
+        optimizer = ContextOptimizer(base_dir=str(tmp_path))
+        instruction = _make_instruction(apply_to="**/*.py")
+        optimizer.optimize_instruction_placement([instruction])
+
+        core_dir = tmp_path / "src/core"
+        score = optimizer._calculate_inheritance_pollution(core_dir, "**/*.py")
+        assert score == 0.0
+
+
+class TestCacheResetAndRebuild:
+    """Indexes are cleared and rebuilt deterministically on project analysis reset."""
+
+    def test_indexes_cleared_on_optimize_call(self, tmp_path: Path) -> None:
+        """optimize_instruction_placement clears and rebuilds indexes."""
+        _touch(tmp_path, "src/main.py")
+
+        optimizer = ContextOptimizer(base_dir=str(tmp_path))
+        instruction = _make_instruction(apply_to="**/*.py")
+
+        optimizer.optimize_instruction_placement([instruction])
+        first_files_index = dict(optimizer._files_by_directory)
+        first_children_index = dict(optimizer._children_by_directory)
+
+        # Second call must clear and rebuild
+        optimizer.optimize_instruction_placement([instruction])
+
+        assert optimizer._files_by_directory == first_files_index
+        assert optimizer._children_by_directory == first_children_index
+
+    def test_indexes_rebuilt_when_hidden_root_changes(self, tmp_path: Path) -> None:
+        """Indexes reflect newly admitted hidden-tool roots after re-optimization."""
+        _touch(tmp_path, ".github/instructions/guide.md")
+        _touch(tmp_path, "src/app.py")
+
+        optimizer = ContextOptimizer(base_dir=str(tmp_path))
+        # First call without targeting .github
+        optimizer.optimize_instruction_placement([_make_instruction(apply_to="**/*.py")])
+
+        github_instr_dir = tmp_path / ".github/instructions"
+        assert github_instr_dir not in optimizer._files_by_directory
+
+        # Second call targets .github
+        optimizer.optimize_instruction_placement([_make_instruction(apply_to=".github/**/*.md")])
+        assert github_instr_dir in optimizer._files_by_directory
+        file_names = {p.name for p in optimizer._files_by_directory[github_instr_dir]}
+        assert "guide.md" in file_names
+
+    def test_get_all_files_populates_indexes(self, tmp_path: Path) -> None:
+        """_get_all_files triggers analysis which populates indexes."""
+        _touch(tmp_path, "app.py")
+        _touch(tmp_path, "lib/helper.py")
+
+        optimizer = ContextOptimizer(base_dir=str(tmp_path))
+        assert optimizer._files_by_directory == {}
+        assert optimizer._children_by_directory == {}
+
+        optimizer._get_all_files()
+
+        assert tmp_path in optimizer._files_by_directory
+        assert tmp_path in optimizer._children_by_directory
+
+
+class TestIterationCountGuard:
+    """Deterministic scaling guard: index-based paths must not perform filesystem calls
+    proportional to (P * D) where P = patterns and D = directories.
+    """
+
+    def test_no_iterdir_scaling_with_patterns(self, tmp_path: Path) -> None:
+        """With N patterns and D directories, zero iterdir calls occur.
+
+        Pre-optimization: N*D iterdir calls in _find_matching_directories.
+        Post-optimization: 0 iterdir calls (all from in-memory index).
+        """
+        # Create a representative tree: 20 directories, 3 files each
+        for i in range(20):
+            for j in range(3):
+                _touch(tmp_path, f"dir_{i:02d}/file_{j}.py")
+
+        optimizer = ContextOptimizer(base_dir=str(tmp_path))
+        optimizer._placement_hidden_tool_trees = frozenset()
+        optimizer._analyze_project_structure()
+
+        iterdir_count = 0
+        original_iterdir = Path.iterdir
+
+        def counting_iterdir(self_path):
+            nonlocal iterdir_count
+            iterdir_count += 1
+            return original_iterdir(self_path)
+
+        # Run 10 different patterns through _find_matching_directories
+        patterns = [
+            "**/*.py",
+            "**/*.md",
+            "dir_00/**",
+            "dir_01/*.py",
+            "*.py",
+            "dir_1*/*.py",
+            "**/*.txt",
+            "dir_05/**/*.py",
+            "**/*_0.py",
+            "dir_19/*.py",
+        ]
+
+        with patch.object(Path, "iterdir", counting_iterdir):
+            for pattern in patterns:
+                optimizer._pattern_cache.pop(pattern, None)
+                optimizer._find_matching_directories(pattern)
+
+        assert iterdir_count == 0, (
+            f"Expected 0 iterdir calls with index-based lookup, got {iterdir_count}. "
+            f"10 patterns x 20 directories would have caused 200 iterdir calls "
+            f"in the pre-optimization implementation."
+        )
+
+    def test_no_iterdir_scaling_with_pollution_candidates(self, tmp_path: Path) -> None:
+        """With C candidate directories, zero iterdir calls in pollution scoring.
+
+        Pre-optimization: C iterdir calls in _calculate_inheritance_pollution.
+        Post-optimization: 0 iterdir calls (all from in-memory index).
+        """
+        # Create tree with parent + 15 children
+        for i in range(15):
+            _touch(tmp_path, f"src/child_{i:02d}/file.py")
+        _touch(tmp_path, "src/app.py")
+
+        optimizer = ContextOptimizer(base_dir=str(tmp_path))
+        instruction = _make_instruction(apply_to="**/*.py")
+        optimizer.optimize_instruction_placement([instruction])
+
+        iterdir_count = 0
+        original_iterdir = Path.iterdir
+
+        def counting_iterdir(self_path):
+            nonlocal iterdir_count
+            iterdir_count += 1
+            return original_iterdir(self_path)
+
+        src_dir = tmp_path / "src"
+        with patch.object(Path, "iterdir", counting_iterdir):
+            # Call pollution scoring multiple times (simulating candidate evaluation)
+            for _ in range(10):
+                optimizer._calculate_inheritance_pollution(src_dir, "**/*.py")
+
+        assert iterdir_count == 0, (
+            f"Expected 0 iterdir calls with index-based lookup, got {iterdir_count}. "
+            f"10 candidate evaluations would have caused 10 iterdir calls "
+            f"in the pre-optimization implementation."
+        )

--- a/tests/unit/compilation/test_context_optimizer_single_walk.py
+++ b/tests/unit/compilation/test_context_optimizer_single_walk.py
@@ -9,6 +9,7 @@ ordering, and cache lifecycle.
 from __future__ import annotations
 
 import os
+from collections.abc import Iterator
 from pathlib import Path
 from unittest.mock import patch
 
@@ -37,6 +38,25 @@ def _touch(base: Path, rel: str) -> None:
     p = base / rel
     p.parent.mkdir(parents=True, exist_ok=True)
     p.touch()
+
+
+def _walk_with_nested_subtree(
+    base: Path,
+    subtree_name: str,
+    descended: list[Path],
+) -> Iterator[tuple[str, list[str], list[str]]]:
+    root_dirs = [subtree_name]
+    yield str(base), root_dirs, ["app.py"]
+    if subtree_name not in root_dirs:
+        return
+
+    subtree = base / subtree_name
+    child_dirs = ["deep"]
+    yield str(subtree), child_dirs, []
+    if child_dirs:
+        deep = subtree / "deep"
+        descended.append(deep)
+        yield str(deep), [], ["ignored.py"]
 
 
 class TestSingleWalkPopulatesBothCaches:
@@ -191,6 +211,51 @@ class TestExclusionInUnifiedWalk:
 
         assert "vendor" not in dir_names
         assert "lib.py" not in file_names
+
+    def test_default_exclusion_safety_net_prunes_nested_subtree(self, tmp_path: Path) -> None:
+        """The safety net stops descent when parent pruning is bypassed."""
+        _touch(tmp_path, "app.py")
+        descended: list[Path] = []
+        optimizer = ContextOptimizer(base_dir=str(tmp_path))
+
+        with (
+            patch(
+                "apm_cli.compilation.context_optimizer.os.walk",
+                side_effect=lambda _top: _walk_with_nested_subtree(
+                    tmp_path,
+                    "node_modules",
+                    descended,
+                ),
+            ),
+            patch.object(optimizer, "_should_exclude_subdir", return_value=False),
+        ):
+            optimizer._analyze_project_structure()
+
+        assert descended == []
+
+    def test_configurable_exclusion_safety_net_prunes_nested_subtree(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A current-path exclusion stops descent when parent pruning is bypassed."""
+        _touch(tmp_path, "app.py")
+        descended: list[Path] = []
+        optimizer = ContextOptimizer(base_dir=str(tmp_path), exclude_patterns=["vendor"])
+
+        with (
+            patch(
+                "apm_cli.compilation.context_optimizer.os.walk",
+                side_effect=lambda _top: _walk_with_nested_subtree(
+                    tmp_path,
+                    "vendor",
+                    descended,
+                ),
+            ),
+            patch.object(optimizer, "_should_exclude_subdir", return_value=False),
+        ):
+            optimizer._analyze_project_structure()
+
+        assert descended == []
 
 
 class TestHiddenToolRootsInUnifiedWalk:

--- a/tests/unit/compilation/test_context_optimizer_single_walk.py
+++ b/tests/unit/compilation/test_context_optimizer_single_walk.py
@@ -1,0 +1,276 @@
+"""Regression tests for the unified single-walk traversal in ContextOptimizer.
+
+Asserts that ``optimize_instruction_placement`` and ``_get_all_files``
+both reuse the same ``os.walk`` traversal result, and that behavioral
+correctness is preserved across exclusions, hidden-tool roots, stable
+ordering, and cache lifecycle.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from apm_cli.compilation.context_optimizer import ContextOptimizer
+from apm_cli.primitives.models import Instruction
+
+pytestmark = pytest.mark.component
+
+
+def _make_instruction(
+    name: str = "inst",
+    apply_to: str = "**/*.py",
+) -> Instruction:
+    return Instruction(
+        name=name,
+        file_path=Path(f"{name}.instructions.md"),
+        description=f"{name} description",
+        apply_to=apply_to,
+        content=f"{name} content",
+    )
+
+
+def _touch(base: Path, rel: str) -> None:
+    p = base / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.touch()
+
+
+class TestSingleWalkPopulatesBothCaches:
+    """Regression: optimize_instruction_placement must call os.walk exactly once
+    and populate both _directory_cache and _file_list_cache in that single pass.
+    """
+
+    def test_single_walk_populates_directory_cache_and_file_list_cache(
+        self, tmp_path: Path
+    ) -> None:
+        """One os.walk traversal must populate both caches.
+
+        Regression for the dual-walk footprint: before the fix,
+        _analyze_project_structure and _get_all_files each ran their own
+        os.walk, doubling filesystem I/O on every compile.
+        """
+        _touch(tmp_path, "src/main.py")
+        _touch(tmp_path, "src/utils.py")
+        _touch(tmp_path, "tests/test_main.py")
+
+        optimizer = ContextOptimizer(base_dir=str(tmp_path))
+        instruction = _make_instruction(apply_to="**/*.py")
+
+        real_walk = os.walk
+        walk_call_count = 0
+
+        def counting_walk(top, **kwargs):
+            nonlocal walk_call_count
+            walk_call_count += 1
+            yield from real_walk(top, **kwargs)
+
+        with patch("apm_cli.compilation.context_optimizer.os.walk", side_effect=counting_walk):
+            optimizer.optimize_instruction_placement([instruction])
+
+        assert walk_call_count == 1, (
+            f"expected exactly 1 os.walk call, got {walk_call_count} "
+            "(dual-walk regression: _analyze_project_structure and _get_all_files "
+            "must share the same traversal result)"
+        )
+
+        assert optimizer._directory_cache, "_directory_cache must be non-empty after optimization"
+        assert optimizer._file_list_cache is not None, "_file_list_cache must not be None"
+        assert len(optimizer._file_list_cache) > 0, "_file_list_cache must contain files"
+
+        dir_names = {p.name for p in optimizer._directory_cache}
+        assert "src" in dir_names
+        assert "tests" in dir_names
+
+        file_names = {p.name for p in optimizer._file_list_cache}
+        assert "main.py" in file_names
+        assert "utils.py" in file_names
+        assert "test_main.py" in file_names
+
+
+class TestGetAllFilesRoutesThroughAnalyze:
+    """_get_all_files must route through _analyze_project_structure when cache is None."""
+
+    def test_get_all_files_before_optimize_triggers_single_walk(self, tmp_path: Path) -> None:
+        """_get_all_files called before optimize must use _analyze_project_structure."""
+        _touch(tmp_path, "app.py")
+        _touch(tmp_path, "lib/helper.py")
+
+        optimizer = ContextOptimizer(base_dir=str(tmp_path))
+        assert optimizer._file_list_cache is None
+
+        real_walk = os.walk
+        walk_call_count = 0
+
+        def counting_walk(top, **kwargs):
+            nonlocal walk_call_count
+            walk_call_count += 1
+            yield from real_walk(top, **kwargs)
+
+        with patch("apm_cli.compilation.context_optimizer.os.walk", side_effect=counting_walk):
+            files = optimizer._get_all_files()
+
+        assert walk_call_count == 1
+        assert optimizer._file_list_cache is not None
+        assert files is optimizer._file_list_cache
+        assert set(optimizer._directory_cache) == {tmp_path, tmp_path / "lib"}
+        assert optimizer._directory_cache[tmp_path].total_files == 1
+        assert optimizer._directory_cache[tmp_path / "lib"].total_files == 1
+
+    def test_optimize_rebuilds_direct_cache_for_selected_hidden_root(self, tmp_path: Path) -> None:
+        """Optimize must replace a direct-call cache when hidden roots become eligible."""
+        _touch(tmp_path, ".github/instructions/guide.md")
+        _touch(tmp_path, "src/app.py")
+
+        optimizer = ContextOptimizer(base_dir=str(tmp_path))
+        initial_files = optimizer._get_all_files()
+
+        assert tmp_path / ".github/instructions/guide.md" not in initial_files
+        assert tmp_path / ".github/instructions" not in optimizer._directory_cache
+
+        optimizer.optimize_instruction_placement([_make_instruction(apply_to=".github/**/*.md")])
+
+        assert tmp_path / ".github/instructions/guide.md" in optimizer._file_list_cache
+        assert tmp_path / ".github/instructions" in optimizer._directory_cache
+
+    def test_get_all_files_reuses_cache_without_second_walk(self, tmp_path: Path) -> None:
+        """After the first walk, a second call to _get_all_files reuses the cache."""
+        _touch(tmp_path, "app.py")
+
+        optimizer = ContextOptimizer(base_dir=str(tmp_path))
+        first = optimizer._get_all_files()
+
+        real_walk = os.walk
+        walk_call_count = 0
+
+        def counting_walk(top, **kwargs):
+            nonlocal walk_call_count
+            walk_call_count += 1
+            yield from real_walk(top, **kwargs)
+
+        with patch("apm_cli.compilation.context_optimizer.os.walk", side_effect=counting_walk):
+            second = optimizer._get_all_files()
+
+        assert walk_call_count == 0, "second _get_all_files call must not walk again"
+        assert first is second
+
+
+class TestExclusionInUnifiedWalk:
+    """DEFAULT_EXCLUDED_DIRNAMES and configurable patterns honored in unified walk."""
+
+    def test_default_excluded_dirnames_absent_from_both_caches(self, tmp_path: Path) -> None:
+        """Files inside node_modules and __pycache__ must not appear in either cache."""
+        _touch(tmp_path, "src/app.py")
+        _touch(tmp_path, "node_modules/pkg/index.js")
+        _touch(tmp_path, "__pycache__/module.pyc")
+
+        optimizer = ContextOptimizer(base_dir=str(tmp_path))
+        optimizer.optimize_instruction_placement([_make_instruction(apply_to="**/*.py")])
+
+        dir_names = {p.name for p in optimizer._directory_cache}
+        file_names = {p.name for p in optimizer._file_list_cache}
+
+        assert "node_modules" not in dir_names
+        assert "__pycache__" not in dir_names
+        assert "index.js" not in file_names
+        assert "module.pyc" not in file_names
+
+    def test_configurable_exclude_patterns_prune_both_caches(self, tmp_path: Path) -> None:
+        """Paths matching configurable exclude patterns absent from both caches."""
+        _touch(tmp_path, "src/app.py")
+        _touch(tmp_path, "vendor/lib.py")
+
+        optimizer = ContextOptimizer(base_dir=str(tmp_path), exclude_patterns=["vendor"])
+        optimizer.optimize_instruction_placement([_make_instruction(apply_to="**/*.py")])
+
+        dir_names = {p.name for p in optimizer._directory_cache}
+        file_names = {p.name for p in optimizer._file_list_cache}
+
+        assert "vendor" not in dir_names
+        assert "lib.py" not in file_names
+
+
+class TestHiddenToolRootsInUnifiedWalk:
+    """Supported hidden-tool roots in applyTo are admitted; others are pruned."""
+
+    def test_supported_hidden_root_in_apply_to_traversed_by_unified_walk(
+        self, tmp_path: Path
+    ) -> None:
+        """A supported hidden root named in applyTo appears in both caches."""
+        apm_dir = tmp_path / ".apm"
+        apm_dir.mkdir()
+        instr_dir = apm_dir / "instructions"
+        instr_dir.mkdir()
+        (instr_dir / "guide.md").touch()
+
+        optimizer = ContextOptimizer(base_dir=str(tmp_path))
+        instruction = _make_instruction(apply_to=".apm/**/*.md")
+        optimizer.optimize_instruction_placement([instruction])
+
+        dir_names = {p.name for p in optimizer._directory_cache}
+        file_names = {p.name for p in optimizer._file_list_cache}
+
+        assert "instructions" in dir_names
+        assert "guide.md" in file_names
+
+    def test_unsupported_hidden_dir_pruned_from_both_caches(self, tmp_path: Path) -> None:
+        """A hidden directory not in PLACEMENT_HIDDEN_TOOL_TREES is pruned."""
+        hidden = tmp_path / ".secret"
+        hidden.mkdir()
+        (hidden / "data.txt").touch()
+        _touch(tmp_path, "src/app.py")
+
+        optimizer = ContextOptimizer(base_dir=str(tmp_path))
+        optimizer.optimize_instruction_placement([_make_instruction(apply_to="src/**/*.py")])
+
+        dir_names = {p.name for p in optimizer._directory_cache}
+        file_names = {p.name for p in optimizer._file_list_cache}
+
+        assert ".secret" not in dir_names
+        assert "data.txt" not in file_names
+
+
+class TestStableOrderingInUnifiedWalk:
+    """File list from the unified walk must be in stable sorted order."""
+
+    def test_file_list_cache_sorted_within_directory(self, tmp_path: Path) -> None:
+        """Files within each directory appear in sorted (lexicographic) order."""
+        _touch(tmp_path, "src/z_last.py")
+        _touch(tmp_path, "src/a_first.py")
+        _touch(tmp_path, "src/m_mid.py")
+
+        optimizer = ContextOptimizer(base_dir=str(tmp_path))
+        optimizer.optimize_instruction_placement([_make_instruction(apply_to="**/*.py")])
+
+        src_files = [p.name for p in optimizer._file_list_cache if p.parent.name == "src"]
+        assert src_files == sorted(src_files), f"files in src/ not in sorted order: {src_files}"
+
+    def test_file_list_cache_sorted_across_directories(self, tmp_path: Path) -> None:
+        """Files from sibling directories follow sorted traversal order."""
+        _touch(tmp_path, "zeta/a.py")
+        _touch(tmp_path, "alpha/z.py")
+
+        optimizer = ContextOptimizer(base_dir=str(tmp_path))
+        optimizer.optimize_instruction_placement([_make_instruction(apply_to="**/*.py")])
+
+        relative_files = [path.relative_to(tmp_path) for path in optimizer._file_list_cache]
+        assert relative_files == [Path("alpha/z.py"), Path("zeta/a.py")]
+
+    def test_file_list_cache_stable_across_repeated_optimize_calls(self, tmp_path: Path) -> None:
+        """Repeated optimization calls produce identical file lists."""
+        for name in ["z.py", "a.py", "m.py"]:
+            _touch(tmp_path, f"src/{name}")
+
+        optimizer = ContextOptimizer(base_dir=str(tmp_path))
+        instruction = _make_instruction(apply_to="**/*.py")
+
+        optimizer.optimize_instruction_placement([instruction])
+        first = list(optimizer._file_list_cache)
+
+        optimizer.optimize_instruction_placement([instruction])
+        second = list(optimizer._file_list_cache)
+
+        assert first == second, "file list must be identical across repeated runs"

--- a/tests/unit/policy/test_cache_merged_effective.py
+++ b/tests/unit/policy/test_cache_merged_effective.py
@@ -1273,8 +1273,8 @@ def test_ado_chain_preserves_backend_for_explicit_and_same_org_parent(
 
     with (
         patch(
-            "apm_cli.policy.discovery._extract_org_from_git_remote",
-            return_value=("contoso", "dev.azure.com"),
+            "apm_cli.policy.discovery._extract_org_host_port_from_git_remote",
+            return_value=("contoso", "dev.azure.com", None),
         ),
         patch("apm_cli.policy.discovery._fetch_ado_contents", side_effect=fetch_ado) as ado,
         patch(

--- a/tests/unit/policy/test_discovery.py
+++ b/tests/unit/policy/test_discovery.py
@@ -21,6 +21,7 @@ from apm_cli.policy.discovery import (
     _auto_discover,
     _cache_key,
     _extract_org_from_git_remote,
+    _extract_org_host_port_from_git_remote,
     _fetch_ado_contents,
     _fetch_from_ado_repo,
     _fetch_from_repo,
@@ -173,6 +174,34 @@ class TestExtractOrgFromGitRemote(unittest.TestCase):
     def test_timeout(self, mock_run):
         mock_run.side_effect = subprocess.TimeoutExpired(cmd="git", timeout=5)
         result = _extract_org_from_git_remote(Path("/fake"))
+        self.assertIsNone(result)
+
+    @patch("apm_cli.policy.discovery._parse_remote_url")
+    @patch("apm_cli.policy.discovery.subprocess.run")
+    def test_remote_parser_value_error_returns_none(self, mock_run, mock_parse):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="https://dev.azure.com/contoso/project/_git/repo\n",
+        )
+        mock_parse.side_effect = ValueError("invalid remote coordinates")
+
+        result = _extract_org_host_port_from_git_remote(Path("/fake"))
+
+        self.assertIsNone(result)
+
+    @patch("apm_cli.policy.discovery.urlparse")
+    @patch("apm_cli.policy.discovery._parse_remote_url")
+    @patch("apm_cli.policy.discovery.subprocess.run")
+    def test_remote_port_value_error_returns_none(self, mock_run, mock_parse, mock_urlparse):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="https://ghe.example.com:invalid/contoso/repo.git\n",
+        )
+        mock_parse.return_value = ("contoso", "ghe.example.com")
+        mock_urlparse.side_effect = ValueError("invalid port")
+
+        result = _extract_org_host_port_from_git_remote(Path("/fake"))
+
         self.assertIsNone(result)
 
 
@@ -945,14 +974,17 @@ class TestAutoDiscover(unittest.TestCase):
             self.assertEqual(result.outcome, "absent")
 
     @patch("apm_cli.policy.discovery._fetch_from_ado_repo")
-    def test_auto_discover_ado_git_subprocess_invoked_exactly_once(self, mock_ado_fetch):
+    @patch("apm_cli.policy.discovery._policy_repo_candidates")
+    def test_auto_discover_ado_git_subprocess_invoked_exactly_once(
+        self,
+        mock_candidates,
+        mock_ado_fetch,
+    ):
         """_auto_discover must invoke the git remote subprocess exactly once.
 
-        Before the A1 fix, _auto_discover ran git remote twice: once via
-        _extract_org_from_git_remote (which delegates to
-        _extract_org_host_port_from_git_remote) and again via the now-removed
-        _extract_port_from_git_remote. This regression guard asserts exactly one
-        subprocess call and that the parsed explicit port reaches the ADO fetch path.
+        Before the A1 fix, separate org/host and port callers in _auto_discover
+        each ran git remote. This guard asserts one subprocess call and verifies
+        that the parsed host and explicit port reach their routing consumers.
         """
         ado_url = "https://ado.example.test:8443/DefaultCollection/project/_git/repo"
 
@@ -963,6 +995,7 @@ class TestAutoDiscover(unittest.TestCase):
             return proc
 
         mock_ado_fetch.return_value = PolicyFetchResult(outcome="absent")
+        mock_candidates.return_value = ("_apm",)
 
         with (
             patch("apm_cli.policy.discovery.subprocess.run", side_effect=fake_run) as mock_run,
@@ -977,6 +1010,7 @@ class TestAutoDiscover(unittest.TestCase):
             f"Expected exactly 1 git subprocess call, got {mock_run.call_count}. "
             "_auto_discover must not invoke git remote multiple times.",
         )
+        mock_candidates.assert_called_once_with("ado.example.test")
         self.assertEqual(mock_ado_fetch.call_args.kwargs["port"], 8443)
 
 

--- a/tests/unit/policy/test_discovery.py
+++ b/tests/unit/policy/test_discovery.py
@@ -728,10 +728,10 @@ class TestAutoDiscover(unittest.TestCase):
     """Test _auto_discover logic with cascading candidate repos."""
 
     @patch("apm_cli.policy.discovery._fetch_from_repo")
-    @patch("apm_cli.policy.discovery._extract_org_from_git_remote")
+    @patch("apm_cli.policy.discovery._extract_org_host_port_from_git_remote")
     def test_github_com_first_candidate_found(self, mock_extract, mock_fetch):
         """When .github-private has a policy, it wins immediately."""
-        mock_extract.return_value = ("contoso", "github.com")
+        mock_extract.return_value = ("contoso", "github.com", None)
         mock_fetch.return_value = PolicyFetchResult(
             policy=ApmPolicy(), source="org:contoso/.github-private", outcome="found"
         )
@@ -744,10 +744,10 @@ class TestAutoDiscover(unittest.TestCase):
             self.assertTrue(result.found)
 
     @patch("apm_cli.policy.discovery._fetch_from_repo")
-    @patch("apm_cli.policy.discovery._extract_org_from_git_remote")
+    @patch("apm_cli.policy.discovery._extract_org_host_port_from_git_remote")
     def test_github_com_cascades_to_dot_apm(self, mock_extract, mock_fetch):
         """.github-private and .github absent -> falls back to .apm."""
-        mock_extract.return_value = ("contoso", "github.com")
+        mock_extract.return_value = ("contoso", "github.com", None)
         mock_fetch.side_effect = [
             PolicyFetchResult(outcome="absent"),  # .github-private 404
             PolicyFetchResult(outcome="absent"),  # .github 404
@@ -765,10 +765,10 @@ class TestAutoDiscover(unittest.TestCase):
             self.assertTrue(result.found)
 
     @patch("apm_cli.policy.discovery._fetch_from_repo")
-    @patch("apm_cli.policy.discovery._extract_org_from_git_remote")
+    @patch("apm_cli.policy.discovery._extract_org_host_port_from_git_remote")
     def test_github_com_cascades_to_underscore_apm(self, mock_extract, mock_fetch):
         """All dot-prefixed repos absent -> falls back to _apm."""
-        mock_extract.return_value = ("contoso", "github.com")
+        mock_extract.return_value = ("contoso", "github.com", None)
         mock_fetch.side_effect = [
             PolicyFetchResult(outcome="absent"),  # .github-private 404
             PolicyFetchResult(outcome="absent"),  # .github 404
@@ -784,10 +784,10 @@ class TestAutoDiscover(unittest.TestCase):
             self.assertTrue(result.found)
 
     @patch("apm_cli.policy.discovery._fetch_from_repo")
-    @patch("apm_cli.policy.discovery._extract_org_from_git_remote")
+    @patch("apm_cli.policy.discovery._extract_org_host_port_from_git_remote")
     def test_github_com_all_absent(self, mock_extract, mock_fetch):
         """All candidates return absent -> outcome is absent."""
-        mock_extract.return_value = ("contoso", "github.com")
+        mock_extract.return_value = ("contoso", "github.com", None)
         mock_fetch.return_value = PolicyFetchResult(outcome="absent")
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -797,10 +797,10 @@ class TestAutoDiscover(unittest.TestCase):
             self.assertFalse(result.found)
 
     @patch("apm_cli.policy.discovery._fetch_from_repo")
-    @patch("apm_cli.policy.discovery._extract_org_from_git_remote")
+    @patch("apm_cli.policy.discovery._extract_org_host_port_from_git_remote")
     def test_github_com_error_fail_closed(self, mock_extract, mock_fetch):
         """Auth error on first candidate -> fail-closed, no fallback."""
-        mock_extract.return_value = ("contoso", "github.com")
+        mock_extract.return_value = ("contoso", "github.com", None)
         mock_fetch.return_value = PolicyFetchResult(
             error="401: Unauthorized", outcome="cache_miss_fetch_fail"
         )
@@ -814,10 +814,10 @@ class TestAutoDiscover(unittest.TestCase):
             self.assertIn("401", result.error)
 
     @patch("apm_cli.policy.discovery._fetch_from_repo")
-    @patch("apm_cli.policy.discovery._extract_org_from_git_remote")
+    @patch("apm_cli.policy.discovery._extract_org_host_port_from_git_remote")
     def test_403_is_error_not_absent(self, mock_extract, mock_fetch):
         """HTTP 403 -> fail-closed (cache_miss_fetch_fail), not absent."""
-        mock_extract.return_value = ("contoso", "github.com")
+        mock_extract.return_value = ("contoso", "github.com", None)
         mock_fetch.return_value = PolicyFetchResult(
             error="403: Access denied to contoso/.github-private",
             outcome="cache_miss_fetch_fail",
@@ -831,10 +831,10 @@ class TestAutoDiscover(unittest.TestCase):
             self.assertFalse(result.found)
 
     @patch("apm_cli.policy.discovery._fetch_from_repo")
-    @patch("apm_cli.policy.discovery._extract_org_from_git_remote")
+    @patch("apm_cli.policy.discovery._extract_org_host_port_from_git_remote")
     def test_github_private_auth_error_does_not_fall_through(self, mock_extract, mock_fetch):
         """.github-private auth error -> fail-closed, .github NOT tried."""
-        mock_extract.return_value = ("contoso", "github.com")
+        mock_extract.return_value = ("contoso", "github.com", None)
         mock_fetch.side_effect = [
             PolicyFetchResult(error="403: Access denied", outcome="cache_miss_fetch_fail"),
             PolicyFetchResult(policy=ApmPolicy(), outcome="found"),
@@ -847,10 +847,10 @@ class TestAutoDiscover(unittest.TestCase):
             self.assertFalse(result.found)
 
     @patch("apm_cli.policy.discovery._fetch_from_repo")
-    @patch("apm_cli.policy.discovery._extract_org_from_git_remote")
+    @patch("apm_cli.policy.discovery._extract_org_host_port_from_git_remote")
     def test_github_private_absent_falls_back_to_github(self, mock_extract, mock_fetch):
         """.github-private absent (404) -> cascade to .github."""
-        mock_extract.return_value = ("contoso", "github.com")
+        mock_extract.return_value = ("contoso", "github.com", None)
         mock_fetch.side_effect = [
             PolicyFetchResult(outcome="absent"),  # .github-private 404
             PolicyFetchResult(
@@ -866,9 +866,9 @@ class TestAutoDiscover(unittest.TestCase):
             self.assertTrue(result.found)
 
     @patch("apm_cli.policy.discovery._fetch_from_repo")
-    @patch("apm_cli.policy.discovery._extract_org_from_git_remote")
+    @patch("apm_cli.policy.discovery._extract_org_host_port_from_git_remote")
     def test_ghe_repo_ref_includes_host(self, mock_extract, mock_fetch):
-        mock_extract.return_value = ("contoso", "ghe.example.com")
+        mock_extract.return_value = ("contoso", "ghe.example.com", None)
         mock_fetch.return_value = PolicyFetchResult(
             policy=ApmPolicy(),
             source="org:ghe.example.com/contoso/.github-private",
@@ -880,7 +880,7 @@ class TestAutoDiscover(unittest.TestCase):
             first_call = mock_fetch.call_args_list[0]
             self.assertEqual(first_call[0][0], "ghe.example.com/contoso/.github-private")
 
-    @patch("apm_cli.policy.discovery._extract_org_from_git_remote")
+    @patch("apm_cli.policy.discovery._extract_org_host_port_from_git_remote")
     def test_no_remote_returns_error(self, mock_extract):
         mock_extract.return_value = None
 
@@ -890,10 +890,10 @@ class TestAutoDiscover(unittest.TestCase):
             self.assertIn("Could not determine org", result.error)
 
     @patch("apm_cli.policy.discovery._fetch_from_ado_repo")
-    @patch("apm_cli.policy.discovery._extract_org_from_git_remote")
+    @patch("apm_cli.policy.discovery._extract_org_host_port_from_git_remote")
     def test_ado_host_only_tries_underscore_apm(self, mock_extract, mock_ado_fetch):
         """ADO host profile skips .github and .apm, only tries _apm."""
-        mock_extract.return_value = ("contoso", "dev.azure.com")
+        mock_extract.return_value = ("contoso", "dev.azure.com", None)
         mock_ado_fetch.return_value = PolicyFetchResult(
             policy=ApmPolicy(), source="org:dev.azure.com/contoso/_apm/_apm", outcome="found"
         )
@@ -907,20 +907,16 @@ class TestAutoDiscover(unittest.TestCase):
             self.assertTrue(result.found)
 
     @patch("apm_cli.policy.discovery._fetch_from_ado_repo")
-    @patch(
-        "apm_cli.policy.discovery._extract_port_from_git_remote",
-        return_value=8443,
-    )
-    @patch("apm_cli.policy.discovery._extract_org_from_git_remote")
+    @patch("apm_cli.policy.discovery._extract_org_host_port_from_git_remote")
     def test_ado_server_auto_discovery_preserves_remote_port(
         self,
         mock_extract,
-        _mock_port,
         mock_ado_fetch,
     ):
         mock_extract.return_value = (
             "DefaultCollection",
             "ado.example.test",
+            8443,
         )
         mock_ado_fetch.return_value = PolicyFetchResult(outcome="absent")
 
@@ -937,16 +933,51 @@ class TestAutoDiscover(unittest.TestCase):
         self.assertEqual(mock_ado_fetch.call_args.kwargs["port"], 8443)
 
     @patch("apm_cli.policy.discovery._fetch_from_ado_repo")
-    @patch("apm_cli.policy.discovery._extract_org_from_git_remote")
+    @patch("apm_cli.policy.discovery._extract_org_host_port_from_git_remote")
     def test_ado_visualstudio_host(self, mock_extract, mock_ado_fetch):
         """*.visualstudio.com hosts also use ADO profile."""
-        mock_extract.return_value = ("contoso", "contoso.visualstudio.com")
+        mock_extract.return_value = ("contoso", "contoso.visualstudio.com", None)
         mock_ado_fetch.return_value = PolicyFetchResult(outcome="absent")
 
         with tempfile.TemporaryDirectory() as tmpdir:
             result = _auto_discover(Path(tmpdir), no_cache=True)
             mock_ado_fetch.assert_called_once()
             self.assertEqual(result.outcome, "absent")
+
+    @patch("apm_cli.policy.discovery._fetch_from_ado_repo")
+    def test_auto_discover_ado_git_subprocess_invoked_exactly_once(self, mock_ado_fetch):
+        """_auto_discover must invoke the git remote subprocess exactly once.
+
+        Before the A1 fix, _auto_discover ran git remote twice: once via
+        _extract_org_from_git_remote (which delegates to
+        _extract_org_host_port_from_git_remote) and again via the now-removed
+        _extract_port_from_git_remote. This regression guard asserts exactly one
+        subprocess call and that the parsed explicit port reaches the ADO fetch path.
+        """
+        ado_url = "https://ado.example.test:8443/DefaultCollection/project/_git/repo"
+
+        def fake_run(cmd, **kwargs):
+            proc = MagicMock()
+            proc.returncode = 0
+            proc.stdout = ado_url + "\n"
+            return proc
+
+        mock_ado_fetch.return_value = PolicyFetchResult(outcome="absent")
+
+        with (
+            patch("apm_cli.policy.discovery.subprocess.run", side_effect=fake_run) as mock_run,
+            patch.dict(os.environ, {"ADO_HOST": "ado.example.test"}, clear=False),
+            tempfile.TemporaryDirectory() as tmpdir,
+        ):
+            _auto_discover(Path(tmpdir), no_cache=True)
+
+        self.assertEqual(
+            mock_run.call_count,
+            1,
+            f"Expected exactly 1 git subprocess call, got {mock_run.call_count}. "
+            "_auto_discover must not invoke git remote multiple times.",
+        )
+        self.assertEqual(mock_ado_fetch.call_args.kwargs["port"], 8443)
 
 
 class TestPolicyRepoCandidates(unittest.TestCase):

--- a/tests/unit/test_uninstall_engine_helpers.py
+++ b/tests/unit/test_uninstall_engine_helpers.py
@@ -767,6 +767,242 @@ class TestResolveMarketplacePackages:
 
 
 # ===========================================================================
+# _resolve_marketplace_packages -- multi-entry first-match regression
+# ===========================================================================
+
+
+class TestResolveMarketplacePackagesMultiEntry:
+    """Regression contract for first-match / provenance behavior with multiple same-plugin entries.
+
+    These tests encode the observable ordering semantics that any optimisation
+    of _resolve_marketplace_packages must preserve:
+    - Exact-match (discovered_via == marketplace_name AND marketplace_plugin_name
+      == plugin_name) takes priority over a provenance-mismatch entry regardless
+      of insertion order.
+    - When no exact match exists, the *first* insertion-order same-plugin entry
+      whose discovered_via != marketplace_name is used.
+    - The warning text for the provenance-mismatch path is stable and includes
+      the plugin name, the requested marketplace, the actual marketplace, and
+      the canonical that will be uninstalled.
+    """
+
+    def test_first_exact_match_wins_among_multiple_entries(self):
+        """When multiple entries share the same plugin+marketplace, first one wins."""
+        from apm_cli.commands.uninstall.engine import _resolve_marketplace_packages
+
+        lockfile = LockFile()
+        dep_first = LockedDependency(
+            repo_url="acme/plugin-v1",
+            resolved_commit="aaa",
+            discovered_via="official",
+            marketplace_plugin_name="multi-plugin",
+        )
+        dep_second = LockedDependency(
+            repo_url="acme/plugin-v2",
+            resolved_commit="bbb",
+            discovered_via="official",
+            marketplace_plugin_name="multi-plugin",
+        )
+        lockfile.add_dependency(dep_first)
+        lockfile.add_dependency(dep_second)
+        logger = _make_logger()
+
+        result = _resolve_marketplace_packages(["multi-plugin@official"], lockfile, logger)
+
+        # First insertion-order exact match must win; second entry is never consulted
+        assert result["multi-plugin@official"] == dep_first.get_unique_key()
+        logger.warning.assert_not_called()
+        logger.error.assert_not_called()
+
+    def test_first_provenance_mismatch_entry_wins_among_multiple(self):
+        """When no exact match exists, first insertion-order mismatch entry wins."""
+        from apm_cli.commands.uninstall.engine import _resolve_marketplace_packages
+
+        lockfile = LockFile()
+        dep_first = LockedDependency(
+            repo_url="acme/mismatch-first",
+            resolved_commit="c11",
+            discovered_via="other-marketplace",
+            marketplace_plugin_name="shared-plugin",
+        )
+        dep_second = LockedDependency(
+            repo_url="acme/mismatch-second",
+            resolved_commit="d22",
+            discovered_via="another-marketplace",
+            marketplace_plugin_name="shared-plugin",
+        )
+        lockfile.add_dependency(dep_first)
+        lockfile.add_dependency(dep_second)
+        logger = _make_logger()
+
+        result = _resolve_marketplace_packages(["shared-plugin@official"], lockfile, logger)
+
+        # First insertion-order mismatch entry must win
+        assert result["shared-plugin@official"] == dep_first.get_unique_key()
+        logger.warning.assert_called_once()
+
+    def test_exact_match_priority_over_earlier_mismatch_entry(self):
+        """Exact match wins even when a mismatch entry appears earlier in insertion order."""
+        from apm_cli.commands.uninstall.engine import _resolve_marketplace_packages
+
+        lockfile = LockFile()
+        # Mismatch entry inserted first
+        dep_mismatch = LockedDependency(
+            repo_url="acme/via-other",
+            resolved_commit="e33",
+            discovered_via="other-marketplace",
+            marketplace_plugin_name="ordered-plugin",
+        )
+        # Exact match inserted second
+        dep_exact = LockedDependency(
+            repo_url="acme/via-official",
+            resolved_commit="f44",
+            discovered_via="official",
+            marketplace_plugin_name="ordered-plugin",
+        )
+        lockfile.add_dependency(dep_mismatch)
+        lockfile.add_dependency(dep_exact)
+        logger = _make_logger()
+
+        result = _resolve_marketplace_packages(["ordered-plugin@official"], lockfile, logger)
+
+        # Exact match must always win over any mismatch entry, regardless of order
+        assert result["ordered-plugin@official"] == dep_exact.get_unique_key()
+        logger.warning.assert_not_called()
+        logger.error.assert_not_called()
+
+    def test_provenance_mismatch_warning_text_exact(self):
+        """Warning text for provenance mismatch must contain plugin, marketplace, and canonical."""
+        from apm_cli.commands.uninstall.engine import _resolve_marketplace_packages
+
+        lockfile = LockFile()
+        dep = LockedDependency(
+            repo_url="org/warned-plugin",
+            resolved_commit="g55",
+            discovered_via="source-marketplace",
+            marketplace_plugin_name="warned-plugin",
+        )
+        lockfile.add_dependency(dep)
+        logger = _make_logger()
+
+        result = _resolve_marketplace_packages(
+            ["warned-plugin@target-marketplace"], lockfile, logger
+        )
+
+        assert result["warned-plugin@target-marketplace"] == dep.get_unique_key()
+        logger.warning.assert_called_once()
+        warn_text = logger.warning.call_args[0][0]
+        assert "warned-plugin@target-marketplace" in warn_text
+        assert "installed via source-marketplace" in warn_text
+        assert "Proceeding with uninstall of" in warn_text
+        assert dep.get_unique_key() in warn_text
+
+
+# ===========================================================================
+# _resolve_marketplace_packages -- single-traversal performance contract
+# ===========================================================================
+
+
+class _IterationCountingDepsView:
+    """Wraps a dict to count how many times .values() is iterated.
+
+    Assigned to ``lockfile.dependencies`` so _resolve_marketplace_packages
+    can be audited without touching its internals.
+    """
+
+    def __init__(self, data: dict) -> None:
+        self._data = data
+        self.values_call_count = 0
+
+    def values(self):
+        """Count each call and delegate to the real dict."""
+        self.values_call_count += 1
+        return self._data.values()
+
+    def __contains__(self, key: object) -> bool:
+        return key in self._data
+
+    def get(self, key: object, default: object = None) -> object:
+        return self._data.get(key, default)
+
+    def __getitem__(self, key: object) -> object:
+        return self._data[key]
+
+    def __setitem__(self, key: object, value: object) -> None:
+        self._data[key] = value
+
+
+class TestResolveMarketplacePackagesSingleTraversal:
+    """Iteration-count guard: lockfile.dependencies.values() must be called
+    exactly once for the whole batch, not once or twice per package.
+
+    This test FAILS with the pre-optimisation code (which calls .values() twice
+    per package) and PASSES after the pre-index optimisation is applied.
+    """
+
+    def _make_lockfile_with_counter(self, deps: list) -> tuple:
+        """Return (lockfile, counter) where counter tracks .values() calls."""
+        lockfile = LockFile()
+        for dep in deps:
+            lockfile.add_dependency(dep)
+        counter = _IterationCountingDepsView(lockfile.dependencies)
+        lockfile.dependencies = counter
+        return lockfile, counter
+
+    def test_values_called_once_for_three_package_batch(self):
+        """For a batch of 3 packages, .values() must be called exactly once."""
+        from apm_cli.commands.uninstall.engine import _resolve_marketplace_packages
+
+        dep_a = LockedDependency(
+            repo_url="acme/alpha",
+            resolved_commit="a1",
+            discovered_via="official",
+            marketplace_plugin_name="alpha",
+        )
+        dep_b = LockedDependency(
+            repo_url="acme/beta",
+            resolved_commit="b2",
+            discovered_via="official",
+            marketplace_plugin_name="beta",
+        )
+        lockfile, counter = self._make_lockfile_with_counter([dep_a, dep_b])
+        logger = _make_logger()
+
+        _resolve_marketplace_packages(
+            ["alpha@official", "beta@official", "gamma@official"],
+            lockfile,
+            logger,
+        )
+
+        # Pre-index path: one traversal for the whole batch regardless of N
+        assert counter.values_call_count == 1, (
+            f"Expected exactly 1 traversal of lockfile.dependencies.values() "
+            f"for a 3-package batch, got {counter.values_call_count}. "
+            "The optimisation must pre-index deps once before the package loop."
+        )
+
+    def test_values_called_once_even_when_all_packages_need_fallback(self):
+        """Even when no exact match exists for any package, one traversal suffices."""
+        from apm_cli.commands.uninstall.engine import _resolve_marketplace_packages
+
+        lockfile, counter = self._make_lockfile_with_counter([])
+        logger = _make_logger()
+
+        with patch("apm_cli.marketplace.resolver.resolve_marketplace_plugin") as mock_reg:
+            mock_reg.side_effect = RuntimeError("no network in test")
+            _resolve_marketplace_packages(
+                ["p1@mkt", "p2@mkt", "p3@mkt"],
+                lockfile,
+                logger,
+            )
+
+        assert counter.values_call_count == 1, (
+            f"Expected 1 traversal even when all packages fall through to registry, "
+            f"got {counter.values_call_count}."
+        )
+
+
+# ===========================================================================
 # _validate_uninstall_packages -- marketplace ref extensions
 # ===========================================================================
 

--- a/tests/unit/test_uninstall_engine_helpers.py
+++ b/tests/unit/test_uninstall_engine_helpers.py
@@ -899,12 +899,12 @@ class TestResolveMarketplacePackagesMultiEntry:
 
 
 # ===========================================================================
-# _resolve_marketplace_packages -- single-traversal performance contract
+# _resolve_marketplace_packages -- single-values-call performance contract
 # ===========================================================================
 
 
 class _IterationCountingDepsView:
-    """Wraps a dict to count how many times .values() is iterated.
+    """Wrap a dict to count calls to ``values()``.
 
     Assigned to ``lockfile.dependencies`` so _resolve_marketplace_packages
     can be audited without touching its internals.
@@ -933,7 +933,7 @@ class _IterationCountingDepsView:
 
 
 class TestResolveMarketplacePackagesSingleTraversal:
-    """Iteration-count guard: lockfile.dependencies.values() must be called
+    """Call-count guard: lockfile.dependencies.values() must be called
     exactly once for the whole batch, not once or twice per package.
 
     This test FAILS with the pre-optimisation code (which calls .values() twice
@@ -974,15 +974,15 @@ class TestResolveMarketplacePackagesSingleTraversal:
             logger,
         )
 
-        # Pre-index path: one traversal for the whole batch regardless of N
+        # Pre-index path: one values() call for the whole batch regardless of N.
         assert counter.values_call_count == 1, (
-            f"Expected exactly 1 traversal of lockfile.dependencies.values() "
+            f"Expected exactly 1 call to lockfile.dependencies.values() "
             f"for a 3-package batch, got {counter.values_call_count}. "
-            "The optimisation must pre-index deps once before the package loop."
+            "The optimisation must call values() once before the package loop."
         )
 
     def test_values_called_once_even_when_all_packages_need_fallback(self):
-        """Even when no exact match exists for any package, one traversal suffices."""
+        """Fallback for every package still requires only one values() call."""
         from apm_cli.commands.uninstall.engine import _resolve_marketplace_packages
 
         lockfile, counter = self._make_lockfile_with_counter([])
@@ -997,7 +997,7 @@ class TestResolveMarketplacePackagesSingleTraversal:
             )
 
         assert counter.values_call_count == 1, (
-            f"Expected 1 traversal even when all packages fall through to registry, "
+            f"Expected 1 values() call when all packages fall through to registry, "
             f"got {counter.values_call_count}."
         )
 


### PR DESCRIPTION
# refactor(performance): eliminate repeated I/O and lockfile scans

## TL;DR

This PR consolidates eight `[perf-scan]` reports into four behavior-preserving optimizations across policy discovery, compilation, and marketplace uninstall. It replaces repeated subprocess, tree traversal, directory enumeration, and lockfile scans with one-time parsing or indexes. Deterministic call-count tests guard each gain, while parity tests preserve ordering, exclusions, provenance warnings, and symlink behavior.

> [!NOTE]
> Wall-time ranges below are engineering estimates, not end-to-end benchmark results. The reliable claims are the subprocess, traversal, directory-enumeration, stat, and complexity reductions.

## Problem (WHY)

- [x] Policy auto-discovery parsed the same `git remote origin` through two subprocess calls to obtain host identity and port ([#2463](https://github.com/microsoft/apm/issues/2463)).
- [x] Compilation walked the complete project tree twice per batch, once for directory analysis and once for the project file list ([#2463](https://github.com/microsoft/apm/issues/2463), [#2386](https://github.com/microsoft/apm/issues/2386)).
- [x] Pattern matching and inheritance-pollution scoring reopened directories for every pattern and candidate instead of reusing the canonical traversal ([#2418](https://github.com/microsoft/apm/issues/2418), [#2396](https://github.com/microsoft/apm/issues/2396)).
- [x] Marketplace uninstall scanned all lockfile dependencies up to twice per requested package ([#2434](https://github.com/microsoft/apm/issues/2434), [#2425](https://github.com/microsoft/apm/issues/2425), [#2404](https://github.com/microsoft/apm/issues/2404), [#2378](https://github.com/microsoft/apm/issues/2378)).
- [!] The reports also contained suggestions whose gain was negligible, unsafe for nested values, or coupled to unresolved failure semantics; closing the batch requires recording those dispositions rather than silently implementing them.

Why these matter: this PR converts scanner suggestions into project-specific, executable call-count contracts rather than generic tuning claims, following Agent Skills guidance that ["The key is project-specific material, not generic references."](https://agentskills.io/skill-creation/best-practices)

## Approach (WHAT)

- Parse organization, host, and explicit port from one remote lookup; preserve every policy candidate and failure path.
- Build compile directory and project-file caches in one canonical `os.walk`.
- Build per-directory file and child indexes during that walk; query those indexes during matching and pollution scoring.
- Build first-seen exact and ordered plugin indexes once before resolving an uninstall batch.
- Preserve four independent implementation commits so reviewers can inspect and bisect each optimization separately; keep review feedback in one follow-up commit.

## Implementation (HOW)

| File | Change |
|---|---|
| `src/apm_cli/policy/discovery.py` | Routes `_auto_discover` through the combined remote-identity parser and removes the second port-only subprocess. |
| `src/apm_cli/commands/uninstall/engine.py` | Builds exact and ordered per-plugin lockfile indexes once, retaining exact-match priority and first mismatch fallback. |
| `src/apm_cli/compilation/context_optimizer.py` | Makes `_analyze_project_structure` the single walk owner and populates file/child indexes consumed by matching and pollution scoring. |
| `tests/unit/policy/test_discovery.py` | Proves one remote subprocess and explicit-port propagation while preserving GitHub, GHE, ADO, error, and fallback behavior. |
| `tests/unit/policy/test_cache_merged_effective.py` | Patches the consolidated remote-identity owner in the ADO chain regression scenario. |
| `tests/integration/test_uninstall_policy_pack_flow.py` | Exercises custom-host policy routing plus exact and provenance-mismatch lockfile resolution through the consolidated owners. |
| `tests/unit/test_uninstall_engine_helpers.py` | Pins first-seen ordering, exact-match priority, warning text, fallback behavior, and one lockfile traversal per batch. |
| `tests/unit/compilation/test_context_optimizer_single_walk.py` | Pins one walk, exact cache lifecycle, deterministic order, exclusions, hidden roots, and cache rebuilds. |
| `tests/unit/compilation/test_context_optimizer_iterdir_indexes.py` | Pins zero `iterdir()` calls, matching/pollution parity, scaling, invalidation, and regular/broken/directory symlink behavior. |
| `CHANGELOG.md` | Records the deterministic subprocess, traversal, directory-index, and lockfile-index reductions for the next release. |

## Diagrams

Legend: dashed nodes are the new one-time owners or indexes; downstream work reads their cached results instead of repeating I/O.

```mermaid
flowchart LR
    subgraph Policy[Policy discovery]
        P0["git remote origin"] --> P1["Parse org, host, port once"]
        P1 --> P2["Fetch policy candidates"]
    end
    subgraph Compile[Compile placement]
        C0["Single os.walk"] --> C1["Directory and file caches"]
        C0 --> C2["Files by directory"]
        C0 --> C3["Children by directory"]
        C2 --> C4["Pattern matching"]
        C3 --> C5["Pollution scoring"]
    end
    subgraph Uninstall[Marketplace uninstall]
        U0["Lockfile dependencies"] --> U1["Exact first-seen index"]
        U0 --> U2["Ordered plugin index"]
        U1 --> U3["Requested package loop"]
        U2 --> U3
    end
    classDef new stroke-dasharray: 5 5;
    class P1,C1,C2,C3,U1,U2 new;
```

## Trade-offs

- **One file-type check during index construction.** Chose one `Path.is_file()` per non-hidden file; rejected trusting `os.walk` classification because that would let broken symlinks and non-regular entries change matching results.
- **First-seen indexes instead of compact comprehensions.** Chose explicit insertion-order handling; rejected last-write-wins dictionaries because they change exact and provenance-mismatch precedence.
- **Deterministic counts instead of wall-clock gates.** Chose subprocess/walk/iteration counters; rejected timing thresholds because filesystem and cache state make them brittle.
- **Three scanner suggestions rejected.** `os.getenv` is already an in-memory lookup; tuple-sorted JSON keys fail on nested unhashable values; verifier list-to-set conversion is below one microsecond at current sizes.
- **Bare-cache clone flags deferred.** They may save 25-100ms per package, but combining five best-effort `git config` calls into clone options changes the fatal-failure boundary and needs separate design.

## Benefits

1. Policy discovery performs one `git remote get-url origin` subprocess instead of two; estimated 5-20ms saved per discovery.
2. Compilation performs one complete project `os.walk` instead of two; estimated 10-200ms saved depending on tree and filesystem.
3. Compile queries eliminate `P*D + K` directory enumerations and reduce file/child type checks from repeated query-time stats to one build-time pass; a 500-directory, 10-pattern tree avoids roughly 5,500 enumerations when `K` is about 500.
4. Marketplace lockfile resolution is typically `O(P+L)` after one index build while preserving first-match semantics; pathological same-plugin provenance collisions still scan that plugin's ordered bucket.
5. All eight scanner reports receive one linked disposition and close through this PR rather than remaining as disconnected duplicates.

## Validation

<details><summary>Behavior, quality, and CI-mirror evidence</summary>

Combined policy, compilation, and uninstall suite:

```text
570 passed, 2 subtests passed
```

```bash
uv run --offline --frozen --extra dev pytest -q \
  tests/unit/policy/test_discovery.py \
  tests/unit/test_uninstall_engine_helpers.py \
  tests/unit/test_uninstall_engine_phase3w5.py \
  tests/unit/test_uninstall_engine_validation.py \
  tests/unit/compilation/test_context_optimizer.py \
  tests/unit/compilation/test_context_optimizer_cache_and_placement.py \
  tests/unit/compilation/test_context_optimizer_branches.py \
  tests/unit/compilation/test_context_optimizer_phase3.py \
  tests/unit/compilation/test_context_optimizer_single_walk.py \
  tests/unit/compilation/test_context_optimizer_iterdir_indexes.py \
  tests/integration/test_uninstall_policy_pack_flow.py::TestAutoDiscover \
  tests/integration/test_compilation_coverage.py \
  tests/integration/test_context_optimizer_placement.py
```

Focused advisory regressions for GHE routing, fail-closed parsing, exclusion
pruning, and lockfile call counts:

```text
6 passed
```

```bash
uv run --offline --frozen --extra dev pytest -q \
  tests/unit/compilation/test_context_optimizer_single_walk.py::TestExclusionInUnifiedWalk \
  tests/unit/test_uninstall_engine_helpers.py::TestResolveMarketplacePackagesSingleTraversal
```

Test-quality contracts:

```text
54 passed in 73.87s
AQ001=4, AQ002=12
1105 files scanned, 0 duplicate groups
```

CI `Lint` mirror:

```text
All checks passed!
1605 files already formatted
Your code has been rated at 10.00/10
[+] auth-signal lint clean
[+] architecture boundary lint clean
```

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|---|---|---|---|
| 1 | Enterprise policy discovery keeps the same GitHub/GHE/ADO routing while reading the remote once | Governed by policy, Vendor-neutral, DevX | `tests/unit/policy/test_discovery.py::TestAutoDiscover::test_auto_discover_ado_git_subprocess_invoked_exactly_once` (regression-trap for #2463)<br/>`tests/unit/policy/test_discovery.py::TestAutoDiscover::test_ado_server_auto_discovery_preserves_remote_port`<br/>`tests/integration/test_uninstall_policy_pack_flow.py::TestAutoDiscover::test_custom_host_builds_correct_repo_ref` | unit + integration |
| 2 | `apm compile` produces the same placements, exclusions, order, and hidden-root behavior with one project traversal | Portability by manifest, Multi-harness support, DevX | `tests/unit/compilation/test_context_optimizer_single_walk.py::TestSingleWalkPopulatesBothCaches::test_single_walk_populates_directory_cache_and_file_list_cache` (regression-trap for #2386)<br/>`tests/unit/compilation/test_context_optimizer_single_walk.py::TestHiddenToolRootsInUnifiedWalk`<br/>`tests/integration/test_compilation_coverage.py::TestContextOptimizerIntegration::test_optimizer_analyzes_directory_distribution` | unit + integration |
| 3 | Compile matching ignores broken and directory symlinks without reopening every project directory | Portability by manifest, Secure by default, DevX | `tests/unit/compilation/test_context_optimizer_iterdir_indexes.py::TestMatchingDirectorySetsUnchanged::test_broken_file_symlink_does_not_create_match` (regression-trap for #2418)<br/>`tests/unit/compilation/test_context_optimizer_iterdir_indexes.py::TestIterationCountGuard`<br/>`tests/integration/test_context_optimizer_placement.py::TestOptimizeInstructionPlacement::test_instruction_with_pattern_placed` | unit + integration |
| 4 | Uninstall chooses the exact marketplace entry first, preserves provenance warnings, and scans the lockfile once per batch | Governed by policy, Secure by default, DevX | `tests/unit/test_uninstall_engine_helpers.py::TestResolveMarketplacePackagesMultiEntry::test_exact_match_priority_over_earlier_mismatch_entry` (regression-trap for #2434)<br/>`tests/unit/test_uninstall_engine_helpers.py::TestResolveMarketplacePackagesSingleTraversal::test_values_called_once_for_three_package_batch`<br/>`tests/integration/test_uninstall_policy_pack_flow.py::TestResolveMarketplacePackages::test_stage1_exact_lockfile_match`<br/>`tests/integration/test_uninstall_policy_pack_flow.py::TestResolveMarketplacePackages::test_stage1_provenance_mismatch_fallback` | unit + integration |

## Issue disposition

| Issues | Disposition |
|---|---|
| #2463, #2386 | Single policy lookup and single compile walk implemented. |
| #2418, #2396 | Compile file/child indexes implemented; duplicate uninstall finding folded in. |
| #2434, #2425, #2404, #2378 | Ordered uninstall indexes implemented; environment, tuple-key, verifier-set, and clone-flag suggestions rejected or deferred as documented above. |

Closes #2463
Closes #2434
Closes #2425
Closes #2418
Closes #2404
Closes #2396
Closes #2386
Closes #2378

## How to test

- [ ] Run the combined policy, uninstall, and context-optimizer suite from Validation; expect `570 passed` with 2 subtests.
- [ ] Run `uv run --frozen --extra dev pytest -q tests/integration/test_uninstall_policy_pack_flow.py tests/integration/test_compilation_coverage.py tests/integration/test_context_optimizer_placement.py`; expect no failures.
- [ ] Run the CI `Lint` mirror from `.github/workflows/ci.yml`; expect Ruff, duplication, auth, architecture, YAML, line-length, and relative-path guards to pass.
- [ ] Review the four implementation commits independently, then the single advisory-feedback follow-up.
- [ ] Confirm the PR body links all eight reports and records every rejected or deferred scanner suggestion.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
