### PR TITLE
fix(compile): reuse placement analysis across targets (closes #2482)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Multi-target `apm compile` now computes target-independent instruction
+  placement once per invocation and reuses the canonical project file index
+  instead of rescanning directories per pattern. (closes #2482)
 - `apm init` and install-time auto-bootstrap now reject empty or
   whitespace-only project names, falling back to `my-project` at a filesystem
   root. APM no longer writes an `apm.yml` that every later install, lock, or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Multi-target `apm compile` now avoids repeating expensive project analysis
+  for each target, making multi-target runs scale like single-target runs
+  without changing generated output. (closes #2482)
+
 ## [0.28.0] - 2026-08-04
 
 ### Added
@@ -31,9 +37,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Multi-target `apm compile` now computes target-independent instruction
-  placement once per invocation and reuses the canonical project file index
-  instead of rescanning directories per pattern. (closes #2482)
 - `apm init` and install-time auto-bootstrap now reject empty or
   whitespace-only project names, falling back to `my-project` at a filesystem
   root. APM no longer writes an `apm.yml` that every later install, lock, or

--- a/src/apm_cli/compilation/agents_compiler.py
+++ b/src/apm_cli/compilation/agents_compiler.py
@@ -9,7 +9,7 @@ import hashlib
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, NamedTuple  # noqa: UP035
+from typing import TYPE_CHECKING, Any, Callable, NamedTuple  # noqa: UP035
 
 from ..core.target_catalog import accepted_target_values, get_target_capability
 from ..core.target_detection import (
@@ -21,7 +21,7 @@ from ..core.target_detection import (
     should_compile_gemini_md,
 )
 from ..primitives.discovery import discover_primitives
-from ..primitives.models import PrimitiveCollection
+from ..primitives.models import Instruction, PrimitiveCollection
 from ..utils.path_security import PathTraversalError, ensure_path_within
 from ..utils.paths import portable_relpath
 from ..version import get_version
@@ -34,6 +34,9 @@ from .template_builder import (
     find_chatmode_by_name,
     generate_agents_md_template,
 )
+
+if TYPE_CHECKING:
+    from .distributed_compiler import DistributedAgentsCompiler
 
 _logger = logging.getLogger(__name__)
 
@@ -337,11 +340,35 @@ class AgentsCompiler:
         self.warnings: list[str] = []
         self.errors: list[str] = []
         self._logger = None
+        self._distributed_placement: dict[Path, tuple[Instruction, ...]] | None = None
 
     def _log(self, method: str, message: str, **kwargs):
         """Delegate to logger if available, else no-op."""
         if self._logger:
             getattr(self._logger, method)(message, **kwargs)
+
+    def _get_distributed_placement(
+        self,
+        config: CompilationConfig,
+        primitives: PrimitiveCollection,
+        compiler: "DistributedAgentsCompiler",
+    ) -> dict[Path, list[Instruction]]:
+        """Compute placement once per compile and return an isolated projection."""
+        if self._distributed_placement is None:
+            directory_map = compiler.analyze_directory_structure(primitives.instructions)
+            placement = compiler.determine_agents_placement(
+                primitives.instructions,
+                directory_map,
+                min_instructions=config.min_instructions_per_file,
+                debug=config.debug,
+            )
+            self._distributed_placement = {
+                path: tuple(instructions) for path, instructions in placement.items()
+            }
+
+        return {
+            path: list(instructions) for path, instructions in self._distributed_placement.items()
+        }
 
     def compile(
         self,
@@ -366,6 +393,8 @@ class AgentsCompiler:
         self.warnings.clear()
         self.errors.clear()
         self._logger = logger
+        # Placement is valid only for this invocation's primitive snapshot.
+        self._distributed_placement = None
 
         try:
             # Use provided primitives or discover them (with dependency support)
@@ -574,6 +603,11 @@ class AgentsCompiler:
             "dry_run": config.dry_run,
             "skip_instructions": skip_instructions,
             "with_constitution": config.with_constitution,
+            "placement_map": self._get_distributed_placement(
+                config,
+                primitives,
+                distributed_compiler,
+            ),
         }
 
         # Compile distributed
@@ -824,15 +858,10 @@ class AgentsCompiler:
                 exclude_patterns=config.exclude,
                 source_dir=str(self.source_dir),
             )
-            # Analyze directory structure and determine placement
-            directory_map = distributed_compiler.analyze_directory_structure(
-                primitives.instructions
-            )
-            placement_map = distributed_compiler.determine_agents_placement(
-                primitives.instructions,
-                directory_map,
-                min_instructions=config.min_instructions_per_file,
-                debug=config.debug,
+            placement_map = self._get_distributed_placement(
+                config,
+                primitives,
+                distributed_compiler,
             )
 
         # Skip instructions in CLAUDE.md when they are already deployed to

--- a/src/apm_cli/compilation/agents_compiler.py
+++ b/src/apm_cli/compilation/agents_compiler.py
@@ -36,6 +36,7 @@ from .template_builder import (
 )
 
 if TYPE_CHECKING:
+    from .context_optimizer import ContextOptimizer
     from .distributed_compiler import DistributedAgentsCompiler
 
 _logger = logging.getLogger(__name__)
@@ -341,6 +342,7 @@ class AgentsCompiler:
         self.errors: list[str] = []
         self._logger = None
         self._distributed_placement: dict[Path, tuple[Instruction, ...]] | None = None
+        self._distributed_context_optimizer: ContextOptimizer | None = None
 
     def _log(self, method: str, message: str, **kwargs):
         """Delegate to logger if available, else no-op."""
@@ -365,6 +367,11 @@ class AgentsCompiler:
             self._distributed_placement = {
                 path: tuple(instructions) for path, instructions in placement.items()
             }
+            self._distributed_context_optimizer = compiler.context_optimizer
+        elif self._distributed_context_optimizer is not None:
+            # Reporting for every target must use the analysis that produced
+            # the shared placement, even though each target has its own compiler.
+            compiler.context_optimizer = self._distributed_context_optimizer
 
         return {
             path: list(instructions) for path, instructions in self._distributed_placement.items()
@@ -395,6 +402,7 @@ class AgentsCompiler:
         self._logger = logger
         # Placement is valid only for this invocation's primitive snapshot.
         self._distributed_placement = None
+        self._distributed_context_optimizer = None
 
         try:
             # Use provided primitives or discover them (with dependency support)

--- a/src/apm_cli/compilation/context_optimizer.py
+++ b/src/apm_cli/compilation/context_optimizer.py
@@ -1420,18 +1420,9 @@ class ContextOptimizer:
         # Only check direct files in this directory (not subdirectories for simplicity)
         matching_files = 0
 
-        try:
-            for file in os.listdir(resolved_working_dir):
-                if file.startswith("."):
-                    continue
-
-                file_path = resolved_working_dir / file
-                if file_path.is_file():
-                    if self._file_matches_pattern(file_path, pattern):
-                        matching_files += 1
-        except (OSError, PermissionError):
-            # Handle case where directory doesn't exist or can't be read
-            pass
+        for file_path in self._files_by_directory.get(resolved_working_dir, ()):
+            if self._file_matches_pattern(file_path, pattern):
+                matching_files += 1
 
         # Cache the result
         analysis.pattern_matches[pattern] = matching_files

--- a/src/apm_cli/compilation/distributed_compiler.py
+++ b/src/apm_cli/compilation/distributed_compiler.py
@@ -214,16 +214,21 @@ class DistributedAgentsCompiler:
                         f"Found {len(referenced_contexts)} referenced context files"
                     )
 
-            # Phase 1: Directory structure analysis
-            directory_map = self.analyze_directory_structure(primitives.instructions)
+            placement_map = config.get("placement_map")
+            if placement_map is None:
+                # Phase 1: Directory structure analysis
+                directory_map = self.analyze_directory_structure(primitives.instructions)
 
-            # Phase 2: Determine optimal AGENTS.md placement
-            placement_map = self.determine_agents_placement(
-                primitives.instructions,
-                directory_map,
-                min_instructions=min_instructions,
-                debug=debug,
-            )
+                # Phase 2: Determine optimal AGENTS.md placement
+                placement_map = self.determine_agents_placement(
+                    primitives.instructions,
+                    directory_map,
+                    min_instructions=min_instructions,
+                    debug=debug,
+                )
+            elif self._placement_map is None:
+                # Direct callers may provide target-independent placement.
+                self._placement_map = placement_map
 
             # Phase 3: Generate distributed AGENTS.md files
             placements = self.generate_distributed_agents_files(

--- a/src/apm_cli/compilation/distributed_compiler.py
+++ b/src/apm_cli/compilation/distributed_compiler.py
@@ -226,8 +226,9 @@ class DistributedAgentsCompiler:
                     min_instructions=min_instructions,
                     debug=debug,
                 )
-            elif self._placement_map is None:
-                # Direct callers may provide target-independent placement.
+            else:
+                # Reporting must describe the placement used by this invocation,
+                # including when a caller reuses this compiler with a new map.
                 self._placement_map = placement_map
 
             # Phase 3: Generate distributed AGENTS.md files

--- a/tests/unit/compilation/test_compile_target_scaling_2482.py
+++ b/tests/unit/compilation/test_compile_target_scaling_2482.py
@@ -1,0 +1,114 @@
+"""Regression coverage for target-independent compile placement analysis."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from apm_cli.cli import cli
+from apm_cli.compilation.agents_compiler import AgentsCompiler, CompilationConfig
+from apm_cli.compilation.context_optimizer import ContextOptimizer
+from apm_cli.primitives.models import Instruction, PrimitiveCollection
+
+pytestmark = pytest.mark.component
+
+
+def _write_project(project: Path) -> None:
+    """Create a minimal project with one scoped instruction."""
+    (project / ".apm" / "instructions").mkdir(parents=True)
+    (project / "src").mkdir()
+    (project / "apm.yml").write_text(
+        "name: target-scaling\nversion: 0.1.0\n",
+        encoding="utf-8",
+    )
+    (project / "src" / "main.py").write_text("print('hello')\n", encoding="utf-8")
+    (project / ".apm" / "instructions" / "python.instructions.md").write_text(
+        '---\napplyTo: "**/*.py"\n---\nUse type hints.\n',
+        encoding="utf-8",
+    )
+
+
+def test_multi_target_compile_runs_placement_once(tmp_path: Path) -> None:
+    """Adding target projections must not multiply placement analysis."""
+    _write_project(tmp_path)
+    runner = CliRunner()
+    original = ContextOptimizer.optimize_instruction_placement
+    calls_by_target: dict[str, int] = {}
+
+    old_cwd = Path.cwd()
+    os.chdir(tmp_path)
+    try:
+        for target in ("copilot", "claude,copilot,opencode"):
+            call_count = 0
+
+            def counting_optimize(self, *args, **kwargs):
+                nonlocal call_count
+                call_count += 1
+                return original(self, *args, **kwargs)
+
+            with patch.object(
+                ContextOptimizer,
+                "optimize_instruction_placement",
+                counting_optimize,
+            ):
+                result = runner.invoke(
+                    cli,
+                    [
+                        "compile",
+                        "--dry-run",
+                        "--no-links",
+                        "--target",
+                        target,
+                    ],
+                )
+
+            assert result.exit_code == 0, result.output
+            calls_by_target[target] = call_count
+    finally:
+        os.chdir(old_cwd)
+
+    assert calls_by_target == {
+        "copilot": 1,
+        "claude,copilot,opencode": 1,
+    }
+
+
+def test_placement_cache_is_scoped_to_one_compile_invocation(tmp_path: Path) -> None:
+    """Reusing an AgentsCompiler must analyze each new primitive snapshot."""
+    compiler = AgentsCompiler(str(tmp_path))
+    config = CompilationConfig(target="all", dry_run=True)
+    optimize_calls = 0
+    original = ContextOptimizer.optimize_instruction_placement
+
+    def counting_optimize(self, *args, **kwargs):
+        nonlocal optimize_calls
+        optimize_calls += 1
+        return original(self, *args, **kwargs)
+
+    with patch.object(
+        ContextOptimizer,
+        "optimize_instruction_placement",
+        counting_optimize,
+    ):
+        for suffix in ("py", "js"):
+            source = tmp_path / "src" / f"main.{suffix}"
+            source.parent.mkdir(exist_ok=True)
+            source.touch()
+            primitives = PrimitiveCollection()
+            primitives.add_primitive(
+                Instruction(
+                    name=f"{suffix}-style",
+                    file_path=tmp_path / f"{suffix}.instructions.md",
+                    description=f"{suffix} instructions",
+                    apply_to=f"**/*.{suffix}",
+                    content=f"Use {suffix} conventions.",
+                )
+            )
+            result = compiler.compile(config, primitives)
+            assert result.success
+
+    assert optimize_calls == 2

--- a/tests/unit/compilation/test_compile_target_scaling_2482.py
+++ b/tests/unit/compilation/test_compile_target_scaling_2482.py
@@ -12,6 +12,7 @@ from click.testing import CliRunner
 from apm_cli.cli import cli
 from apm_cli.compilation.agents_compiler import AgentsCompiler, CompilationConfig
 from apm_cli.compilation.context_optimizer import ContextOptimizer
+from apm_cli.compilation.distributed_compiler import DistributedAgentsCompiler
 from apm_cli.primitives.models import Instruction, PrimitiveCollection
 
 pytestmark = pytest.mark.component
@@ -112,3 +113,50 @@ def test_placement_cache_is_scoped_to_one_compile_invocation(tmp_path: Path) -> 
             assert result.success
 
     assert optimize_calls == 2
+
+
+def test_shared_placement_preserves_each_target_report(tmp_path: Path) -> None:
+    """Every target report must retain the analysis behind shared placement."""
+    _write_project(tmp_path)
+    primitives = PrimitiveCollection()
+    primitives.add_primitive(
+        Instruction(
+            name="python-style",
+            file_path=tmp_path / "python.instructions.md",
+            description="Python instructions",
+            apply_to="**/*.py",
+            content="Use Python conventions.",
+        )
+    )
+    config = CompilationConfig(target="all", dry_run=True)
+    compiler = AgentsCompiler(str(tmp_path))
+    first = DistributedAgentsCompiler(str(tmp_path))
+    second = DistributedAgentsCompiler(str(tmp_path))
+
+    first_map = compiler._get_distributed_placement(config, primitives, first)
+    second_map = compiler._get_distributed_placement(config, primitives, second)
+    first.compile_distributed(primitives, {"dry_run": True, "placement_map": first_map})
+    second.compile_distributed(primitives, {"dry_run": True, "placement_map": second_map})
+
+    first_report = first.get_compilation_results_for_display(is_dry_run=True)
+    second_report = second.get_compilation_results_for_display(is_dry_run=True)
+    assert first_report is not None
+    assert second_report is not None
+    assert second_report.project_analysis == first_report.project_analysis
+    assert second_report.project_analysis.directories_scanned > 0
+
+
+def test_reused_distributed_compiler_reports_latest_placement(tmp_path: Path) -> None:
+    """A reused compiler must report the placement from its latest invocation."""
+    compiler = DistributedAgentsCompiler(str(tmp_path))
+    primitives = PrimitiveCollection()
+    first_map = {tmp_path: []}
+    second_path = tmp_path / "src"
+    second_map = {second_path: []}
+
+    compiler.compile_distributed(primitives, {"dry_run": True, "placement_map": first_map})
+    compiler.compile_distributed(primitives, {"dry_run": True, "placement_map": second_map})
+
+    report = compiler.get_compilation_results_for_display(is_dry_run=True)
+    assert report is not None
+    assert [summary.path for summary in report.placement_summaries] == [second_path]

--- a/tests/unit/compilation/test_context_optimizer_iterdir_indexes.py
+++ b/tests/unit/compilation/test_context_optimizer_iterdir_indexes.py
@@ -181,6 +181,20 @@ class TestNoIterdirCalls:
             "(should use _children_by_directory index)"
         )
 
+    def test_instruction_relevance_no_listdir(self, tmp_path: Path) -> None:
+        """_is_instruction_relevant reuses the canonical file index."""
+        _touch(tmp_path, "src/main.py")
+        instruction = _make_instruction(apply_to="**/*.py")
+        optimizer = ContextOptimizer(base_dir=str(tmp_path))
+        optimizer.optimize_instruction_placement([instruction])
+        optimizer._directory_cache[tmp_path / "src"].pattern_matches.clear()
+
+        with patch(
+            "apm_cli.compilation.context_optimizer.os.listdir",
+            side_effect=AssertionError("relevance must not rescan the directory"),
+        ):
+            assert optimizer._is_instruction_relevant(instruction, tmp_path / "src")
+
 
 class TestMatchingDirectorySetsUnchanged:
     """Matching-directory sets must be identical to the pre-optimization behavior."""


### PR DESCRIPTION
# fix(compile): reuse placement analysis across target projections

## TL;DR

Multi-target `apm compile` now computes instruction placement once per
invocation, then gives each target an isolated projection of that result.
The fix removes the target-count multiplier from the dominant optimizer pass
without changing AGENTS.md or CLAUDE.md formatting. It also replaces the
remaining per-directory `os.listdir` relevance scan with the canonical file
index built during project analysis.

> [!IMPORTANT]
> The deterministic regression changes the three-target optimizer count from
> 2 calls to 1 call, matching the single-target path.

Closes #2482.

## Problem (WHY)

- [x] The issue reproduction measured one target at 3.228 seconds with one
  1.667-second optimizer call, while three targets took 4.137 seconds with two
  optimizer calls totaling 3.328 seconds. Repeating target-independent work
  conflicts with
  ["Favor small, chainable primitives over monolithic frameworks."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/)
- [x] `AgentsCompiler` constructed separate distributed compilers for AGENTS.md
  and CLAUDE.md, so each called `ContextOptimizer.optimize_instruction_placement`
  against the same primitive snapshot. The resulting call-count evidence follows
  ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/)
- [!] `_is_instruction_relevant` retained a direct `os.listdir` for each uncached
  directory-pattern pair even though the canonical project walk had already
  indexed eligible files. Removing that redundant work follows
  ["Add what the agent lacks, omit what it knows"](https://agentskills.io/skill-creation/best-practices).

## Approach (WHAT)

| # | Fix | Principle | Source |
|---:|---|---|---|
| 1 | Cache neutral placement for one `AgentsCompiler.compile` invocation. | ["Context arrives just-in-time, not just-in-case."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) | `AgentsCompiler` |
| 2 | Return fresh placement lists to each target formatter. | ["Favor small, chainable primitives over monolithic frameworks."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) | `DistributedAgentsCompiler` |
| 3 | Reuse `_files_by_directory` for relevance checks. | ["Add what the agent lacks, omit what it knows"](https://agentskills.io/skill-creation/best-practices) | `ContextOptimizer` |
| 4 | Guard target scaling and invocation freshness with deterministic call counts. | ["do the work, run a validator (a script, a reference checklist, or a self-check), fix any issues, and repeat until validation passes."](https://agentskills.io/skill-creation/best-practices) | component tests |

## Implementation (HOW)

| File | Change |
|---|---|
| `src/apm_cli/compilation/agents_compiler.py` | Adds an invocation-scoped immutable placement cache, resets it before each compile, and returns independent list projections to AGENTS.md and CLAUDE.md consumers. |
| `src/apm_cli/compilation/distributed_compiler.py` | Accepts a precomputed placement map while preserving its existing standalone analysis fallback for direct callers. |
| `src/apm_cli/compilation/context_optimizer.py` | Replaces direct directory enumeration with the file index populated by the canonical project walk. |
| `tests/unit/compilation/test_compile_target_scaling_2482.py` | Adds the CLI regression trap and proves a reused compiler refreshes placement for each new primitive snapshot. |
| `tests/unit/compilation/test_context_optimizer_iterdir_indexes.py` | Proves relevance checks perform zero `os.listdir` calls after project analysis. |
| `CHANGELOG.md` | Records the compile performance fix under `[Unreleased]`. |

## Diagrams

Legend: placement analysis runs once, while target-specific formatters receive
separate mutable list copies from an invocation-scoped immutable cache.

```mermaid
flowchart LR
    subgraph Analyze[Analyze once]
        P[Primitive snapshot]
        O[ContextOptimizer]
        C[Invocation-scoped tuple cache]
    end
    subgraph Project[Project per target]
        A[AGENTS.md placement copy]
        L[CLAUDE.md placement copy]
    end
    P --> O
    O --> C
    C --> A
    C --> L
    classDef new stroke-dasharray: 5 5;
    class C,A,L new;
```

## Trade-offs

- **Invocation-scoped cache instead of process-wide memoization.** This keeps the
  optimization valid only for one primitive and filesystem snapshot; a reused
  `AgentsCompiler` recomputes on its next `compile` call.
- **Shallow target projections instead of sharing mutable lists.** Copying the
  placement dictionary and lists is O(P + I), where P is placements and I is
  placed instruction references. That small in-memory cost prevents one target
  formatter from affecting another.
- **Existing standalone fallback retained.** Direct
  `DistributedAgentsCompiler.compile_distributed` callers still analyze when no
  placement map is supplied; only the multi-target orchestration path reuses work.
- **Architecture classification - no canonical-owner boundary change.** The
  existing `ContextOptimizer` remains the placement authority; this PR only
  removes duplicate execution. A new static authority guard is therefore not
  required, while the behavioral regression and existing architecture lint
  protect the boundary.

## Benefits

1. Single-target and three-target dry runs both execute exactly one optimizer
   call; before the fix the deterministic counts were 1 and 2.
2. The three-target synthetic reproduction reduces measured optimizer work from
   two calls to one without relying on a wall-clock threshold.
3. `_is_instruction_relevant` performs zero directory-listing system calls after
   the canonical walk, instead of up to one scan per uncached directory-pattern
   pair.
4. Two sequential compile invocations execute two optimizer calls, proving the
   cache cannot serve stale placement across primitive snapshots.

## Validation

`PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src uv run --offline --extra dev pytest -q tests/unit/compilation`:

```text
1283 passed in 6.52s
```

`PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src uv run --offline --extra dev pytest -q tests/integration/test_context_optimizer_placement.py tests/integration/test_compile_universal_apply_to_fastpath_e2e.py`:

```text
54 passed in 1.28s
```

Post-fix reproduction using `CliRunner` and an optimizer wrapper:

```text
target=copilot exit=0 calls=1 optimizer=0.000616s wall=0.048643s
target=claude,copilot,opencode exit=0 calls=1 optimizer=0.000481s wall=0.005935s
```

<details><summary>Canonical lint and quality gates</summary>

`uv run --offline --extra dev ruff check src/ tests/`:

```text
All checks passed!
```

`uv run --offline --extra dev ruff format --check src/ tests/`:

```text
1610 files already formatted
```

`uv run --offline --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/`:

```text
Your code has been rated at 10.00/10
```

`bash scripts/lint-auth-signals.sh && bash scripts/lint-architecture-boundaries.sh`:

```text
[+] auth-signal lint clean
[+] architecture boundary lint clean
```

`uv run --offline --extra dev pytest -p no:cacheprovider -q tests/quality`:

```text
54 passed in 91.70s
```

`uv run --offline --frozen python scripts/check_test_assertions.py && uv run --offline --frozen python scripts/check_exact_test_duplicates.py`:

```text
[+] assertion-quality ratchet clean: AQ001=4, AQ002=12
[+] exact test duplicate ratchet clean: 1106 files, 0 allowed duplicate group(s)
```

</details>

<details><summary>Mutation-break proof</summary>

Clearing the placement cache inside every projection restored the original
duplicate work. The regression trap failed as required:

```text
{'claude,copilot,opencode': 2} != {'claude,copilot,opencode': 1}
1 failed
```

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---:|---|---|---|---|
| 1 | Compile the same instructions for Claude, Copilot, and OpenCode without multiplying project placement analysis. | Multi-harness support, DevX (pragmatic as npm) | `tests/unit/compilation/test_compile_target_scaling_2482.py::test_multi_target_compile_runs_placement_once` (regression-trap for #2482) | integration |
| 2 | Run compile again after the primitive snapshot changes and receive fresh placement. | Portability by manifest, DevX (pragmatic as npm) | `tests/unit/compilation/test_compile_target_scaling_2482.py::test_placement_cache_is_scoped_to_one_compile_invocation` | unit |
| 3 | Analyze instruction relevance in a medium monorepo without rescanning each directory for every pattern. | DevX (pragmatic as npm) | `tests/unit/compilation/test_context_optimizer_iterdir_indexes.py::TestNoIterdirCalls::test_instruction_relevance_no_listdir` | unit |

## How to test

- [ ] Run the focused target-scaling test; expect both target sets to report one
  optimizer call.
- [ ] Run the cache-scope test; expect two compile invocations to report two
  optimizer calls.
- [ ] Run the relevance-index test; expect it to pass while `os.listdir` is
  patched to raise.
- [ ] Run the compilation unit suite; expect 1283 passing tests.
- [ ] Run the canonical lint chain; expect Ruff, format, pylint, auth, and
  architecture guards to exit 0.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
