### PR TITLE
chore: release v0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,35 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.0] - 2026-08-04
+
 ### Added
 
+- New xAI Grok targets: `grok-build` deploys native `.grok/` rules, agents,
+  commands, and skills alongside compiled `AGENTS.md` context, and the
+  explicit-only experimental `grok-cloud` target deploys skills to project or
+  user `.grok/skills/`. (closes #2419, #2420)
+- Kiro IDE/CLI v3 now receives agents from `.apm/agents/` as Markdown files
+  under `.kiro/agents/<relative-stem>.md`, forwarding only `description`,
+  `model`, and `tools` frontmatter. Tools are permission-bearing, so APM fails
+  closed with no partial write when a tool value falls outside Kiro's approved
+  capability set. (closes #2089, #2440)
+- Registry object-form dependencies (`- id: owner/repo`) now support `skills:`
+  and `targets:` subset installs, matching git-longhand parity -- no need to
+  switch to verbose git-longhand form just to narrow what gets deployed.
+  Registry deps also serialize back to `apm.yml` as object-form entries instead
+  of collapsing to a plain git string. (by @nadav-y, #2166)
 - `apm pack --check-versions` now reads `plugin.json` for local Plugin
   collections without `apm.yml`; when present, `apm.yml` remains authoritative.
   (#2454)
-- Kiro IDE/CLI v3 now receives agents from `.apm/agents/` as Markdown files
-  under `.kiro/agents/<relative-stem>.md`. Only `description`, `model`, and
-  `tools` frontmatter fields are forwarded; `name` and unknown fields are
-  stripped. Tools are permission-bearing: APM fails closed (no partial write)
-  if any tool value is outside the approved Kiro capability set (`read`,
-  `write`, `shell`, `web`, `subagent`, `knowledge`, `context`, `todo_list`,
-  `@mcp`, `@builtin`, `*`). Nested source paths under `.apm/agents/` are
-  preserved, and the targets matrix is updated to reflect the new `agents`
-  primitive for `kiro`. Sources: https://kiro.dev/docs/custom-agents/ and
-  https://kiro.dev/docs/cli/v3/ (accessed 2026-08-03). (#2089)
-- Stable Grok Build target support for native `.grok/` rules, agents, commands,
-  and skills, plus compiled `AGENTS.md` context.
-- Registry object-form dependencies (`- id: owner/repo`) now accept a `skills:` subset
-  and a `targets:` subset, matching git-longhand parity. `to_apm_yml_entry()` also
-  correctly round-trips registry deps as dict form instead of collapsing them to a
-- Registry object-form dependencies (`- id: owner/repo`) now support `skills:` and
-  `targets:` subset installs, matching git-longhand parity -- no need to switch to
-  verbose git-longhand form just to narrow what gets deployed. Registry deps also now
-  serialize correctly as object-form entries in `apm.yml` instead of collapsing to a
-  plain git string. (by @nadav-y, #2166)
 
 ### Fixed
 
-- `apm compile --clean` preserves APM-generated `AGENTS.md` files tracked by nested Git worktrees. (#2473)
+- `apm init` and install-time auto-bootstrap now reject empty or
+  whitespace-only project names, falling back to `my-project` at a filesystem
+  root. APM no longer writes an `apm.yml` that every later install, lock, or
+  compile command rejects. (by @nadav-y, #2200)
+- `apm pack` now treats `dependencies: {}` as a declared mapping and emits the
+  local bundle; omitted or null `dependencies:` still produce no bundle.
+  (closes #2431, #2458)
+- `apm compile --clean` preserves APM-generated `AGENTS.md` files tracked by
+  nested Git worktrees. (#2473)
 - Required MCP runtime defaults are now overrideable prompts, while secret
   defaults remain hidden and VS Code OCI launchers resolve every runtime
   placeholder without writing secret values to `mcp.json`. (#2455)
@@ -43,17 +47,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is skipped, so CI cannot report success after an incomplete local audit.
   (#2460)
 - Claude project hooks now run reliably when Claude launches them outside the
-  repository while keeping generated settings portable across clones. (#2408)
+  repository while keeping generated settings portable across clones.
+  (closes #2408, #2442)
 - Marketplace package sources now accept full HTTPS repository URLs with nested
   paths while retaining strict shorthand validation. (#2439)
 - YAML-list `applyTo` entries now preserve every pattern during compilation
   and target-native instruction conversion, including explicitly targeted
   supported hidden tool roots. (#2441)
-- `apm pack --check-clean` now honors `--marketplace-path` overrides. (#2427)
-- Release publication now excludes opt-in live ADO PAT tests and credentials; those tests fail closed in the Auth Acceptance workflow instead. (#2426)
-- Release promotions now run marker-bounded lifecycle integration on macOS Intel
-  while retaining the full corpus on macOS ARM and Linux, preventing Intel
-  runner capacity timeouts. (#2423)
+- `apm pack --check-clean` now honors `--marketplace-path` overrides.
+  (closes #2427, #2461)
 - Public `github.com` dependency installs now preserve caller-owned Git URL
   rewrites and transport policy across anonymous and authenticated retries;
   policy cache metadata and diagnostics also omit credentials embedded in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apm-cli"
-version = "0.27.0"
+version = "0.28.0"
 description = "MCP configuration tool"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/apm_cli/commands/install.py
+++ b/src/apm_cli/commands/install.py
@@ -12,6 +12,10 @@ from typing import TYPE_CHECKING, Any
 
 import click
 
+from apm_cli.install.argv import (
+    _get_invocation_argv,
+    _split_argv_at_double_dash,
+)
 from apm_cli.install.artifactory_resolver import _resolve_artifactory_boundary
 from apm_cli.install.errors import (
     AuthenticationError,
@@ -184,41 +188,6 @@ class InstallContext:
     audit_override: str | None = None
     install_result: InstallResult | None = None
     target_decision: "EffectiveTargetDecision | None" = None
-
-
-# ---------------------------------------------------------------------------
-# Argv `--` boundary helpers (W3 --mcp flag)
-# ---------------------------------------------------------------------------
-#
-# Click's ``nargs=-1`` silently swallows the ``--`` separator and merges
-# everything after it into the positional argument tuple.  For
-# ``apm install --mcp foo -- npx -y srv`` we cannot distinguish that from
-# ``apm install --mcp foo npx -y srv`` once Click is done parsing.
-#
-# We therefore inspect ``sys.argv`` ourselves to detect the boundary and
-# extract the post-``--`` portion as the stdio command argv.  ``--`` IS
-# present in ``sys.argv`` even though Click strips it from the parsed
-# arguments.  The pre-``--`` portion is used to flag conflicts (E1).
-#
-# ``_get_invocation_argv`` exists as a tiny seam so tests using
-# ``CliRunner`` (which does not modify ``sys.argv``) can patch it without
-# resorting to ``monkeypatch.setattr('sys.argv', ...)``.
-
-
-def _get_invocation_argv():
-    """Return the process invocation argv. Wrapped for test injection."""
-    return sys.argv
-
-
-def _split_argv_at_double_dash(argv):
-    """Return ``(clean_argv, command_argv_tuple)``.
-
-    If ``--`` is not present, ``command_argv_tuple`` is ``()``.
-    """
-    if "--" not in argv:
-        return argv, ()
-    idx = argv.index("--")
-    return argv[:idx], builtins.tuple(argv[idx + 1 :])
 
 
 # APM Dependencies (conditional import for graceful degradation)

--- a/src/apm_cli/install/argv.py
+++ b/src/apm_cli/install/argv.py
@@ -1,0 +1,34 @@
+"""Argv ``--`` boundary helpers shared by the install and mcp commands.
+
+Click's ``nargs=-1`` silently swallows the ``--`` separator and merges
+everything after it into the positional argument tuple.  For
+``apm install --mcp foo -- npx -y srv`` we cannot distinguish that from
+``apm install --mcp foo npx -y srv`` once Click is done parsing.
+
+We therefore inspect ``sys.argv`` ourselves to detect the boundary and
+extract the post-``--`` portion as the stdio command argv.  ``--`` IS
+present in ``sys.argv`` even though Click strips it from the parsed
+arguments.  The pre-``--`` portion is used to flag conflicts.
+
+``_get_invocation_argv`` exists as a tiny seam so tests using
+``CliRunner`` (which does not modify ``sys.argv``) can patch it without
+resorting to ``monkeypatch.setattr('sys.argv', ...)``.
+"""
+
+import sys
+
+
+def _get_invocation_argv():
+    """Return the process invocation argv. Wrapped for test injection."""
+    return sys.argv
+
+
+def _split_argv_at_double_dash(argv):
+    """Return ``(clean_argv, command_argv_tuple)``.
+
+    If ``--`` is not present, ``command_argv_tuple`` is ``()``.
+    """
+    if "--" not in argv:
+        return argv, ()
+    idx = argv.index("--")
+    return argv[:idx], tuple(argv[idx + 1 :])

--- a/tests/unit/install/test_architecture_invariants.py
+++ b/tests/unit/install/test_architecture_invariants.py
@@ -244,12 +244,18 @@ def test_install_py_under_legacy_budget():
     recording block between the registry bypass path and the normal GitHub
     probe path, eliminating duplicated ``update_existing_dependency_entry_if_needed``
     + ``valid_outcomes.append`` + provenance blocks.
+
+    Argv-boundary extraction reduced 2111 -> 2080 by moving
+    ``_get_invocation_argv`` / ``_split_argv_at_double_dash`` (and their
+    explanatory block comment) into ``apm_cli/install/argv.py``, which
+    ``commands/mcp.py`` already consumed through this module.  Budget
+    tightened 2150 -> 2100 to match the CI file-length guardrail.
     """
     install_py = Path(__file__).resolve().parents[3] / "src" / "apm_cli" / "commands" / "install.py"
     assert install_py.is_file()
     n = _line_count(install_py)
-    assert n <= 2150, (
-        f"commands/install.py grew to {n} LOC (budget 2150). "
+    assert n <= 2100, (
+        f"commands/install.py grew to {n} LOC (budget 2100). "
         "Do NOT trim cosmetically -- engage the python-architecture skill "
         "(.apm/skills/python-architecture/SKILL.md) and propose an "
         "extraction into apm_cli/install/."

--- a/uv.lock
+++ b/uv.lock
@@ -203,7 +203,7 @@ wheels = [
 
 [[package]]
 name = "apm-cli"
-version = "0.27.0"
+version = "0.28.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Cut release 0.28.0.

- Bump `pyproject.toml` to 0.28.0 (and `uv.lock`).
- Move `[Unreleased]` to `[0.28.0] - 2026-08-04` in `CHANGELOG.md`, with one short "so what?" entry per PR merged since v0.27.0.

## Why MINOR (0.28.0), not PATCH (0.27.1)

Signal: semver-rubric Row 3 (new user-facing manifest fields) fires first, and Row 6 (new integration hosts) also fires.

Per-PR rationale:

| PR | Signal |
|----|--------|
| #2166 registry object-form `skills:` / `targets:` | Row 3 -- new manifest fields |
| #2420 `grok-build` + experimental `grok-cloud` targets | Row 6 -- new integration hosts |
| #2440 Kiro `agents` primitive | Row 6 -- new target primitive |
| #2454 `apm pack --check-versions` reads `plugin.json` | Row 3 -- new authoritative source |
| #2200, #2422, #2439, #2441, #2455, #2458, #2460, #2461, #2461, #2473 | Row 7 -- fixes, subordinate |
| #2472 | Row 7 -- performance |
| #2471, #2475, #2476 | dropped -- `chore(deps)` internal |

Why not MAJOR: pre-1.0 framing, and no BREAKING change landed this cycle.

## Changelog housekeeping folded in

- Consolidated a duplicated / truncated pair of `#2166` entries into one.
- Corrected the Grok entry: it claimed only "stable Grok Build" support with no PR number; #2420 added both `grok-build` and the explicit-only experimental `grok-cloud`.
- Added missing entries for #2200 (empty project-name rejection) and #2458 (`dependencies: {}` bundle routing).
- Replaced bare issue references with PR-backed `(closes #issue, #pr)` form for #2408/#2442, #2427/#2461, #2089/#2440.
- Dropped two CI-only entries (#2423, #2426) that were left in `[Unreleased]` after the v0.27.0 cut; both are release-workflow / test-harness internals. #2422 was in the same leftover group but is user-facing (Git URL rewrites, credential redaction), so it ships here.

## Folded-in lint fix

CI's file-length guardrail (2100 lines) failed on `src/apm_cli/commands/install.py` at 2111 lines -- drift that landed on `main` via #2166 and #2200 and only surfaced here because CI evaluates the merge commit.

Fixed by extracting `_get_invocation_argv` / `_split_argv_at_double_dash` into `apm_cli/install/argv.py` (`commands/mcp.py` already reached through `commands/install.py` for both, so they were never install-specific). `commands/install.py` re-exports them so the `_get_invocation_argv` test seam is unchanged. 2111 -> 2080 lines; architecture-invariant budget ratcheted 2150 -> 2100 to match the CI gate.

## Validation

All CI checks green on the PR head. Lint mirror also verified locally (ruff check + format, pylint R0801, auth-signals), plus architecture boundary lint and 2084 tests across `tests/unit/install/` and `tests/integration/test_architecture_authorities.py`. See `.apm/instructions/linting.instructions.md` for the contract this mirrors.

Note: `uv lock` could not reach `files.pythonhosted.org` from this environment, so the `uv.lock` `apm-cli` version field was updated surgically (0.27.0 -> 0.28.0) -- byte-identical to what `uv lock` would emit, with no dependency drift.

## Post-merge

Tag `v0.28.0` to trigger the release workflow:

```
git tag v0.28.0
git push origin v0.28.0
```

