### PR TITLE
fix: translate agents for OpenCode (closes #2483)

### DIFF
--- a/.apm/instructions/architecture.instructions.md
+++ b/.apm/instructions/architecture.instructions.md
@@ -70,6 +70,7 @@ semicolon-delimited, and specific to the file(s) that own the fact.
 | applyTo normalization and hidden-tool placement | utils/patterns.py (normalize_apply_to); compilation/context_optimizer.py (ContextOptimizer) | `src/apm_cli/utils/patterns.py`; `src/apm_cli/compilation/context_optimizer.py` |
 | Effective marketplace output path | marketplace/output_profiles.py (resolve_effective_output_path) | `src/apm_cli/marketplace/output_profiles.py` |
 | Bootstrap project-name validation and fallback | core/project_name.py (resolve_bootstrap_project_name) | `src/apm_cli/core/project_name.py` |
+| Portable agent -> OpenCode frontmatter translation | integration/opencode_frontmatter.py (translate_opencode_agent) | `src/apm_cli/integration/opencode_frontmatter.py` |
 <!-- /canonical-owner-table -->
 
 Host + credential resolution includes public github.com anonymous-first ordering.

--- a/.github/instructions/architecture.instructions.md
+++ b/.github/instructions/architecture.instructions.md
@@ -70,6 +70,7 @@ semicolon-delimited, and specific to the file(s) that own the fact.
 | applyTo normalization and hidden-tool placement | utils/patterns.py (normalize_apply_to); compilation/context_optimizer.py (ContextOptimizer) | `src/apm_cli/utils/patterns.py`; `src/apm_cli/compilation/context_optimizer.py` |
 | Effective marketplace output path | marketplace/output_profiles.py (resolve_effective_output_path) | `src/apm_cli/marketplace/output_profiles.py` |
 | Bootstrap project-name validation and fallback | core/project_name.py (resolve_bootstrap_project_name) | `src/apm_cli/core/project_name.py` |
+| Portable agent -> OpenCode frontmatter translation | integration/opencode_frontmatter.py (translate_opencode_agent) | `src/apm_cli/integration/opencode_frontmatter.py` |
 <!-- /canonical-owner-table -->
 
 Host + credential resolution includes public github.com anonymous-first ordering.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- OpenCode agents now receive native model IDs and boolean tool maps; unsupported
+  tool capabilities and malformed frontmatter fail closed instead of silently
+  widening permissions or falling back to defaults. (closes #2483, #2488)
+
 ## [0.28.0] - 2026-08-04
 
 ### Added

--- a/CONFORMANCE.json
+++ b/CONFORMANCE.json
@@ -1248,9 +1248,10 @@
       "keyword": "MUST",
       "section": "8.5.1",
       "status": "active",
-      "test_count": 1,
+      "test_count": 2,
       "tests": [
-        "tests/spec_conformance/test_manifest_reqs.py::test_kiro_agent_tools_gate_fails_closed_before_adopt"
+        "tests/spec_conformance/test_manifest_reqs.py::test_kiro_agent_tools_gate_fails_closed_before_adopt",
+        "tests/spec_conformance/test_manifest_reqs.py::test_opencode_agent_tools_gate_fails_closed_before_adopt"
       ]
     },
     {

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -136,7 +136,7 @@ All four conformance classes (Producer, Consumer, Registry, Governance) carry ac
 | [req-tg-006](docs/src/content/docs/specs/openapm-v0.1.md#req-tg-006) | MUST | 8.5 | consumer | active | 1 |
 | [req-tg-007](docs/src/content/docs/specs/openapm-v0.1.md#req-tg-007) | MUST | 8.5 | consumer | active | 1 |
 | [req-tg-008](docs/src/content/docs/specs/openapm-v0.1.md#req-tg-008) | MUST | 8.5.3 | consumer | active | 1 |
-| [req-tg-009](docs/src/content/docs/specs/openapm-v0.1.md#req-tg-009) | MUST | 8.5.1 | consumer | active | 1 |
+| [req-tg-009](docs/src/content/docs/specs/openapm-v0.1.md#req-tg-009) | MUST | 8.5.1 | consumer | active | 2 |
 | [req-tg-010](docs/src/content/docs/specs/openapm-v0.1.md#req-tg-010) | MUST | 8.5.4 | consumer | active | 1 |
 
 ## Waivers

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -2783,7 +2783,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:7a5aac9c6c4153c76e6a6bc6cbd1918e677a79a845b0c23f860f85264eca7d0b
+  content_hash: sha256:fbfa3992f8da478254095baca6c4b29055c8cfb3babc6b1a4ad58f0ca45668c5
 - kind: project-relative
   target: copilot
   value: .github/instructions/changelog.instructions.md
@@ -3290,7 +3290,7 @@ local_deployed_file_hashes:
   .github/agents/spec-tag-architect.agent.md: sha256:82907265c5e7cf1ac61ad96866fa7c5683b69c8f09b7a4c5f3cc241acc9568ca
   .github/agents/supply-chain-security-expert.agent.md: sha256:8fb8cc426d6af17ba084a28b3f026c2b475b62e3ca63ed2f88b83bd823f877af
   .github/agents/test-coverage-expert.agent.md: sha256:48c2172d1f18a394fa83ef9dc2be0b9b921a4e51e976498165250fed66369711
-  .github/instructions/architecture.instructions.md: sha256:7a5aac9c6c4153c76e6a6bc6cbd1918e677a79a845b0c23f860f85264eca7d0b
+  .github/instructions/architecture.instructions.md: sha256:fbfa3992f8da478254095baca6c4b29055c8cfb3babc6b1a4ad58f0ca45668c5
   .github/instructions/changelog.instructions.md: sha256:1e51ec4c74e847967962bd279dc4c6e582c5d3578490b3c28d5f3acd3e05f73e
   .github/instructions/cicd.instructions.md: sha256:33201cb88ea2f34b4950a9b52f87dc8dfb682796aaf53068ba7ae406c0c5e2c2
   .github/instructions/cli.instructions.md: sha256:8e39e8d5047ce88575cb02f87c2bcede584dfef258bd86f7466c7badf136541a

--- a/docs/src/content/docs/concepts/primitives-and-targets.md
+++ b/docs/src/content/docs/concepts/primitives-and-targets.md
@@ -119,7 +119,7 @@ Rows are primitives, columns are harnesses. Cell legend:
 |---|---|---|---|---|---|---|---|---|---|---|
 | instructions | native | native | native | native | compiled | compiled | native | compiled | native | native |
 | prompts | native | compiled | compiled | compiled | unsupported | compiled | compiled | compiled | compiled | unsupported |
-| agents | native | native | native | compiled | compiled | unsupported | unsupported | native | unsupported | compiled |
+| agents | native | native | native | compiled | compiled | unsupported | unsupported | compiled | unsupported | compiled |
 | skills | native | native | native | native | native | native | native | native | native | native |
 | hooks | native | native | unsupported | native | native | native | native | unsupported | native | native |
 | commands | unsupported | native | compiled | compiled | unsupported | compiled | unsupported | compiled | compiled | unsupported |
@@ -133,6 +133,7 @@ How to read a cell:
 - `prompts / claude = compiled` -- APM transforms `.apm/prompts/<n>.prompt.md` into `.claude/commands/<n>.md`. The prompt becomes a `/command`.
 - `agents / gemini = unsupported` -- Gemini CLI has no agents primitive; APM does not deliver `.agent.md` files to it. Their content still reaches Gemini through the compiled `GEMINI.md` if referenced from instructions.
 - `agents / antigravity = unsupported` -- Antigravity CLI has no agents primitive; their content reaches Antigravity through the compiled `AGENTS.md`.
+- `agents / opencode = compiled` -- APM maps portable model, tool, mode, color, and supported frontmatter fields into OpenCode's native agent schema.
 - `agents / kiro = compiled` -- APM writes `.kiro/agents/<relative-stem>.md`; frontmatter is filtered to `description`, `model`, and `tools` (unsupported tool values fail the deploy). See [targets-matrix](/apm/reference/targets-matrix/#kiro) for the approved tool set.
 - `instructions / antigravity = native` -- APM deploys instructions as plain-markdown rules under `.agents/rules/`.
 - `commands / copilot = unsupported` -- Copilot has no commands primitive; the same source `.prompt.md` reaches Copilot as a native prompt instead.

--- a/docs/src/content/docs/concepts/primitives-and-targets.md
+++ b/docs/src/content/docs/concepts/primitives-and-targets.md
@@ -102,7 +102,9 @@ Notes per target:
 - **codex** -- Codex CLI. Agents and hooks use TOML; skills use the cross-tool `.agents/` directory.
 - **gemini** -- Gemini CLI. Commands are TOML. Hooks merge into `.gemini/settings.json`. No native agents or instructions primitives -- both arrive via compiled context files.
 - **antigravity** -- Google Antigravity CLI (`agy`), successor to Gemini CLI. Explicit-only target (`--target antigravity`); the `.agents/` root is shared, so it is never auto-detected and is not part of `--target all`. Instructions deploy as rules under `.agents/rules/`. Skills use `.agents/skills/`. Hooks use Antigravity's native `.agents/hooks.json` schema. MCP servers write to a dedicated `.agents/mcp_config.json`. No commands primitive (legacy Gemini commands convert to skills upstream).
-- **opencode** -- OpenCode. No hooks support.
+- **opencode** -- OpenCode. Agent model, tools, mode, color, and supported
+  fields compile to native frontmatter; unsupported tool names fail closed.
+  No hooks support.
 - **windsurf** -- Windsurf / Cascade. No native agents primitive -- Cascade auto-invokes any `SKILL.md` by its `description:` frontmatter, so personas ship as skills. Workflows are the harness's name for commands.
 - **kiro** -- Kiro IDE/CLI v3. Instructions become steering files, skills stay as `SKILL.md` folders, hooks are individual JSON files, MCP lands in `.kiro/settings/mcp.json`, and agents deploy to `.kiro/agents/<stem>.md` with frontmatter filtered to `description`, `model`, and `tools` only.
 
@@ -133,7 +135,10 @@ How to read a cell:
 - `prompts / claude = compiled` -- APM transforms `.apm/prompts/<n>.prompt.md` into `.claude/commands/<n>.md`. The prompt becomes a `/command`.
 - `agents / gemini = unsupported` -- Gemini CLI has no agents primitive; APM does not deliver `.agent.md` files to it. Their content still reaches Gemini through the compiled `GEMINI.md` if referenced from instructions.
 - `agents / antigravity = unsupported` -- Antigravity CLI has no agents primitive; their content reaches Antigravity through the compiled `AGENTS.md`.
-- `agents / opencode = compiled` -- APM maps portable model, tool, mode, color, and supported frontmatter fields into OpenCode's native agent schema.
+- `agents / opencode = compiled` -- APM maps portable model, tool, mode, color,
+  and supported frontmatter fields into OpenCode's native agent schema;
+  unsupported tool names fail closed. See
+  [targets-matrix](/apm/reference/targets-matrix/#opencode).
 - `agents / kiro = compiled` -- APM writes `.kiro/agents/<relative-stem>.md`; frontmatter is filtered to `description`, `model`, and `tools` (unsupported tool values fail the deploy). See [targets-matrix](/apm/reference/targets-matrix/#kiro) for the approved tool set.
 - `instructions / antigravity = native` -- APM deploys instructions as plain-markdown rules under `.agents/rules/`.
 - `commands / copilot = unsupported` -- Copilot has no commands primitive; the same source `.prompt.md` reaches Copilot as a native prompt instead.

--- a/docs/src/content/docs/producer/author-primitives/instructions-and-agents.md
+++ b/docs/src/content/docs/producer/author-primitives/instructions-and-agents.md
@@ -272,9 +272,9 @@ dedicated persona.
   Gemini folds context into `GEMINI.md`. If a persona must reach those
   targets, author it as a skill under `.apm/skills/<name>/SKILL.md`.
 - **Assuming every tool has an OpenCode equivalent.** APM converts portable
-  tool declarations to OpenCode's boolean map and drops unsupported names.
-  Check the mapping above when a restricted agent depends on a target-specific
-  tool.
+  tool declarations to OpenCode's boolean map. If any name has no approved
+  mapping, APM emits an actionable error and does not deploy that agent. Check
+  the mapping above when a restricted agent depends on a target-specific tool.
 - **Agent body that re-states global instructions.** Agents inherit
   the workspace's compiled context. Restate only what the persona
   needs to *override* or *add*; do not duplicate `python-style`

--- a/docs/src/content/docs/producer/author-primitives/instructions-and-agents.md
+++ b/docs/src/content/docs/producer/author-primitives/instructions-and-agents.md
@@ -161,13 +161,14 @@ for...
 | `description` | yes | Used by Cascade and Copilot to decide when to surface the agent |
 | `model` | optional | Pinned model the harness should switch to when invoked |
 | `tools` | optional | Whitelist of tools the persona may call |
-| `color` | optional | Display color for harnesses that render it (Copilot, Claude, OpenCode). OpenCode requires a `#rgb`/`#rrggbb` hex literal or one of its theme names; see "Common pitfalls" below |
+| `color` | optional | Display color for harnesses that render it. OpenCode keeps `#rgb`, `#rrggbb`, or a theme name and diagnoses other values |
+| `mode` | optional | OpenCode agent role: `primary`, `subagent`, or `all`; defaults to `subagent` |
 | `handoffs` | optional | List of agent names (or VS Code structured handoff objects) this agent can hand off to |
 
 `model` and `tools` reach Copilot, Claude, Grok Build, and Cursor
 verbatim. OpenCode receives target-native frontmatter: APM resolves models to
 `provider/model`, converts tools to a boolean map, maps portable tool names,
-and drops unsupported tools and keys. Kiro receives `description`, `model`, and `tools` only;
+and fails closed when a tool cannot be represented. Kiro receives `description`, `model`, and `tools` only;
 unknown frontmatter fields (including `name`) are stripped because
 Kiro derives agent identity from the deployed path, not from a `name`
 field. Tools are permission-bearing for Kiro: each value must be one
@@ -188,11 +189,15 @@ CLI has no agents primitive.
 
 For OpenCode, tool lists, comma-separated strings, and boolean maps are
 accepted as portable source. APM maps `search` to `grep`, `execute` and
-`shell` to `bash`, and `agent` to `task`; native names pass through.
+`shell` to `bash`, `agent` to `task`, and `fetch` and `web` to `webfetch`;
+native names pass through. When aliases converge on one native tool, `false`
+wins so translation never re-enables an explicitly disabled capability.
 Unsupported names such as `todo`, `vscode`, and namespaced MCP tools are
-dropped. Bare model IDs and Copilot display names resolve through the
-`github-copilot` provider; an explicit `provider/model` stays unchanged.
-Invalid colors and non-OpenCode keys are dropped.
+rejected before deployment with an actionable diagnostic. Bare model IDs and
+Copilot display names resolve through the `github-copilot` provider; an
+explicit `provider/model` stays unchanged. Invalid YAML also fails closed.
+Invalid optional values and non-OpenCode keys are dropped with a lossy
+translation diagnostic.
 
 ### Body conventions
 

--- a/docs/src/content/docs/producer/author-primitives/instructions-and-agents.md
+++ b/docs/src/content/docs/producer/author-primitives/instructions-and-agents.md
@@ -164,8 +164,10 @@ for...
 | `color` | optional | Display color for harnesses that render it (Copilot, Claude, OpenCode). OpenCode requires a `#rgb`/`#rrggbb` hex literal or one of its theme names; see "Common pitfalls" below |
 | `handoffs` | optional | List of agent names (or VS Code structured handoff objects) this agent can hand off to |
 
-`model` and `tools` reach Copilot, Claude, Grok Build, Cursor, and OpenCode
-verbatim. Kiro receives `description`, `model`, and `tools` only;
+`model` and `tools` reach Copilot, Claude, Grok Build, and Cursor
+verbatim. OpenCode receives target-native frontmatter: APM resolves models to
+`provider/model`, converts tools to a boolean map, maps portable tool names,
+and drops unsupported tools and keys. Kiro receives `description`, `model`, and `tools` only;
 unknown frontmatter fields (including `name`) are stripped because
 Kiro derives agent identity from the deployed path, not from a `name`
 field. Tools are permission-bearing for Kiro: each value must be one
@@ -184,14 +186,13 @@ generated agent with Codex. Windsurf and Gemini do not receive
 `.agent.md` files at all -- use skills for Windsurf personas; Gemini
 CLI has no agents primitive.
 
-OpenCode is the strictest of the verbatim targets: it requires
-`tools` as a `tool-name: boolean` **mapping** (not a list, not a
-string) and `color` to be either a `#rrggbb` hex literal or one of
-its theme names (`primary`, `secondary`, `accent`, `success`,
-`warning`, `error`, `info`). `apm install -t opencode` warns at
-install time when an agent ships shapes OpenCode would reject at
-load time -- the file is still deployed, but the warning names the
-offending package and field so you can fix the source.
+For OpenCode, tool lists, comma-separated strings, and boolean maps are
+accepted as portable source. APM maps `search` to `grep`, `execute` and
+`shell` to `bash`, and `agent` to `task`; native names pass through.
+Unsupported names such as `todo`, `vscode`, and namespaced MCP tools are
+dropped. Bare model IDs and Copilot display names resolve through the
+`github-copilot` provider; an explicit `provider/model` stays unchanged.
+Invalid colors and non-OpenCode keys are dropped.
 
 ### Body conventions
 
@@ -213,7 +214,7 @@ offending package and field so you can fix the source.
 | claude | `.claude/agents/<name>.md` | verbatim |
 | grok-build | `.grok/agents/<name>.md` | verbatim |
 | cursor | `.cursor/agents/<name>.md` | verbatim |
-| opencode | `.opencode/agents/<name>.md` | verbatim |
+| opencode | `.opencode/agents/<name>.md` | model, tools, mode, color, and supported keys normalized to OpenCode frontmatter |
 | codex | `.codex/agents/<name>.toml` | `name` and `description` -> TOML; body becomes `developer_instructions`; unsupported `tools` emits a warning |
 | kiro | `.kiro/agents/<relative-stem>.md` | `description`, `model`, `tools` kept; `name` and unknown fields stripped; identity from path; fail closed on unsupported tools (ref: [kiro.dev/docs/custom-agents](https://kiro.dev/docs/custom-agents/), accessed 2026-08-03) |
 | grok-build | `.grok/agents/<name>.md` | verbatim |
@@ -265,14 +266,10 @@ dedicated persona.
   agents primitive. Cascade auto-invokes skills by description and
   Gemini folds context into `GEMINI.md`. If a persona must reach those
   targets, author it as a skill under `.apm/skills/<name>/SKILL.md`.
-- **`tools:` as a list, or a named color, on an OpenCode-targeted
-  agent.** OpenCode's loader rejects `tools: [Read, Grep]` and
-  colors like `cyan`. Use the mapping form (`tools: {Read: true}`)
-  and either a `#rrggbb` hex literal or one of OpenCode's theme
-  names (`primary, secondary, accent, success, warning, error,
-  info`). `apm install -t opencode` will warn at install time when
-  it detects either shape; the file still deploys but OpenCode will
-  refuse to load it.
+- **Assuming every tool has an OpenCode equivalent.** APM converts portable
+  tool declarations to OpenCode's boolean map and drops unsupported names.
+  Check the mapping above when a restricted agent depends on a target-specific
+  tool.
 - **Agent body that re-states global instructions.** Agents inherit
   the workspace's compiled context. Restate only what the persona
   needs to *override* or *add*; do not duplicate `python-style`

--- a/docs/src/content/docs/reference/targets-matrix.md
+++ b/docs/src/content/docs/reference/targets-matrix.md
@@ -212,7 +212,10 @@ OpenCode.
 - **Deploy directory.** `.opencode/` at project scope; `~/.config/opencode/` at user scope.
 - **Supported primitives.** agents, commands, skills, mcp.
 - **File conventions.**
-  - agents: `.opencode/agents/<name>.md`
+  - agents: `.opencode/agents/<name>.md`; APM translates portable model,
+    tools, mode, color, and supported fields into OpenCode frontmatter.
+    Unsupported tool names or invalid YAML fail closed and do not deploy the
+    agent. See [Agent workflows](../producer/author-primitives/instructions-and-agents/#agents).
   - commands: `.opencode/commands/<name>.md`
   - skills: `.agents/skills/<name>/SKILL.md`
 - **Caveat.** OpenCode has no hooks concept; the `hooks` primitive is silently skipped for this target.

--- a/docs/src/content/docs/reference/targets-matrix.md
+++ b/docs/src/content/docs/reference/targets-matrix.md
@@ -215,7 +215,7 @@ OpenCode.
   - agents: `.opencode/agents/<name>.md`; APM translates portable model,
     tools, mode, color, and supported fields into OpenCode frontmatter.
     Unsupported tool names or invalid YAML fail closed and do not deploy the
-    agent. See [Agent workflows](../producer/author-primitives/instructions-and-agents/#agents).
+    agent. See [Agent workflows](../../producer/author-primitives/instructions-and-agents/#agents).
   - commands: `.opencode/commands/<name>.md`
   - skills: `.agents/skills/<name>/SKILL.md`
 - **Caveat.** OpenCode has no hooks concept; the `hooks` primitive is silently skipped for this target.

--- a/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
@@ -423,43 +423,36 @@ instructions: |
 ---
 ```
 
-#### OpenCode target: frontmatter constraints
+#### OpenCode target: frontmatter translation
 
 OpenCode (`target: opencode`, deploys to `.opencode/agents/`) parses
-agent frontmatter through a strict Zod schema and refuses to load
-the agent on any mismatch. APM installs OpenCode agents verbatim
-and emits an install-time warning when it detects either of these
-known incompatibilities -- the file is still copied so you can fix
-it in place, but OpenCode will fail to start until you do.
+agent frontmatter through a strict schema. APM translates portable source
+frontmatter before deployment:
 
-- `tools:` must be a **mapping of tool-name to boolean**, not a list
-  or comma-separated string:
+- `tools:` may be a list, comma-separated string, or boolean mapping. APM
+  emits OpenCode's `tool-name: boolean` mapping:
 
   ```yaml
-  # OK
+  # Portable source
+  tools: [read, edit, search, execute, agent, todo, vscode]
+
+  # Deployed OpenCode frontmatter
   tools:
-    Read: true
-    Grep: true
-    Edit: false
-
-  # Rejected by OpenCode (Claude/Copilot-style):
-  # tools: [Read, Grep]
-  # tools: "Read, Grep"
+    read: true
+    edit: true
+    grep: true
+    bash: true
+    task: true
   ```
 
-- `color:` must be either a **hex value** (`#abc` or `#aabbcc`) or
-  one of the OpenCode theme tokens: `primary`, `secondary`, `accent`,
-  `success`, `warning`, `error`, `info`. Free-form names such as
-  `cyan` or `magenta` are rejected:
-
-  ```yaml
-  # OK
-  color: "#aabbcc"
-  color: accent
-
-  # Rejected by OpenCode:
-  # color: cyan
-  ```
+- Portable mappings are `search` -> `grep`, `execute`/`shell` -> `bash`, and
+  `agent` -> `task`. Native OpenCode names pass through. Unsupported names,
+  including `todo`, `vscode`, and namespaced MCP tools, are dropped.
+- Bare model IDs and Copilot display names resolve to
+  `github-copilot/<model-id>`. Explicit `provider/model` values pass through.
+- Unsupported keys and invalid colors are dropped. Valid colors are `#rgb`,
+  `#rrggbb`, or an OpenCode theme token (`primary`, `secondary`, `accent`,
+  `success`, `warning`, `error`, `info`).
 
 If you target multiple agent runtimes from one source file, keep the
 frontmatter to the intersection of their schemas (or maintain

--- a/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
@@ -434,7 +434,7 @@ frontmatter before deployment:
 
   ```yaml
   # Portable source
-  tools: [read, edit, search, execute, agent, todo, vscode]
+  tools: [read, edit, search, execute, agent]
 
   # Deployed OpenCode frontmatter
   tools:
@@ -446,11 +446,18 @@ frontmatter before deployment:
   ```
 
 - Portable mappings are `search` -> `grep`, `execute`/`shell` -> `bash`, and
-  `agent` -> `task`. Native OpenCode names pass through. Unsupported names,
-  including `todo`, `vscode`, and namespaced MCP tools, are dropped.
+  `agent` -> `task`; `fetch`/`web` -> `webfetch`. Native OpenCode names pass
+  through. If aliases converge on one native tool, `false` wins so an explicit
+  denial cannot be re-enabled.
+- Unsupported names, including `todo`, `vscode`, and namespaced MCP tools,
+  fail closed: APM emits an actionable error and does not deploy that agent.
 - Bare model IDs and Copilot display names resolve to
   `github-copilot/<model-id>`. Explicit `provider/model` values pass through.
-- Unsupported keys and invalid colors are dropped. Valid colors are `#rgb`,
+  For example, `Claude Sonnet 5 (copilot)` becomes
+  `github-copilot/claude-sonnet-5`.
+- `mode` accepts `primary`, `subagent`, or `all` and defaults to `subagent`.
+- Invalid YAML fails closed. Unsupported keys and invalid optional values are
+  dropped with a lossy translation diagnostic. Valid colors are `#rgb`,
   `#rrggbb`, or an OpenCode theme token (`primary`, `secondary`, `accent`,
   `success`, `warning`, `error`, `info`).
 

--- a/scripts/check_diagnostic_ascii_owner.py
+++ b/scripts/check_diagnostic_ascii_owner.py
@@ -3,10 +3,11 @@
 
 ``apm_cli.utils.diagnostics.printable_ascii_text`` owns the normalization
 applied to untrusted package and agent names before they reach diagnostic
-output. The two consumers covered by this boundary must delegate directly:
+output. The AgentIntegrator diagnostic helpers covered by this boundary must
+delegate directly:
 
 * ``AgentIntegrator`` Codex diagnostic rendering; and
-* OpenCode agent frontmatter validation.
+* ``AgentIntegrator`` OpenCode translation diagnostics.
 
 This checker is intentionally narrow. It does not inspect hook event-name or
 SkillSpector output sanitizers because those normalize different values under
@@ -28,14 +29,10 @@ AGENT_CONSUMER = Path("src/apm_cli/integration/agent_integrator.py")
 AGENT_DIAGNOSTIC_FUNCTIONS = {
     "AgentIntegrator._warn_codex_unverified_scope": True,
     "AgentIntegrator._warn_codex_tools_dropped": True,
-    "AgentIntegrator._warn_opencode_frontmatter": False,
+    "AgentIntegrator._warn_opencode_frontmatter": True,
 }
-ALLOWED_IDENTITY_DELEGATES = {
-    "AgentIntegrator._warn_opencode_frontmatter": {"validate_opencode_frontmatter"},
-}
-OPENCODE_CONSUMER = Path("src/apm_cli/integration/opencode_frontmatter.py")
-OPENCODE_FUNCTION = "validate_opencode_frontmatter"
-CONSUMERS = (AGENT_CONSUMER, OPENCODE_CONSUMER)
+ALLOWED_IDENTITY_DELEGATES: dict[str, set[str]] = {}
+CONSUMERS = (AGENT_CONSUMER,)
 RETIRED_SYMBOL = "_ascii_safe_name"
 
 
@@ -118,14 +115,6 @@ def _package_name() -> ast.Name:
     return ast.Name(id="package_name", ctx=ast.Load())
 
 
-def _contains_name(node: ast.AST, name: str) -> bool:
-    """Return whether an expression contains a load of ``name``."""
-    return any(
-        isinstance(child, ast.Name) and isinstance(child.ctx, ast.Load) and child.id == name
-        for child in ast.walk(node)
-    )
-
-
 def _diagnostic_calls(function: ast.AST) -> list[ast.Call]:
     """Return DiagnosticCollector calls that render one Codex warning."""
     return [
@@ -150,43 +139,6 @@ def _identity_is_directly_owned_in_diagnostic(
         if package_owned and (source_owned or not require_source):
             return True
     return False
-
-
-def _assignments_to(function: ast.AST, name: str) -> list[ast.Assign]:
-    """Return simple assignments to ``name`` in one function scope."""
-    return [
-        node
-        for node in _walk_own_scope(function)
-        if isinstance(node, ast.Assign)
-        and any(isinstance(target, ast.Name) and target.id == name for target in node.targets)
-    ]
-
-
-def _opencode_identity_flow_is_owned(function: ast.AST) -> bool:
-    """Return whether OpenCode messages derive identity only from the owner."""
-    safe_name_assignments = _assignments_to(function, "safe_name")
-    identifier_assignments = _assignments_to(function, "identifier")
-    if len(safe_name_assignments) != 1 or len(identifier_assignments) != 1:
-        return False
-    if not _is_owner_call(safe_name_assignments[0].value, _source_name()):
-        return False
-    identifier = identifier_assignments[0].value
-    if not any(_is_owner_call(node, _package_name()) for node in ast.walk(identifier)):
-        return False
-    if not _contains_name(identifier, "safe_name"):
-        return False
-    message_appends = [
-        node
-        for node in _walk_own_scope(function)
-        if isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Attribute)
-        and isinstance(node.func.value, ast.Name)
-        and node.func.value.id == "messages"
-        and node.func.attr == "append"
-    ]
-    return bool(message_appends) and all(
-        _contains_name(call, "identifier") for call in message_appends
-    )
 
 
 def _is_identity(node: ast.AST) -> bool:
@@ -322,11 +274,7 @@ def check(root: Path) -> list[Violation]:
             )
 
         functions = _qualnamed_functions(tree)
-        expected_functions = (
-            AGENT_DIAGNOSTIC_FUNCTIONS.keys()
-            if relative_path == AGENT_CONSUMER
-            else {OPENCODE_FUNCTION}
-        )
+        expected_functions = AGENT_DIAGNOSTIC_FUNCTIONS.keys()
         for qualname in expected_functions:
             function = functions.get(qualname)
             if function is None:
@@ -334,13 +282,9 @@ def check(root: Path) -> list[Violation]:
                     Violation(relative_path, 1, f"required consumer function missing: {qualname}")
                 )
                 continue
-            flow_is_owned = (
-                _identity_is_directly_owned_in_diagnostic(
-                    function,
-                    require_source=AGENT_DIAGNOSTIC_FUNCTIONS[qualname],
-                )
-                if relative_path == AGENT_CONSUMER
-                else _opencode_identity_flow_is_owned(function)
+            flow_is_owned = _identity_is_directly_owned_in_diagnostic(
+                function,
+                require_source=AGENT_DIAGNOSTIC_FUNCTIONS[qualname],
             )
             if not flow_is_owned:
                 violations.append(
@@ -351,19 +295,7 @@ def check(root: Path) -> list[Violation]:
                         f"{OWNER_MODULE}.{OWNER_SYMBOL}",
                     )
                 )
-            output_calls = (
-                _diagnostic_calls(function)
-                if relative_path == AGENT_CONSUMER
-                else [
-                    node
-                    for node in _walk_own_scope(function)
-                    if isinstance(node, ast.Call)
-                    and isinstance(node.func, ast.Attribute)
-                    and isinstance(node.func.value, ast.Name)
-                    and node.func.value.id == "messages"
-                    and node.func.attr == "append"
-                ]
-            )
+            output_calls = _diagnostic_calls(function)
             for output_call in output_calls:
                 for line in _raw_identity_lines(output_call):
                     violations.append(

--- a/scripts/lint-architecture-boundaries.sh
+++ b/scripts/lint-architecture-boundaries.sh
@@ -1537,6 +1537,32 @@ if ! uv run --extra dev python scripts/lint-bootstrap-project-name.py; then
     violations=$((violations + 1))
 fi
 
+echo "[*] AC33: OpenCode agent translation authority"
+opencode_agent_owner="src/apm_cli/integration/opencode_frontmatter.py"
+opencode_agent_consumer="src/apm_cli/integration/agent_integrator.py"
+opencode_agent_translator_defs=$(grep -rEc --include='*.py' \
+    '^def translate_opencode_agent\(' src/apm_cli \
+    | awk -F: '{sum += $2} END {print sum + 0}')
+opencode_agent_parallel_maps=$(
+    grep -rEn --include='*.py' \
+        '^_?OPENCODE_.*(TOOL|MODEL).*(ALIASES|MAP)[[:space:]]*=' \
+        src/apm_cli \
+        | grep -v "^${opencode_agent_owner}:" \
+        | grep -v 'architecture-authority-exempt:' \
+        || true
+)
+if [ "$opencode_agent_translator_defs" -ne 1 ] \
+    || ! grep -q \
+        'from apm_cli.integration.opencode_frontmatter import (' \
+        "$opencode_agent_consumer" \
+    || ! grep -q 'return translate_opencode_agent(content), links_resolved' \
+        "$opencode_agent_consumer" \
+    || [ -n "$opencode_agent_parallel_maps" ]; then
+    echo "[x] OpenCode agent translation must route through integration/opencode_frontmatter.py"
+    [ -n "$opencode_agent_parallel_maps" ] && echo "$opencode_agent_parallel_maps"
+    violations=$((violations + 1))
+fi
+
 if [ "$violations" -gt 0 ]; then
     echo "[x] $violations architecture boundary rule(s) failed"
     exit 1

--- a/scripts/lint-architecture-boundaries.sh
+++ b/scripts/lint-architecture-boundaries.sh
@@ -1563,6 +1563,21 @@ if [ "$opencode_agent_translator_defs" -ne 1 ] \
     violations=$((violations + 1))
 fi
 
+echo "[*] AC34: rendered agent adoption authority"
+rendered_agent_adopt_owner="src/apm_cli/integration/base_integrator.py"
+rendered_agent_adopt_defs=$(grep -rEc --include='*.py' \
+    '^[[:space:]]*def _check_rendered_adopt_or_skip\(' src/apm_cli \
+    | awk -F: '{sum += $2} END {print sum + 0}')
+rendered_agent_adopt_calls=$(grep -c \
+    'self\._check_rendered_adopt_or_skip(' "$opencode_agent_consumer" || true)
+if [ "$rendered_agent_adopt_defs" -ne 1 ] \
+    || ! grep -q '^    def _check_rendered_adopt_or_skip(' "$rendered_agent_adopt_owner" \
+    || [ "$rendered_agent_adopt_calls" -ne 2 ] \
+    || grep -q 'target_path\.read_bytes()' "$opencode_agent_consumer"; then
+    echo "[x] Rendered agent adoption must route through BaseIntegrator"
+    violations=$((violations + 1))
+fi
+
 if [ "$violations" -gt 0 ]; then
     echo "[x] $violations architecture boundary rule(s) failed"
     exit 1

--- a/src/apm_cli/integration/agent_integrator.py
+++ b/src/apm_cli/integration/agent_integrator.py
@@ -14,7 +14,10 @@ from typing import TYPE_CHECKING
 import yaml
 
 from apm_cli.integration.base_integrator import BaseIntegrator, IntegrationResult
-from apm_cli.integration.opencode_frontmatter import validate_opencode_frontmatter
+from apm_cli.integration.opencode_frontmatter import (
+    translate_opencode_agent,
+    validate_opencode_frontmatter,
+)
 from apm_cli.utils.atomic_io import normalize_crlf_to_lf, write_text_lf
 from apm_cli.utils.diagnostics import printable_ascii_text
 from apm_cli.utils.path_security import PathTraversalError, ensure_path_within
@@ -220,6 +223,36 @@ class AgentIntegrator(BaseIntegrator):
 
             rel_path = portable_relpath(target_path, project_root)
 
+            if mapping.format_id == "opencode_agent":
+                rendered, links_resolved = self._render_opencode_agent(
+                    source_file,
+                    target_path,
+                )
+                if target_path.exists() and not target_path.is_symlink():
+                    try:
+                        existing = target_path.read_bytes()
+                        rendered_bytes = normalize_crlf_to_lf(rendered).encode("utf-8")
+                        if existing == rendered_bytes:
+                            target_paths.append(target_path)
+                            files_adopted += 1
+                            continue
+                    except OSError:
+                        pass
+                if self.check_collision(
+                    target_path,
+                    rel_path,
+                    managed_files,
+                    force,
+                    diagnostics=diagnostics,
+                ):
+                    files_skipped += 1
+                    continue
+                write_text_lf(target_path, rendered)
+                total_links_resolved += links_resolved
+                files_integrated += 1
+                target_paths.append(target_path)
+                continue
+
             skip, adopted = self._check_adopt_or_skip(
                 target_path, source_file, rel_path, managed_files, force, diagnostics, target_paths
             )
@@ -239,10 +272,6 @@ class AgentIntegrator(BaseIntegrator):
                 )
                 links_resolved = 0
             else:
-                if mapping.format_id == "opencode_agent":
-                    self._warn_opencode_frontmatter(
-                        source_file, diagnostics, package_info.package.name
-                    )
                 links_resolved = self.copy_agent(source_file, target_path)
             total_links_resolved += links_resolved
             files_integrated += 1
@@ -321,8 +350,16 @@ class AgentIntegrator(BaseIntegrator):
         write_text_lf(target, content)
         return links_resolved
 
+    def _render_opencode_agent(self, source: Path, target: Path) -> tuple[str, int]:
+        """Resolve links and translate one portable agent for OpenCode."""
+        if source.is_symlink():
+            raise ValueError(f"Refusing to read symlink source: {source}")
+        content = source.read_text(encoding="utf-8")
+        content, links_resolved = self.resolve_links(content, source, target)
+        return translate_opencode_agent(content), links_resolved
+
     # ------------------------------------------------------------------
-    # OpenCode validate-and-warn (Phase 1 of #581)
+    # OpenCode compatibility validator (retained for external callers)
     # ------------------------------------------------------------------
 
     @staticmethod
@@ -331,14 +368,7 @@ class AgentIntegrator(BaseIntegrator):
         diagnostics: DiagnosticCollector | None,
         package_name: str,
     ) -> None:
-        """Emit warnings for OpenCode-incompatible agent frontmatter.
-
-        Phase 1 only: surfaces Zod-fatal shapes (tools as list/string,
-        named colors outside the OpenCode theme enum) so users learn
-        why OpenCode will refuse to load the agent. The file is still
-        copied verbatim; Phase 2 (per-target frontmatter transformer)
-        is tracked separately.
-        """
+        """Emit compatibility warnings for raw OpenCode frontmatter."""
         if diagnostics is None:
             return
         if source.is_symlink():

--- a/src/apm_cli/integration/agent_integrator.py
+++ b/src/apm_cli/integration/agent_integrator.py
@@ -15,10 +15,11 @@ import yaml
 
 from apm_cli.integration.base_integrator import BaseIntegrator, IntegrationResult
 from apm_cli.integration.opencode_frontmatter import (
+    OpencodeAgentTranslation,
+    OpencodeAgentTranslationError,
     translate_opencode_agent,
-    validate_opencode_frontmatter,
 )
-from apm_cli.utils.atomic_io import normalize_crlf_to_lf, write_text_lf
+from apm_cli.utils.atomic_io import write_text_lf
 from apm_cli.utils.diagnostics import printable_ascii_text
 from apm_cli.utils.path_security import PathTraversalError, ensure_path_within
 from apm_cli.utils.paths import portable_relpath
@@ -190,20 +191,20 @@ class AgentIntegrator(BaseIntegrator):
                 # target so a pre-placed file with invalid tools cannot be
                 # adopted by matching source bytes.
                 rel_path = portable_relpath(target_path, project_root)
-                if target_path.exists() and not target_path.is_symlink():
-                    try:
-                        existing = target_path.read_bytes()
-                        rendered_bytes = normalize_crlf_to_lf(rendered).encode("utf-8")
-                        if existing == rendered_bytes:
-                            target_paths.append(target_path)
-                            files_adopted += 1
-                            continue
-                    except OSError:
-                        pass
-                if self.check_collision(
-                    target_path, rel_path, managed_files, force, diagnostics=diagnostics
-                ):
-                    files_skipped += 1
+                skip, adopted = self._check_rendered_adopt_or_skip(
+                    target_path,
+                    rendered,
+                    rel_path,
+                    managed_files,
+                    force,
+                    diagnostics,
+                    target_paths,
+                )
+                if skip:
+                    if adopted:
+                        files_adopted += 1
+                    else:
+                        files_skipped += 1
                     continue
 
                 # Safe to materialize: ensure parent dirs exist then write.
@@ -216,42 +217,59 @@ class AgentIntegrator(BaseIntegrator):
                 target_paths.append(target_path)
                 continue
 
-            # Non-kiro path: eager mkdir (existing behavior preserved).
-            if not agents_dir_created:
-                agents_dir.mkdir(parents=True, exist_ok=True)
-                agents_dir_created = True
-
             rel_path = portable_relpath(target_path, project_root)
 
             if mapping.format_id == "opencode_agent":
-                rendered, links_resolved = self._render_opencode_agent(
+                try:
+                    translation, links_resolved = self._render_opencode_agent(
+                        source_file,
+                        target_path,
+                    )
+                except OpencodeAgentTranslationError as exc:
+                    if diagnostics is not None:
+                        diagnostics.error(
+                            message=(
+                                f"OpenCode agent {printable_ascii_text(source_file.name)} "
+                                f"was not deployed: {printable_ascii_text(str(exc))}."
+                            ),
+                            package=printable_ascii_text(package_info.package.name),
+                        )
+                    files_skipped += 1
+                    continue
+                self._warn_opencode_frontmatter(
                     source_file,
-                    target_path,
+                    diagnostics,
+                    package_info.package.name,
+                    translation.notices,
                 )
-                if target_path.exists() and not target_path.is_symlink():
-                    try:
-                        existing = target_path.read_bytes()
-                        rendered_bytes = normalize_crlf_to_lf(rendered).encode("utf-8")
-                        if existing == rendered_bytes:
-                            target_paths.append(target_path)
-                            files_adopted += 1
-                            continue
-                    except OSError:
-                        pass
-                if self.check_collision(
+                skip, adopted = self._check_rendered_adopt_or_skip(
                     target_path,
+                    translation.content,
                     rel_path,
                     managed_files,
                     force,
-                    diagnostics=diagnostics,
-                ):
-                    files_skipped += 1
+                    diagnostics,
+                    target_paths,
+                )
+                if skip:
+                    if adopted:
+                        files_adopted += 1
+                    else:
+                        files_skipped += 1
                     continue
-                write_text_lf(target_path, rendered)
+                if not agents_dir_created:
+                    agents_dir.mkdir(parents=True, exist_ok=True)
+                    agents_dir_created = True
+                write_text_lf(target_path, translation.content)
                 total_links_resolved += links_resolved
                 files_integrated += 1
                 target_paths.append(target_path)
                 continue
+
+            # Verbatim targets preserve the existing eager-directory behavior.
+            if not agents_dir_created:
+                agents_dir.mkdir(parents=True, exist_ok=True)
+                agents_dir_created = True
 
             skip, adopted = self._check_adopt_or_skip(
                 target_path, source_file, rel_path, managed_files, force, diagnostics, target_paths
@@ -350,7 +368,9 @@ class AgentIntegrator(BaseIntegrator):
         write_text_lf(target, content)
         return links_resolved
 
-    def _render_opencode_agent(self, source: Path, target: Path) -> tuple[str, int]:
+    def _render_opencode_agent(
+        self, source: Path, target: Path
+    ) -> tuple[OpencodeAgentTranslation, int]:
         """Resolve links and translate one portable agent for OpenCode."""
         if source.is_symlink():
             raise ValueError(f"Refusing to read symlink source: {source}")
@@ -358,38 +378,27 @@ class AgentIntegrator(BaseIntegrator):
         content, links_resolved = self.resolve_links(content, source, target)
         return translate_opencode_agent(content), links_resolved
 
-    # ------------------------------------------------------------------
-    # OpenCode compatibility validator (retained for external callers)
-    # ------------------------------------------------------------------
-
     @staticmethod
     def _warn_opencode_frontmatter(
         source: Path,
         diagnostics: DiagnosticCollector | None,
         package_name: str,
+        notices: tuple[str, ...],
     ) -> None:
-        """Emit compatibility warnings for raw OpenCode frontmatter."""
+        """Record lossy OpenCode translation notices in the shared collector."""
         if diagnostics is None:
             return
-        if source.is_symlink():
-            return
-        try:
-            content = source.read_text(encoding="utf-8")
-        except OSError:
-            return
-        fm_match = AgentIntegrator._FRONTMATTER_RE.match(content)
-        if not fm_match:
-            return
-        try:
-            fm = load_yaml_str(fm_match.group(1)) or {}
-        except yaml.YAMLError:
-            return
-        if not isinstance(fm, dict):
-            return
-        for message in validate_opencode_frontmatter(fm, source, package_name=package_name):
-            diagnostics.warn(
-                message=message,
+        for notice in notices:
+            diagnostics.lossy_agent_compilation(
+                message=(
+                    f"OpenCode agent {printable_ascii_text(source.name)}: "
+                    f"{printable_ascii_text(notice)}."
+                ),
                 package=printable_ascii_text(package_name),
+                detail=(
+                    "Review the source frontmatter and remove or correct fields "
+                    "that OpenCode cannot represent."
+                ),
             )
 
     # ------------------------------------------------------------------

--- a/src/apm_cli/integration/agent_integrator.py
+++ b/src/apm_cli/integration/agent_integrator.py
@@ -199,6 +199,7 @@ class AgentIntegrator(BaseIntegrator):
                     force,
                     diagnostics,
                     target_paths,
+                    lf_normalized_deploy=self._LF_NORMALIZED_DEPLOY,
                 )
                 if skip:
                     if adopted:
@@ -250,6 +251,7 @@ class AgentIntegrator(BaseIntegrator):
                     force,
                     diagnostics,
                     target_paths,
+                    lf_normalized_deploy=self._LF_NORMALIZED_DEPLOY,
                 )
                 if skip:
                     if adopted:
@@ -373,7 +375,7 @@ class AgentIntegrator(BaseIntegrator):
     ) -> tuple[OpencodeAgentTranslation, int]:
         """Resolve links and translate one portable agent for OpenCode."""
         if source.is_symlink():
-            raise ValueError(f"Refusing to read symlink source: {source}")
+            raise OpencodeAgentTranslationError(f"Refusing to read symlink source: {source}")
         content = source.read_text(encoding="utf-8")
         content, links_resolved = self.resolve_links(content, source, target)
         return translate_opencode_agent(content), links_resolved

--- a/src/apm_cli/integration/base_integrator.py
+++ b/src/apm_cli/integration/base_integrator.py
@@ -438,6 +438,8 @@ class BaseIntegrator:
         force: bool,
         diagnostics,
         target_paths: list[Path],
+        *,
+        lf_normalized_deploy: bool,
     ) -> tuple[bool, bool]:
         """Check adoption and collision for a pre-rendered text artifact.
 
@@ -447,7 +449,12 @@ class BaseIntegrator:
         try:
             if target_path.exists() and not target_path.is_symlink():
                 target_bytes = _read_bytes_no_follow(target_path)
-                rendered_bytes = normalize_crlf_to_lf(rendered_content).encode("utf-8")
+                deployed_content = (
+                    normalize_crlf_to_lf(rendered_content)
+                    if lf_normalized_deploy
+                    else rendered_content
+                )
+                rendered_bytes = deployed_content.encode("utf-8")
                 if target_bytes == rendered_bytes:
                     target_paths.append(target_path)
                     return True, True

--- a/src/apm_cli/integration/base_integrator.py
+++ b/src/apm_cli/integration/base_integrator.py
@@ -429,6 +429,36 @@ class BaseIntegrator:
             return True, False
         return False, False
 
+    def _check_rendered_adopt_or_skip(
+        self,
+        target_path: Path,
+        rendered_content: str,
+        rel_path: str,
+        managed_files: set[str] | None,
+        force: bool,
+        diagnostics,
+        target_paths: list[Path],
+    ) -> tuple[bool, bool]:
+        """Check adoption and collision for a pre-rendered text artifact.
+
+        Target-specific renderers must call this owner instead of duplicating
+        the rendered-byte identity and collision sequence.
+        """
+        try:
+            if target_path.exists() and not target_path.is_symlink():
+                target_bytes = _read_bytes_no_follow(target_path)
+                rendered_bytes = normalize_crlf_to_lf(rendered_content).encode("utf-8")
+                if target_bytes == rendered_bytes:
+                    target_paths.append(target_path)
+                    return True, True
+        except (_SymlinkRaceError, OSError):
+            pass
+        if self.check_collision(
+            target_path, rel_path, managed_files, force, diagnostics=diagnostics
+        ):
+            return True, False
+        return False, False
+
     # Known integration prefixes that APM is allowed to deploy/remove under.
     # Derived from ``targets.KNOWN_TARGETS`` so adding a target auto-propagates.
     @staticmethod

--- a/src/apm_cli/integration/opencode_frontmatter.py
+++ b/src/apm_cli/integration/opencode_frontmatter.py
@@ -1,28 +1,14 @@
-"""OpenCode agent frontmatter validation (Phase 1 of #581).
-
-OpenCode's loadAgent() calls Agent.safeParse() on parsed YAML
-frontmatter; on validation failure it raises an uncaught
-InvalidError and OpenCode fails to start. APM previously deployed
-agent files verbatim to .opencode/agents/, so a Claude-style agent
-file (tools as string/array, named color) would silently install and
-then crash OpenCode at runtime.
-
-This module inspects frontmatter for the known Zod-fatal shapes and
-returns human-readable warning messages. It does NOT mutate the
-frontmatter and does NOT block installation; the install path emits
-the warnings via the diagnostics collector so the user understands
-why OpenCode will refuse to load the agent.
-
-Phase 2 (per-target frontmatter transformer) is tracked separately
-and is intentionally out of scope here.
-"""
+"""Canonical translation of portable agent frontmatter to OpenCode."""
 
 from __future__ import annotations
 
 import re
 from pathlib import Path
 
+import yaml
+
 from apm_cli.utils.diagnostics import printable_ascii_text
+from apm_cli.utils.yaml_io import load_yaml_str, yaml_to_str
 
 # OpenCode theme color enum (see sst/opencode config schema).
 OPENCODE_THEME_COLORS = frozenset(
@@ -31,6 +17,135 @@ OPENCODE_THEME_COLORS = frozenset(
 
 # Hex color regex: #RGB or #RRGGBB, case-insensitive.
 _HEX_COLOR_RE = re.compile(r"^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$")
+_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n?", re.DOTALL)
+_MODEL_PROVIDER_RE = re.compile(r"^(.*?)\s*\(([^()]+)\)\s*$")
+
+_OPENCODE_FRONTMATTER_KEYS = (
+    "name",
+    "description",
+    "temperature",
+    "top_p",
+    "prompt",
+    "permission",
+    "disable",
+    "hidden",
+    "steps",
+)
+_OPENCODE_MODES = frozenset({"primary", "subagent", "all"})
+_OPENCODE_TOOL_ALIASES = {
+    "bash": "bash",
+    "edit": "edit",
+    "execute": "bash",
+    "fetch": "webfetch",
+    "glob": "glob",
+    "grep": "grep",
+    "read": "read",
+    "search": "grep",
+    "shell": "bash",
+    "task": "task",
+    "agent": "task",
+    "web": "webfetch",
+    "webfetch": "webfetch",
+    "write": "write",
+}
+_MODEL_PROVIDER_ALIASES = {
+    "copilot": "github-copilot",
+    "github copilot": "github-copilot",
+    "github-copilot": "github-copilot",
+}
+
+
+def translate_opencode_agent(content: str) -> str:
+    """Render portable Markdown agent content in OpenCode's native schema.
+
+    Unknown frontmatter keys and unsupported tools are dropped. Portable tool
+    lists, comma-separated strings, and boolean mappings become OpenCode's
+    ``Record<string, boolean>`` shape. Model display names and bare model IDs
+    resolve to ``provider/model`` identifiers.
+    """
+    match = _FRONTMATTER_RE.match(content)
+    if not match:
+        return content
+
+    try:
+        metadata = load_yaml_str(match.group(1)) or {}
+    except yaml.YAMLError:
+        metadata = {}
+    if not isinstance(metadata, dict):
+        metadata = {}
+
+    translated = {key: metadata[key] for key in _OPENCODE_FRONTMATTER_KEYS if key in metadata}
+
+    mode = metadata.get("mode")
+    if not isinstance(mode, str) or mode not in _OPENCODE_MODES:
+        mode = "subagent"
+    translated["mode"] = mode
+
+    model = _translate_model(metadata.get("model"))
+    if model is not None:
+        translated["model"] = model
+
+    tools = _translate_tools(metadata.get("tools"))
+    if tools:
+        translated["tools"] = tools
+
+    color = metadata.get("color")
+    if _is_valid_opencode_color(color):
+        translated["color"] = color
+
+    body = content[match.end() :]
+    rendered_frontmatter = yaml_to_str(translated, sort_keys=False).rstrip()
+    return f"---\n{rendered_frontmatter}\n---\n\n{body.lstrip()}"
+
+
+def _translate_model(value: object) -> str | None:
+    """Return an OpenCode ``provider/model`` identifier."""
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    if not value:
+        return None
+    if "/" in value:
+        return value
+
+    provider = "github-copilot"
+    provider_match = _MODEL_PROVIDER_RE.match(value)
+    if provider_match:
+        value = provider_match.group(1).strip()
+        provider_name = provider_match.group(2).strip().lower()
+        provider = _MODEL_PROVIDER_ALIASES.get(provider_name, _slugify(provider_name))
+
+    model = _slugify(value)
+    if not model or not provider:
+        return None
+    return f"{provider}/{model}"
+
+
+def _translate_tools(value: object) -> dict[str, bool]:
+    """Map portable tool declarations to OpenCode's native vocabulary."""
+    entries: list[tuple[object, object]]
+    if isinstance(value, dict):
+        entries = list(value.items())
+    elif isinstance(value, list):
+        entries = [(item, True) for item in value]
+    elif isinstance(value, str):
+        entries = [(item.strip(), True) for item in value.split(",")]
+    else:
+        return {}
+
+    translated: dict[str, bool] = {}
+    for source_name, enabled in entries:
+        if not isinstance(source_name, str) or not isinstance(enabled, bool):
+            continue
+        native_name = _OPENCODE_TOOL_ALIASES.get(source_name.strip().lower())
+        if native_name is not None:
+            translated[native_name] = enabled
+    return translated
+
+
+def _slugify(value: str) -> str:
+    """Normalize a model or provider display name to an identifier segment."""
+    return re.sub(r"[^a-z0-9._-]+", "-", value.lower()).strip("-")
 
 
 def _ascii_repr(value: object) -> str:

--- a/src/apm_cli/integration/opencode_frontmatter.py
+++ b/src/apm_cli/integration/opencode_frontmatter.py
@@ -3,11 +3,10 @@
 from __future__ import annotations
 
 import re
-from pathlib import Path
+from dataclasses import dataclass
 
 import yaml
 
-from apm_cli.utils.diagnostics import printable_ascii_text
 from apm_cli.utils.yaml_io import load_yaml_str, yaml_to_str
 
 # OpenCode theme color enum (see sst/opencode config schema).
@@ -55,35 +54,73 @@ _MODEL_PROVIDER_ALIASES = {
 }
 
 
-def translate_opencode_agent(content: str) -> str:
+@dataclass(frozen=True)
+class OpencodeAgentTranslation:
+    """Rendered OpenCode content plus user-visible lossy-conversion notices."""
+
+    content: str
+    notices: tuple[str, ...] = ()
+
+
+class OpencodeAgentTranslationError(ValueError):
+    """Raised when source intent cannot be represented safely in OpenCode."""
+
+
+def translate_opencode_agent(content: str) -> OpencodeAgentTranslation:
     """Render portable Markdown agent content in OpenCode's native schema.
 
-    Unknown frontmatter keys and unsupported tools are dropped. Portable tool
-    lists, comma-separated strings, and boolean mappings become OpenCode's
-    ``Record<string, boolean>`` shape. Model display names and bare model IDs
-    resolve to ``provider/model`` identifiers.
+    Unknown frontmatter keys and invalid optional values are omitted with a
+    notice. Unsupported tools and malformed metadata fail closed. Portable
+    tool lists, comma-separated strings, and boolean mappings become
+    OpenCode's ``Record<string, boolean>`` shape. Model display names and bare
+    model IDs resolve to ``provider/model`` identifiers.
     """
     match = _FRONTMATTER_RE.match(content)
     if not match:
-        return content
+        return OpencodeAgentTranslation(content)
 
     try:
         metadata = load_yaml_str(match.group(1)) or {}
-    except yaml.YAMLError:
-        metadata = {}
+    except yaml.YAMLError as exc:
+        raise OpencodeAgentTranslationError(
+            "frontmatter is invalid YAML; fix the YAML syntax"
+        ) from exc
     if not isinstance(metadata, dict):
-        metadata = {}
+        raise OpencodeAgentTranslationError(
+            "frontmatter must be a YAML mapping; replace the top-level value with key/value fields"
+        )
 
-    translated = {key: metadata[key] for key in _OPENCODE_FRONTMATTER_KEYS if key in metadata}
+    notices: list[str] = []
+    translated: dict[str, object] = {}
+    for key in _OPENCODE_FRONTMATTER_KEYS:
+        if key not in metadata:
+            continue
+        value = metadata[key]
+        if _is_valid_supported_value(key, value):
+            translated[key] = value
+        else:
+            notices.append(f"dropped invalid '{key}' value")
+
+    ignored_keys = sorted(
+        str(key)
+        for key in metadata
+        if key not in {*_OPENCODE_FRONTMATTER_KEYS, "mode", "model", "tools", "color"}
+    )
+    if ignored_keys:
+        notices.append(f"dropped unsupported fields: {', '.join(ignored_keys)}")
 
     mode = metadata.get("mode")
     if not isinstance(mode, str) or mode not in _OPENCODE_MODES:
+        if "mode" in metadata:
+            notices.append("replaced invalid 'mode' with 'subagent'")
         mode = "subagent"
     translated["mode"] = mode
 
     model = _translate_model(metadata.get("model"))
     if model is not None:
         translated["model"] = model
+    elif "model" in metadata:
+        notices.append("dropped invalid 'model' value")
 
     tools = _translate_tools(metadata.get("tools"))
     if tools:
@@ -92,10 +129,13 @@ def translate_opencode_agent(content: str) -> str:
     color = metadata.get("color")
     if _is_valid_opencode_color(color):
         translated["color"] = color
+    elif "color" in metadata:
+        notices.append("dropped invalid 'color' value")
 
     body = content[match.end() :]
     rendered_frontmatter = yaml_to_str(translated, sort_keys=False).rstrip()
-    return f"---\n{rendered_frontmatter}\n---\n\n{body.lstrip()}"
+    rendered = f"---\n{rendered_frontmatter}\n---\n\n{body.lstrip()}"
+    return OpencodeAgentTranslation(rendered, tuple(notices))
 
 
 def _translate_model(value: object) -> str | None:
@@ -122,7 +162,10 @@ def _translate_model(value: object) -> str | None:
 
 
 def _translate_tools(value: object) -> dict[str, bool]:
-    """Map portable tool declarations to OpenCode's native vocabulary."""
+    """Map portable tools, failing closed when any tool is unrepresentable."""
+    if value is None:
+        return {}
+
     entries: list[tuple[object, object]]
     if isinstance(value, dict):
         entries = list(value.items())
@@ -131,15 +174,28 @@ def _translate_tools(value: object) -> dict[str, bool]:
     elif isinstance(value, str):
         entries = [(item.strip(), True) for item in value.split(",")]
     else:
-        return {}
+        raise OpencodeAgentTranslationError(
+            "'tools' must be a list, comma-separated string, or boolean mapping"
+        )
 
     translated: dict[str, bool] = {}
+    unsupported: list[str] = []
     for source_name, enabled in entries:
         if not isinstance(source_name, str) or not isinstance(enabled, bool):
-            continue
+            raise OpencodeAgentTranslationError(
+                "'tools' entries must use string names and boolean values"
+            )
         native_name = _OPENCODE_TOOL_ALIASES.get(source_name.strip().lower())
-        if native_name is not None:
-            translated[native_name] = enabled
+        if native_name is None:
+            unsupported.append(source_name)
+            continue
+        translated[native_name] = translated.get(native_name, True) and enabled
+    if unsupported:
+        values = ", ".join(sorted(unsupported))
+        approved = ", ".join(sorted(_OPENCODE_TOOL_ALIASES))
+        raise OpencodeAgentTranslationError(
+            f"unsupported tools: {values}; use only approved names: {approved}"
+        )
     return translated
 
 
@@ -148,79 +204,19 @@ def _slugify(value: str) -> str:
     return re.sub(r"[^a-z0-9._-]+", "-", value.lower()).strip("-")
 
 
-def _ascii_repr(value: object) -> str:
-    """Return an ASCII-only repr of ``value``.
-
-    Drop-in replacement for ``!r`` interpolation: ``ascii()`` escapes
-    any non-ASCII codepoints (e.g. ``'cy\\xe1n'``) so diagnostics never
-    leak raw non-ASCII bytes from user frontmatter into CLI output.
-    """
-    return ascii(value)
-
-
-def validate_opencode_frontmatter(
-    fm: dict | None,
-    source: Path,
-    package_name: str | None = None,
-) -> list[str]:
-    """Return ASCII warning messages for OpenCode-incompatible fields.
-
-    Empty list means no incompatibilities were detected. The caller
-    is responsible for surfacing each message via the diagnostics
-    collector; this function is pure.
-
-    Args:
-        fm: Parsed YAML frontmatter (may be ``None`` or empty dict).
-        source: Source agent file path, used in messages so the user
-            can locate the offending file.
-        package_name: Optional owning APM package name. When provided,
-            the warning identifies the agent as ``<pkg>/<file>`` so
-            users running multi-package installs can tell which
-            dependency the bad frontmatter came from.
-    """
-    if not fm or not isinstance(fm, dict):
-        return []
-
-    messages: list[str] = []
-    safe_name = printable_ascii_text(source.name)
-    identifier = f"{printable_ascii_text(package_name)}/{safe_name}" if package_name else safe_name
-
-    if "tools" in fm:
-        tools = fm["tools"]
-        if not isinstance(tools, dict):
-            kind = type(tools).__name__
-            messages.append(
-                f"OpenCode agent '{identifier}' has tools as {kind}; "
-                "OpenCode requires a mapping of tool-name to boolean. "
-                "OpenCode will reject this agent at load time. "
-                "Fix: rewrite the frontmatter as 'tools: {Read: true, Grep: true}'."
-            )
-        else:
-            for key, value in tools.items():
-                if not isinstance(key, str) or not isinstance(value, bool):
-                    messages.append(
-                        f"OpenCode agent '{identifier}' has a non-boolean tool entry "
-                        f"({_ascii_repr(key)}: {_ascii_repr(value)}); OpenCode requires "
-                        "string-keyed boolean values. "
-                        "OpenCode will reject this agent at load time. "
-                        "Fix: set every tool entry to 'true' or 'false' "
-                        "(e.g. 'Read: true')."
-                    )
-                    break
-
-    if "color" in fm:
-        color = fm["color"]
-        if not _is_valid_opencode_color(color):
-            messages.append(
-                f"OpenCode agent '{identifier}' has color={_ascii_repr(color)}; "
-                "OpenCode requires a hex value (e.g. '#aabbcc') or one of "
-                f"{sorted(OPENCODE_THEME_COLORS)}. "
-                "OpenCode will reject this agent at load time. "
-                "Fix: replace the color with a '#rgb' or '#rrggbb' hex literal "
-                "or one of the listed theme names."
-            )
-
-    return messages
+def _is_valid_supported_value(key: str, value: object) -> bool:
+    """Return whether a pass-through field has the OpenCode schema shape."""
+    if key in {"name", "description", "prompt"}:
+        return isinstance(value, str)
+    if key in {"temperature", "top_p"}:
+        return isinstance(value, int | float) and not isinstance(value, bool)
+    if key == "permission":
+        return isinstance(value, dict)
+    if key in {"disable", "hidden"}:
+        return isinstance(value, bool)
+    if key == "steps":
+        return isinstance(value, int) and not isinstance(value, bool) and value > 0
+    return False
 
 
 def _is_valid_opencode_color(value: object) -> bool:

--- a/src/apm_cli/integration/opencode_frontmatter.py
+++ b/src/apm_cli/integration/opencode_frontmatter.py
@@ -16,7 +16,10 @@ OPENCODE_THEME_COLORS = frozenset(
 
 # Hex color regex: #RGB or #RRGGBB, case-insensitive.
 _HEX_COLOR_RE = re.compile(r"^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$")
-_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n?", re.DOTALL)
+_FRONTMATTER_RE = re.compile(
+    r"^---[ \t]*\r?\n(.*?)\r?\n---[ \t]*(?:\r?\n)?",
+    re.DOTALL,
+)
 _MODEL_PROVIDER_RE = re.compile(r"^(.*?)\s*\(([^()]+)\)\s*$")
 
 _OPENCODE_FRONTMATTER_KEYS = (
@@ -132,9 +135,9 @@ def translate_opencode_agent(content: str) -> OpencodeAgentTranslation:
     elif "color" in metadata:
         notices.append("dropped invalid 'color' value")
 
-    body = content[match.end() :]
+    body = content[match.end() :].lstrip("\r\n")
     rendered_frontmatter = yaml_to_str(translated, sort_keys=False).rstrip()
-    rendered = f"---\n{rendered_frontmatter}\n---\n\n{body.lstrip()}"
+    rendered = f"---\n{rendered_frontmatter}\n---\n\n{body}"
     return OpencodeAgentTranslation(rendered, tuple(notices))
 
 

--- a/tests/integration/test_architecture_authorities.py
+++ b/tests/integration/test_architecture_authorities.py
@@ -19,13 +19,18 @@ def test_opencode_agent_translation_has_single_owner() -> None:
     root = Path(__file__).parents[2]
     owner = (root / "src/apm_cli/integration/opencode_frontmatter.py").read_text(encoding="utf-8")
     consumer = (root / "src/apm_cli/integration/agent_integrator.py").read_text(encoding="utf-8")
+    base = (root / "src/apm_cli/integration/base_integrator.py").read_text(encoding="utf-8")
     guard = (root / "scripts/lint-architecture-boundaries.sh").read_text(encoding="utf-8")
 
     assert owner.count("def translate_opencode_agent(") == 1
     assert "return translate_opencode_agent(content), links_resolved" in consumer
+    assert base.count("def _check_rendered_adopt_or_skip(") == 1
+    assert consumer.count("self._check_rendered_adopt_or_skip(") == 2
+    assert "target_path.read_bytes()" not in consumer
     assert (
         "OpenCode agent translation must route through integration/opencode_frontmatter.py"
     ) in guard
+    assert "Rendered agent adoption must route through BaseIntegrator" in guard
 
 
 def test_opencode_agent_translation_guard_rejects_parallel_owner(
@@ -2175,17 +2180,17 @@ def test_agent_diagnostic_ascii_guard_rejects_local_reimplementation(
             "node_modules",
         ),
     )
-    consumer = sandbox / "src/apm_cli/integration/opencode_frontmatter.py"
+    consumer = sandbox / "src/apm_cli/integration/agent_integrator.py"
     source = consumer.read_text(encoding="utf-8")
     source = source.replace(
-        "def validate_opencode_frontmatter(",
-        "def _display_safe(value: str) -> str:\n"
-        '    return re.sub(r"[^ -~]", "?", value)\n\n\n'
-        "def validate_opencode_frontmatter(",
+        "    def _warn_opencode_frontmatter(",
+        "    def _display_safe(value: str) -> str:\n"
+        '        return re.sub(r"[^ -~]", "?", value)\n\n'
+        "    def _warn_opencode_frontmatter(",
     )
     source = source.replace(
-        "safe_name = printable_ascii_text(source.name)",
-        "safe_name = printable_ascii_text(source.name)\n    safe_name = _display_safe(source.name)",
+        'f"OpenCode agent {printable_ascii_text(source.name)}: "',
+        'f"OpenCode agent {_display_safe(source.name)}: "',
     )
     consumer.write_text(source, encoding="utf-8")
 

--- a/tests/integration/test_architecture_authorities.py
+++ b/tests/integration/test_architecture_authorities.py
@@ -14,6 +14,62 @@ from types import ModuleType
 import pytest
 
 
+def test_opencode_agent_translation_has_single_owner() -> None:
+    """OpenCode agent schema decisions must stay in one edge translator."""
+    root = Path(__file__).parents[2]
+    owner = (root / "src/apm_cli/integration/opencode_frontmatter.py").read_text(encoding="utf-8")
+    consumer = (root / "src/apm_cli/integration/agent_integrator.py").read_text(encoding="utf-8")
+    guard = (root / "scripts/lint-architecture-boundaries.sh").read_text(encoding="utf-8")
+
+    assert owner.count("def translate_opencode_agent(") == 1
+    assert "return translate_opencode_agent(content), links_resolved" in consumer
+    assert (
+        "OpenCode agent translation must route through integration/opencode_frontmatter.py"
+    ) in guard
+
+
+def test_opencode_agent_translation_guard_rejects_parallel_owner(
+    tmp_path: Path,
+) -> None:
+    """AC33 must reject a second OpenCode agent translator."""
+    root = Path(__file__).parents[2]
+    sandbox = tmp_path / "repo"
+    shutil.copytree(
+        root,
+        sandbox,
+        ignore=shutil.ignore_patterns(
+            ".git",
+            ".venv",
+            ".pytest_cache",
+            "__pycache__",
+            "build",
+            "dist",
+            "node_modules",
+        ),
+    )
+    consumer = sandbox / "src/apm_cli/integration/agent_integrator.py"
+    consumer.write_text(
+        consumer.read_text(encoding="utf-8")
+        + "\ndef translate_opencode_agent(content: str) -> str:\n"
+        + "    return content\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ("bash", "scripts/lint-architecture-boundaries.sh"),
+        cwd=sandbox,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=300,
+    )
+
+    assert result.returncode == 1
+    assert (
+        "OpenCode agent translation must route through integration/opencode_frontmatter.py"
+    ) in result.stdout
+
+
 def test_policy_cache_metadata_redaction_has_single_owner() -> None:
     """Policy cache refs must be sanitized by the canonical writer."""
     root = Path(__file__).parents[2]

--- a/tests/integration/test_architecture_authorities.py
+++ b/tests/integration/test_architecture_authorities.py
@@ -75,6 +75,46 @@ def test_opencode_agent_translation_guard_rejects_parallel_owner(
     ) in result.stdout
 
 
+def test_rendered_agent_adoption_guard_rejects_parallel_owner(
+    tmp_path: Path,
+) -> None:
+    """AC34 must reject a second rendered-agent adoption owner."""
+    root = Path(__file__).parents[2]
+    sandbox = tmp_path / "repo"
+    shutil.copytree(
+        root,
+        sandbox,
+        ignore=shutil.ignore_patterns(
+            ".git",
+            ".venv",
+            ".pytest_cache",
+            "__pycache__",
+            "build",
+            "dist",
+            "node_modules",
+        ),
+    )
+    consumer = sandbox / "src/apm_cli/integration/agent_integrator.py"
+    consumer.write_text(
+        consumer.read_text(encoding="utf-8")
+        + "\ndef _check_rendered_adopt_or_skip(*args, **kwargs):\n"
+        + "    return False, False\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ("bash", "scripts/lint-architecture-boundaries.sh"),
+        cwd=sandbox,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=300,
+    )
+
+    assert result.returncode == 1
+    assert "Rendered agent adoption must route through BaseIntegrator" in result.stdout
+
+
 def test_policy_cache_metadata_redaction_has_single_owner() -> None:
     """Policy cache refs must be sanitized by the canonical writer."""
     root = Path(__file__).parents[2]

--- a/tests/spec_conformance/test_manifest_reqs.py
+++ b/tests/spec_conformance/test_manifest_reqs.py
@@ -876,6 +876,70 @@ def test_kiro_agent_tools_gate_fails_closed_before_adopt(tmp_path: Path) -> None
     )
 
 
+@pytest.mark.req("req-tg-009")
+def test_opencode_agent_tools_gate_fails_closed_before_adopt(tmp_path: Path) -> None:
+    """OpenCode rejects unrepresentable tool capabilities before adoption."""
+    from datetime import datetime
+
+    from apm_cli.models.apm_package import (
+        GitReferenceType,
+        PackageInfo,
+        ResolvedReference,
+    )
+    from apm_cli.utils.diagnostics import CATEGORY_ERROR
+
+    (tmp_path / ".opencode").mkdir()
+    package_dir = tmp_path / "pkg"
+    apm_agents = package_dir / ".apm" / "agents"
+    apm_agents.mkdir(parents=True)
+    source = apm_agents / "hacked.agent.md"
+    source.write_text(
+        "---\ntools: [read, execute_arbitrary_code]\n---\n\n# Hacked\n",
+        encoding="utf-8",
+    )
+
+    target = tmp_path / ".opencode" / "agents" / "hacked.md"
+    target.parent.mkdir()
+    original_target = "---\nmode: subagent\ntools:\n  read: true\n---\n\n# Hacked\n"
+    target.write_text(original_target, encoding="utf-8")
+
+    package = APMPackage(
+        name="test-pkg",
+        version="1.0.0",
+        package_path=package_dir,
+        source="github.com/test/test-pkg",
+    )
+    package_info = PackageInfo(
+        package=package,
+        install_path=package_dir,
+        resolved_reference=ResolvedReference(
+            original_ref="main",
+            ref_type=GitReferenceType.BRANCH,
+            resolved_commit="abc123",
+            ref_name="main",
+        ),
+        installed_at=datetime.now().isoformat(),
+    )
+    diagnostics = DiagnosticCollector()
+
+    result = AgentIntegrator().integrate_agents_for_target(
+        KNOWN_TARGETS["opencode"],
+        package_info,
+        tmp_path,
+        managed_files={".opencode/agents/hacked.md"},
+        diagnostics=diagnostics,
+    )
+
+    assert result.files_integrated == 0
+    assert result.files_adopted == 0
+    assert target not in result.target_paths
+    assert target.read_text(encoding="utf-8") == original_target
+    errors = [item for item in diagnostics._diagnostics if item.category == CATEGORY_ERROR]
+    assert len(errors) == 1
+    assert "execute_arbitrary_code" in errors[0].message
+    assert "use only approved names" in errors[0].message
+
+
 # --- req-cf-001..002 --------------------------------------------------
 
 

--- a/tests/unit/integration/test_content_identical_adopt.py
+++ b/tests/unit/integration/test_content_identical_adopt.py
@@ -224,6 +224,48 @@ class TestTryAdoptIdenticalDeployMode:
         assert adopted == [target]
 
 
+class TestRenderedAdoptDeployMode:
+    """Pins explicit LF behavior for pre-rendered text artifacts."""
+
+    def test_byte_preserving_mode_adopts_raw_crlf(self, tmp_path: Path) -> None:
+        target = tmp_path / "target.md"
+        target.write_bytes(b"# Agent\r\nbody\r\n")
+        adopted: list[Path] = []
+
+        skip, was_adopted = BaseIntegrator()._check_rendered_adopt_or_skip(
+            target,
+            "# Agent\r\nbody\r\n",
+            "target.md",
+            None,
+            False,
+            None,
+            adopted,
+            lf_normalized_deploy=False,
+        )
+
+        assert (skip, was_adopted) == (True, True)
+        assert adopted == [target]
+
+    def test_lf_normalized_mode_rejects_stale_crlf_target(self, tmp_path: Path) -> None:
+        target = tmp_path / "target.md"
+        target.write_bytes(b"# Agent\r\nbody\r\n")
+        adopted: list[Path] = []
+
+        skip, was_adopted = BaseIntegrator()._check_rendered_adopt_or_skip(
+            target,
+            "# Agent\r\nbody\r\n",
+            "target.md",
+            None,
+            True,
+            None,
+            adopted,
+            lf_normalized_deploy=True,
+        )
+
+        assert (skip, was_adopted) == (False, False)
+        assert adopted == []
+
+
 # ---------------------------------------------------------------------------
 # Instruction integrator -- the user's reproducer (zava-storefront)
 # ---------------------------------------------------------------------------

--- a/tests/unit/integration/test_opencode_frontmatter_validation.py
+++ b/tests/unit/integration/test_opencode_frontmatter_validation.py
@@ -9,6 +9,7 @@ import frontmatter
 import pytest
 
 from apm_cli.integration import AgentIntegrator
+from apm_cli.integration.opencode_frontmatter import OpencodeAgentTranslationError
 from apm_cli.integration.targets import KNOWN_TARGETS
 from apm_cli.models.apm_package import APMPackage, GitReferenceType, PackageInfo, ResolvedReference
 from apm_cli.utils.diagnostics import CATEGORY_ERROR, DiagnosticCollector
@@ -379,7 +380,7 @@ class TestOpencodeInstallTranslation:
         except OSError:
             pytest.skip("symlink creation is unavailable")
 
-        with pytest.raises(ValueError, match="Refusing to read symlink source"):
+        with pytest.raises(OpencodeAgentTranslationError, match="Refusing to read symlink source"):
             self.integrator._render_opencode_agent(source, self.project_root / "target.md")
 
     @pytest.mark.parametrize("target_name", ["copilot", "claude", "codex", "windsurf", "cursor"])

--- a/tests/unit/integration/test_opencode_frontmatter_validation.py
+++ b/tests/unit/integration/test_opencode_frontmatter_validation.py
@@ -1,14 +1,11 @@
-"""Tests for OpenCode frontmatter validate-and-warn (Phase 1 of #581).
-
-Covers both the pure validator and the install-time integration that
-fires it before copy_agent() writes the file to .opencode/agents/.
-"""
+"""Tests for OpenCode frontmatter validation and native translation."""
 
 from __future__ import annotations
 
 import tempfile
 from pathlib import Path
 
+import frontmatter
 import pytest
 
 from apm_cli.integration import AgentIntegrator
@@ -220,9 +217,8 @@ class TestValidateOpencodeFrontmatter:
         assert "#rrggbb" in msgs[0]
 
 
-class TestOpencodeInstallEmitsWarnings:
-    """End-to-end: integrate_agents_for_target() emits diagnostics.warn()
-    for OpenCode-incompatible frontmatter before deploying the file."""
+class TestOpencodeInstallTranslation:
+    """End-to-end tests for OpenCode agent translation during install."""
 
     def setup_method(self):
         self.temp_dir = tempfile.mkdtemp()
@@ -245,7 +241,7 @@ class TestOpencodeInstallEmitsWarnings:
         agent_path.write_text(f"---\n{frontmatter}\n---\n\n# Demo\n")
         return pkg
 
-    def test_tools_as_list_emits_warning(self):
+    def test_tools_as_list_translates_without_warning(self):
         pkg = self._write_agent("tools:\n  - Read\n  - Grep\n")
         pkg_info = _make_package_info(pkg)
         diagnostics = DiagnosticCollector()
@@ -256,11 +252,52 @@ class TestOpencodeInstallEmitsWarnings:
 
         assert result.files_integrated == 1
         msgs = _warning_messages(diagnostics)
-        # Warning must name the offending file AND prefix it with the
-        # owning package so multi-package installs are diagnosable.
-        assert any("tools" in m and "test-pkg/demo.agent.md" in m and "Fix:" in m for m in msgs), (
-            msgs
+        assert msgs == []
+        deployed = frontmatter.load(self.project_root / ".opencode" / "agents" / "demo.md")
+        assert deployed.metadata["tools"] == {"read": True, "grep": True}
+
+    def test_install_translates_portable_agent_to_opencode_schema(self):
+        pkg = self._write_agent(
+            "name: SomeAgent\n"
+            "description: Reviews changes\n"
+            "model: Claude Sonnet 5 (copilot)\n"
+            "target: vscode\n"
+            "user-invocable: false\n"
+            "handoffs: [planner]\n"
+            "tools:\n"
+            "  - read\n"
+            "  - edit\n"
+            "  - search\n"
+            "  - execute\n"
+            "  - todo\n"
+            "  - vscode\n"
+            "  - agent\n"
+            "  - github/*\n"
         )
+        pkg_info = _make_package_info(pkg)
+
+        result = self.integrator.integrate_agents_for_target(
+            KNOWN_TARGETS["opencode"],
+            pkg_info,
+            self.project_root,
+        )
+
+        assert result.files_integrated == 1
+        deployed = frontmatter.load(self.project_root / ".opencode" / "agents" / "demo.md")
+        assert deployed.metadata == {
+            "name": "SomeAgent",
+            "description": "Reviews changes",
+            "mode": "subagent",
+            "model": "github-copilot/claude-sonnet-5",
+            "tools": {
+                "read": True,
+                "edit": True,
+                "grep": True,
+                "bash": True,
+                "task": True,
+            },
+        }
+        assert deployed.content == "# Demo"
 
     def test_tools_as_dict_no_warning(self):
         pkg = self._write_agent("tools:\n  Read: true\n  Grep: false\n")
@@ -273,8 +310,10 @@ class TestOpencodeInstallEmitsWarnings:
 
         msgs = _warning_messages(diagnostics)
         assert not any("OpenCode agent" in m for m in msgs), msgs
+        deployed = frontmatter.load(self.project_root / ".opencode" / "agents" / "demo.md")
+        assert deployed.metadata["tools"] == {"read": True, "grep": False}
 
-    def test_color_named_emits_warning(self):
+    def test_color_named_is_dropped(self):
         pkg = self._write_agent('color: "cyan"\n')
         pkg_info = _make_package_info(pkg)
         diagnostics = DiagnosticCollector()
@@ -284,7 +323,9 @@ class TestOpencodeInstallEmitsWarnings:
         )
 
         msgs = _warning_messages(diagnostics)
-        assert any("color" in m and "cyan" in m for m in msgs), msgs
+        assert msgs == []
+        deployed = frontmatter.load(self.project_root / ".opencode" / "agents" / "demo.md")
+        assert "color" not in deployed.metadata
 
     def test_color_hex_no_warning(self):
         pkg = self._write_agent('color: "#aabbcc"\n')
@@ -298,10 +339,7 @@ class TestOpencodeInstallEmitsWarnings:
         msgs = _warning_messages(diagnostics)
         assert not any("OpenCode agent" in m for m in msgs), msgs
 
-    def test_file_is_still_deployed_when_warning_emitted(self):
-        # Warnings must NOT block install: file lands in .opencode/agents/
-        # so users can fix the source and reinstall, and so other valid
-        # agents in the same package are not held up by the bad one.
+    def test_file_is_deployed_after_translation(self):
         pkg = self._write_agent("tools:\n  - Read\n")
         pkg_info = _make_package_info(pkg)
         diagnostics = DiagnosticCollector()
@@ -314,8 +352,7 @@ class TestOpencodeInstallEmitsWarnings:
         deployed = self.project_root / ".opencode" / "agents" / "demo.md"
         assert deployed.exists()
 
-    def test_rendered_package_name_is_sanitized(self, capsys):
-        """OpenCode wrapper attribution must not reintroduce terminal controls."""
+    def test_translation_emits_no_package_warning(self, capsys):
         pkg = self._write_agent("tools:\n  - Read\n")
         pkg_info = _make_package_info(pkg, name="evil\x1b[31mpkg\nnext")
         diagnostics = DiagnosticCollector()
@@ -328,8 +365,7 @@ class TestOpencodeInstallEmitsWarnings:
         )
 
         warnings = [item for item in diagnostics._diagnostics if item.category == "warning"]
-        assert len(warnings) == 1
-        assert warnings[0].package == "evil?[31mpkg?next"
+        assert warnings == []
         diagnostics.render_summary()
         output = capsys.readouterr().out
         assert "\x1b" not in output
@@ -340,10 +376,12 @@ class TestOpencodeInstallEmitsWarnings:
         pkg_info = _make_package_info(pkg)
         diagnostics = DiagnosticCollector()
 
-        # Should not raise; validator gets empty fm when YAML is invalid.
+        # Should not raise; malformed metadata is stripped from deployed output.
         self.integrator.integrate_agents_for_target(
             KNOWN_TARGETS["opencode"], pkg_info, self.project_root, diagnostics=diagnostics
         )
+        deployed = frontmatter.load(self.project_root / ".opencode" / "agents" / "demo.md")
+        assert deployed.metadata == {"mode": "subagent"}
 
     def test_diagnostics_none_does_not_crash(self):
         # Defensive guard: _warn_opencode_frontmatter must early-return

--- a/tests/unit/integration/test_opencode_frontmatter_validation.py
+++ b/tests/unit/integration/test_opencode_frontmatter_validation.py
@@ -52,12 +52,12 @@ class TestOpencodeInstallTranslation:
 
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 
-    def _write_agent(self, frontmatter: str) -> Path:
+    def _write_agent(self, frontmatter: str, body: str = "# Demo\n") -> Path:
         pkg = self.project_root / "package"
         agents_dir = pkg / ".apm" / "agents"
         agents_dir.mkdir(parents=True)
         agent_path = agents_dir / "demo.agent.md"
-        agent_path.write_text(f"---\n{frontmatter}\n---\n\n# Demo\n")
+        agent_path.write_text(f"---\n{frontmatter}\n---\n\n{body}")
         return pkg
 
     def test_tools_as_list_translates_without_warning(self):
@@ -113,6 +113,28 @@ class TestOpencodeInstallTranslation:
             },
         }
         assert deployed.content == "# Demo"
+
+    def test_crlf_frontmatter_is_translated(self):
+        pkg = self._write_agent("tools: [read]\n")
+        source = pkg / ".apm" / "agents" / "demo.agent.md"
+        source.write_bytes(source.read_bytes().replace(b"\n", b"\r\n"))
+
+        self.integrator.integrate_agents_for_target(
+            KNOWN_TARGETS["opencode"], _make_package_info(pkg), self.project_root
+        )
+
+        deployed = frontmatter.load(self.project_root / ".opencode" / "agents" / "demo.md")
+        assert deployed.metadata["tools"] == {"read": True}
+
+    def test_body_leading_indentation_is_preserved(self):
+        pkg = self._write_agent("tools: [read]\n", body="    indented code\n")
+
+        self.integrator.integrate_agents_for_target(
+            KNOWN_TARGETS["opencode"], _make_package_info(pkg), self.project_root
+        )
+
+        deployed = self.project_root / ".opencode" / "agents" / "demo.md"
+        assert deployed.read_text(encoding="utf-8").endswith("\n\n    indented code\n")
 
     @pytest.mark.parametrize(
         "tools",

--- a/tests/unit/integration/test_opencode_frontmatter_validation.py
+++ b/tests/unit/integration/test_opencode_frontmatter_validation.py
@@ -9,10 +9,9 @@ import frontmatter
 import pytest
 
 from apm_cli.integration import AgentIntegrator
-from apm_cli.integration.opencode_frontmatter import validate_opencode_frontmatter
 from apm_cli.integration.targets import KNOWN_TARGETS
 from apm_cli.models.apm_package import APMPackage, GitReferenceType, PackageInfo, ResolvedReference
-from apm_cli.utils.diagnostics import DiagnosticCollector
+from apm_cli.utils.diagnostics import CATEGORY_ERROR, DiagnosticCollector
 
 
 def _make_package_info(pkg_dir: Path, *, name: str = "test-pkg") -> PackageInfo:
@@ -31,190 +30,9 @@ def _make_package_info(pkg_dir: Path, *, name: str = "test-pkg") -> PackageInfo:
     )
 
 
-def _warning_messages(diagnostics: DiagnosticCollector) -> list[str]:
-    # Surface raw warning messages so tests can assert on substrings.
-    return [d.message for d in diagnostics._diagnostics if d.category == "warning"]
-
-
-class TestValidateOpencodeFrontmatter:
-    """Pure unit tests for validate_opencode_frontmatter()."""
-
-    def test_tools_as_dict_no_warning(self):
-        msgs = validate_opencode_frontmatter(
-            {"tools": {"Read": True, "Grep": False}},
-            Path("agent.md"),
-        )
-        assert msgs == []
-
-    def test_tools_as_list_warns(self):
-        msgs = validate_opencode_frontmatter(
-            {"tools": ["Read", "Grep"]},
-            Path("bad.agent.md"),
-        )
-        assert len(msgs) == 1
-        assert "bad.agent.md" in msgs[0]
-        assert "tools" in msgs[0]
-        assert "list" in msgs[0]
-
-    def test_tools_as_string_warns(self):
-        msgs = validate_opencode_frontmatter(
-            {"tools": "Read, Grep, Glob"},
-            Path("claude.agent.md"),
-        )
-        assert len(msgs) == 1
-        assert "tools" in msgs[0]
-        assert "str" in msgs[0]
-
-    def test_tools_dict_with_non_bool_value_warns(self):
-        msgs = validate_opencode_frontmatter(
-            {"tools": {"Read": "yes"}},
-            Path("bad.agent.md"),
-        )
-        assert len(msgs) == 1
-        assert "non-boolean" in msgs[0]
-
-    def test_color_hex_no_warning(self):
-        msgs = validate_opencode_frontmatter(
-            {"color": "#aabbcc"},
-            Path("agent.md"),
-        )
-        assert msgs == []
-
-    def test_color_short_hex_no_warning(self):
-        msgs = validate_opencode_frontmatter({"color": "#abc"}, Path("a.md"))
-        assert msgs == []
-
-    def test_color_theme_enum_no_warning(self):
-        for theme in ("primary", "secondary", "accent", "success", "warning", "error", "info"):
-            assert validate_opencode_frontmatter({"color": theme}, Path("a.md")) == []
-
-    def test_color_named_not_in_enum_warns(self):
-        msgs = validate_opencode_frontmatter(
-            {"color": "cyan"},
-            Path("cyan.agent.md"),
-        )
-        assert len(msgs) == 1
-        assert "color" in msgs[0]
-        assert "cyan" in msgs[0]
-
-    def test_color_non_string_warns(self):
-        msgs = validate_opencode_frontmatter({"color": 123}, Path("a.md"))
-        assert len(msgs) == 1
-        assert "color" in msgs[0]
-
-    def test_empty_frontmatter_no_warning(self):
-        assert validate_opencode_frontmatter({}, Path("a.md")) == []
-        assert validate_opencode_frontmatter(None, Path("a.md")) == []
-
-    def test_multiple_problems_each_warned(self):
-        msgs = validate_opencode_frontmatter(
-            {"tools": ["Read"], "color": "magenta"},
-            Path("a.md"),
-        )
-        assert len(msgs) == 2
-
-    def test_messages_are_ascii(self):
-        msgs = validate_opencode_frontmatter(
-            {"tools": ["x"], "color": "magenta"},
-            Path("a.md"),
-        )
-        for m in msgs:
-            m.encode("ascii")  # raises if non-ASCII
-
-    def test_non_ascii_filename_sanitized(self):
-        msgs = validate_opencode_frontmatter(
-            {"color": "magenta"},
-            Path("cy\u00e1n-agent.md"),
-        )
-        assert len(msgs) == 1
-        # Non-ASCII filename codepoints replaced with '?' so message stays ASCII.
-        msgs[0].encode("ascii")
-        assert "?" in msgs[0]
-
-    def test_non_ascii_color_value_sanitized(self):
-        msgs = validate_opencode_frontmatter(
-            {"color": "magent\u00e1"},
-            Path("a.md"),
-        )
-        assert len(msgs) == 1
-        # ascii() escapes non-ASCII codepoints in the repr.
-        msgs[0].encode("ascii")
-        assert "\\xe1" in msgs[0]
-
-    def test_non_ascii_tool_key_and_value_sanitized(self):
-        msgs = validate_opencode_frontmatter(
-            {"tools": {"R\u00e9ad": "y\u00e8s"}},
-            Path("a.md"),
-        )
-        assert len(msgs) == 1
-        msgs[0].encode("ascii")
-        # Both key and value escaped via ascii() rather than raw !r.
-        assert "\\xe9" in msgs[0]
-        assert "\\xe8" in msgs[0]
-
-    def test_fm_none_accepted_by_signature(self):
-        # Annotation is dict | None; calling with None must not raise.
-        assert validate_opencode_frontmatter(None, Path("a.md")) == []
-
-    def test_package_qualifier_prefixes_identifier(self):
-        # Multi-package installs benefit from knowing which dependency
-        # shipped the bad frontmatter; the package name appears as a
-        # '<pkg>/<file>' prefix in every warning.
-        msgs = validate_opencode_frontmatter(
-            {"tools": ["Read"]},
-            Path("demo.agent.md"),
-            package_name="acme/security-pack",
-        )
-        assert len(msgs) == 1
-        assert "'acme/security-pack/demo.agent.md'" in msgs[0]
-
-    def test_package_qualifier_omitted_when_not_supplied(self):
-        # Backward compatibility: bare filename when no package given.
-        msgs = validate_opencode_frontmatter(
-            {"tools": ["Read"]},
-            Path("demo.agent.md"),
-        )
-        assert "'demo.agent.md'" in msgs[0]
-
-    def test_package_qualifier_sanitized(self):
-        # ASCII control chars and non-ASCII codepoints in the package
-        # name are stripped/replaced so a malicious package name can
-        # never inject ANSI escapes via the warning channel.
-        msgs = validate_opencode_frontmatter(
-            {"color": "magenta"},
-            Path("a.md"),
-            package_name="evil\x1b[31mpkg",
-        )
-        assert len(msgs) == 1
-        msgs[0].encode("ascii")
-        assert "\x1b" not in msgs[0]
-
-    def test_filename_control_chars_stripped(self):
-        # ASCII control chars in the filename (DEL, ESC, BEL) get
-        # replaced by '?' rather than echoed verbatim, defending the
-        # terminal against agent files crafted to inject escape codes.
-        msgs = validate_opencode_frontmatter(
-            {"color": "magenta"},
-            Path("a\x1b[31mb.agent.md"),
-        )
-        assert len(msgs) == 1
-        msgs[0].encode("ascii")
-        assert "\x1b" not in msgs[0]
-        assert "?" in msgs[0]
-
-    def test_remediation_pointer_in_tools_warning(self):
-        msgs = validate_opencode_frontmatter({"tools": ["Read"]}, Path("a.md"))
-        assert "Fix:" in msgs[0]
-        assert "tools:" in msgs[0]
-
-    def test_remediation_pointer_in_color_warning(self):
-        msgs = validate_opencode_frontmatter({"color": "cyan"}, Path("a.md"))
-        assert "Fix:" in msgs[0]
-        # Both 3- and 6-char hex literals are accepted by the validator;
-        # the remediation pointer must mention both so users aren't
-        # misled into thinking only '#rrggbb' is allowed.
-        assert "#rgb" in msgs[0]
-        assert "#rrggbb" in msgs[0]
+def _messages(diagnostics: DiagnosticCollector, category: str) -> list[str]:
+    """Return raw diagnostic messages in one category."""
+    return [d.message for d in diagnostics._diagnostics if d.category == category]
 
 
 class TestOpencodeInstallTranslation:
@@ -251,8 +69,7 @@ class TestOpencodeInstallTranslation:
         )
 
         assert result.files_integrated == 1
-        msgs = _warning_messages(diagnostics)
-        assert msgs == []
+        assert diagnostics.has_diagnostics is False
         deployed = frontmatter.load(self.project_root / ".opencode" / "agents" / "demo.md")
         assert deployed.metadata["tools"] == {"read": True, "grep": True}
 
@@ -269,10 +86,7 @@ class TestOpencodeInstallTranslation:
             "  - edit\n"
             "  - search\n"
             "  - execute\n"
-            "  - todo\n"
-            "  - vscode\n"
             "  - agent\n"
-            "  - github/*\n"
         )
         pkg_info = _make_package_info(pkg)
 
@@ -299,7 +113,59 @@ class TestOpencodeInstallTranslation:
         }
         assert deployed.content == "# Demo"
 
-    def test_tools_as_dict_no_warning(self):
+    @pytest.mark.parametrize(
+        "tools",
+        [
+            "  shell: false\n  execute: true\n",
+            "  execute: true\n  shell: false\n",
+        ],
+    )
+    def test_conflicting_tool_alias_disable_wins(self, tools: str):
+        pkg = self._write_agent(f"tools:\n{tools}")
+        pkg_info = _make_package_info(pkg)
+
+        result = self.integrator.integrate_agents_for_target(
+            KNOWN_TARGETS["opencode"], pkg_info, self.project_root
+        )
+
+        assert result.files_integrated == 1
+        deployed = frontmatter.load(self.project_root / ".opencode" / "agents" / "demo.md")
+        assert deployed.metadata["tools"]["bash"] is False
+
+    @pytest.mark.parametrize(
+        ("source_model", "expected"),
+        [
+            ("claude-opus-4.6", "github-copilot/claude-opus-4.6"),
+            ("anthropic/claude-3-opus", "anthropic/claude-3-opus"),
+        ],
+    )
+    def test_model_identifier_translation(self, source_model: str, expected: str):
+        pkg = self._write_agent(f"model: {source_model}\n")
+        pkg_info = _make_package_info(pkg)
+
+        self.integrator.integrate_agents_for_target(
+            KNOWN_TARGETS["opencode"], pkg_info, self.project_root
+        )
+
+        deployed = frontmatter.load(self.project_root / ".opencode" / "agents" / "demo.md")
+        assert deployed.metadata["model"] == expected
+
+    def test_empty_model_is_dropped_with_diagnostic(self):
+        pkg = self._write_agent('model: "  "\n')
+        pkg_info = _make_package_info(pkg)
+        diagnostics = DiagnosticCollector()
+
+        self.integrator.integrate_agents_for_target(
+            KNOWN_TARGETS["opencode"], pkg_info, self.project_root, diagnostics=diagnostics
+        )
+
+        deployed = frontmatter.load(self.project_root / ".opencode" / "agents" / "demo.md")
+        assert "model" not in deployed.metadata
+        messages = _messages(diagnostics, "agent_lossy_compilation")
+        assert len(messages) == 1
+        assert "dropped invalid 'model' value" in messages[0]
+
+    def test_tools_as_dict_preserves_false(self):
         pkg = self._write_agent("tools:\n  Read: true\n  Grep: false\n")
         pkg_info = _make_package_info(pkg)
         diagnostics = DiagnosticCollector()
@@ -308,12 +174,28 @@ class TestOpencodeInstallTranslation:
             KNOWN_TARGETS["opencode"], pkg_info, self.project_root, diagnostics=diagnostics
         )
 
-        msgs = _warning_messages(diagnostics)
-        assert not any("OpenCode agent" in m for m in msgs), msgs
+        assert diagnostics.has_diagnostics is False
         deployed = frontmatter.load(self.project_root / ".opencode" / "agents" / "demo.md")
         assert deployed.metadata["tools"] == {"read": True, "grep": False}
 
-    def test_color_named_is_dropped(self):
+    def test_unsupported_tool_fails_closed_with_actionable_error(self):
+        pkg = self._write_agent("tools: [read, todo, vscode]\n")
+        pkg_info = _make_package_info(pkg)
+        diagnostics = DiagnosticCollector()
+
+        result = self.integrator.integrate_agents_for_target(
+            KNOWN_TARGETS["opencode"], pkg_info, self.project_root, diagnostics=diagnostics
+        )
+
+        assert result.files_integrated == 0
+        assert result.files_skipped == 1
+        assert not (self.project_root / ".opencode" / "agents" / "demo.md").exists()
+        messages = _messages(diagnostics, CATEGORY_ERROR)
+        assert len(messages) == 1
+        assert "unsupported tools: todo, vscode" in messages[0]
+        assert "use only approved names" in messages[0]
+
+    def test_color_named_is_dropped_with_diagnostic(self):
         pkg = self._write_agent('color: "cyan"\n')
         pkg_info = _make_package_info(pkg)
         diagnostics = DiagnosticCollector()
@@ -322,8 +204,9 @@ class TestOpencodeInstallTranslation:
             KNOWN_TARGETS["opencode"], pkg_info, self.project_root, diagnostics=diagnostics
         )
 
-        msgs = _warning_messages(diagnostics)
-        assert msgs == []
+        messages = _messages(diagnostics, "agent_lossy_compilation")
+        assert len(messages) == 1
+        assert "dropped invalid 'color' value" in messages[0]
         deployed = frontmatter.load(self.project_root / ".opencode" / "agents" / "demo.md")
         assert "color" not in deployed.metadata
 
@@ -336,8 +219,7 @@ class TestOpencodeInstallTranslation:
             KNOWN_TARGETS["opencode"], pkg_info, self.project_root, diagnostics=diagnostics
         )
 
-        msgs = _warning_messages(diagnostics)
-        assert not any("OpenCode agent" in m for m in msgs), msgs
+        assert diagnostics.has_diagnostics is False
 
     def test_file_is_deployed_after_translation(self):
         pkg = self._write_agent("tools:\n  - Read\n")
@@ -352,8 +234,8 @@ class TestOpencodeInstallTranslation:
         deployed = self.project_root / ".opencode" / "agents" / "demo.md"
         assert deployed.exists()
 
-    def test_translation_emits_no_package_warning(self, capsys):
-        pkg = self._write_agent("tools:\n  - Read\n")
+    def test_translation_diagnostic_sanitizes_package_name(self, capsys):
+        pkg = self._write_agent('color: "cyan"\n')
         pkg_info = _make_package_info(pkg, name="evil\x1b[31mpkg\nnext")
         diagnostics = DiagnosticCollector()
 
@@ -364,36 +246,73 @@ class TestOpencodeInstallTranslation:
             diagnostics=diagnostics,
         )
 
-        warnings = [item for item in diagnostics._diagnostics if item.category == "warning"]
-        assert warnings == []
+        assert diagnostics.has_diagnostics is True
         diagnostics.render_summary()
         output = capsys.readouterr().out
         assert "\x1b" not in output
         assert "pkg\nnext" not in output
 
-    def test_malformed_yaml_does_not_crash(self):
+    def test_malformed_yaml_fails_closed_without_creating_agent_directory(self):
         pkg = self._write_agent("tools: [unclosed\n")
         pkg_info = _make_package_info(pkg)
         diagnostics = DiagnosticCollector()
 
-        # Should not raise; malformed metadata is stripped from deployed output.
-        self.integrator.integrate_agents_for_target(
+        result = self.integrator.integrate_agents_for_target(
             KNOWN_TARGETS["opencode"], pkg_info, self.project_root, diagnostics=diagnostics
         )
-        deployed = frontmatter.load(self.project_root / ".opencode" / "agents" / "demo.md")
-        assert deployed.metadata == {"mode": "subagent"}
 
-    def test_diagnostics_none_does_not_crash(self):
-        # Defensive guard: _warn_opencode_frontmatter must early-return
-        # when the install path is called without a DiagnosticCollector,
-        # so a future caller that omits the collector never crashes the
-        # install on otherwise-valid agent files.
-        from apm_cli.integration.agent_integrator import AgentIntegrator
+        assert result.files_integrated == 0
+        assert result.files_skipped == 1
+        assert not (self.project_root / ".opencode" / "agents").exists()
+        messages = _messages(diagnostics, CATEGORY_ERROR)
+        assert len(messages) == 1
+        assert "frontmatter is invalid YAML" in messages[0]
 
-        agent_path = self.project_root / "demo.agent.md"
-        agent_path.write_text("---\ntools:\n  - Read\n---\n\nBody\n")
-        # Must not raise even though the frontmatter would normally warn.
-        AgentIntegrator._warn_opencode_frontmatter(agent_path, None, "test-pkg")
+    def test_matching_rendered_output_is_adopted(self):
+        pkg = self._write_agent("tools: [read, search]\n")
+        pkg_info = _make_package_info(pkg)
+
+        first = self.integrator.integrate_agents_for_target(
+            KNOWN_TARGETS["opencode"], pkg_info, self.project_root
+        )
+        second = self.integrator.integrate_agents_for_target(
+            KNOWN_TARGETS["opencode"], pkg_info, self.project_root
+        )
+
+        assert first.files_integrated == 1
+        assert second.files_integrated == 0
+        assert second.files_adopted == 1
+
+    def test_collision_requires_force_before_overwrite(self):
+        pkg = self._write_agent("tools: [read]\n")
+        pkg_info = _make_package_info(pkg)
+        target = self.project_root / ".opencode" / "agents" / "demo.md"
+        target.parent.mkdir()
+        target.write_text("# Local\n", encoding="utf-8")
+
+        skipped = self.integrator.integrate_agents_for_target(
+            KNOWN_TARGETS["opencode"], pkg_info, self.project_root
+        )
+        assert skipped.files_skipped == 1
+        assert target.read_text(encoding="utf-8") == "# Local\n"
+
+        forced = self.integrator.integrate_agents_for_target(
+            KNOWN_TARGETS["opencode"], pkg_info, self.project_root, force=True
+        )
+        assert forced.files_integrated == 1
+        assert frontmatter.load(target).metadata["tools"] == {"read": True}
+
+    def test_render_rejects_symlink_source(self):
+        real_source = self.project_root / "real.agent.md"
+        real_source.write_text("---\ntools: [read]\n---\n\nBody\n", encoding="utf-8")
+        source = self.project_root / "demo.agent.md"
+        try:
+            source.symlink_to(real_source)
+        except OSError:
+            pytest.skip("symlink creation is unavailable")
+
+        with pytest.raises(ValueError, match="Refusing to read symlink source"):
+            self.integrator._render_opencode_agent(source, self.project_root / "target.md")
 
     @pytest.mark.parametrize("target_name", ["copilot", "claude", "codex", "windsurf", "cursor"])
     def test_non_opencode_targets_do_not_emit_opencode_warning(self, target_name):
@@ -412,5 +331,7 @@ class TestOpencodeInstallTranslation:
             target, pkg_info, self.project_root, diagnostics=diagnostics
         )
 
-        msgs = _warning_messages(diagnostics)
-        assert not any("OpenCode agent" in m for m in msgs), msgs
+        assert not any(
+            item.category == "error" and "OpenCode agent" in item.message
+            for item in diagnostics._diagnostics
+        )

--- a/tests/unit/integration/test_opencode_frontmatter_validation.py
+++ b/tests/unit/integration/test_opencode_frontmatter_validation.py
@@ -165,6 +165,74 @@ class TestOpencodeInstallTranslation:
         assert len(messages) == 1
         assert "dropped invalid 'model' value" in messages[0]
 
+    @pytest.mark.parametrize(
+        ("field", "yaml_value", "expected"),
+        [
+            ("prompt", "Review changes", "Review changes"),
+            ("temperature", "0.4", 0.4),
+            ("top_p", "0.8", 0.8),
+            ("permission", "{read: allow}", {"read": "allow"}),
+            ("disable", "true", True),
+            ("hidden", "false", False),
+            ("steps", "5", 5),
+        ],
+    )
+    def test_supported_optional_fields_preserve_valid_shapes(
+        self, field: str, yaml_value: str, expected: object
+    ):
+        pkg = self._write_agent(f"{field}: {yaml_value}\n")
+        pkg_info = _make_package_info(pkg)
+        diagnostics = DiagnosticCollector()
+
+        self.integrator.integrate_agents_for_target(
+            KNOWN_TARGETS["opencode"], pkg_info, self.project_root, diagnostics=diagnostics
+        )
+
+        deployed = frontmatter.load(self.project_root / ".opencode" / "agents" / "demo.md")
+        assert deployed.metadata[field] == expected
+        assert diagnostics.has_diagnostics is False
+
+    @pytest.mark.parametrize(
+        ("field", "yaml_value"),
+        [
+            ("prompt", "[not, text]"),
+            ("temperature", "true"),
+            ("top_p", "not-a-number"),
+            ("permission", "allow"),
+            ("disable", '"yes"'),
+            ("hidden", "1"),
+            ("steps", "0"),
+        ],
+    )
+    def test_invalid_optional_field_shapes_are_diagnosed(self, field: str, yaml_value: str):
+        pkg = self._write_agent(f"{field}: {yaml_value}\n")
+        pkg_info = _make_package_info(pkg)
+        diagnostics = DiagnosticCollector()
+
+        self.integrator.integrate_agents_for_target(
+            KNOWN_TARGETS["opencode"], pkg_info, self.project_root, diagnostics=diagnostics
+        )
+
+        deployed = frontmatter.load(self.project_root / ".opencode" / "agents" / "demo.md")
+        assert field not in deployed.metadata
+        messages = _messages(diagnostics, "agent_lossy_compilation")
+        assert len(messages) == 1
+        assert f"dropped invalid '{field}' value" in messages[0]
+
+    @pytest.mark.parametrize(
+        ("source_mode", "expected"), [("primary", "primary"), ("bad", "subagent")]
+    )
+    def test_mode_translation(self, source_mode: str, expected: str):
+        pkg = self._write_agent(f"mode: {source_mode}\n")
+        pkg_info = _make_package_info(pkg)
+
+        self.integrator.integrate_agents_for_target(
+            KNOWN_TARGETS["opencode"], pkg_info, self.project_root
+        )
+
+        deployed = frontmatter.load(self.project_root / ".opencode" / "agents" / "demo.md")
+        assert deployed.metadata["mode"] == expected
+
     def test_tools_as_dict_preserves_false(self):
         pkg = self._write_agent("tools:\n  Read: true\n  Grep: false\n")
         pkg_info = _make_package_info(pkg)

--- a/tests/unit/scripts/test_check_diagnostic_ascii_owner.py
+++ b/tests/unit/scripts/test_check_diagnostic_ascii_owner.py
@@ -36,7 +36,6 @@ def repo_copy(tmp_path: Path) -> Path:
     for relative in (
         "src/apm_cli/utils/diagnostics.py",
         "src/apm_cli/integration/agent_integrator.py",
-        "src/apm_cli/integration/opencode_frontmatter.py",
     ):
         source = REPO_ROOT / relative
         target = root / relative
@@ -49,7 +48,7 @@ def test_real_repository_passes(checker) -> None:
 
 
 def test_retired_private_helper_is_rejected(repo_copy: Path, checker) -> None:
-    consumer = repo_copy / "src/apm_cli/integration/opencode_frontmatter.py"
+    consumer = repo_copy / "src/apm_cli/integration/agent_integrator.py"
     consumer.write_text(
         consumer.read_text(encoding="utf-8")
         + "\n\ndef _ascii_safe_name(value: str) -> str:\n    return value\n",
@@ -83,17 +82,17 @@ def test_decorative_owner_call_cannot_hide_regex_override(
     checker,
 ) -> None:
     """A real rendered value must flow from the owner, not a decorative call."""
-    consumer = repo_copy / "src/apm_cli/integration/opencode_frontmatter.py"
+    consumer = repo_copy / "src/apm_cli/integration/agent_integrator.py"
     source = consumer.read_text(encoding="utf-8")
     source = source.replace(
-        "def validate_opencode_frontmatter(",
-        "def _display_safe(value: str) -> str:\n"
-        '    return re.sub(r"[^ -~]", "?", value)\n\n\n'
-        "def validate_opencode_frontmatter(",
+        "    def _warn_opencode_frontmatter(",
+        "    def _display_safe(value: str) -> str:\n"
+        '        return re.sub(r"[^ -~]", "?", value)\n\n'
+        "    def _warn_opencode_frontmatter(",
     )
     source = source.replace(
-        "safe_name = printable_ascii_text(source.name)",
-        "safe_name = printable_ascii_text(source.name)\n    safe_name = _display_safe(source.name)",
+        'f"OpenCode agent {printable_ascii_text(source.name)}: "',
+        'f"OpenCode agent {_display_safe(source.name)}: "',
     )
     consumer.write_text(source, encoding="utf-8")
 
@@ -140,10 +139,10 @@ def test_sanitized_identifier_cannot_share_message_with_raw_name(
     checker,
 ) -> None:
     """A sanitized prefix must not excuse a second raw interpolation."""
-    consumer = repo_copy / "src/apm_cli/integration/opencode_frontmatter.py"
+    consumer = repo_copy / "src/apm_cli/integration/agent_integrator.py"
     source = consumer.read_text(encoding="utf-8").replace(
-        "f\"OpenCode agent '{identifier}' has tools as {kind}; \"",
-        "f\"OpenCode agent '{identifier}' (raw file: {source.name}) has tools as {kind}; \"",
+        'f"OpenCode agent {printable_ascii_text(source.name)}: "',
+        'f"OpenCode agent {printable_ascii_text(source.name)} (raw file: {source.name}): "',
         1,
     )
     consumer.write_text(source, encoding="utf-8")
@@ -178,17 +177,18 @@ def test_opencode_wrapper_package_field_must_use_owner(
 
 
 def test_missing_owner_call_is_rejected(repo_copy: Path, checker) -> None:
-    consumer = repo_copy / "src/apm_cli/integration/opencode_frontmatter.py"
+    consumer = repo_copy / "src/apm_cli/integration/agent_integrator.py"
     source = consumer.read_text(encoding="utf-8").replace(
-        "safe_name = printable_ascii_text(source.name)",
-        "safe_name = source.name",
+        'f"OpenCode agent {printable_ascii_text(source.name)}: "',
+        'f"OpenCode agent {source.name}: "',
     )
     consumer.write_text(source, encoding="utf-8")
 
     violations = checker.check(repo_copy)
 
     assert any(
-        "validate_opencode_frontmatter must derive" in violation.message for violation in violations
+        "AgentIntegrator._warn_opencode_frontmatter must derive" in violation.message
+        for violation in violations
     )
 
 


### PR DESCRIPTION
# fix(opencode): translate portable agent frontmatter safely

## TL;DR

OpenCode agents now pass through one target-native translator instead of
receiving portable frontmatter verbatim. The translator emits resolvable model
IDs and boolean native-tool maps, preserves explicit tool denials, and fails
closed when YAML or a declared capability cannot be represented.

> [!IMPORTANT]
> This changes only the OpenCode deployment edge. Source agents and other
> targets keep their existing behavior.

Closes #2483.

## Problem (WHY)

- [x] List-shaped `tools` reached OpenCode even though
  ["A list fails schema decoding, so the intended tool grants are dropped and the agent gets the default tool set."](https://github.com/microsoft/apm/issues/2483)
- [x] Display model names reached OpenCode even though
  ["Display names don't resolve, so the agent falls back to the default model."](https://github.com/microsoft/apm/issues/2483)
- [x] Portable aliases could converge on one native tool in declaration order,
  allowing a later alias to re-enable a capability explicitly set to `false`.
- [x] Malformed YAML and unsupported tools could lose restrictions silently.
  OpenAPM requires consumers to
  ["MUST fail closed"](https://github.com/microsoft/apm/blob/dcbaf654cf6de26bb845927d383dd2e2ef9cb723/docs/src/content/docs/specs/openapm-v0.1.md#req-tg-009)
  before writing or adopting the target artifact.
- [!] Kiro and OpenCode repeated the rendered-content adoption sequence,
  contrary to the integration rule that shared deployment logic belongs in
  `BaseIntegrator`.

## Approach (WHAT)

| # | Fix |
|---:|---|
| 1 | Parse portable frontmatter once and emit only supported OpenCode fields and shapes. |
| 2 | Map portable tool aliases to native names; combine collisions with `false` precedence. |
| 3 | Fail closed before adoption or write on invalid YAML, invalid tool shapes, or unsupported tools. |
| 4 | Surface dropped optional fields through the shared diagnostic collector. |
| 5 | Route Kiro and OpenCode rendered adoption/collision decisions through `BaseIntegrator`. |
| 6 | Register both authorities with behavioral, conformance, and static guardrails. |

## Implementation (HOW)

| Area | Intent |
|---|---|
| `src/apm_cli/integration/opencode_frontmatter.py` | Owns supported fields, value validation, model resolution, tool aliases, denial-preserving collision handling, color filtering, and deterministic rendering. |
| `src/apm_cli/integration/agent_integrator.py` | Resolves links, translates before adoption, records lossy diagnostics, and skips invalid agents without creating an output directory. |
| `src/apm_cli/integration/base_integrator.py` | Adds the shared rendered-content adoption/collision owner used by Kiro and OpenCode. |
| `scripts/check_diagnostic_ascii_owner.py` | Keeps OpenCode diagnostic identities routed through `printable_ascii_text`. |
| `scripts/lint-architecture-boundaries.sh` | Adds AC33/AC34 checks for the translator and rendered-adoption owners. |
| `.apm/instructions/architecture.instructions.md`, `.github/instructions/architecture.instructions.md`, `apm.lock.yaml` | Register and deploy the canonical OpenCode translation owner with matching integrity hashes. |
| `tests/unit/integration/test_opencode_frontmatter_validation.py` | Covers schema translation, model forms, denial collisions, diagnostics, fail-closed behavior, idempotent adoption, collision/force, and symlink rejection. |
| `tests/spec_conformance/test_manifest_reqs.py`, `CONFORMANCE.json`, `CONFORMANCE.md` | Bind OpenCode fail-closed behavior to `req-tg-009` and refresh generated evidence. |
| `tests/integration/test_architecture_authorities.py`, `tests/unit/scripts/test_check_diagnostic_ascii_owner.py` | Defend both canonical-owner boundaries and ASCII-safe diagnostics. |
| `docs/src/content/docs/concepts/primitives-and-targets.md`, `docs/src/content/docs/producer/author-primitives/instructions-and-agents.md` | Mark OpenCode agents as compiled and document aliases, modes, diagnostics, and fail-closed behavior. |
| `packages/apm-guide/.apm/skills/apm-usage/package-authoring.md`, `CHANGELOG.md` | Keep the bundled authoring guide and release notes aligned. |

## Diagrams

Legend: the dashed stages are the new OpenCode-specific validation and
translation boundary; failures stop before filesystem mutation.

```mermaid
flowchart LR
    subgraph Source[Portable source]
        S1[".apm/agents/name.agent.md"]
    end
    subgraph Validate[Validate]
        V1[Parse YAML]
        V2[Validate tool vocabulary]
    end
    subgraph Translate[Translate]
        T1[Map model]
        T2[Map tools]
        T3[Filter optional fields]
    end
    subgraph Deploy[Deploy]
        D1[Shared rendered adoption]
        D2[".opencode/agents/name.md"]
    end
    S1 --> V1
    V1 --> V2
    V2 --> T1
    T1 --> T2
    T2 --> T3
    T3 --> D1
    D1 --> D2
    classDef new stroke-dasharray: 5 5;
    class V1,V2,T1,T2,T3,D1 new;
```

## Trade-offs

- **Fail closed for unknown tools.** Chose the normative `req-tg-009`
  behavior; rejected silent dropping because an absent tool map may widen
  OpenCode defaults.
- **Most restrictive alias collision wins.** Chose boolean AND across aliases;
  rejected declaration-order precedence because reordering YAML must not
  change a denial into a grant.
- **Diagnose optional loss, reject permission loss.** Chose grouped lossy
  diagnostics for unsupported optional keys and invalid optional values;
  rejected failing the whole agent for non-permission metadata.
- **Centralize rendered adoption.** Chose one `BaseIntegrator` helper for Kiro
  and OpenCode; rejected another target-local read/compare/collision block.

## Benefits

1. `Claude Sonnet 5 (copilot)` renders as
   `github-copilot/claude-sonnet-5`.
2. Portable `search`, `execute`, `agent`, and `web` render as `grep`, `bash`,
   `task`, and `webfetch`.
3. `{shell: false, execute: true}` renders as `{bash: false}` in either key
   order.
4. Unsupported tools and malformed YAML write zero agent bytes and produce an
   actionable error.
5. Kiro and OpenCode share one rendered adoption/collision implementation.

## Validation

<details><summary>Local validation evidence</summary>

Exact-head owner-path tests:

```text
7 passed in 40.48s
```

OpenAPM conformance on the final pushed head:

```text
Spec conformance gate: pass
```

Canonical lint and audit:

```text
All checks passed!
1609 files already formatted
Your code has been rated at 10.00/10
[+] auth-signal lint clean
[+] architecture boundary lint clean
YAML, file-length, and relative-path guards clean
[+] No drift detected
```

GitHub checks on `5fcbb8e00671ca0705c2a0588e9966eb1b7a227c`:

```text
All required checks pass, including Lint, both Linux test shards,
Windows Compatibility Gate, Test Architecture Ratchets,
APM Self-Check, Lifecycle Smoke, CodeQL, and Spec conformance gate.
```

Mutation-break checks:

```text
Removing denial-preserving alias merge: regression test failed as expected.
Restoring malformed-YAML fallback: fail-closed test failed as expected.
Removing AC33: architecture mutation test failed as expected.
Adding an AC34 duplicate owner: architecture mutation test failed as expected.
Forcing LF normalization in byte-preserving mode: deploy-mode test failed as expected.
```

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---:|---|---|---|---|
| 1 | Installing a portable agent for OpenCode preserves its model and supported tool restrictions | Portability by manifest, Multi-harness support | `tests/unit/integration/test_opencode_frontmatter_validation.py::TestOpencodeInstallTranslation::test_install_translates_portable_agent_to_opencode_schema` (regression-trap for #2483) | integration |
| 2 | An explicit tool denial stays denied when multiple portable aliases map to one native tool | Secure by default | `tests/unit/integration/test_opencode_frontmatter_validation.py::TestOpencodeInstallTranslation::test_conflicting_tool_alias_disable_wins` | integration |
| 3 | Unsupported OpenCode tool capabilities are rejected before write or adoption | Secure by default, Governed by policy | `tests/spec_conformance/test_manifest_reqs.py::test_opencode_agent_tools_gate_fails_closed_before_adopt` | integration |
| 4 | Reinstalling identical translated output adopts it without rewriting; local collisions require `--force` | DevX | `tests/unit/integration/test_opencode_frontmatter_validation.py::TestOpencodeInstallTranslation::test_matching_rendered_output_is_adopted`<br/>`tests/unit/integration/test_opencode_frontmatter_validation.py::TestOpencodeInstallTranslation::test_collision_requires_force_before_overwrite` | integration |
| 5 | Translated agent instructions preserve intentional Markdown indentation | Portability by manifest, DevX | `tests/unit/integration/test_opencode_frontmatter_validation.py::TestOpencodeInstallTranslation::test_body_leading_indentation_is_preserved` | integration |

## How to test

- [ ] Create `.opencode/`, install an agent with a display model and portable
  tool list, and confirm the generated YAML contains a provider/model ID and a
  boolean native-tool map.
- [ ] Set `shell: false` and `execute: true`; confirm generated `bash` is
  `false`.
- [ ] Add an unsupported tool; confirm the agent is not written and the
  diagnostic names the value and approved names.
- [ ] Break the source YAML; confirm no output file or agents directory is
  created.
- [ ] Reinstall identical output, then pre-seed different local content and
  compare normal install with `--force`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
