### PR TITLE
fix: allow --frozen to hydrate repo-root claude_skill deps lacking apm.yml (#2443)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `apm install --frozen` no longer rejects repo-root `claude_skill`
+  dependencies (e.g. `owner/repo` without a virtual path) that legitimately
+  ship no `apm.yml`. The `_allows_missing_manifest` helper now checks the
+  locked package type before the virtual-subdirectory gate, consistent with
+  how `skill_bundle` is handled. (by @sergio-sisternes-epam, closes #2443)
+
 ## [0.28.0] - 2026-08-04
 
 ### Added

--- a/src/apm_cli/integration/mcp_config_view.py
+++ b/src/apm_cli/integration/mcp_config_view.py
@@ -214,20 +214,31 @@ def _allows_missing_manifest(
     if dependency.package_type == PackageType.SKILL_BUNDLE.value:
         return True
 
+    # A ``claude_skill`` legitimately ships no ``apm.yml`` by design --
+    # whether the dependency is a repo-root reference (``owner/repo``) or a
+    # virtual subdirectory (``owner/repo/path``).  The lockfile records
+    # ``package_type: claude_skill`` for both shapes, and
+    # ``detect_package_type`` classifies them identically via cascade rule 3
+    # (root ``SKILL.md``, no ``apm.yml``).  Gate on the locked package type
+    # rather than on the virtual-type so repo-root skills are not rejected.
+    if dependency.package_type == PackageType.CLAUDE_SKILL.value:
+        # ``apm audit --ci`` may run without materialised ``apm_modules/``:
+        # the drift replay uses a throwaway scratch dir, and a setup-only CI
+        # job never populates the real modules tree.  When the package
+        # directory is absent, fall back to the frozen lockfile
+        # classification.  Once the modules ARE materialised the strict shape
+        # probe still runs and guards against a mislabelled package.
+        if not package_dir.exists():
+            return True
+        package_type, _ = detect_package_type(package_dir)
+        return package_type is PackageType.CLAUDE_SKILL
+
     dependency_ref = dependency.to_dependency_ref()
     if not dependency_ref.is_virtual_subdirectory():
         return False
 
-    # ``apm audit --ci`` runs without materialising ``apm_modules/``: the drift
-    # replay uses a throwaway scratch dir, and a setup-only CI job (install the
-    # CLI, then audit -- no ``apm install``) never populates the real modules
-    # tree.  When the package directory is absent we cannot probe the on-disk
-    # shape, so fall back to the frozen lockfile classification -- a virtual
-    # ``claude_skill`` legitimately ships no ``apm.yml`` by design.  Once the
-    # modules ARE materialised the strict shape probe below still runs and
-    # guards against a mislabeled or malformed installed package.
     if not package_dir.exists():
-        return dependency.package_type == PackageType.CLAUDE_SKILL.value
+        return False
 
     package_type, _ = detect_package_type(package_dir)
     return (

--- a/src/apm_cli/integration/mcp_config_view.py
+++ b/src/apm_cli/integration/mcp_config_view.py
@@ -233,18 +233,9 @@ def _allows_missing_manifest(
         package_type, _ = detect_package_type(package_dir)
         return package_type is PackageType.CLAUDE_SKILL
 
-    dependency_ref = dependency.to_dependency_ref()
-    if not dependency_ref.is_virtual_subdirectory():
-        return False
-
-    if not package_dir.exists():
-        return False
-
-    package_type, _ = detect_package_type(package_dir)
-    return (
-        package_type is PackageType.CLAUDE_SKILL
-        and dependency.package_type == PackageType.CLAUDE_SKILL.value
-    )
+    # Only skill_bundle and claude_skill may legitimately omit apm.yml.
+    # Any other package type reaching this point is missing its manifest.
+    return False
 
 
 def _collect_locked_dependencies(

--- a/tests/unit/install/test_frozen.py
+++ b/tests/unit/install/test_frozen.py
@@ -142,9 +142,10 @@ class TestEnforceFrozen:
         A repo-root ``claude_skill`` dependency (e.g. ``makinux/adversarial-panel``)
         has no ``apm.yml`` by design.  When the project also declares MCP servers,
         ``enforce_frozen`` should not report the missing manifest as lockfile drift.
-        """
-        from apm_cli.integration.mcp_config_view import CurrentMcpConfigView
 
+        This test lets ``CurrentMcpConfigView.derive()`` run for real so that
+        ``_allows_missing_manifest`` is exercised on the actual repo-root path.
+        """
         _write_apm_yml(tmp_path)
 
         locked_skill = LockedDependency(
@@ -156,25 +157,30 @@ class TestEnforceFrozen:
         )
         _write_lockfile(tmp_path, [locked_skill])
 
+        # Write the MCP server into the lockfile so the diff is empty.
         lock = LockFile.read(tmp_path / "apm.lock.yaml")
         assert lock is not None
         lock.mcp_servers = ["deepwiki"]
-        lock.mcp_configs = {"deepwiki": {"name": "deepwiki"}}
+        lock.mcp_configs = {"deepwiki": {"name": "deepwiki", "transport": "http"}}
         lock.save(tmp_path / "apm.lock.yaml")
+
+        # Create the repo-root skill shape on disk (SKILL.md, no apm.yml).
+        modules_root = tmp_path / "apm_modules"
+        skill_dir = locked_skill.to_dependency_ref().get_install_path(modules_root)
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("# Adversarial Panel\n", encoding="utf-8")
 
         dep = DependencyReference(repo_url="https://github.com/makinux/adversarial-panel")
         req = _make_request(project_dir=tmp_path, manifest_deps=[dep])
+        req.apm_package.package_path = tmp_path
 
+        # Root MCP dep: needs .name and .to_dict() to match the lockfile config.
         mcp_dep = MagicMock()
         mcp_dep.name = "deepwiki"
+        mcp_dep.to_dict.return_value = {"name": "deepwiki", "transport": "http"}
         req.apm_package.get_all_mcp_dependencies.return_value = [mcp_dep]
 
-        current = CurrentMcpConfigView(
-            dependencies=(),
-            configs={"deepwiki": {"name": "deepwiki"}},
-            provenance={},
-            problems=(),
-        )
-
-        with patch.object(CurrentMcpConfigView, "derive", return_value=current):
+        # Patch get_modules_dir to return our controlled directory so derive()
+        # exercises the real _allows_missing_manifest path.
+        with patch("apm_cli.core.scope.get_modules_dir", return_value=modules_root):
             InstallService.enforce_frozen(req)

--- a/tests/unit/install/test_frozen.py
+++ b/tests/unit/install/test_frozen.py
@@ -135,3 +135,46 @@ class TestEnforceFrozen:
             InstallService.enforce_frozen(req)
 
         assert any("stale-mcp" in reason for reason in exc_info.value.reasons)
+
+    def test_repo_root_claude_skill_with_mcp_state_accepted(self, tmp_path: Path):
+        """Regression guard for #2443: repo-root claude_skill + MCP must not fail.
+
+        A repo-root ``claude_skill`` dependency (e.g. ``makinux/adversarial-panel``)
+        has no ``apm.yml`` by design.  When the project also declares MCP servers,
+        ``enforce_frozen`` should not report the missing manifest as lockfile drift.
+        """
+        from apm_cli.integration.mcp_config_view import CurrentMcpConfigView
+
+        _write_apm_yml(tmp_path)
+
+        locked_skill = LockedDependency(
+            repo_url="https://github.com/makinux/adversarial-panel",
+            resolved_ref="main",
+            resolved_commit="a" * 40,
+            package_type="claude_skill",
+            depth=1,
+        )
+        _write_lockfile(tmp_path, [locked_skill])
+
+        lock = LockFile.read(tmp_path / "apm.lock.yaml")
+        assert lock is not None
+        lock.mcp_servers = ["deepwiki"]
+        lock.mcp_configs = {"deepwiki": {"name": "deepwiki"}}
+        lock.save(tmp_path / "apm.lock.yaml")
+
+        dep = DependencyReference(repo_url="https://github.com/makinux/adversarial-panel")
+        req = _make_request(project_dir=tmp_path, manifest_deps=[dep])
+
+        mcp_dep = MagicMock()
+        mcp_dep.name = "deepwiki"
+        req.apm_package.get_all_mcp_dependencies.return_value = [mcp_dep]
+
+        current = CurrentMcpConfigView(
+            dependencies=(),
+            configs={"deepwiki": {"name": "deepwiki"}},
+            provenance={},
+            problems=(),
+        )
+
+        with patch.object(CurrentMcpConfigView, "derive", return_value=current):
+            InstallService.enforce_frozen(req)

--- a/tests/unit/integration/test_mcp_config_view.py
+++ b/tests/unit/integration/test_mcp_config_view.py
@@ -407,8 +407,13 @@ def test_manifestless_virtual_skill_skipped_when_modules_not_materialized(
     assert view.problems == ()
 
 
-def test_manifestless_nonvirtual_claude_skill_records_problem(tmp_path: Path) -> None:
-    """A Claude-skill filesystem shape does not waive non-virtual manifests."""
+def test_manifestless_nonvirtual_claude_skill_is_accepted(tmp_path: Path) -> None:
+    """A local claude_skill with valid SKILL.md shape is accepted without apm.yml.
+
+    ``claude_skill`` packages never ship ``apm.yml`` by design.  The exemption
+    keys on the locked ``package_type`` plus the on-disk shape probe, not on
+    the virtual-type of the reference.  Regression guard for #2443.
+    """
     root = _write_manifest(tmp_path, name="root")
     skill_dir = tmp_path / "packages" / "skill"
     skill_dir.mkdir(parents=True)
@@ -423,8 +428,59 @@ def test_manifestless_nonvirtual_claude_skill_records_problem(tmp_path: Path) ->
 
     view = _derive(root, _lock(locked), tmp_path / "apm_modules")
 
-    assert len(view.problems) == 1
-    assert "manifest not found" in view.problems[0].message
+    assert view.dependencies == ()
+    assert view.problems == ()
+
+
+def test_repo_root_claude_skill_is_accepted(tmp_path: Path) -> None:
+    """Repo-root claude_skill deps (``owner/repo``) must not be rejected.
+
+    A repo-root skill has no ``virtual_path`` and ``is_virtual_subdirectory()``
+    returns ``False``.  The ``_allows_missing_manifest`` helper must still
+    accept it when the locked ``package_type`` is ``claude_skill`` and the
+    on-disk shape confirms a valid Claude skill.  Regression guard for #2443.
+    """
+    root = _write_manifest(tmp_path, name="root")
+    modules_root = tmp_path / "apm_modules"
+    locked = LockedDependency(
+        repo_url="makinux/adversarial-panel",
+        package_type="claude_skill",
+        depth=1,
+    )
+    skill_dir = locked.to_dependency_ref().get_install_path(modules_root)
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# Adversarial Panel\n", encoding="utf-8")
+
+    view = _derive(root, _lock(locked), modules_root)
+
+    assert not (skill_dir / "apm.yml").exists()
+    assert view.dependencies == ()
+    assert view.problems == ()
+
+
+def test_repo_root_claude_skill_skipped_when_modules_not_materialized(
+    tmp_path: Path,
+) -> None:
+    """Repo-root claude_skill with absent apm_modules falls back to lockfile type.
+
+    ``apm audit --ci`` may run without materialised ``apm_modules/``.  A
+    repo-root ``claude_skill`` must be accepted via the frozen lockfile
+    classification just as subdirectory skills are.  Regression guard for #2443.
+    """
+    root = _write_manifest(tmp_path, name="root")
+    modules_root = tmp_path / "apm_modules"
+    locked = LockedDependency(
+        repo_url="makinux/adversarial-panel",
+        package_type="claude_skill",
+        depth=1,
+    )
+    skill_dir = locked.to_dependency_ref().get_install_path(modules_root)
+
+    view = _derive(root, _lock(locked), modules_root)
+
+    assert not skill_dir.exists()
+    assert view.dependencies == ()
+    assert view.problems == ()
 
 
 def test_manifestless_virtual_package_without_skill_shape_records_problem(


### PR DESCRIPTION
## TL;DR

Fix `--frozen` falsely rejecting repo-root `claude_skill` dependencies (e.g. `makinux/adversarial-panel`) that legitimately ship no `apm.yml`.

## Problem (WHY)

Since v0.27.0, `apm install --frozen` fails with `apm.lock.yaml is out of sync` for repo-root `claude_skill` dependencies when the project also carries MCP state. The lockfile is not actually stale -- `apm audit` confirms no drift.

The `_allows_missing_manifest` helper in `mcp_config_view.py` gates the `claude_skill` exemption behind `is_virtual_subdirectory()`, which returns `False` for repo-root references (`owner/repo` with no `virtual_path`). The on-disk `detect_package_type` probe never runs, so the function reports the absent `apm.yml` as corruption.

## Approach (WHAT)

Move the `claude_skill` check before the `is_virtual_subdirectory()` gate so both repo-root and subdirectory skills reach the disk probe (or the lockfile-type fallback when `apm_modules` is absent). This is consistent with the `skill_bundle` unconditional exemption directly above it.

## Implementation (HOW)

- **`src/apm_cli/integration/mcp_config_view.py`**: Restructured `_allows_missing_manifest` to check `dependency.package_type == claude_skill` early, before the virtual-type gate. When the package dir exists, the strict `detect_package_type` shape probe still runs and rejects mislabelled packages. When absent, the frozen lockfile classification is trusted (matching the existing cold-cache tolerance for `apm audit --ci`).

- **`tests/unit/integration/test_mcp_config_view.py`**: Added 3 new regression tests covering repo-root claude_skill (materialised), repo-root claude_skill (absent modules), and local claude_skill acceptance. Updated 1 existing test whose assertion was wrong (local `claude_skill` with valid `SKILL.md` should be accepted, not rejected).

- **`tests/unit/install/test_frozen.py`**: Added regression test for `enforce_frozen` with a repo-root `claude_skill` dependency alongside MCP state -- the exact scenario from the issue report.

## Trade-offs

- The `detect_package_type` probe still runs when the package directory exists, so the guard against mislabelled packages is preserved.
- The virtual-subdirectory fallback path retains its existing lock-type + disk-shape double check for non-`claude_skill` types.

## How to test

```bash
uv run --extra dev pytest tests/unit/integration/test_mcp_config_view.py tests/unit/install/test_frozen.py -x -q
```

Fixes #2443