### PR TITLE
fix(install): re-download aliased deps after a manifest ref bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,10 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `apm install` now re-downloads an aliased dependency after its `ref:` changes
   in `apm.yml`. Previously the pinned-ref and already-resolved cache-reuse
   shortcuts skipped the fetch, so `apm_modules/<alias>/` and every primitive
-  deployed from it stayed on the old revision. (#2481)
+  deployed from it stayed on the old revision. (#2484)
 - `apm install --target all` no longer aborts on targets that have no MCP
   client, such as `grok-build`. Non-MCP targets are skipped with a note instead
-  of raising `Unsupported client type`. (#2481)
+  of raising `Unsupported client type`. (#2484)
 - `apm init` and install-time auto-bootstrap now reject empty or
   whitespace-only project names, falling back to `my-project` at a filesystem
   root. APM no longer writes an `apm.yml` that every later install, lock, or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `apm install` now re-downloads an aliased dependency after its `ref:` changes
+  in `apm.yml`. Previously the pinned-ref and already-resolved cache-reuse
+  shortcuts skipped the fetch, so `apm_modules/<alias>/` and every primitive
+  deployed from it stayed on the old revision. (#2481)
+- `apm install --target all` no longer aborts on targets that have no MCP
+  client, such as `grok-build`. Non-MCP targets are skipped with a note instead
+  of raising `Unsupported client type`. (#2481)
 - `apm init` and install-time auto-bootstrap now reject empty or
   whitespace-only project names, falling back to `my-project` at a filesystem
   root. APM no longer writes an `apm.yml` that every later install, lock, or

--- a/src/apm_cli/install/phases/_skip_logic.py
+++ b/src/apm_cli/install/phases/_skip_logic.py
@@ -15,6 +15,7 @@ def _compute_skip_download(
     update_refs: bool,
     already_resolved: bool,
     lockfile_match: bool,
+    ref_changed: bool = False,
 ) -> bool:
     """Return True when the sequential loop should skip downloading a package.
 
@@ -27,13 +28,23 @@ def _compute_skip_download(
       the user has not requested an update.
     * The lockfile SHA matches the local checkout (``lockfile_match``).
 
+    ``ref_changed`` vetoes the two cache-reuse clauses.  When the manifest ref
+    drifted away from the lockfile the user explicitly asked for a different
+    revision, so bytes already sitting at ``install_path`` must never be
+    trusted -- not even when the BFS callback fetched this dep earlier in the
+    same run, because the callback materialises to the canonical
+    ``<org>/<repo>`` path while an aliased dep integrates from
+    ``apm_modules/<alias>`` (#2481).  ``lockfile_match`` is left untouched: it
+    is only set in normal mode when the ref did not change, and in update mode
+    after the remote SHA was confirmed identical.
+
     Callers may further override this result (e.g. content-hash verification
     or registry-only enforcement) -- this function only computes the initial
     decision.
     """
     return install_path_exists and (
-        (is_cacheable and not update_refs)
-        or (already_resolved and not update_refs)
+        (is_cacheable and not update_refs and not ref_changed)
+        or (already_resolved and not update_refs and not ref_changed)
         or lockfile_match
     )
 

--- a/src/apm_cli/install/phases/integrate.py
+++ b/src/apm_cli/install/phases/integrate.py
@@ -241,6 +241,7 @@ def _resolve_download_strategy(
         update_refs=update_refs,
         already_resolved=already_resolved,
         lockfile_match=lockfile_match,
+        ref_changed=ref_changed,
     )
 
     # Verify content integrity when lockfile has a hash.

--- a/src/apm_cli/integration/mcp_integrator_install.py
+++ b/src/apm_cli/integration/mcp_integrator_install.py
@@ -611,6 +611,30 @@ def _resolve_target_runtimes(
             else:
                 selection_source = _TargetSelectionSource.DISCOVERY
 
+    # Not every accepted target can host MCP servers: `grok-build` writes
+    # native .grok configuration but has no MCP client adapter.  Drop
+    # non-MCP-capable runtimes here so that expanding `--target all` does
+    # not hard-fail the install on a runtime that cannot take MCP config.
+    # ClientFactory is the single source of truth for MCP capability.
+    # Direct `--runtime` calls bypass this: the adapter layer owns the
+    # warning/error behavior for legacy runtime strings.
+    if selection_source is not _TargetSelectionSource.RUNTIME:
+        from apm_cli.factory import ClientFactory as _McpCF
+
+        mcp_capable = _McpCF.supported_clients()
+        non_mcp = [rt for rt in target_runtimes if rt not in mcp_capable]
+        if non_mcp:
+            target_runtimes = [rt for rt in target_runtimes if rt in mcp_capable]
+            logger.progress(f"Skipped targets without MCP support: {', '.join(sorted(non_mcp))}")
+        if not target_runtimes and non_mcp:
+            logger.warning(
+                "No selected target supports MCP -- skipping MCP configuration. "
+                f"Targets without an MCP client: {', '.join(sorted(non_mcp))}. "
+                "Re-run with an MCP-capable target (for example "
+                "`--target copilot`) to install MCP servers."
+            )
+            return None
+
     # Exclusion narrows every selected source, including explicit CLI choices.
     # Apply it before progress output so the message names the narrowed set.
     if exclude:

--- a/tests/integration/test_marketplace_builder_hermetic.py
+++ b/tests/integration/test_marketplace_builder_hermetic.py
@@ -89,8 +89,12 @@ def _make_output_report(**kwargs) -> MarketplaceOutputReport:
 def _make_marketplace_yml_file(tmp_path: Path, content: dict | None = None) -> Path:
     """Write a minimal marketplace.yml and return its path."""
     default = {
+        "name": "test-marketplace",
+        "description": "Fixture marketplace for builder unit coverage",
+        "version": "0.1.0",
+        "owner": {"name": "test-owner"},
         "claude": {"output": "marketplace.json"},
-        "build": {"tag_pattern": "v{version}"},
+        "build": {"tagPattern": "v{version}"},
         "packages": [],
     }
     data = content if content is not None else default

--- a/tests/integration/test_marketplace_builder_phase3w4.py
+++ b/tests/integration/test_marketplace_builder_phase3w4.py
@@ -89,8 +89,12 @@ def _make_output_report(**kwargs) -> MarketplaceOutputReport:
 def _make_marketplace_yml_file(tmp_path: Path, content: dict | None = None) -> Path:
     """Write a minimal marketplace.yml and return its path."""
     default = {
+        "name": "test-marketplace",
+        "description": "Fixture marketplace for builder unit coverage",
+        "version": "0.1.0",
+        "owner": {"name": "test-owner"},
         "claude": {"output": "marketplace.json"},
-        "build": {"tag_pattern": "v{version}"},
+        "build": {"tagPattern": "v{version}"},
         "packages": [],
     }
     data = content if content is not None else default

--- a/tests/unit/test_install_update_refs.py
+++ b/tests/unit/test_install_update_refs.py
@@ -185,6 +185,59 @@ class TestAlreadyResolvedSkipLogic:
             is True
         )
 
+    # --- ref_changed veto (#2481) ---
+
+    def test_ref_changed_vetoes_cacheable_skip(self):
+        """Manifest ref drift beats the pinned-ref cache-reuse clause.
+
+        A commit-pinned dep is ``is_cacheable``, so before #2481 a plain
+        install reused whatever bytes already sat at ``install_path`` even
+        after the user bumped ``ref:`` in apm.yml.
+        """
+        assert (
+            _compute_skip_download(
+                install_path_exists=True,
+                is_cacheable=True,
+                update_refs=False,
+                already_resolved=False,
+                lockfile_match=False,
+                ref_changed=True,
+            )
+            is False
+        )
+
+    def test_ref_changed_vetoes_already_resolved_skip(self):
+        """Manifest ref drift beats the BFS-callback cache-reuse clause.
+
+        The callback materialises to the canonical ``<org>/<repo>`` path, so
+        for an aliased dep ``already_resolved`` says nothing about the bytes at
+        ``apm_modules/<alias>`` that the integration loop actually reads.
+        """
+        assert (
+            _compute_skip_download(
+                install_path_exists=True,
+                is_cacheable=False,
+                update_refs=False,
+                already_resolved=True,
+                lockfile_match=False,
+                ref_changed=True,
+            )
+            is False
+        )
+
+    def test_ref_changed_defaults_false_preserving_legacy_calls(self):
+        """Omitting ``ref_changed`` keeps the pre-#2481 skip behaviour."""
+        assert (
+            _compute_skip_download(
+                install_path_exists=True,
+                is_cacheable=True,
+                update_refs=False,
+                already_resolved=False,
+                lockfile_match=False,
+            )
+            is True
+        )
+
     # --- is_cacheable gate ---
 
     def test_cacheable_skips_normal_install(self):


### PR DESCRIPTION
## TL;DR

Fixes the three release-blocking integration failures that surfaced on the
`v0.28.0` tag run. Two are product bugs (aliased-dependency updates were
silently ignored; `--target all` crashed on `grok-build`); one is stale test
fixtures.

## Problem (WHY)

The `v0.28.0` release run reached the full `tests/integration` stage for the
first time this cycle and failed four tests across the macOS and Linux jobs:

| Test | Symptom |
| --- | --- |
| `test_kiro_agent_lifecycle.py::test_kiro_agent_update_replacement` | Deployed agent stays at v1 after the manifest `ref:` is bumped to v2 |
| `test_intellij_target.py::...[all,intellij-True]` | `Unsupported client type: grok-build` |
| `test_marketplace_builder_hermetic.py::TestOutputPath::test_output_override_used_when_no_marketplace_output` | `MarketplaceYmlError: 'name' is required` |
| `test_marketplace_builder_phase3w4.py::TestOutputPath::...` | same |

### 1. Aliased dependency updates were silently ignored

Two competing install-path derivations exist. The BFS resolver, lockfile
`get_installed_paths()`, drift detection, and cache pinning all use the
alias-blind canonical path `apm_modules/<org>/<repo>`. The download and
integration phases instead use `apm_modules/<alias>` when an alias is
declared.

When the user bumps `ref:` in `apm.yml`, `detect_ref_change` correctly
returns `True` and the BFS callback refreshes the *canonical* directory. But
the integration loop reads from the *alias* directory, and
`_compute_skip_download` returned `True` there via either the
`is_cacheable and not update_refs` clause (a commit pin is always cacheable)
or the `already_resolved and not update_refs` clause (the callback did fetch
-- just to a different path). The stale alias bytes were then deployed.

### 2. `--target all` crashed on `grok-build`

`grok-build` was added to `TARGET_CAPABILITIES` with `in_all=True` in #2420
but has no entry in `_MCP_CLIENT_REGISTRY`. `EffectiveTargetDecision.runtime_targets`
returns every target's runtime name with no MCP-capability filter, so MCP
install hard-failed on `--target all`.

### 3. Stale marketplace fixtures

#2461 changed `MarketplaceBuilder._output_path()` to call `_load_yml()`,
which runs full schema validation. The two builder test fixtures wrote a
minimal yml with none of the required keys and used the snake_case
`tag_pattern` instead of `tagPattern`.

## Approach (WHAT)

Surgical, one fix per failure. Notably this does **not** unify the two
install-path derivations -- that was tried and regressed
`test_hook_js_sidecar_lifecycle_contract.py` (uninstall + reinstall dropped
back to the v1 hook script). Vetoing the cache-reuse clauses on ref drift is
the minimal correct change: it makes the alias/canonical split irrelevant to
correctness without touching path derivation.

## Implementation (HOW)

**`_skip_logic.py` / `integrate.py`** -- `_compute_skip_download` takes a new
`ref_changed: bool = False` parameter that vetoes the two cache-reuse
clauses:

```python
return install_path_exists and (
    (is_cacheable and not update_refs and not ref_changed)
    or (already_resolved and not update_refs and not ref_changed)
    or lockfile_match
)
```

`lockfile_match` is deliberately left ungated: in normal mode it is only
computed under `elif not ref_changed`, and in update mode only after the
resolved remote SHA was confirmed equal to the lockfile SHA. The parameter
defaults to `False` so no existing call site changes behaviour.

**`mcp_integrator_install.py`** -- `_resolve_target_runtimes` filters
resolved targets against `ClientFactory.supported_clients()` (the documented
single source of truth for MCP capability) unless the selection came from an
explicit runtime choice, in which case the user asked for that target by name
and deserves the hard error. Skipped targets are logged; if nothing
MCP-capable remains, it warns and returns `None`. This mirrors the existing
user-scope filter pattern in the same module.

**Test fixtures** -- added `name`, `description`, `version`, and
`owner: {name: ...}` to both `_make_marketplace_yml_file` defaults, and
renamed `tag_pattern` to `tagPattern`.

## Trade-offs

- **Chose:** veto cache reuse on ref drift. **Over:** unifying the two
  install-path derivations. The unification is the deeper fix but regressed
  the hook sidecar lifecycle contract, and a release-blocking hotfix is the
  wrong place to relitigate path derivation. The dual-directory split remains
  and should be tracked separately.
- **Chose:** filter non-MCP targets with a note. **Over:** adding `grok-build`
  to `_MCP_CLIENT_REGISTRY`. `grok-build` genuinely has no MCP client; a stub
  entry would be a lie that fails later and worse.
- **Cost:** a ref bump now always re-downloads even when the new ref happens
  to resolve to identical bytes. Correctness over one avoidable fetch.

## Validation evidence

| Check | Result |
| --- | --- |
| `tests/integration/test_kiro_agent_lifecycle.py` + `test_hook_js_sidecar_lifecycle_contract.py` | 12 passed |
| Marketplace builder suites | 132 passed |
| IntelliJ target suite | passed |
| Full `tests/unit` | 19790 passed, 2 skipped, 21 xfailed |
| Full `tests/integration` | 8417 passed; residual failures are local-harness artifacts (venv console script is a Python shim, so PyInstaller-prefix assertions fail) and xdist collisions on repo-relative `apm_modules/` -- all pass in isolation |
| `ruff check` / `ruff format --check` | clean |
| `pylint R0801` | 10.00/10 |
| `scripts/lint-auth-signals.sh` | clean |

## How to test

```bash
APM_E2E_TESTS=1 APM_BINARY_PATH="$PWD/.venv/bin/apm" \
  uv run --extra dev python -m pytest \
  tests/integration/test_kiro_agent_lifecycle.py \
  tests/integration/test_hook_js_sidecar_lifecycle_contract.py \
  tests/integration/test_marketplace_builder_hermetic.py \
  tests/integration/test_marketplace_builder_phase3w4.py \
  tests/integration/test_intellij_target.py -q
```

Unit regression traps for the new veto live in
`tests/unit/test_install_update_refs.py`.


apm-spec-waiver: bug fixes restoring already-specified install and MCP-target behaviour; no new normative surface

