### PR TITLE
Fix Windows Defender false positive via Authenticode signing (#2435)

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -121,6 +121,16 @@ jobs:
         run: |
           uv run pwsh scripts/windows/build-binary.ps1
 
+      - name: Sign Windows binary (Authenticode)
+        if: matrix.platform == 'windows' && env.WINDOWS_CERT_PFX != ''
+        shell: pwsh
+        env:
+          WINDOWS_CERT_PFX: ${{ secrets.WINDOWS_CERT_PFX }}
+          WINDOWS_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
+          BINARY_DIR: dist\apm-windows-x86_64
+        run: |
+          uv run pwsh scripts/windows/sign-binary.ps1
+
       - name: Upload binary as workflow artifact
         uses: actions/upload-artifact@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Windows binary is now Authenticode-signed in the release workflow, eliminating
+  the `Trojan:Script/Wacatac.H!ml` Windows Defender false positive triggered by
+  unsigned PyInstaller bundles. The signing step is gated on the
+  `WINDOWS_CERT_PFX` secret so contributor and fork builds continue to work
+  unsigned. A troubleshooting section documents workarounds (Defender exclusion,
+  pip install) for users on older releases. (#2435)
 - Multi-target `apm compile` now avoids repeating expensive project analysis
   for each target, making multi-target runs scale like single-target runs
   without changing generated output. (closes #2482)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Windows binary is now Authenticode-signed in the release workflow, eliminating
+  the `Trojan:Script/Wacatac.H!ml` false positive. Gated on `WINDOWS_CERT_PFX`
+  secret so fork builds remain unchanged. (#2435)
 - `apm install` now re-downloads an aliased dependency after its `ref:` changes
   in `apm.yml`. Previously the pinned-ref and already-resolved cache-reuse
   shortcuts skipped the fetch, so `apm_modules/<alias>/` and every primitive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Windows binary is now Authenticode-signed in the release workflow, eliminating
-  the `Trojan:Script/Wacatac.H!ml` Windows Defender false positive triggered by
-  unsigned PyInstaller bundles. The signing step is gated on the
-  `WINDOWS_CERT_PFX` secret so contributor and fork builds continue to work
-  unsigned. A troubleshooting section documents workarounds (Defender exclusion,
-  pip install) for users on older releases. (#2435)
+  the `Trojan:Script/Wacatac.H!ml` Windows Defender false positive on unsigned
+  PyInstaller bundles. (#2435)
 - Multi-target `apm compile` now avoids repeating expensive project analysis
   for each target, making multi-target runs scale like single-target runs
   without changing generated output. (closes #2482)
@@ -43,9 +40,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Windows binary is now Authenticode-signed in the release workflow, eliminating
-  the `Trojan:Script/Wacatac.H!ml` false positive. Gated on `WINDOWS_CERT_PFX`
-  secret so fork builds remain unchanged. (#2435)
 - `apm install` now re-downloads an aliased dependency after its `ref:` changes
   in `apm.yml`. Previously the pinned-ref and already-resolved cache-reuse
   shortcuts skipped the fetch, so `apm_modules/<alias>/` and every primitive

--- a/docs/src/content/docs/troubleshooting/install-failures.md
+++ b/docs/src/content/docs/troubleshooting/install-failures.md
@@ -290,3 +290,48 @@ APM_DEBUG=1 apm install --verbose 2>&1 | tee install.log
 ```
 
 If you file an issue, attach `install.log`, the relevant `apm.yml` and `apm.lock.yaml`, and the output of `apm cache info`.
+
+## 7. Windows Defender flags the APM binary
+
+**Symptom:** Windows Defender (or another enterprise AV) quarantines or removes
+the APM executable with a detection such as `Trojan:Script/Wacatac.H!ml` or a
+similar generic ML-based heuristic name.
+
+**Why it happens:** PyInstaller-packed binaries use a self-extracting-archive
+bootloader pattern that triggers ML-based AV heuristics, particularly on
+unsigned executables. This is a false positive -- the APM binary contains no
+malicious code.
+
+**Long-term fix:** APM releases from v0.28.1 onward ship with Authenticode
+code signatures. Signed binaries carry a trusted publisher identity and do not
+trigger these heuristics. Upgrade to the latest release.
+
+**Workarounds for older releases or enterprise policies that block new
+downloads:**
+
+1. **Add a Defender exclusion for the install directory** (PowerShell, admin):
+
+   ```powershell
+   Add-MpPreference -ExclusionPath "$env:LOCALAPPDATA\Programs\apm"
+   ```
+
+   Remove the exclusion once you have upgraded to a signed release:
+
+   ```powershell
+   Remove-MpPreference -ExclusionPath "$env:LOCALAPPDATA\Programs\apm"
+   ```
+
+2. **Install via pip** -- the PyPI package (`apm-cli`) is a pure Python wheel
+   and is not affected by PE-level AV heuristics:
+
+   ```bash
+   pip install apm-cli
+   apm --version
+   ```
+
+   Requires Python 3.10+. See [Installation](../installation/#from-source-or-pip).
+
+3. **Submit the binary to Microsoft** if your organisation needs the detection
+   cleared for an older release: use the
+   [Microsoft Security Intelligence submission portal](https://www.microsoft.com/en-us/wdsi/filesubmission)
+   and select "Incorrect detection (False positive)" with the quarantined file.

--- a/docs/src/content/docs/troubleshooting/install-failures.md
+++ b/docs/src/content/docs/troubleshooting/install-failures.md
@@ -302,9 +302,9 @@ bootloader pattern that triggers ML-based AV heuristics, particularly on
 unsigned executables. This is a false positive -- the APM binary contains no
 malicious code.
 
-**Long-term fix:** APM releases from v0.28.1 onward ship with Authenticode
-code signatures. Signed binaries carry a trusted publisher identity and do not
-trigger these heuristics. Upgrade to the latest release.
+**Long-term fix:** Recent APM releases ship with Authenticode code signatures.
+Signed binaries carry a trusted publisher identity and do not trigger these
+heuristics. Upgrade to the latest release.
 
 **Workarounds for older releases or enterprise policies that block new
 downloads:**
@@ -329,7 +329,7 @@ downloads:**
    apm --version
    ```
 
-   Requires Python 3.10+. See [Installation](../installation/#from-source-or-pip).
+   Requires Python 3.10+. See [pip install](../../getting-started/installation/#pip-install).
 
 3. **Submit the binary to Microsoft** if your organisation needs the detection
    cleared for an older release: use the

--- a/docs/src/content/docs/troubleshooting/install-failures.md
+++ b/docs/src/content/docs/troubleshooting/install-failures.md
@@ -1,6 +1,6 @@
 ---
 title: "Install failures"
-description: "Diagnose and recover from apm install failures: auth, network, lockfile, cache, and partial installs."
+description: "Diagnose and recover from apm install failures: auth, network, lockfile, cache, partial installs, and Windows Defender false positives."
 sidebar:
   order: 2
 ---

--- a/scripts/windows/build-binary.ps1
+++ b/scripts/windows/build-binary.ps1
@@ -64,6 +64,20 @@ try {
     # Rename the directory to have the platform-specific name
     Rename-Item "dist/apm" $BinaryName
 
+    # Authenticode-sign the binary when signing credentials are available.
+    # Signing is optional: builds without WINDOWS_CERT_PFX succeed unsigned.
+    if ($env:WINDOWS_CERT_PFX) {
+        Write-Host "Signing binary (Authenticode)..." -ForegroundColor Yellow
+        $env:BINARY_DIR = "dist/$BinaryName"
+        & pwsh scripts/windows/sign-binary.ps1
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "Signing failed with exit code $LASTEXITCODE" -ForegroundColor Red
+            exit $LASTEXITCODE
+        }
+    } else {
+        Write-Host "WINDOWS_CERT_PFX not set -- skipping Authenticode signing" -ForegroundColor Yellow
+    }
+
     # Test the binary (temporarily relax error preference so stderr from native
     # commands does not throw under $ErrorActionPreference = "Stop")
     Write-Host "Testing binary..." -ForegroundColor Yellow

--- a/scripts/windows/build-binary.ps1
+++ b/scripts/windows/build-binary.ps1
@@ -67,15 +67,15 @@ try {
     # Authenticode-sign the binary when signing credentials are available.
     # Signing is optional: builds without WINDOWS_CERT_PFX succeed unsigned.
     if ($env:WINDOWS_CERT_PFX) {
-        Write-Host "Signing binary (Authenticode)..." -ForegroundColor Yellow
+        Write-Host "[*] Signing binary (Authenticode)..."
         $env:BINARY_DIR = "dist/$BinaryName"
         & pwsh scripts/windows/sign-binary.ps1
         if ($LASTEXITCODE -ne 0) {
-            Write-Host "Signing failed with exit code $LASTEXITCODE" -ForegroundColor Red
+            Write-Host "[x] Signing failed with exit code $LASTEXITCODE"
             exit $LASTEXITCODE
         }
     } else {
-        Write-Host "WINDOWS_CERT_PFX not set -- skipping Authenticode signing" -ForegroundColor Yellow
+        Write-Host "[i] WINDOWS_CERT_PFX not set -- skipping Authenticode signing"
     }
 
     # Test the binary (temporarily relax error preference so stderr from native

--- a/scripts/windows/sign-binary.ps1
+++ b/scripts/windows/sign-binary.ps1
@@ -75,7 +75,7 @@ Write-Host "[i] Using signtool: $SignToolPath"
 
 $TempCert = $null
 try {
-    $TempCert = [System.IO.Path]::GetTempFileName() + ".pfx"
+    $TempCert = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName() + ".pfx")
     $certBytes = [System.Convert]::FromBase64String($env:WINDOWS_CERT_PFX)
     [System.IO.File]::WriteAllBytes($TempCert, $certBytes)
     Write-Host "[i] Certificate decoded to temporary path"
@@ -102,7 +102,7 @@ try {
         "sign",
         "/fd", "SHA256",
         "/td", "SHA256",
-        "/tr", "http://timestamp.digicert.com",
+        "/tr", "https://timestamp.digicert.com",
         "/f", $TempCert,
         "/p", $env:WINDOWS_CERT_PASSWORD,
         "/q"

--- a/scripts/windows/sign-binary.ps1
+++ b/scripts/windows/sign-binary.ps1
@@ -1,0 +1,138 @@
+# Authenticode-sign the APM Windows binary directory.
+#
+# Prerequisites (all mandatory for signing to proceed):
+#   $env:WINDOWS_CERT_PFX       -- base64-encoded PFX certificate bundle
+#   $env:WINDOWS_CERT_PASSWORD  -- PFX private-key password
+#   $env:BINARY_DIR             -- path to the onedir bundle (default: dist\apm-windows-x86_64)
+#
+# If WINDOWS_CERT_PFX is absent or empty the script exits 0 without signing;
+# this lets contributor / fork builds complete normally.
+#
+# Signing covers:
+#   1. apm.exe (the main entry point)
+#   2. Every bundled *.dll (unsigned DLLs can re-trigger Defender heuristics
+#      even when the EXE itself is signed)
+#
+# A DigiCert RFC 3161 timestamp is embedded so signatures remain valid after
+# certificate expiry.
+
+$ErrorActionPreference = "Stop"
+
+# -- Guard: skip gracefully when no certificate is configured ---------------
+
+if (-not $env:WINDOWS_CERT_PFX) {
+    Write-Host "[i] WINDOWS_CERT_PFX not set -- skipping Authenticode signing"
+    exit 0
+}
+
+if (-not $env:WINDOWS_CERT_PASSWORD) {
+    Write-Host "[x] WINDOWS_CERT_PFX is set but WINDOWS_CERT_PASSWORD is missing"
+    exit 1
+}
+
+# -- Locate binary directory -------------------------------------------------
+
+$BinaryDir = if ($env:BINARY_DIR) { $env:BINARY_DIR } else { "dist\apm-windows-x86_64" }
+
+if (-not (Test-Path $BinaryDir)) {
+    Write-Host "[x] Binary directory not found: $BinaryDir"
+    exit 1
+}
+
+$ExePath = Join-Path $BinaryDir "apm.exe"
+if (-not (Test-Path $ExePath)) {
+    Write-Host "[x] apm.exe not found in $BinaryDir"
+    exit 1
+}
+
+# -- Locate signtool.exe ------------------------------------------------------
+
+# Windows SDK ships signtool.exe; GitHub runners have it on PATH via the
+# Visual Studio component. Fall back to the well-known SDK x64 path.
+$SignTool = Get-Command "signtool.exe" -ErrorAction SilentlyContinue
+if (-not $SignTool) {
+    $FallbackPaths = @(
+        "${env:ProgramFiles(x86)}\Windows Kits\10\bin\x64\signtool.exe",
+        "${env:ProgramFiles(x86)}\Windows Kits\10\bin\10.0.22621.0\x64\signtool.exe"
+    )
+    foreach ($p in $FallbackPaths) {
+        if (Test-Path $p) { $SignTool = Get-Item $p; break }
+    }
+}
+if (-not $SignTool) {
+    Write-Host "[x] signtool.exe not found -- install Windows SDK or ensure it is on PATH"
+    exit 1
+}
+
+$SignToolPath = if ($SignTool -is [System.Management.Automation.ApplicationInfo]) {
+    $SignTool.Source
+} else {
+    $SignTool.FullName
+}
+Write-Host "[i] Using signtool: $SignToolPath"
+
+# -- Extract PFX to a temp file ----------------------------------------------
+
+$TempCert = $null
+try {
+    $TempCert = [System.IO.Path]::GetTempFileName() + ".pfx"
+    $certBytes = [System.Convert]::FromBase64String($env:WINDOWS_CERT_PFX)
+    [System.IO.File]::WriteAllBytes($TempCert, $certBytes)
+    Write-Host "[i] Certificate decoded to temporary path"
+
+    # -- Collect targets: apm.exe + all bundled DLLs -------------------------
+
+    $Targets = @($ExePath)
+    $DllTargets = Get-ChildItem -Path $BinaryDir -Filter "*.dll" -Recurse |
+        Select-Object -ExpandProperty FullName
+    $Targets += $DllTargets
+
+    Write-Host "[*] Signing $($Targets.Count) file(s)..."
+
+    # -- Sign all targets in a single signtool invocation --------------------
+    # Flags:
+    #   /fd SHA256      -- file-digest algorithm
+    #   /td SHA256      -- timestamp-digest algorithm
+    #   /tr <url>       -- RFC 3161 timestamp server
+    #   /f  <pfx>       -- certificate file
+    #   /p  <password>  -- private-key password
+    #   /q              -- quiet (only errors)
+
+    $SignArgs = @(
+        "sign",
+        "/fd", "SHA256",
+        "/td", "SHA256",
+        "/tr", "http://timestamp.digicert.com",
+        "/f", $TempCert,
+        "/p", $env:WINDOWS_CERT_PASSWORD,
+        "/q"
+    ) + $Targets
+
+    $proc = Start-Process -FilePath $SignToolPath -ArgumentList $SignArgs `
+        -Wait -PassThru -NoNewWindow
+    if ($proc.ExitCode -ne 0) {
+        Write-Host "[x] signtool sign failed with exit code $($proc.ExitCode)"
+        exit $proc.ExitCode
+    }
+
+    Write-Host "[+] Signing complete"
+
+    # -- Verify the EXE signature --------------------------------------------
+
+    Write-Host "[*] Verifying signature on apm.exe..."
+    $VerifyArgs = @("verify", "/pa", "/v", $ExePath)
+    $verifyProc = Start-Process -FilePath $SignToolPath -ArgumentList $VerifyArgs `
+        -Wait -PassThru -NoNewWindow
+    if ($verifyProc.ExitCode -ne 0) {
+        Write-Host "[x] signtool verify failed -- signature may be invalid"
+        exit $verifyProc.ExitCode
+    }
+
+    Write-Host "[+] Signature verified"
+
+} finally {
+    if ($TempCert -and (Test-Path $TempCert)) {
+        Remove-Item -Force $TempCert -ErrorAction SilentlyContinue
+        Write-Host "[i] Temporary certificate file removed"
+    }
+}

--- a/scripts/windows/sign-binary.ps1
+++ b/scripts/windows/sign-binary.ps1
@@ -77,8 +77,31 @@ $TempCert = $null
 try {
     $TempCert = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName() + ".pfx")
     $certBytes = [System.Convert]::FromBase64String($env:WINDOWS_CERT_PFX)
-    [System.IO.File]::WriteAllBytes($TempCert, $certBytes)
-    Write-Host "[i] Certificate decoded to temporary path"
+
+    # Write PFX with exclusive lock (FileShare.None) so no other process can
+    # open the file during the write window.
+    $fs = [System.IO.File]::Open(
+        $TempCert,
+        [System.IO.FileMode]::CreateNew,
+        [System.IO.FileAccess]::Write,
+        [System.IO.FileShare]::None
+    )
+    try { $fs.Write($certBytes, 0, $certBytes.Length) }
+    finally { $fs.Dispose() }
+
+    # Restrict ACL to current user only: disable ACE inheritance and remove
+    # any inherited rules, then grant FullControl to this process's identity.
+    $acl = Get-Acl -Path $TempCert
+    $acl.SetAccessRuleProtection($true, $false)
+    $rule = [System.Security.AccessControl.FileSystemAccessRule]::new(
+        [System.Security.Principal.WindowsIdentity]::GetCurrent().Name,
+        'FullControl',
+        [System.Security.AccessControl.AccessControlType]::Allow
+    )
+    $acl.SetAccessRule($rule)
+    Set-Acl -Path $TempCert -AclObject $acl
+
+    Write-Host "[i] Certificate decoded to temporary path (owner-only ACL applied)"
 
     # -- Collect targets: apm.exe + all bundled DLLs -------------------------
 

--- a/tests/unit/test_windows_signing_contract.py
+++ b/tests/unit/test_windows_signing_contract.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import pytest
 
 from tests.workflow_contracts import (
+    WorkflowNode,
     load_workflow,
     workflow_job,
     workflow_step,
@@ -29,11 +30,11 @@ BUILD_STEP = "Build binary (Windows)"
 UPLOAD_STEP = "Upload binary as workflow artifact"
 
 
-def _workflow() -> dict:
+def _workflow() -> WorkflowNode:
     return load_workflow(WORKFLOW)
 
 
-def _assert_signing_step(workflow: dict) -> None:
+def _assert_signing_step(workflow: WorkflowNode) -> None:
     """Assert the Authenticode signing step is correctly configured."""
     job = workflow_job(workflow, "build-and-test")
     step = workflow_step(job, SIGNING_STEP)
@@ -54,7 +55,8 @@ def _assert_signing_step(workflow: dict) -> None:
     assert "sign-binary.ps1" in run_text, "signing step must invoke scripts/windows/sign-binary.ps1"
 
     # Must pass the certificate secret via env.
-    env: dict = step.get("env", {})
+    env = step.get("env", {})
+    assert isinstance(env, dict), f"signing step env must be a mapping, got {type(env)!r}"
     assert "WINDOWS_CERT_PFX" in env, "signing step env must include WINDOWS_CERT_PFX"
     assert "WINDOWS_CERT_PASSWORD" in env, "signing step env must include WINDOWS_CERT_PASSWORD"
 

--- a/tests/unit/test_windows_signing_contract.py
+++ b/tests/unit/test_windows_signing_contract.py
@@ -1,0 +1,124 @@
+"""Static contract: Windows Authenticode signing step exists in build-release.yml.
+
+Regression guard for microsoft/apm#2435: the Windows binary release was flagged
+as Trojan:Script/Wacatac.H!ml by Windows Defender because PyInstaller-packed
+binaries trigger ML-based AV heuristics without Authenticode signatures. The fix
+adds a signing step gated on the WINDOWS_CERT_PFX secret. This test pins that
+contract so it cannot be silently removed by a future workflow edit.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from tests.workflow_contracts import (
+    load_workflow,
+    workflow_job,
+    workflow_step,
+    workflow_step_index,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "build-release.yml"
+
+SIGNING_STEP = "Sign Windows binary (Authenticode)"
+BUILD_STEP = "Build binary (Windows)"
+UPLOAD_STEP = "Upload binary as workflow artifact"
+
+
+def _workflow() -> dict:
+    return load_workflow(WORKFLOW)
+
+
+def _assert_signing_step(workflow: dict) -> None:
+    """Assert the Authenticode signing step is correctly configured."""
+    job = workflow_job(workflow, "build-and-test")
+    step = workflow_step(job, SIGNING_STEP)
+
+    # Must only run on the Windows matrix entry.
+    step_if: str = step.get("if", "")
+    assert "windows" in step_if, (
+        f"signing step must be gated on Windows platform, got if={step_if!r}"
+    )
+
+    # Must reference the WINDOWS_CERT_PFX secret so unsigned builds skip it.
+    assert "WINDOWS_CERT_PFX" in step_if, (
+        "signing step must be gated on WINDOWS_CERT_PFX secret being non-empty"
+    )
+
+    # Must invoke sign-binary.ps1.
+    run_text: str = step.get("run", "")
+    assert "sign-binary.ps1" in run_text, "signing step must invoke scripts/windows/sign-binary.ps1"
+
+    # Must pass the certificate secret via env.
+    env: dict = step.get("env", {})
+    assert "WINDOWS_CERT_PFX" in env, "signing step env must include WINDOWS_CERT_PFX"
+    assert "WINDOWS_CERT_PASSWORD" in env, "signing step env must include WINDOWS_CERT_PASSWORD"
+
+    # Ordering: signing must occur after build and before upload.
+    build_idx = workflow_step_index(job, BUILD_STEP)
+    sign_idx = workflow_step_index(job, SIGNING_STEP)
+    upload_idx = workflow_step_index(job, UPLOAD_STEP)
+    assert build_idx < sign_idx < upload_idx, (
+        f"signing step order wrong: build={build_idx} sign={sign_idx} upload={upload_idx}"
+    )
+
+
+def test_signing_step_exists() -> None:
+    """Signing step is present in the build-and-test job."""
+    _assert_signing_step(_workflow())
+
+
+def test_signing_step_gated_on_windows() -> None:
+    """Removing the Windows platform gate must fail the contract."""
+    workflow = deepcopy(_workflow())
+    step = workflow_step(workflow_job(workflow, "build-and-test"), SIGNING_STEP)
+    step["if"] = "env.WINDOWS_CERT_PFX != ''"  # no platform gate
+
+    with pytest.raises(AssertionError, match="Windows platform"):
+        _assert_signing_step(workflow)
+
+
+def test_signing_step_gated_on_secret() -> None:
+    """Removing the secret gate must fail -- signing must skip gracefully."""
+    workflow = deepcopy(_workflow())
+    step = workflow_step(workflow_job(workflow, "build-and-test"), SIGNING_STEP)
+    step["if"] = "matrix.platform == 'windows'"  # no secret gate
+
+    with pytest.raises(AssertionError, match="WINDOWS_CERT_PFX"):
+        _assert_signing_step(workflow)
+
+
+def test_signing_step_references_script() -> None:
+    """Replacing the script reference must fail the contract."""
+    workflow = deepcopy(_workflow())
+    step = workflow_step(workflow_job(workflow, "build-and-test"), SIGNING_STEP)
+    step["run"] = "echo skipping signing\n"
+
+    with pytest.raises(AssertionError, match=r"sign-binary\.ps1"):
+        _assert_signing_step(workflow)
+
+
+def test_signing_step_order() -> None:
+    """Moving the signing step after upload must fail the contract."""
+    workflow = deepcopy(_workflow())
+    job = workflow_job(workflow, "build-and-test")
+    steps: list = job["steps"]
+
+    # Find and remove the signing step, then insert it after the upload step.
+    sign_step = next(
+        (s for s in steps if isinstance(s, dict) and s.get("name") == SIGNING_STEP),
+        None,
+    )
+    assert sign_step is not None, "signing step not found for order mutation"
+    steps.remove(sign_step)
+    upload_idx = next(
+        i for i, s in enumerate(steps) if isinstance(s, dict) and s.get("name") == UPLOAD_STEP
+    )
+    steps.insert(upload_idx + 1, sign_step)
+
+    with pytest.raises(AssertionError, match="order"):
+        _assert_signing_step(workflow)

--- a/tests/unit/test_windows_signing_contract.py
+++ b/tests/unit/test_windows_signing_contract.py
@@ -124,3 +124,15 @@ def test_signing_step_order() -> None:
 
     with pytest.raises(AssertionError, match="order"):
         _assert_signing_step(workflow)
+
+
+def test_signing_step_requires_password_env() -> None:
+    """Removing WINDOWS_CERT_PASSWORD from env must fail the contract."""
+    workflow = deepcopy(_workflow())
+    step = workflow_step(workflow_job(workflow, "build-and-test"), SIGNING_STEP)
+    env = step.get("env", {})
+    assert isinstance(env, dict), "env must be a mapping for this mutation test"
+    env.pop("WINDOWS_CERT_PASSWORD", None)
+
+    with pytest.raises(AssertionError, match="WINDOWS_CERT_PASSWORD"):
+        _assert_signing_step(workflow)

--- a/tests/unit/test_windows_signing_contract.py
+++ b/tests/unit/test_windows_signing_contract.py
@@ -136,3 +136,44 @@ def test_signing_step_requires_password_env() -> None:
 
     with pytest.raises(AssertionError, match="WINDOWS_CERT_PASSWORD"):
         _assert_signing_step(workflow)
+
+
+# ---------------------------------------------------------------------------
+# Static code contracts for scripts/windows/sign-binary.ps1
+# ---------------------------------------------------------------------------
+
+SIGN_SCRIPT = ROOT / "scripts" / "windows" / "sign-binary.ps1"
+
+
+def _sign_script_text() -> str:
+    return SIGN_SCRIPT.read_text(encoding="utf-8")
+
+
+def test_sign_script_restricts_acl() -> None:
+    """sign-binary.ps1 must call SetAccessRuleProtection to disable ACL inheritance.
+
+    Regression guard for the FU-3a supply-chain finding: the temp PFX file
+    must not be world-readable on shared runners. SetAccessRuleProtection with
+    ($true, $false) removes inherited rules and ensures only an explicit
+    current-user grant remains.
+    """
+    text = _sign_script_text()
+    assert "SetAccessRuleProtection" in text, (
+        "sign-binary.ps1 must call SetAccessRuleProtection to restrict the "
+        "temporary PFX file to the current user only -- world-readable temp "
+        "files expose the private key on shared runners"
+    )
+
+
+def test_sign_script_uses_exclusive_file_lock() -> None:
+    """sign-binary.ps1 must use FileShare.None when writing the temp PFX.
+
+    Ensures no concurrent reader can observe the private key bytes during
+    the file-write window, even on a shared runner.
+    """
+    text = _sign_script_text()
+    assert "FileShare" in text, (
+        "sign-binary.ps1 must open the temp PFX with FileShare.None (exclusive "
+        "lock) to prevent a concurrent process from reading the private key "
+        "bytes during the write window"
+    )


### PR DESCRIPTION
## TL;DR

Add Authenticode code signing to the Windows release pipeline to eliminate the `Trojan:Script/Wacatac.H!ml` Windows Defender false positive that blocks enterprise Windows users from installing APM.

## Problem (WHY)

> "APM is getting removed from our system because of this. Windows Defender is flagging it." -- #2435

PyInstaller-packed binaries use a self-extracting-archive bootloader pattern. Without an Authenticode signature, Windows Defender's ML heuristics assign high risk to the unsigned executable regardless of its actual content. The existing mitigations (UPX disabled, PE version info embedded, `optimize=2`) reduce surface area but are insufficient without a code signature.

From the triage panel:
> `Wacatac.H!ml` is a generic ML-based heuristic signature frequently triggered by PyInstaller bundles. A code-signed binary is the correct long-term fix.

## Approach (WHAT)

- **Authenticode sign** `apm.exe` and all bundled DLLs after the PyInstaller build, before packaging into the release ZIP
- **Graceful degradation**: the signing step is gated on the `WINDOWS_CERT_PFX` secret being non-empty, so contributor builds, fork PRs, and local builds work unchanged
- **Timestamp** every signature via DigiCert RFC 3161 so signatures remain valid after certificate expiry
- **Document workarounds** for users on older unsigned releases

## Implementation (HOW)

```
scripts/windows/sign-binary.ps1          (new)  -- signing helper
scripts/windows/build-binary.ps1         (edit) -- optional local signing
.github/workflows/build-release.yml      (edit) -- CI signing step
tests/unit/test_windows_signing_contract.py (new)  -- regression guard
docs/troubleshooting/install-failures.md (edit) -- Defender section
CHANGELOG.md                             (edit) -- Fixed entry
```

### Workflow change

```yaml
- name: Sign Windows binary (Authenticode)
  if: matrix.platform == 'windows' && env.WINDOWS_CERT_PFX != ''
  shell: pwsh
  env:
    WINDOWS_CERT_PFX: ${{ secrets.WINDOWS_CERT_PFX }}
    WINDOWS_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
    BINARY_DIR: dist\apm-windows-x86_64
  run: |
    uv run pwsh scripts/windows/sign-binary.ps1
```

This step sits between "Build binary (Windows)" and "Upload binary as workflow artifact".

### Sign script flow

```
decode WINDOWS_CERT_PFX (base64) -> temp .pfx
signtool sign /fd SHA256 /td SHA256 /tr http://timestamp.digicert.com apm.exe *.dll
signtool verify /pa apm.exe
rm temp .pfx (finally block)
```

### Architecture diagram

```mermaid
flowchart LR
    Build["Build binary (Windows)\nbuild-binary.ps1"] --> Sign["Sign Windows binary\nsign-binary.ps1"]
    Sign --> Upload["Upload artifact\napm-windows-x86_64.zip"]
    Sign -.->|WINDOWS_CERT_PFX absent| Skip["Skip signing\nexit 0"]
    Skip --> Upload
```

## Trade-offs

| Decision | Rationale |
|----------|-----------|
| Separate `sign-binary.ps1` vs inline | Single-responsibility; reusable for local maintainer builds |
| Gate on env var, not matrix condition | Lets maintainers sign locally without workflow changes |
| Sign all DLLs, not just apm.exe | Unsigned bundled DLLs can re-trigger heuristics even when EXE is signed |
| DigiCert timestamp server | Widely trusted, RFC 3161, no rate limits for low-volume use |

## Validation evidence

- `uv run --extra dev pytest tests/unit/test_windows_signing_contract.py -v` -- 5/5 passed
- `uv run --extra dev ruff check src/ tests/ && ruff format --check src/ tests/` -- clean
- `uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/` -- 10.00/10
- `bash scripts/lint-auth-signals.sh` -- clean

## How to test

1. Set repository secrets `WINDOWS_CERT_PFX` (base64 PFX) and `WINDOWS_CERT_PASSWORD`
2. Trigger `build-release.yml` via workflow dispatch
3. After the "Sign Windows binary" step completes, verify the EXE is signed:
   ```powershell
   Get-AuthenticodeSignature .\dist\apm-windows-x86_64\apm.exe
   ```
4. Upload the resulting ZIP to VirusTotal -- signed binaries should not trigger `Wacatac.H!ml`

Without the secrets set, the step is skipped and the build completes unsigned (existing behaviour).

## Out of scope

- EV certificate procurement (external; maintainer decision -- EV certs build SmartScreen reputation faster)
- Submitting the v0.27.0 binary to Microsoft's AV submission portal (manual maintainer action recommended in parallel)

Closes #2435