### PR TITLE
Fix YAML expansion guard false positive on large anchor-free lockfiles (#2389)

### DIFF
--- a/src/apm_cli/utils/yaml_io.py
+++ b/src/apm_cli/utils/yaml_io.py
@@ -68,7 +68,7 @@ class _BoundedSafeLoader(yaml.SafeLoader):
     **Two-budget strategy (fix for issue #2389):** ``_guard_expansion`` now
     pre-scans for aliases via ``_has_aliases`` before computing expansion
     weights. Anchor-free documents (no shared node objects in the composed
-    graph) cannot amplify -- their weight equals O(1) of input size -- so the
+    graph) cannot amplify -- their weight scales linearly with input size -- so the
     tight expansion budget is skipped entirely for them. Only documents that
     contain aliases are subjected to the 5M weight cap. The merge-entry and
     depth guards are orthogonal and unaffected.
@@ -144,7 +144,7 @@ class _BoundedSafeLoader(yaml.SafeLoader):
         #
         # Anchor-free documents (no shared node objects in the composed graph)
         # cannot produce alias-expansion amplification -- their total weight
-        # equals O(1) of literal input size.  Applying the tight 5M cap to
+        # scales linearly with literal input size (O(N)).  Applying the tight 5M cap to
         # them produces false-positive rejections of legitimate large lockfiles
         # (APM's own generated output).  We therefore pre-scan with
         # _has_aliases: if the graph is alias-free, return immediately.

--- a/src/apm_cli/utils/yaml_io.py
+++ b/src/apm_cli/utils/yaml_io.py
@@ -64,6 +64,14 @@ class _BoundedSafeLoader(yaml.SafeLoader):
     ``load_yaml`` consumer uniformly, including the non-trust
     ``apm lifecycle validate`` / ``test`` paths that never run
     ``_is_fingerprint_safe``.
+
+    **Two-budget strategy (fix for issue #2389):** ``_guard_expansion`` now
+    pre-scans for aliases via ``_has_aliases`` before computing expansion
+    weights. Anchor-free documents (no shared node objects in the composed
+    graph) cannot amplify -- their weight equals O(1) of input size -- so the
+    tight expansion budget is skipped entirely for them. Only documents that
+    contain aliases are subjected to the 5M weight cap. The merge-entry and
+    depth guards are orthogonal and unaffected.
     """
 
     _MAX_MERGE_ENTRIES = 100_000
@@ -85,36 +93,94 @@ class _BoundedSafeLoader(yaml.SafeLoader):
             getattr(node, "start_mark", None),
         )
 
+    @staticmethod
+    def _has_aliases(root: Any) -> bool:
+        """Return True if the composed node graph contains any shared nodes.
+
+        PyYAML represents every ``*alias`` reference as a pointer to the same
+        node object.  If any node's ``id()`` is encountered more than once
+        during a full graph traversal the document contains aliases (or a
+        self-referential cycle), meaning alias-expansion amplification is
+        possible.  Anchor-free documents are pure trees whose node objects are
+        never shared, so this returns False for them.
+
+        The traversal uses two sets:
+
+        * ``stack`` -- node IDs currently on the active recursion path.  A
+          hit here means a back-edge (cycle / self-referential anchor).
+        * ``seen`` -- node IDs already fully visited from a prior path.  A
+          hit here means a cross-edge (classic alias, reachable from two
+          different parents).
+
+        Both cases mean shared nodes are present; we return True immediately.
+        """
+        seen: set[int] = set()
+        stack: set[int] = set()
+
+        def visit(node: Any) -> bool:
+            nid = id(node)
+            if nid in stack or nid in seen:
+                return True
+            stack.add(nid)
+            found = False
+            if isinstance(node, yaml.nodes.MappingNode):
+                for key_node, value_node in node.value:
+                    if visit(key_node) or visit(value_node):
+                        found = True
+                        break
+            elif isinstance(node, yaml.nodes.SequenceNode):
+                for child in node.value:
+                    if visit(child):
+                        found = True
+                        break
+            stack.discard(nid)
+            seen.add(nid)
+            return found
+
+        return visit(root)
+
     def _guard_expansion(self, root: Any) -> None:
-        # Bound the LOGICAL (alias-expanded) size of the composed node graph
-        # BEFORE construction. PyYAML shares one node object across every
-        # ``*alias`` reference, so a pure-alias billion-laughs graph
-        # (``lN: &lN [*l(N-1), *l(N-1)]``) is only O(N) objects yet expands
-        # to O(2^N) the moment any consumer materializes it (``str()``,
-        # deepcopy, re-serialize). It carries no ``<<`` so the merge-entry
-        # budget never engages, and non-trust consumers
-        # (``apm lifecycle validate`` / ``test``) never run the post-parse
-        # ``_is_fingerprint_safe`` guard -- so without this the bomb wedges
-        # them. We compute a memoized per-node expansion weight (shared nodes
-        # are walked once but summed per occurrence by each parent) and fail
-        # closed as a ``yaml.YAMLError`` the instant the running total crosses
-        # the budget. A self-referential anchor (``a: &a [*a]``) is a cycle in
-        # the node graph; the in-progress sentinel detects it and fails closed
-        # rather than recursing forever. The budget is orders of magnitude
-        # above any legitimate config, so real anchors/aliases still resolve.
+        # Two-budget alias-expansion guard (issue #2389):
+        #
+        # Anchor-free documents (no shared node objects in the composed graph)
+        # cannot produce alias-expansion amplification -- their total weight
+        # equals O(1) of literal input size.  Applying the tight 5M cap to
+        # them produces false-positive rejections of legitimate large lockfiles
+        # (APM's own generated output).  We therefore pre-scan with
+        # _has_aliases: if the graph is alias-free, return immediately.
+        #
+        # Only alias-containing documents proceed to the full weight check:
+        # PyYAML shares one node object across every ``*alias`` reference, so
+        # a pure-alias billion-laughs graph (``lN: &lN [*l(N-1), *l(N-1)]``)
+        # is only O(N) objects yet expands to O(2^N) the moment any consumer
+        # materializes it (``str()``, deepcopy, re-serialize).  It carries no
+        # ``<<`` so the merge-entry budget never engages, and non-trust
+        # consumers (``apm lifecycle validate`` / ``test``) never run the
+        # post-parse ``_is_fingerprint_safe`` guard -- so without this the
+        # bomb wedges them.  We compute a memoized per-node expansion weight
+        # (shared nodes are walked once but summed per occurrence by each
+        # parent) and fail closed as a ``yaml.YAMLError`` the instant the
+        # running total crosses the budget.  A self-referential anchor
+        # (``a: &a [*a]``) is detected as aliases-present by _has_aliases and
+        # then caught by the in-progress sentinel below.
         #
         # Leaf weight is BYTE-AWARE, not a flat 1: PyYAML's representer reports
         # ``ignore_aliases() == True`` for ``str`` / ``int`` / ``float`` /
         # ``bytes`` / ``bool``, so on the dump side (``dump_yaml`` /
         # ``yaml_to_str``) a shared scalar is NOT re-anchored -- its full text
-        # is re-emitted once PER alias occurrence. A single ~50KB anchored
+        # is re-emitted once PER alias occurrence.  A single ~50KB anchored
         # scalar aliased tens of thousands of times therefore composes as only
         # O(N) nodes (passing a node-count guard) yet re-serializes to ~GBs and
         # hangs/OOMs the emitter -- reachable pre-trust on the
-        # ``apm install`` / ``apm uninstall`` apm.yml round-trip. Charging each
-        # scalar occurrence its emitted byte length makes the budget model the
-        # real dump-amplification cost, so the bomb fails closed at parse while
-        # a single large scalar (referenced a handful of times) still resolves.
+        # ``apm install`` / ``apm uninstall`` apm.yml round-trip.  Charging
+        # each scalar occurrence its emitted byte length makes the budget model
+        # the real dump-amplification cost, so the bomb fails closed at parse
+        # while a single large scalar (referenced a handful of times) still
+        # resolves.
+        if not self._has_aliases(root):
+            # Anchor-free document: literal tree, no amplification possible.
+            return
+
         weights: dict[int, int] = {}
 
         def weight(node: Any) -> int:

--- a/tests/red_team/parser/test_yaml_bomb.py
+++ b/tests/red_team/parser/test_yaml_bomb.py
@@ -153,8 +153,8 @@ def test_large_anchor_free_lockfile_loads_successfully(tmp_path: Path):
     positive "billion-laughs expansion bomb" error.  After the fix, anchor-free
     documents bypass the tight expansion cap entirely.
 
-    The generated document contains approximately 200,000 scalar bytes across
-    20,000 mapping entries (no anchors, no aliases) -- well above the 5M weight
+    The generated document contains approximately 6,000,000 scalar bytes across
+    150,000 mapping entries (no anchors, no aliases) -- well above the 5M weight
     threshold -- and must load without error.
     """
     from apm_cli.utils.yaml_io import load_yaml

--- a/tests/red_team/parser/test_yaml_bomb.py
+++ b/tests/red_team/parser/test_yaml_bomb.py
@@ -142,3 +142,66 @@ def test_shallow_alias_doc_still_parses_under_budget(tmp_path: Path, levels: int
     assert finished, f"depth={levels}: load did not finish"
     assert exc is None, f"depth={levels}: shallow doc wrongly rejected: {exc!r}"
     assert isinstance(result, dict)
+
+
+def test_large_anchor_free_lockfile_loads_successfully(tmp_path: Path):
+    """Regression for issue #2389: large anchor-free lockfile must not be rejected.
+
+    APM-generated lockfiles can accumulate a YAML node-weight sum that exceeds
+    the 5M alias-expansion budget purely through literal size, with zero anchors
+    or aliases.  Before the two-budget fix ``_guard_expansion`` raised a false-
+    positive "billion-laughs expansion bomb" error.  After the fix, anchor-free
+    documents bypass the tight expansion cap entirely.
+
+    The generated document contains approximately 200,000 scalar bytes across
+    20,000 mapping entries (no anchors, no aliases) -- well above the 5M weight
+    threshold -- and must load without error.
+    """
+    from apm_cli.utils.yaml_io import load_yaml
+
+    # Build a document whose accumulated leaf byte cost exceeds 5_000_000.
+    # Each entry contributes: key (8 bytes) + value (32 bytes hex) = ~40 bytes.
+    # 150_000 entries * 40 bytes = ~6_000_000 -- comfortably above the cap.
+    entry_count = 150_000
+    lines = ["packages:\n"]
+    for i in range(entry_count):
+        # 32-char hex value ensures enough byte weight per leaf.
+        lines.append(f"  pkg{i:06d}: abcdef1234567890abcdef1234567890\n")
+    doc = tmp_path / "apm.lock.yaml"
+    doc.write_text("".join(lines), encoding="utf-8")
+
+    finished, result, exc = run_guarded(lambda: load_yaml(doc), timeout=30.0)
+    assert finished, "load_yaml timed out on large anchor-free lockfile"
+    assert exc is None, f"large anchor-free lockfile wrongly rejected (false positive): {exc!r}"
+    assert isinstance(result, dict)
+    assert len(result["packages"]) == entry_count
+
+
+def test_merge_key_bomb_still_rejected(tmp_path: Path):
+    """Merge-key bomb is rejected by the merge-entry budget regardless of alias check.
+
+    A merge-key chain (``<<: [*a, *a]`` at each level) uses aliases AND the
+    ``<<`` merge key, so both the alias check and the merge-entry guard engage.
+    The merge-entry guard fires first and must raise ``yaml.YAMLError``.
+    This verifies the two-budget refactor did not break the orthogonal
+    ``flatten_mapping`` / merge-entry guard path.
+    """
+    import yaml
+
+    from apm_cli.utils.yaml_io import load_yaml
+
+    # 30 levels of doubling merge: 2**30 > 1_000_000_000 total entries.
+    levels = 30
+    lines = ["a0: &a0\n  x: 1\n"]
+    prev = "a0"
+    for i in range(1, levels + 1):
+        lines.append(f"a{i}: &a{i}\n  <<: [*{prev}, *{prev}]\n  y{i}: {i}\n")
+        prev = f"a{i}"
+    doc = tmp_path / "merge_bomb.yml"
+    doc.write_text("".join(lines), encoding="utf-8")
+
+    finished, _result, exc = run_guarded(lambda: load_yaml(doc), timeout=8.0)
+    assert finished, "load_yaml hung on merge-key bomb"
+    assert isinstance(exc, yaml.YAMLError), (
+        f"merge-key bomb must be rejected with yaml.YAMLError, got {exc!r}"
+    )


### PR DESCRIPTION
## TL;DR

`_BoundedSafeLoader._guard_expansion` applied a tight 5 M alias-expansion budget to **all** YAML documents. APM-generated lockfiles with zero anchors/aliases were rejected as "billion-laughs bombs" once their literal byte-weight exceeded the cap. This PR implements the two-budget fix recommended by the triage panel: anchor-free documents bypass the expansion check entirely; alias-containing documents are still subject to the full 5 M weight guard.

Fixes #2389.

---

## Problem (WHY)

> "Both contain zero anchors/aliases." -- issue reporter

`_guard_expansion` accumulated byte-weighted node costs across the entire document tree. For a 6.55 MB anchor-free lockfile the sum reached ~5.9 M, tripping the cap. The error message ("possible billion-laughs expansion bomb") was maximally misleading: the document was APM's own generated output and contained no amplification vector whatsoever.

The root confusion: the 5 M budget was designed to bound **alias-expansion amplification** (O(2^N) from O(N) shared nodes). Without aliases, expansion weight equals O(1) of literal input size -- the cap solves a problem that does not exist for anchor-free documents.

---

## Approach (WHAT)

Two-budget strategy, as recommended by the triage panel:

1. **Anchor-free path** -- if the composed node graph contains no shared node objects (no aliases, no cycles), `_guard_expansion` returns immediately. Literal documents are bounded by their input size; no tight cap needed.
2. **Alias path** -- if shared nodes exist, run the full 5 M weight check unchanged. Billion-laughs and large-scalar-alias bombs are still rejected.

The merge-entry and depth guards in `flatten_mapping` are orthogonal and untouched.

---

## Implementation (HOW)

### `src/apm_cli/utils/yaml_io.py`

**New `_BoundedSafeLoader._has_aliases(root)`** (static method):

```
Walk the composed node graph using two sets:
  - stack: node IDs on the active recursion path (back-edges = cycles)
  - seen:  node IDs already fully visited (cross-edges = classic aliases)
Return True immediately on either hit; return False if the graph is a pure tree.
O(N) time, O(N) space.
```

**Modified `_BoundedSafeLoader._guard_expansion(root)`**:

```python
if not self._has_aliases(root):
    return   # anchor-free: literal tree, no amplification possible
# ... existing weight computation unchanged ...
```

Updated class docstring to describe the two-budget approach.

### `tests/red_team/parser/test_yaml_bomb.py`

Two new regression tests:

| Test | Assertion |
|---|---|
| `test_large_anchor_free_lockfile_loads_successfully` | 150 k entries, ~6 M byte weight, zero anchors -- must load without error (regression for #2389) |
| `test_merge_key_bomb_still_rejected` | 30-level doubling merge chain -- must raise `yaml.YAMLError` (orthogonal merge-entry guard unaffected) |

Existing alias-bomb tests (`test_deep_alias_bomb_fails_closed_fast`, `test_load_yaml_fails_closed_on_alias_bomb`) confirm no security regression.

---

## Validation evidence

```
uv run --extra dev pytest tests/red_team/parser/test_yaml_bomb.py tests/unit/test_yaml_io.py -x -q
# 50 passed

uv run --extra dev ruff check src/ tests/     # All checks passed
uv run --extra dev ruff format --check src/ tests/  # 1609 files already formatted
uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/
# Your code has been rated at 10.00/10
bash scripts/lint-auth-signals.sh
# [+] auth-signal lint clean
```

---

## How to test

```bash
# Reproduce the original bug (before fix):
python -c "
import yaml
from apm_cli.utils.yaml_io import _BoundedSafeLoader
# 6M+ byte-weight anchor-free document
text = 'packages:\n' + ''.join(
    f'  pkg{i:06d}: abcdef1234567890abcdef1234567890\n'
    for i in range(150_000)
)
# Before fix: raises yaml.YAMLError (false positive)
# After fix: returns dict
result = yaml.load(text, Loader=_BoundedSafeLoader)
print('OK, loaded', len(result['packages']), 'entries')
"

# Run regression suite:
uv run --extra dev pytest tests/red_team/parser/test_yaml_bomb.py -v
```

---

## Trade-offs

- **Security preserved**: alias bombs and merge-key bombs still rejected. The `_has_aliases` pre-scan is O(N) and adds a bounded traversal before the weight check, which is also O(N) for alias-free docs (previously always ran). Net cost for anchor-free docs: one O(N) traversal instead of one O(N) traversal -- identical asymptotic cost, different exit path.
- **No API change**: `_BoundedSafeLoader`, `load_yaml`, `load_yaml_str`, `_bounded_load` signatures unchanged.
- **`_MAX_EXPANSION_WEIGHT` unchanged**: the constant is still 5 M; it now applies only to alias-containing documents.