### PR TITLE
fix(tests): make local marketplace canonical assertions platform-native

### DIFF
--- a/tests/unit/marketplace/test_resolver_local_git.py
+++ b/tests/unit/marketplace/test_resolver_local_git.py
@@ -42,6 +42,7 @@ def _plugin(name: str, source: object) -> MarketplacePlugin:
     return MarketplacePlugin(name=name, source=source)
 
 
+@pytest.mark.windows_compat
 def test_local_marketplace_relative_source_yields_local_path_canonical(tmp_path: Path) -> None:
     src = MarketplaceSource(name="local-mkt", url=f"file://{tmp_path}", ref="main")
     plugin = _plugin("my-skill", "./skills/my-skill")
@@ -51,10 +52,14 @@ def test_local_marketplace_relative_source_yields_local_path_canonical(tmp_path:
         result = resolve_marketplace_plugin("my-skill", "local-mkt")
 
     assert result.dependency_reference is None
-    assert result.canonical == f"{tmp_path}/skills/my-skill"
+    # Local canonicals are OS-native filesystem paths (``str(Path)``), so the
+    # expectation must be built with the platform separator -- a hard-coded
+    # "/" only matches on POSIX.
+    assert result.canonical == str(tmp_path / "skills" / "my-skill")
     assert DependencyReference.is_local_path(result.canonical)
 
 
+@pytest.mark.windows_compat
 def test_local_marketplace_bare_name_source_with_plugin_root(tmp_path: Path) -> None:
     src = MarketplaceSource(name="local-mkt", url=f"file://{tmp_path}", ref="main")
     plugin = _plugin("hello", "hello")
@@ -68,9 +73,10 @@ def test_local_marketplace_bare_name_source_with_plugin_root(tmp_path: Path) -> 
     ):
         result = resolve_marketplace_plugin("hello", "local-mkt")
 
-    assert result.canonical == f"{tmp_path}/plugins/hello"
+    assert result.canonical == str(tmp_path / "plugins" / "hello")
 
 
+@pytest.mark.windows_compat
 def test_local_marketplace_root_source_returns_repo_root(tmp_path: Path) -> None:
     src = MarketplaceSource(name="local-mkt", url=f"file://{tmp_path}", ref="main")
     plugin = _plugin("root-plugin", ".")


### PR DESCRIPTION
## TL;DR

The `v0.28.0` release build failed on the `windows-latest` unit shard. Two assertions in `tests/unit/marketplace/test_resolver_local_git.py` compare `result.canonical` against an f-string that hard-codes `/` separators, so they only match on POSIX. This is a test-expectation bug, not a resolver regression -- fixed by building the expectations with `tmp_path / ... / ...`, and marked `windows_compat` so the PR gate catches this class next time.

## Problem (WHY)

[Release run 30976933061](https://github.com/microsoft/apm/actions/runs/30976933061), job `Build & Test (windows-latest, x86_64, windows, apm-windows-x86_64)`:

```
FAILED tests/unit/marketplace/test_resolver_local_git.py::test_local_marketplace_relative_source_yields_local_path_canonical
  AssertionError: assert 'C:\\...\\skills\\my-skill' == 'C:\\...\\skills/my-skill'
FAILED tests/unit/marketplace/test_resolver_local_git.py::test_local_marketplace_bare_name_source_with_plugin_root
  AssertionError: assert 'C:\\...\\plugins\\hello' == 'C:\\...\\plugins/hello'
= 2 failed, 19712 passed, 80 skipped, 21 xfailed in 177.54s =
```

`resolve_marketplace_plugin` returns local canonicals as **OS-native** filesystem paths. #2460 routed them through `resolve_local_plugin_path`, which returns a `Path` that `_resolve_local_relative_source` stringifies with the platform separator. That is the correct contract:

- `DependencyReference.is_local_path` explicitly accepts both `C:\` and `C:/` forms.
- The sibling `test_local_marketplace_root_source_returns_repo_root` already asserts against `str(tmp_path)` (native) and passes on Windows.

So the resolver is right and the two expectations are wrong.

## Why it reached a release tag

The PR-time `Windows Compatibility Gate` runs `pytest -m windows_compat tests/unit` -- marker-scoped, not the full suite. These tests carried no marker, so the only Windows job that would have caught them is the full matrix in `build-release.yml`, which runs **post-merge, on tag push**. Per `.github/instructions/tests.instructions.md`, backslash path separators are precisely the defect class `windows_compat` exists for, so the three local-path tests in this module are now marked.

## Approach (WHAT)

- Replace `f"{tmp_path}/skills/my-skill"` with `str(tmp_path / "skills" / "my-skill")` (and the `plugins/hello` equivalent).
- Add `@pytest.mark.windows_compat` to the three local-path resolution tests. Narrowest-true granularity per the instructions -- not a module-level `pytestmark`, since the generic-git / ADO / GitHub tests in this file do not exercise filesystem paths.
- No `ci.yml` edit: the gate selects by marker.

## Validation

- `pytest tests/unit/marketplace/test_resolver_local_git.py` -- 7 passed.
- `pytest -m windows_compat tests/unit --collect-only` -- 89 collected (was 86).
- `pytest tests/unit/test_windows_compat_gate_workflow.py` -- 12 passed (gate-shape invariants hold).
- `ruff check` + `ruff format --check` clean.

## How to test

```bash
uv run --extra dev pytest tests/unit/marketplace/test_resolver_local_git.py -q
uv run --extra dev pytest -m windows_compat tests/unit --collect-only -q
```

## Follow-up

Once merged, the `v0.28.0` tag needs to be moved to the new `main` head so the release workflow re-runs from a green tree. No `v0.28.0` GitHub Release or assets were published by the failed run, so moving the tag is safe.
