### PR TITLE
Fix: marketplace validate accepts malformed marketplace.json (#2424)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,13 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `apm marketplace validate` now fails with a clear structural error when
-  `marketplace.json` contains a malformed `plugins` field (e.g. a non-list
-  value), instead of silently accepting it as a valid empty manifest. A raw-JSON
-  structural pre-check runs before the permissive parser, surfacing type
-  violations that the parser would otherwise coerce to safe defaults. The
-  permissive runtime parser used by install and search flows is unchanged.
-  (closes #2424)
+- `apm marketplace validate` now rejects structurally invalid `marketplace.json` files (e.g. `plugins` is not a list) instead of silently reporting a false-positive clean result. (#2498)
 - `apm init` and install-time auto-bootstrap now reject empty or
   whitespace-only project names, falling back to `my-project` at a filesystem
   root. APM no longer writes an `apm.yml` that every later install, lock, or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `apm marketplace validate` now rejects structurally invalid `marketplace.json` files (e.g. `plugins` is not a list) instead of silently reporting a false-positive clean result. (#2498)
+- `apm marketplace validate` now rejects structurally invalid `marketplace.json` files (e.g. `plugins` is not an array, or the root is not an object) instead of silently reporting a false-positive clean result. (#2424)
 - `apm install` now re-downloads an aliased dependency after its `ref:` changes
   in `apm.yml`. Previously the pinned-ref and already-resolved cache-reuse
   shortcuts skipped the fetch, so `apm_modules/<alias>/` and every primitive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `apm marketplace validate` now fails with a clear structural error when
+  `marketplace.json` contains a malformed `plugins` field (e.g. a non-list
+  value), instead of silently accepting it as a valid empty manifest. A raw-JSON
+  structural pre-check runs before the permissive parser, surfacing type
+  violations that the parser would otherwise coerce to safe defaults. The
+  permissive runtime parser used by install and search flows is unchanged.
+  (closes #2424)
 - `apm init` and install-time auto-bootstrap now reject empty or
   whitespace-only project names, falling back to `my-project` at a filesystem
   root. APM no longer writes an `apm.yml` that every later install, lock, or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `apm marketplace validate` now rejects structurally invalid `marketplace.json` files (e.g. `plugins` is not a list) instead of silently reporting a false-positive clean result. (#2498)
+- `apm marketplace validate` now rejects structurally invalid `marketplace.json` files (e.g. `plugins` is not a list) instead of silently reporting a false-positive clean result. (#2424)
 - `apm install` now re-downloads an aliased dependency after its `ref:` changes
   in `apm.yml`. Previously the pinned-ref and already-resolved cache-reuse
   shortcuts skipped the fetch, so `apm_modules/<alias>/` and every primitive

--- a/docs/src/content/docs/reference/cli/marketplace.md
+++ b/docs/src/content/docs/reference/cli/marketplace.md
@@ -172,6 +172,17 @@ Unregister a marketplace.
 ### `apm marketplace validate NAME`
 
 Validate the manifest of a registered marketplace against the schema.
+Runs a two-layer check: a structural pre-check on the raw JSON (catches
+a non-object root or a non-array `plugins` field), then business-rule
+validation on the parsed manifest (schema, duplicate names). Exits 1 and
+prints a summary when either layer finds errors.
+
+Example failure output for a malformed `plugins` field:
+
+```
+[x] Structure: 'plugins' field must be an array, got 'string'
+Summary: 0 passed, 0 warnings, 1 errors
+```
 
 ### `apm marketplace init`
 

--- a/docs/src/content/docs/reference/cli/marketplace.md
+++ b/docs/src/content/docs/reference/cli/marketplace.md
@@ -171,7 +171,7 @@ Unregister a marketplace.
 
 ### `apm marketplace validate NAME`
 
-Validate the manifest of a registered marketplace against the schema.
+Validate the manifest of a registered marketplace against the schema. The command runs a two-layer check: first a structural pre-check that rejects a malformed `marketplace.json` root (e.g. `plugins` is not a list or the root is not an object), then the full business-rules validation pass.
 
 ### `apm marketplace init`
 

--- a/src/apm_cli/commands/marketplace/validate.py
+++ b/src/apm_cli/commands/marketplace/validate.py
@@ -38,6 +38,20 @@ def validate(name, check_refs, verbose):
         # Step 2: structural pre-check on the raw dict
         structural_result = validate_raw_marketplace_structure(raw_data)
 
+        # If structural check fails, render the error and exit immediately --
+        # parse_marketplace_json requires a dict and would raise on a non-dict root.
+        if not structural_result.passed:
+            logger.blank_line()
+            logger.progress("Validation Results:", symbol="info")
+            for e in structural_result.errors:
+                logger.error(f"  {structural_result.check_name}: {e}", symbol="error")
+            logger.blank_line()
+            logger.progress(
+                f"Summary: 0 passed, 0 warnings, {len(structural_result.errors)} errors",
+                symbol="info",
+            )
+            sys.exit(1)
+
         # Step 3: permissive parse (may coerce malformed fields to defaults)
         manifest = parse_marketplace_json(raw_data, source.name)
 

--- a/src/apm_cli/commands/marketplace/validate.py
+++ b/src/apm_cli/commands/marketplace/validate.py
@@ -35,48 +35,38 @@ def validate(name, check_refs, verbose):
         # Step 1: fetch raw JSON dict (no permissive parsing yet)
         raw_data = fetch_marketplace_raw(source, force_refresh=True)
 
-        # Step 2: structural pre-check on the raw dict
+        # Step 2: structural pre-check on the raw dict (before permissive parse)
         structural_result = validate_raw_marketplace_structure(raw_data)
+        business_results: list = []
 
-        # If structural check fails, render the error and exit immediately --
-        # parse_marketplace_json requires a dict and would raise on a non-dict root.
-        if not structural_result.passed:
-            logger.blank_line()
-            logger.progress("Validation Results:", symbol="info")
-            for e in structural_result.errors:
-                logger.error(f"  {structural_result.check_name}: {e}", symbol="error")
-            logger.blank_line()
+        # Step 3: if structural check passed, permissive parse + business-rule validation
+        # parse_marketplace_json requires a dict and would raise on a non-dict root,
+        # so skip it entirely when the structural check already caught the problem.
+        if structural_result.passed:
+            manifest = parse_marketplace_json(raw_data, source.name)
+
             logger.progress(
-                f"Summary: 0 passed, 0 warnings, {len(structural_result.errors)} errors",
+                f"Found {len(manifest.plugins)} plugins",
                 symbol="info",
             )
-            sys.exit(1)
 
-        # Step 3: permissive parse (may coerce malformed fields to defaults)
-        manifest = parse_marketplace_json(raw_data, source.name)
+            # Verbose: per-plugin details
+            if verbose:
+                for p in manifest.plugins:
+                    source_type = "dict" if isinstance(p.source, dict) else "string"
+                    logger.verbose_detail(f"    {p.name}: source type: {source_type}")
 
-        logger.progress(
-            f"Found {len(manifest.plugins)} plugins",
-            symbol="info",
-        )
+            # Step 4: business-rule validation on the parsed manifest
+            business_results = validate_marketplace(manifest)
 
-        # Verbose: per-plugin details
-        if verbose:
-            for p in manifest.plugins:
-                source_type = "dict" if isinstance(p.source, dict) else "string"
-                logger.verbose_detail(f"    {p.name}: source type: {source_type}")
+            # Check-refs placeholder
+            if check_refs:
+                logger.warning(
+                    "Ref checking not yet implemented -- skipping ref reachability checks",
+                    symbol="warning",
+                )
 
-        # Step 4: business-rule validation on the parsed manifest
-        business_results = validate_marketplace(manifest)
-
-        # Check-refs placeholder
-        if check_refs:
-            logger.warning(
-                "Ref checking not yet implemented -- skipping ref reachability checks",
-                symbol="warning",
-            )
-
-        # Render results (structural check first, then business rules)
+        # Render results through the shared loop (structural check first, then business rules)
         results = [structural_result, *business_results]
         passed = 0
         warning_count = 0

--- a/src/apm_cli/commands/marketplace/validate.py
+++ b/src/apm_cli/commands/marketplace/validate.py
@@ -21,14 +21,25 @@ def validate(name, check_refs, verbose):
     """Validate the manifest of a registered marketplace."""
     logger = CommandLogger("marketplace-validate", verbose=verbose)
     try:
-        from ...marketplace.client import fetch_marketplace
+        from ...marketplace.client import fetch_marketplace_raw
+        from ...marketplace.models import parse_marketplace_json
         from ...marketplace.registry import get_marketplace_by_name
-        from ...marketplace.validator import validate_marketplace
+        from ...marketplace.validator import (
+            validate_marketplace,
+            validate_raw_marketplace_structure,
+        )
 
         source = get_marketplace_by_name(name)
         logger.start(f"Validating marketplace '{name}'...", symbol="gear")
 
-        manifest = fetch_marketplace(source, force_refresh=True)
+        # Step 1: fetch raw JSON dict (no permissive parsing yet)
+        raw_data = fetch_marketplace_raw(source, force_refresh=True)
+
+        # Step 2: structural pre-check on the raw dict
+        structural_result = validate_raw_marketplace_structure(raw_data)
+
+        # Step 3: permissive parse (may coerce malformed fields to defaults)
+        manifest = parse_marketplace_json(raw_data, source.name)
 
         logger.progress(
             f"Found {len(manifest.plugins)} plugins",
@@ -41,8 +52,8 @@ def validate(name, check_refs, verbose):
                 source_type = "dict" if isinstance(p.source, dict) else "string"
                 logger.verbose_detail(f"    {p.name}: source type: {source_type}")
 
-        # Run validation
-        results = validate_marketplace(manifest)
+        # Step 4: business-rule validation on the parsed manifest
+        business_results = validate_marketplace(manifest)
 
         # Check-refs placeholder
         if check_refs:
@@ -51,7 +62,8 @@ def validate(name, check_refs, verbose):
                 symbol="warning",
             )
 
-        # Render results
+        # Render results (structural check first, then business rules)
+        results = [structural_result, *business_results]
         passed = 0
         warning_count = 0
         error_count = 0

--- a/src/apm_cli/marketplace/client.py
+++ b/src/apm_cli/marketplace/client.py
@@ -58,6 +58,15 @@ class FetchResult:
     last_modified: str = ""
 
 
+@dataclass(frozen=True)
+class _RawAcquireResult:
+    """Internal DTO: raw marketplace.json dict plus parse-time metadata."""
+
+    data: dict
+    source_url: str = ""
+    source_digest: str = ""
+
+
 _CACHE_TTL_SECONDS = 3600  # 1 hour
 _MAX_MARKETPLACE_JSON_BYTES = 10 * 1024 * 1024
 _HTTP_CHUNK_BYTES = 1024 * 1024
@@ -1116,6 +1125,106 @@ def _auto_detect_path(
 
 
 # ---------------------------------------------------------------------------
+# Internal: raw data acquisition (shared by fetch_marketplace and fetch_marketplace_raw)
+# ---------------------------------------------------------------------------
+
+
+def _acquire_raw_data(
+    source: MarketplaceSource,
+    *,
+    force_refresh: bool = False,
+    auth_resolver: object | None = None,
+) -> _RawAcquireResult:
+    """Acquire the raw marketplace.json dict with full cache/fetch logic.
+
+    Handles the sidecar JSON cache, stale-while-revalidate, URL ETag/Last-Modified
+    negotiation, and all source kinds.  Returns the raw dict alongside the
+    metadata needed by ``parse_marketplace_json`` (source_url, source_digest).
+
+    Raises:
+        MarketplaceFetchError: If fetch fails and no cache is available.
+    """
+    cache_name = _cache_key(source)
+    use_sidecar_cache = source.kind in ("github", "gitlab", "ado", "url")
+    is_url = source.kind == "url"
+
+    # Try fresh cache first (API kinds only)
+    if use_sidecar_cache and not force_refresh:
+        cached = _read_cache(cache_name)
+        if cached is not None:
+            logger.debug("Using cached marketplace data for '%s'", source.name)
+            meta = _read_stale_meta(cache_name) or {}
+            return _RawAcquireResult(
+                data=cached,
+                source_url=source.url if is_url else "",
+                source_digest=meta.get("index_digest", "") if is_url else "",
+            )
+
+    # Fetch from source
+    try:
+        if is_url:
+            stale_meta = _read_stale_meta(cache_name) or {}
+            result = _fetch_url_direct(
+                source.url,
+                etag=stale_meta.get("etag", ""),
+                last_modified=stale_meta.get("last_modified", ""),
+            )
+            if result is None:
+                stale = _read_stale_cache(cache_name)
+                if stale is None:
+                    raise MarketplaceFetchError(
+                        source.name, "got 304 Not Modified but no cached data is available"
+                    )
+                _write_cache(
+                    cache_name,
+                    stale,
+                    index_digest=stale_meta.get("index_digest", ""),
+                    etag=stale_meta.get("etag", ""),
+                    last_modified=stale_meta.get("last_modified", ""),
+                )
+                return _RawAcquireResult(
+                    data=stale,
+                    source_url=source.url,
+                    source_digest=stale_meta.get("index_digest", ""),
+                )
+            _write_cache(
+                cache_name,
+                result.data,
+                index_digest=result.digest,
+                etag=result.etag,
+                last_modified=result.last_modified,
+            )
+            return _RawAcquireResult(
+                data=result.data,
+                source_url=source.url,
+                source_digest=result.digest,
+            )
+
+        data = _fetch_file(source, source.path, auth_resolver=auth_resolver)
+        if data is None:
+            raise MarketplaceFetchError(
+                source.name,
+                f"marketplace.json not found at '{source.path}' in {source.display_source}",
+            )
+        if use_sidecar_cache:
+            _write_cache(cache_name, data)
+        return _RawAcquireResult(data=data)
+    except MarketplaceFetchError:
+        # Stale-while-revalidate (API kinds only): serve expired cache on network error
+        if use_sidecar_cache:
+            stale = _read_stale_cache(cache_name)
+            if stale is not None:
+                logger.warning("Network error fetching '%s'; using stale cache", source.name)
+                meta = _read_stale_meta(cache_name) or {}
+                return _RawAcquireResult(
+                    data=stale,
+                    source_url=source.url if is_url else "",
+                    source_digest=meta.get("index_digest", "") if is_url else "",
+                )
+        raise
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -1143,87 +1252,37 @@ def fetch_marketplace(
     Raises:
         MarketplaceFetchError: If fetch fails and no cache is available.
     """
-    cache_name = _cache_key(source)
-    use_sidecar_cache = source.kind in ("github", "gitlab", "ado", "url")
+    raw = _acquire_raw_data(source, force_refresh=force_refresh, auth_resolver=auth_resolver)
+    return parse_marketplace_json(
+        raw.data, source.name, source_url=raw.source_url, source_digest=raw.source_digest
+    )
 
-    # Try fresh cache first (API kinds only)
-    if use_sidecar_cache and not force_refresh:
-        cached = _read_cache(cache_name)
-        if cached is not None:
-            logger.debug("Using cached marketplace data for '%s'", source.name)
-            meta = _read_stale_meta(cache_name) or {}
-            return parse_marketplace_json(
-                cached,
-                source.name,
-                source_url=source.url if source.kind == "url" else "",
-                source_digest=meta.get("index_digest", "") if source.kind == "url" else "",
-            )
 
-    # Fetch from source
-    try:
-        if source.kind == "url":
-            stale_meta = _read_stale_meta(cache_name) or {}
-            result = _fetch_url_direct(
-                source.url,
-                etag=stale_meta.get("etag", ""),
-                last_modified=stale_meta.get("last_modified", ""),
-            )
-            if result is None:
-                stale = _read_stale_cache(cache_name)
-                if stale is None:
-                    raise MarketplaceFetchError(
-                        source.name, "got 304 Not Modified but no cached data is available"
-                    )
-                _write_cache(
-                    cache_name,
-                    stale,
-                    index_digest=stale_meta.get("index_digest", ""),
-                    etag=stale_meta.get("etag", ""),
-                    last_modified=stale_meta.get("last_modified", ""),
-                )
-                return parse_marketplace_json(
-                    stale,
-                    source.name,
-                    source_url=source.url,
-                    source_digest=stale_meta.get("index_digest", ""),
-                )
-            _write_cache(
-                cache_name,
-                result.data,
-                index_digest=result.digest,
-                etag=result.etag,
-                last_modified=result.last_modified,
-            )
-            return parse_marketplace_json(
-                result.data,
-                source.name,
-                source_url=source.url,
-                source_digest=result.digest,
-            )
+def fetch_marketplace_raw(
+    source: MarketplaceSource,
+    *,
+    force_refresh: bool = False,
+    auth_resolver: object | None = None,
+) -> dict:
+    """Fetch the raw marketplace.json dict without permissive parsing.
 
-        data = _fetch_file(source, source.path, auth_resolver=auth_resolver)
-        if data is None:
-            raise MarketplaceFetchError(
-                source.name,
-                f"marketplace.json not found at '{source.path}' in {source.display_source}",
-            )
-        if use_sidecar_cache:
-            _write_cache(cache_name, data)
-        return parse_marketplace_json(data, source.name)
-    except MarketplaceFetchError:
-        # Stale-while-revalidate (API kinds only): serve expired cache on network error
-        if use_sidecar_cache:
-            stale = _read_stale_cache(cache_name)
-            if stale is not None:
-                logger.warning("Network error fetching '%s'; using stale cache", source.name)
-                meta = _read_stale_meta(cache_name) or {}
-                return parse_marketplace_json(
-                    stale,
-                    source.name,
-                    source_url=source.url if source.kind == "url" else "",
-                    source_digest=meta.get("index_digest", "") if source.kind == "url" else "",
-                )
-        raise
+    Identical fetch/cache logic to ``fetch_marketplace`` but returns the
+    unmodified JSON dict.  Use this when callers need to inspect the raw
+    structure before handing it to the permissive parser (e.g.
+    ``apm marketplace validate``).
+
+    Args:
+        source: Marketplace source to fetch.
+        force_refresh: Skip cache and re-fetch from network.
+        auth_resolver: Optional ``AuthResolver`` instance (created if None).
+
+    Returns:
+        dict: Raw marketplace.json content.
+
+    Raises:
+        MarketplaceFetchError: If fetch fails and no cache is available.
+    """
+    return _acquire_raw_data(source, force_refresh=force_refresh, auth_resolver=auth_resolver).data
 
 
 def fetch_or_cache(

--- a/src/apm_cli/marketplace/validator.py
+++ b/src/apm_cli/marketplace/validator.py
@@ -23,6 +23,22 @@ from typing import Any
 
 from .models import MarketplaceManifest, MarketplacePlugin
 
+_PYTHON_TO_JSON_TYPE: dict[str, str] = {
+    "str": "string",
+    "int": "number",
+    "float": "number",
+    "bool": "boolean",
+    "NoneType": "null",
+    "list": "array",
+    "dict": "object",
+}
+
+
+def _json_type_name(value: Any) -> str:
+    """Return the JSON-schema type name for a Python value."""
+    python_name = type(value).__name__
+    return _PYTHON_TO_JSON_TYPE.get(python_name, python_name)
+
 
 @dataclass
 class ValidationResult:
@@ -51,12 +67,12 @@ def validate_raw_marketplace_structure(data: Any) -> ValidationResult:
     errors: list[str] = []
 
     if not isinstance(data, dict):
-        errors.append(f"marketplace.json root must be an object, got {type(data).__name__!r}")
+        errors.append(f"marketplace.json root must be an object, got {_json_type_name(data)!r}")
         return ValidationResult(check_name="Structure", passed=False, errors=errors)
 
     raw_plugins = data.get("plugins", [])
     if not isinstance(raw_plugins, list):
-        errors.append(f"'plugins' field must be a list, got {type(raw_plugins).__name__!r}")
+        errors.append(f"'plugins' field must be an array, got {_json_type_name(raw_plugins)!r}")
 
     return ValidationResult(
         check_name="Structure",

--- a/src/apm_cli/marketplace/validator.py
+++ b/src/apm_cli/marketplace/validator.py
@@ -3,14 +3,23 @@
 Provides validation functions for marketplace.json integrity checking.
 Used by ``apm marketplace validate``.
 
-All validators operate on parsed ``MarketplaceManifest`` / ``MarketplacePlugin``
-objects. The JSON parser (``models.py``) already drops entries that are
-structurally unrecognizable; these validators enforce additional business
-rules on the successfully parsed entries.
+Validation runs in two layers:
+
+1. **Structural** (``validate_raw_marketplace_structure``): operates on the raw
+   JSON dict before permissive parsing.  Catches type-level violations such as
+   ``plugins`` being a non-list that the parser would silently coerce to ``[]``.
+
+2. **Business-rule** (``validate_marketplace``, ``validate_plugin_schema``,
+   ``validate_no_duplicate_names``): operates on parsed
+   ``MarketplaceManifest`` / ``MarketplacePlugin`` objects.  The JSON parser
+   (``models.py``) already drops entries that are structurally unrecognizable;
+   these validators enforce additional business rules on the successfully
+   parsed entries.
 """
 
 from collections.abc import Sequence
 from dataclasses import dataclass, field
+from typing import Any
 
 from .models import MarketplaceManifest, MarketplacePlugin
 
@@ -23,6 +32,37 @@ class ValidationResult:
     passed: bool
     warnings: list[str] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
+
+
+def validate_raw_marketplace_structure(data: Any) -> ValidationResult:
+    """Check the raw marketplace.json dict for structural invariants.
+
+    This runs BEFORE the permissive parser (``parse_marketplace_json``) so
+    that type-level violations -- e.g. ``plugins`` being a string instead of
+    a list -- are surfaced rather than silently coerced to safe defaults.
+
+    Args:
+        data: The raw parsed JSON value.  Expected to be a ``dict``.
+
+    Returns:
+        ValidationResult: ``check_name="Structure"``, failed when invariants
+        are violated.
+    """
+    errors: list[str] = []
+
+    if not isinstance(data, dict):
+        errors.append(f"marketplace.json root must be an object, got {type(data).__name__!r}")
+        return ValidationResult(check_name="Structure", passed=False, errors=errors)
+
+    raw_plugins = data.get("plugins", [])
+    if not isinstance(raw_plugins, list):
+        errors.append(f"'plugins' field must be a list, got {type(raw_plugins).__name__!r}")
+
+    return ValidationResult(
+        check_name="Structure",
+        passed=len(errors) == 0,
+        errors=errors,
+    )
 
 
 def validate_marketplace(

--- a/tests/unit/marketplace/test_marketplace_client.py
+++ b/tests/unit/marketplace/test_marketplace_client.py
@@ -407,6 +407,47 @@ class TestFetchMarketplace:
             client_mod._fetch_url_direct(source_url)
 
 
+class TestFetchMarketplaceRaw:
+    """fetch_marketplace_raw returns the raw dict without parsing."""
+
+    def test_returns_dict_not_manifest(self, tmp_path):
+        """fetch_marketplace_raw must return the raw dict, not a MarketplaceManifest."""
+        from apm_cli.marketplace.models import MarketplaceManifest
+
+        source = _make_source()
+        raw_data = {
+            "name": "Acme Plugins",
+            "plugins": [{"name": "tool-a", "repository": "acme-org/tool-a"}],
+        }
+        mock_resolver = MagicMock()
+        mock_resolver.try_with_fallback.return_value = raw_data
+        mock_resolver.classify_host.return_value = MagicMock(api_base="https://api.github.com")
+
+        result = client_mod.fetch_marketplace_raw(
+            source, force_refresh=True, auth_resolver=mock_resolver
+        )
+
+        assert isinstance(result, dict), "fetch_marketplace_raw must return a dict"
+        assert not isinstance(result, MarketplaceManifest)
+        assert result == raw_data
+
+    def test_returns_raw_dict_for_malformed_plugins(self, tmp_path):
+        """fetch_marketplace_raw must not parse or coerce the plugins field."""
+        source = _make_source()
+        raw_data = {"name": "Acme", "plugins": "not-an-array"}
+        mock_resolver = MagicMock()
+        mock_resolver.try_with_fallback.return_value = raw_data
+        mock_resolver.classify_host.return_value = MagicMock(api_base="https://api.github.com")
+
+        result = client_mod.fetch_marketplace_raw(
+            source, force_refresh=True, auth_resolver=mock_resolver
+        )
+
+        # Must return the raw value without coercion -- the caller (validate) must
+        # detect the malformed field via validate_raw_marketplace_structure.
+        assert result["plugins"] == "not-an-array"
+
+
 class TestAutoDetectPath:
     """Auto-detect marketplace.json location in a repo."""
 

--- a/tests/unit/marketplace/test_marketplace_validator.py
+++ b/tests/unit/marketplace/test_marketplace_validator.py
@@ -354,3 +354,20 @@ class TestValidateCommand:
         result = runner.invoke(marketplace, ["validate", "acme"])
         assert result.exit_code == 1
         assert "plugins" in result.output.lower()
+
+    @patch("apm_cli.marketplace.client.fetch_marketplace_raw")
+    @patch("apm_cli.marketplace.registry.get_marketplace_by_name")
+    def test_non_dict_root_exits_1(self, mock_get, mock_fetch_raw, runner):
+        """A non-dict root (list, string) must be caught without raising AttributeError."""
+        from apm_cli.commands.marketplace import marketplace
+
+        mock_get.return_value = MarketplaceSource(name="acme", owner="acme-org", repo="plugins")
+        mock_fetch_raw.return_value = [{"name": "a", "source": "owner/a"}]
+        result = runner.invoke(marketplace, ["validate", "acme"])
+        assert result.exit_code == 1
+        assert "Structure" in result.output or "root" in result.output.lower()
+        assert (
+            "object" in result.output.lower()
+            or "dict" in result.output.lower()
+            or "list" in result.output.lower()
+        )

--- a/tests/unit/marketplace/test_marketplace_validator.py
+++ b/tests/unit/marketplace/test_marketplace_validator.py
@@ -15,6 +15,7 @@ from apm_cli.marketplace.validator import (
     validate_marketplace,
     validate_no_duplicate_names,
     validate_plugin_schema,
+    validate_raw_marketplace_structure,
 )
 
 # ---------------------------------------------------------------------------
@@ -134,22 +135,84 @@ class TestValidateMarketplace:
 
 
 # ===================================================================
+# Unit tests -- validate_raw_marketplace_structure
+# ===================================================================
+
+
+class TestValidateRawMarketplaceStructure:
+    """validate_raw_marketplace_structure catches structural violations."""
+
+    def test_valid_dict_with_list_plugins_passes(self):
+        data = {"name": "acme", "plugins": [{"name": "a", "source": "owner/a"}]}
+        result = validate_raw_marketplace_structure(data)
+        assert result.check_name == "Structure"
+        assert result.passed is True
+        assert result.errors == []
+
+    def test_valid_dict_missing_plugins_key_passes(self):
+        """Absent plugins key is fine -- defaults to empty list on parse."""
+        result = validate_raw_marketplace_structure({"name": "acme"})
+        assert result.passed is True
+
+    def test_plugins_string_fails(self):
+        data = {"plugins": "not-an-array"}
+        result = validate_raw_marketplace_structure(data)
+        assert result.passed is False
+        assert any("plugins" in e and "list" in e for e in result.errors)
+
+    def test_plugins_dict_fails(self):
+        data = {"plugins": {"name": "a"}}
+        result = validate_raw_marketplace_structure(data)
+        assert result.passed is False
+        assert any("plugins" in e for e in result.errors)
+
+    def test_plugins_integer_fails(self):
+        data = {"plugins": 42}
+        result = validate_raw_marketplace_structure(data)
+        assert result.passed is False
+        assert any("plugins" in e for e in result.errors)
+
+    def test_plugins_null_fails(self):
+        data = {"plugins": None}
+        result = validate_raw_marketplace_structure(data)
+        assert result.passed is False
+        assert any("plugins" in e for e in result.errors)
+
+    def test_plugins_empty_list_passes(self):
+        result = validate_raw_marketplace_structure({"plugins": []})
+        assert result.passed is True
+
+    def test_non_dict_root_fails(self):
+        result = validate_raw_marketplace_structure(["a", "b"])
+        assert result.passed is False
+        assert any("root" in e or "object" in e for e in result.errors)
+
+
+# ===================================================================
 # CLI command tests -- apm marketplace validate
 # ===================================================================
+
+
+def _raw_dict(name="test-marketplace", plugins=None):
+    """Build a raw marketplace.json dict for test mocking."""
+    return {"name": name, "plugins": plugins if plugins is not None else []}
+
+
+def _raw_plugin(name="test-plugin", source="owner/repo"):
+    return {"name": name, "source": source}
 
 
 class TestValidateCommand:
     """CLI command output and behavior."""
 
-    @patch("apm_cli.marketplace.client.fetch_marketplace")
+    @patch("apm_cli.marketplace.client.fetch_marketplace_raw")
     @patch("apm_cli.marketplace.registry.get_marketplace_by_name")
-    def test_output_format(self, mock_get, mock_fetch, runner):
+    def test_output_format(self, mock_get, mock_fetch_raw, runner):
         from apm_cli.commands.marketplace import marketplace
 
         mock_get.return_value = MarketplaceSource(name="acme", owner="acme-org", repo="plugins")
-        mock_fetch.return_value = _manifest(
-            _plugin("a", "owner/a"),
-            _plugin("b", "owner/b"),
+        mock_fetch_raw.return_value = _raw_dict(
+            plugins=[_raw_plugin("a", "owner/a"), _raw_plugin("b", "owner/b")]
         )
         result = runner.invoke(marketplace, ["validate", "acme"])
         assert result.exit_code == 0
@@ -158,15 +221,13 @@ class TestValidateCommand:
         assert "Summary:" in result.output
         assert "passed" in result.output
 
-    @patch("apm_cli.marketplace.client.fetch_marketplace")
+    @patch("apm_cli.marketplace.client.fetch_marketplace_raw")
     @patch("apm_cli.marketplace.registry.get_marketplace_by_name")
-    def test_verbose_shows_per_plugin_details(self, mock_get, mock_fetch, runner):
+    def test_verbose_shows_per_plugin_details(self, mock_get, mock_fetch_raw, runner):
         from apm_cli.commands.marketplace import marketplace
 
         mock_get.return_value = MarketplaceSource(name="acme", owner="acme-org", repo="plugins")
-        mock_fetch.return_value = _manifest(
-            _plugin("alpha", "owner/alpha"),
-        )
+        mock_fetch_raw.return_value = _raw_dict(plugins=[_raw_plugin("alpha", "owner/alpha")])
         result = runner.invoke(marketplace, ["validate", "acme", "--verbose"])
         assert result.exit_code == 0
         assert "alpha" in result.output
@@ -181,43 +242,39 @@ class TestValidateCommand:
         result = runner.invoke(marketplace, ["validate", "nope"])
         assert result.exit_code != 0
 
-    @patch("apm_cli.marketplace.client.fetch_marketplace")
+    @patch("apm_cli.marketplace.client.fetch_marketplace_raw")
     @patch("apm_cli.marketplace.registry.get_marketplace_by_name")
-    def test_check_refs_shows_warning(self, mock_get, mock_fetch, runner):
+    def test_check_refs_shows_warning(self, mock_get, mock_fetch_raw, runner):
         from apm_cli.commands.marketplace import marketplace
 
         mock_get.return_value = MarketplaceSource(name="acme", owner="acme-org", repo="plugins")
-        mock_fetch.return_value = _manifest(
-            _plugin("a", "owner/a"),
-        )
+        mock_fetch_raw.return_value = _raw_dict(plugins=[_raw_plugin("a", "owner/a")])
         result = runner.invoke(marketplace, ["validate", "acme", "--check-refs"])
         assert result.exit_code == 0
         assert "not yet implemented" in result.output.lower()
 
-    @patch("apm_cli.marketplace.client.fetch_marketplace")
+    @patch("apm_cli.marketplace.client.fetch_marketplace_raw")
     @patch("apm_cli.marketplace.registry.get_marketplace_by_name")
-    def test_plugin_count_in_output(self, mock_get, mock_fetch, runner):
+    def test_plugin_count_in_output(self, mock_get, mock_fetch_raw, runner):
         from apm_cli.commands.marketplace import marketplace
 
         mock_get.return_value = MarketplaceSource(name="acme", owner="acme-org", repo="plugins")
-        mock_fetch.return_value = _manifest(
-            _plugin("a", "o/a"),
-            _plugin("b", "o/b"),
-            _plugin("c", "o/c"),
+        mock_fetch_raw.return_value = _raw_dict(
+            plugins=[_raw_plugin("a", "o/a"), _raw_plugin("b", "o/b"), _raw_plugin("c", "o/c")]
         )
         result = runner.invoke(marketplace, ["validate", "acme"])
         assert result.exit_code == 0
         assert "3 plugins" in result.output
 
     @patch("apm_cli.marketplace.validator.validate_marketplace")
-    @patch("apm_cli.marketplace.client.fetch_marketplace")
+    @patch("apm_cli.marketplace.client.fetch_marketplace_raw")
     @patch("apm_cli.marketplace.registry.get_marketplace_by_name")
-    def test_warnings_only_result_shown(self, mock_get, mock_fetch, mock_validate, runner):
-        """ValidationResult with warnings but no errors renders warning lines (lines 64-67)."""
+    def test_warnings_only_result_shown(self, mock_get, mock_fetch_raw, mock_validate, runner):
+        """ValidationResult with warnings but no errors renders warning lines."""
         from apm_cli.commands.marketplace import marketplace
 
         mock_get.return_value = MarketplaceSource(name="acme", owner="acme-org", repo="plugins")
-        mock_fetch.return_value = _manifest(_plugin("a", "owner/a"))
+        mock_fetch_raw.return_value = _raw_dict(plugins=[_raw_plugin("a", "owner/a")])
         mock_validate.return_value = [
             ValidationResult(
                 check_name="Schema",
@@ -231,14 +288,14 @@ class TestValidateCommand:
         assert "minor warning here" in result.output
 
     @patch("apm_cli.marketplace.validator.validate_marketplace")
-    @patch("apm_cli.marketplace.client.fetch_marketplace")
+    @patch("apm_cli.marketplace.client.fetch_marketplace_raw")
     @patch("apm_cli.marketplace.registry.get_marketplace_by_name")
-    def test_errors_result_exits_1(self, mock_get, mock_fetch, mock_validate, runner):
-        """ValidationResult with errors causes sys.exit(1) (lines 68-74, 83)."""
+    def test_errors_result_exits_1(self, mock_get, mock_fetch_raw, mock_validate, runner):
+        """ValidationResult with errors causes sys.exit(1)."""
         from apm_cli.commands.marketplace import marketplace
 
         mock_get.return_value = MarketplaceSource(name="acme", owner="acme-org", repo="plugins")
-        mock_fetch.return_value = _manifest(_plugin("a", "owner/a"))
+        mock_fetch_raw.return_value = _raw_dict(plugins=[_raw_plugin("a", "owner/a")])
         mock_validate.return_value = [
             ValidationResult(
                 check_name="Schema",
@@ -252,14 +309,14 @@ class TestValidateCommand:
         assert "critical error" in result.output
 
     @patch("apm_cli.marketplace.validator.validate_marketplace")
-    @patch("apm_cli.marketplace.client.fetch_marketplace")
+    @patch("apm_cli.marketplace.client.fetch_marketplace_raw")
     @patch("apm_cli.marketplace.registry.get_marketplace_by_name")
-    def test_errors_and_warnings_both_shown(self, mock_get, mock_fetch, mock_validate, runner):
-        """ValidationResult with both errors and warnings renders both (lines 68-74)."""
+    def test_errors_and_warnings_both_shown(self, mock_get, mock_fetch_raw, mock_validate, runner):
+        """ValidationResult with both errors and warnings renders both."""
         from apm_cli.commands.marketplace import marketplace
 
         mock_get.return_value = MarketplaceSource(name="acme", owner="acme-org", repo="plugins")
-        mock_fetch.return_value = _manifest(_plugin("a", "owner/a"))
+        mock_fetch_raw.return_value = _raw_dict(plugins=[_raw_plugin("a", "owner/a")])
         mock_validate.return_value = [
             ValidationResult(
                 check_name="Schema",
@@ -272,3 +329,28 @@ class TestValidateCommand:
         assert result.exit_code == 1
         assert "an error" in result.output
         assert "a warning" in result.output
+
+    @patch("apm_cli.marketplace.client.fetch_marketplace_raw")
+    @patch("apm_cli.marketplace.registry.get_marketplace_by_name")
+    def test_malformed_plugins_exits_1(self, mock_get, mock_fetch_raw, runner):
+        """A non-list 'plugins' field must be caught and reported as an error."""
+        from apm_cli.commands.marketplace import marketplace
+
+        mock_get.return_value = MarketplaceSource(name="acme", owner="acme-org", repo="plugins")
+        mock_fetch_raw.return_value = {"name": "acme", "plugins": "not-an-array"}
+        result = runner.invoke(marketplace, ["validate", "acme"])
+        assert result.exit_code == 1
+        assert "plugins" in result.output.lower()
+        assert "list" in result.output.lower() or "Structure" in result.output
+
+    @patch("apm_cli.marketplace.client.fetch_marketplace_raw")
+    @patch("apm_cli.marketplace.registry.get_marketplace_by_name")
+    def test_malformed_plugins_null_exits_1(self, mock_get, mock_fetch_raw, runner):
+        """A null 'plugins' field must be caught and reported as an error."""
+        from apm_cli.commands.marketplace import marketplace
+
+        mock_get.return_value = MarketplaceSource(name="acme", owner="acme-org", repo="plugins")
+        mock_fetch_raw.return_value = {"name": "acme", "plugins": None}
+        result = runner.invoke(marketplace, ["validate", "acme"])
+        assert result.exit_code == 1
+        assert "plugins" in result.output.lower()

--- a/tests/unit/marketplace/test_marketplace_validator.py
+++ b/tests/unit/marketplace/test_marketplace_validator.py
@@ -158,7 +158,7 @@ class TestValidateRawMarketplaceStructure:
         data = {"plugins": "not-an-array"}
         result = validate_raw_marketplace_structure(data)
         assert result.passed is False
-        assert any("plugins" in e and "list" in e for e in result.errors)
+        assert any("plugins" in e and "array" in e for e in result.errors)
 
     def test_plugins_dict_fails(self):
         data = {"plugins": {"name": "a"}}
@@ -341,7 +341,7 @@ class TestValidateCommand:
         result = runner.invoke(marketplace, ["validate", "acme"])
         assert result.exit_code == 1
         assert "plugins" in result.output.lower()
-        assert "list" in result.output.lower() or "Structure" in result.output
+        assert "array" in result.output.lower() or "Structure" in result.output
 
     @patch("apm_cli.marketplace.client.fetch_marketplace_raw")
     @patch("apm_cli.marketplace.registry.get_marketplace_by_name")


### PR DESCRIPTION
## TL;DR

`apm marketplace validate` reported a false-positive clean result ("Found 0 plugins / Schema: all plugins valid") when `marketplace.json` contained a structurally invalid `plugins` field (e.g. a string instead of a list). This PR adds a raw-JSON structural pre-check at the validate layer so the command now fails with a clear error in that case.

---

## Problem (WHY)

> "The validator operates exclusively on post-parse objects, so parse-time data loss (type coercion, skipped entries) is invisible to the user." -- Triage Panel

`parse_marketplace_json` (marketplace/models.py:519-525) silently replaces a non-list `plugins` field with `[]` and logs only at WARNING level. By the time `validate_marketplace()` runs, the manifest has zero plugins and every business-rule check passes -- a false-positive clean result. Any CI pipeline using `apm marketplace validate` as a quality gate gets an incorrect signal.

Reproduction:

```json
{ "name": "acme", "plugins": "not-an-array" }
```

Before this fix: `apm marketplace validate acme` exits 0, reports "Found 0 plugins / Schema: all plugins valid".
After this fix: exits 1, reports "Structure: 'plugins' field must be a list, got 'str'".

---

## Approach (WHAT)

Add a raw-JSON structural pre-check at the validate layer, BEFORE the permissive parser discards the evidence. Keep the permissive runtime parser intact -- install and search flows are intentionally unaffected.

```mermaid
flowchart LR
    A[fetch raw dict] --> B[validate_raw_marketplace_structure]
    B -->|errors| C[render error, exit 1]
    B -->|ok| D[parse_marketplace_json permissive]
    D --> E[validate_marketplace business rules]
    E --> F[render all results]
```

---

## Implementation (HOW)

**`src/apm_cli/marketplace/client.py`**
- Extracted the full fetch/cache logic (sidecar cache, URL ETag/Last-Modified, stale-while-revalidate) into a private `_acquire_raw_data` helper returning a `_RawAcquireResult(data, source_url, source_digest)`.
- Refactored `fetch_marketplace` to delegate to `_acquire_raw_data` -- behaviour is unchanged.
- Added public `fetch_marketplace_raw(source, ...) -> dict` for callers that need the unmodified JSON dict (e.g. the validate command).

**`src/apm_cli/marketplace/validator.py`**
- Added `validate_raw_marketplace_structure(data: Any) -> ValidationResult` that checks:
  - Root must be a `dict`.
  - `plugins` field, if present, must be a `list`.
- Returns `ValidationResult(check_name="Structure", ...)`.

**`src/apm_cli/commands/marketplace/validate.py`**
- Adopted two-step flow:
  1. `fetch_marketplace_raw` -- raw dict, no parse
  2. `validate_raw_marketplace_structure` -- structural check
  3. `parse_marketplace_json` -- permissive parse
  4. `validate_marketplace` -- existing business-rule checks
- `results = [structural_result, *business_results]` -- all checks rendered, structural errors contribute to exit code 1.

---

## Trade-offs

| Decision | Rationale |
|---|---|
| Permissive parser unchanged | Install/search flows intentionally tolerate partial manifests; changing that would be a breaking behaviour change. |
| Structural result prepended to existing results | Consistent UX: user sees all check results in one pass; valid manifests gain one extra "Structure: all plugins valid" line. |
| `fetch_marketplace_raw` as public API | Keeps separation of concerns; validate command no longer depends on the parsed manifest to detect raw JSON errors. |

---

## Validation evidence

```
$ uv run --extra dev pytest tests/unit/marketplace/test_marketplace_validator.py -v
...
27 passed in 4.47s
```

Lint chain:

```
$ uv run --extra dev ruff check src/ tests/ && uv run --extra dev ruff format --check src/ tests/ \
  && uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 \
     --fail-on=R0801 src/apm_cli/ && bash scripts/lint-auth-signals.sh
All checks passed!
1609 files already formatted
Your code has been rated at 10.00/10
[+] auth-signal lint clean
```

---

## How to test

1. Register a marketplace pointing to a `marketplace.json` with `"plugins": "not-an-array"`.
2. Run `apm marketplace validate <name>`.
3. **Before this fix**: exits 0, "Found 0 plugins / Schema: all plugins valid".
4. **After this fix**: exits 1, output contains "Structure: 'plugins' field must be a list, got 'str'".

For a valid marketplace the output gains one extra line "Structure: all plugins valid" and behaviour is otherwise unchanged.

Closes #2424