### PR TITLE
fix(agent): rewrite deprecated VSCode tool names at Copilot deploy time (#2465)

### DIFF
--- a/.apm/instructions/architecture.instructions.md
+++ b/.apm/instructions/architecture.instructions.md
@@ -80,6 +80,7 @@ semicolon-delimited, and specific to the file(s) that own the fact.
 | APMPackage interpreted-manifest construction | models/apm_package.py (APMPackage.from_mapping) | `src/apm_cli/models/apm_package.py` |
 | Agent Plugin compatibility package projection | agent_plugins/projection.py (project_agent_plugin_package) | `src/apm_cli/agent_plugins/projection.py`; `src/apm_cli/models/validation.py` |
 | Network host literal parsing and loopback classification | utils/net.py (parse_host_address, is_loopback_host) | `src/apm_cli/utils/net.py` |
+| Copilot agent tool alias projection | integration/agent_integrator.py (_render_copilot_agent) | `src/apm_cli/integration/agent_integrator.py` |
 <!-- /canonical-owner-table -->
 
 Host + credential resolution includes public github.com anonymous-first ordering.

--- a/.github/instructions/architecture.instructions.md
+++ b/.github/instructions/architecture.instructions.md
@@ -80,6 +80,7 @@ semicolon-delimited, and specific to the file(s) that own the fact.
 | APMPackage interpreted-manifest construction | models/apm_package.py (APMPackage.from_mapping) | `src/apm_cli/models/apm_package.py` |
 | Agent Plugin compatibility package projection | agent_plugins/projection.py (project_agent_plugin_package) | `src/apm_cli/agent_plugins/projection.py`; `src/apm_cli/models/validation.py` |
 | Network host literal parsing and loopback classification | utils/net.py (parse_host_address, is_loopback_host) | `src/apm_cli/utils/net.py` |
+| Copilot agent tool alias projection | integration/agent_integrator.py (_render_copilot_agent) | `src/apm_cli/integration/agent_integrator.py` |
 <!-- /canonical-owner-table -->
 
 Host + credential resolution includes public github.com anonymous-first ordering.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `apm install --target copilot` now rewrites the six deprecated VSCode
+  Copilot built-in tool names (`askQuestions`, `runInTerminal`,
+  `getTerminalOutput`, `createFile`, `fetch`, `listDirectory`) to their
+  current namespaced equivalents in the deployed `.github/agents/` copy.
+  Package source files are never modified. Eliminates "Tool or toolset has
+  been renamed" IDE warnings without any source changes. (by
+  @sergio-sisternes-epam; closes #2465) (#2500)
 - Multi-target `apm compile` now avoids repeating expensive project analysis
   for each target, making multi-target runs scale like single-target runs
   without changing generated output. (closes #2482)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Windows binary is now Authenticode-signed in the release workflow, eliminating
   the `Trojan:Script/Wacatac.H!ml` Windows Defender false positive on unsigned
   PyInstaller bundles. (#2435)
+- `apm install --target copilot` now rewrites the six deprecated VSCode
+  Copilot built-in tool names (`askQuestions`, `runInTerminal`,
+  `getTerminalOutput`, `createFile`, `fetch`, `listDirectory`) to their
+  current namespaced equivalents in the deployed `.github/agents/` copy.
+  Package source files are never modified. Eliminates "Tool or toolset has
+  been renamed" IDE warnings without any source changes. (by
+  @sergio-sisternes-epam; closes #2465) (#2500)
 - Multi-target `apm compile` now avoids repeating expensive project analysis
   for each target, making multi-target runs scale like single-target runs
   without changing generated output. (closes #2482)

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -2783,7 +2783,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:ab625ab2263bde79d1b5fca67c69afdee1a07037a9a0507f39704378eefea9e6
+  content_hash: sha256:44e95b2e91221e49cc6cac05f2a629b15b988471f414f41bcd8e3499cbd3af7b
 - kind: project-relative
   target: copilot
   value: .github/instructions/changelog.instructions.md
@@ -3290,7 +3290,7 @@ local_deployed_file_hashes:
   .github/agents/spec-tag-architect.agent.md: sha256:82907265c5e7cf1ac61ad96866fa7c5683b69c8f09b7a4c5f3cc241acc9568ca
   .github/agents/supply-chain-security-expert.agent.md: sha256:8fb8cc426d6af17ba084a28b3f026c2b475b62e3ca63ed2f88b83bd823f877af
   .github/agents/test-coverage-expert.agent.md: sha256:48c2172d1f18a394fa83ef9dc2be0b9b921a4e51e976498165250fed66369711
-  .github/instructions/architecture.instructions.md: sha256:ab625ab2263bde79d1b5fca67c69afdee1a07037a9a0507f39704378eefea9e6
+  .github/instructions/architecture.instructions.md: sha256:44e95b2e91221e49cc6cac05f2a629b15b988471f414f41bcd8e3499cbd3af7b
   .github/instructions/changelog.instructions.md: sha256:1e51ec4c74e847967962bd279dc4c6e582c5d3578490b3c28d5f3acd3e05f73e
   .github/instructions/cicd.instructions.md: sha256:33201cb88ea2f34b4950a9b52f87dc8dfb682796aaf53068ba7ae406c0c5e2c2
   .github/instructions/cli.instructions.md: sha256:8e39e8d5047ce88575cb02f87c2bcede584dfef258bd86f7466c7badf136541a

--- a/docs/src/content/docs/producer/author-primitives/instructions-and-agents.md
+++ b/docs/src/content/docs/producer/author-primitives/instructions-and-agents.md
@@ -209,7 +209,7 @@ offending package and field so you can fix the source.
 
 | Target | Output path | Transform |
 |---|---|---|
-| copilot | `.github/agents/<name>.agent.md` | deprecated VSCode built-in tool names renamed to namespaced form; content otherwise verbatim |
+| copilot | `.github/agents/<name>.agent.md` | tool names rewritten; otherwise verbatim |
 | claude | `.claude/agents/<name>.md` | verbatim |
 | grok-build | `.grok/agents/<name>.md` | verbatim |
 | cursor | `.cursor/agents/<name>.md` | verbatim |
@@ -273,13 +273,14 @@ dedicated persona.
   info`). `apm install -t opencode` will warn at install time when
   it detects either shape; the file still deploys but OpenCode will
   refuse to load it.
-- **Old unnamespaced VSCode built-in tool names in a Copilot-targeted
+- **Deprecated VSCode built-in tool names in a Copilot-targeted
   agent.** VSCode Copilot renamed its built-in tools to a namespaced
-  format (e.g. `fetch` became `web/fetch`, `runInTerminal` became
-  `execute/runInTerminal`). APM automatically rewrites the six known
-  old names when deploying to the Copilot target, so you do not need
-  to update existing source files. If you author new agents, prefer
-  the current namespaced names to be explicit:
+  format. APM automatically rewrites the six known old names
+  (`askQuestions`, `runInTerminal`, `getTerminalOutput`, `createFile`,
+  `fetch`, `listDirectory`) when deploying to the Copilot target, so
+  you do not need to update existing source files. The match is
+  exact-string only -- a custom tool named `fetchData` is unaffected.
+  If you author new agents, prefer the current namespaced names:
   `vscode/askQuestions`, `execute/runInTerminal`,
   `execute/getTerminalOutput`, `edit/createFile`, `web/fetch`,
   `search/listDirectory`.

--- a/docs/src/content/docs/producer/author-primitives/instructions-and-agents.md
+++ b/docs/src/content/docs/producer/author-primitives/instructions-and-agents.md
@@ -209,7 +209,7 @@ offending package and field so you can fix the source.
 
 | Target | Output path | Transform |
 |---|---|---|
-| copilot | `.github/agents/<name>.agent.md` | verbatim |
+| copilot | `.github/agents/<name>.agent.md` | deprecated VSCode built-in tool names renamed to namespaced form; content otherwise verbatim |
 | claude | `.claude/agents/<name>.md` | verbatim |
 | grok-build | `.grok/agents/<name>.md` | verbatim |
 | cursor | `.cursor/agents/<name>.md` | verbatim |
@@ -273,6 +273,16 @@ dedicated persona.
   info`). `apm install -t opencode` will warn at install time when
   it detects either shape; the file still deploys but OpenCode will
   refuse to load it.
+- **Old unnamespaced VSCode built-in tool names in a Copilot-targeted
+  agent.** VSCode Copilot renamed its built-in tools to a namespaced
+  format (e.g. `fetch` became `web/fetch`, `runInTerminal` became
+  `execute/runInTerminal`). APM automatically rewrites the six known
+  old names when deploying to the Copilot target, so you do not need
+  to update existing source files. If you author new agents, prefer
+  the current namespaced names to be explicit:
+  `vscode/askQuestions`, `execute/runInTerminal`,
+  `execute/getTerminalOutput`, `edit/createFile`, `web/fetch`,
+  `search/listDirectory`.
 - **Agent body that re-states global instructions.** Agents inherit
   the workspace's compiled context. Restate only what the persona
   needs to *override* or *add*; do not duplicate `python-style`

--- a/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
@@ -438,7 +438,7 @@ For `target: copilot`, APM preserves the package source and rewrites only the
 deployed `.github/agents/` copy of these legacy built-in tool names:
 `askQuestions`, `runInTerminal`, `getTerminalOutput`, `createFile`, `fetch`,
 and `listDirectory`. Use the namespaced forms in new packages. Already
-namespaced, custom, and MCP tool names pass through unchanged.
+namespaced and non-matching custom or MCP tool names pass through unchanged.
 
 #### OpenCode target: frontmatter constraints
 

--- a/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
@@ -432,6 +432,14 @@ instructions: |
 ---
 ```
 
+#### Copilot tool-name compatibility
+
+For `target: copilot`, APM preserves the package source and rewrites only the
+deployed `.github/agents/` copy of these legacy built-in tool names:
+`askQuestions`, `runInTerminal`, `getTerminalOutput`, `createFile`, `fetch`,
+and `listDirectory`. Use the namespaced forms in new packages. Already
+namespaced, custom, and MCP tool names pass through unchanged.
+
 #### OpenCode target: frontmatter constraints
 
 OpenCode (`target: opencode`, deploys to `.opencode/agents/`) parses

--- a/scripts/check_diagnostic_ascii_owner.py
+++ b/scripts/check_diagnostic_ascii_owner.py
@@ -29,6 +29,7 @@ AGENT_DIAGNOSTIC_FUNCTIONS = {
     "AgentIntegrator._warn_codex_unverified_scope": True,
     "AgentIntegrator._warn_codex_tools_dropped": True,
     "AgentIntegrator._warn_opencode_frontmatter": False,
+    "AgentIntegrator._copy_github_agent": False,
 }
 ALLOWED_IDENTITY_DELEGATES = {
     "AgentIntegrator._warn_opencode_frontmatter": {"validate_opencode_frontmatter"},
@@ -133,7 +134,7 @@ def _diagnostic_calls(function: ast.AST) -> list[ast.Call]:
         for node in _walk_own_scope(function)
         if isinstance(node, ast.Call)
         and isinstance(node.func, ast.Attribute)
-        and node.func.attr in {"warn", "lossy_agent_compilation"}
+        and node.func.attr in {"warn", "lossy_agent_compilation", "info"}
     ]
 
 

--- a/scripts/check_diagnostic_ascii_owner.py
+++ b/scripts/check_diagnostic_ascii_owner.py
@@ -29,7 +29,6 @@ AGENT_DIAGNOSTIC_FUNCTIONS = {
     "AgentIntegrator._warn_codex_unverified_scope": True,
     "AgentIntegrator._warn_codex_tools_dropped": True,
     "AgentIntegrator._warn_opencode_frontmatter": False,
-    "AgentIntegrator._copy_github_agent": False,
 }
 ALLOWED_IDENTITY_DELEGATES = {
     "AgentIntegrator._warn_opencode_frontmatter": {"validate_opencode_frontmatter"},

--- a/scripts/lint-architecture-boundaries.sh
+++ b/scripts/lint-architecture-boundaries.sh
@@ -174,9 +174,22 @@ echo "[*] AC2: validate-before-mutate boundaries"
 generated_bundle_writer_output=$(python3 scripts/check_generated_bundle_text_writers.py 2>&1)
 generated_bundle_writer_status=$?
 if [ "$generated_bundle_writer_status" -ne 0 ]; then
-    echo "[x] Generated bundle metadata writes must use deterministic LF"
-    echo "$generated_bundle_writer_output"
-    violations=$((violations + 1))
+   echo "[x] Generated bundle metadata writes must use deterministic LF"
+   echo "$generated_bundle_writer_output"
+   violations=$((violations + 1))
+fi
+copilot_agent_owner="src/apm_cli/integration/agent_integrator.py"
+copilot_agent_projection_count=$(grep -Ec \
+   '^    def _render_copilot_agent\(' "$copilot_agent_owner" || true)
+copilot_agent_alias_map_count=$(grep -REh --include='*.py' \
+   '^GITHUB_AGENT_TOOL_RENAMES[[:space:]]*[:=]' src/apm_cli | wc -l | tr -d ' ')
+copilot_agent_projection_calls=$(grep -Fc '_render_copilot_agent(' "$copilot_agent_owner" || true)
+if [ "$copilot_agent_projection_count" -ne 1 ] \
+   || [ "$copilot_agent_alias_map_count" -ne 1 ] \
+   || [ "$copilot_agent_projection_calls" -ne 3 ] \
+   || grep -q '_copy_github_agent' "$copilot_agent_owner"; then
+   echo "[x] Copilot agent tool aliases must use AgentIntegrator's single rendered projection"
+   violations=$((violations + 1))
 fi
 compiled_write_hits=$(
     grep -rEn \

--- a/src/apm_cli/integration/agent_integrator.py
+++ b/src/apm_cli/integration/agent_integrator.py
@@ -414,6 +414,7 @@ class AgentIntegrator(BaseIntegrator):
             if isinstance(token, yaml.tokens.ScalarToken)
         ]
         replacements: list[tuple[int, int, str]] = []
+        handled_ranges: set[tuple[int, int]] = set()
         for tool in tools_node.value:
             if not isinstance(tool, yaml.ScalarNode) or tool.value not in GITHUB_AGENT_TOOL_RENAMES:
                 continue
@@ -431,12 +432,14 @@ class AgentIntegrator(BaseIntegrator):
             )
             if scalar_token is None:
                 continue
+            scalar_range = (scalar_token.start_mark.index, scalar_token.end_mark.index)
+            if scalar_range in handled_ranges:
+                continue
+            handled_ranges.add(scalar_range)
             replacement = GITHUB_AGENT_TOOL_RENAMES[tool.value]
             if scalar_token.style in {"'", '"'}:
                 replacement = f"{scalar_token.style}{replacement}{scalar_token.style}"
-            replacements.append(
-                (scalar_token.start_mark.index, scalar_token.end_mark.index, replacement)
-            )
+            replacements.append((*scalar_range, replacement))
         if not replacements:
             return content
         frontmatter = fm_match.group(1)

--- a/src/apm_cli/integration/agent_integrator.py
+++ b/src/apm_cli/integration/agent_integrator.py
@@ -25,6 +25,22 @@ if TYPE_CHECKING:
     from apm_cli.integration.targets import TargetProfile
     from apm_cli.utils.diagnostics import DiagnosticCollector
 
+# Renamed VSCode Copilot built-in tool names.
+# VSCode Copilot migrated built-in tool identifiers to a namespaced format.
+# Any *.agent.md file deployed to the copilot target has these old names
+# rewritten automatically so the IDE does not emit "Tool or toolset has been
+# renamed" warnings.  Only the tools list in the YAML frontmatter is affected;
+# the source package file is never modified.
+# Ref: https://github.com/microsoft/apm/issues/2465
+GITHUB_AGENT_TOOL_RENAMES: dict[str, str] = {
+    "askQuestions": "vscode/askQuestions",
+    "runInTerminal": "execute/runInTerminal",
+    "getTerminalOutput": "execute/getTerminalOutput",
+    "createFile": "edit/createFile",
+    "fetch": "web/fetch",
+    "listDirectory": "search/listDirectory",
+}
+
 # Kiro capability tags approved for agent 'tools' frontmatter.
 # Source: https://kiro.dev/docs/custom-agents/ (accessed 2026-08-03)
 # Fail closed: any value not in this set blocks deployment of that agent.
@@ -238,6 +254,8 @@ class AgentIntegrator(BaseIntegrator):
                     package_name=package_info.package.name,
                 )
                 links_resolved = 0
+            elif mapping.format_id == "github_agent":
+                links_resolved = self._copy_github_agent(source_file, target_path)
             else:
                 if mapping.format_id == "opencode_agent":
                     self._warn_opencode_frontmatter(
@@ -317,6 +335,68 @@ class AgentIntegrator(BaseIntegrator):
         if source.is_symlink():
             raise ValueError(f"Refusing to read symlink source: {source}")
         content = source.read_text(encoding="utf-8")
+        content, links_resolved = self.resolve_links(content, source, target)
+        write_text_lf(target, content)
+        return links_resolved
+
+    # ------------------------------------------------------------------
+    # GitHub (Copilot) agent transformer -- tool name rewrite
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _apply_github_agent_tool_renames(content: str) -> str:
+        """Rewrite deprecated VSCode built-in tool names in a github_agent file.
+
+        Applies GITHUB_AGENT_TOOL_RENAMES to every entry in the YAML
+        frontmatter ``tools:`` list.  All other frontmatter fields and the
+        entire markdown body are left completely unchanged.  Returns the
+        original *content* unchanged when:
+
+        - the file has no YAML frontmatter
+        - the frontmatter is unparseable
+        - there is no ``tools:`` key
+        - ``tools:`` is null or not a list
+        - no entry in the list matches a known rename
+        """
+        fm_match = AgentIntegrator._FRONTMATTER_RE.match(content)
+        if not fm_match:
+            return content
+        try:
+            fm = load_yaml_str(fm_match.group(1)) or {}
+        except yaml.YAMLError:
+            return content
+        if not isinstance(fm, dict):
+            return content
+        tools_raw = fm.get("tools")
+        if not isinstance(tools_raw, list):
+            return content
+        renamed = [GITHUB_AGENT_TOOL_RENAMES.get(str(t), str(t)) for t in tools_raw]
+        if renamed == [str(t) for t in tools_raw]:
+            return content
+        fm["tools"] = renamed
+        body = content[fm_match.end() :]
+        fm_text = yaml_to_str(fm)
+        return f"---\n{fm_text}---\n{body}"
+
+    def _copy_github_agent(self, source: Path, target: Path) -> int:
+        """Copy a github_agent file, rewriting deprecated tool names.
+
+        Like :meth:`copy_agent` but applies
+        :meth:`_apply_github_agent_tool_renames` before link resolution so
+        that deployed ``*.agent.md`` files use the current VSCode namespaced
+        tool identifiers.
+
+        Args:
+            source: Source ``.agent.md`` file path.
+            target: Destination path under ``.github/agents/``.
+
+        Returns:
+            int: Number of context links resolved.
+        """
+        if source.is_symlink():
+            raise ValueError(f"Refusing to read symlink source: {source}")
+        content = source.read_text(encoding="utf-8")
+        content = self._apply_github_agent_tool_renames(content)
         content, links_resolved = self.resolve_links(content, source, target)
         write_text_lf(target, content)
         return links_resolved
@@ -721,7 +801,7 @@ class AgentIntegrator(BaseIntegrator):
                 ):
                     files_skipped += 1
                     continue
-                links_resolved = self.copy_agent(source_file, target_path)
+                links_resolved = self._copy_github_agent(source_file, target_path)
                 total_links_resolved += links_resolved
                 files_integrated += 1
                 target_paths.append(target_path)

--- a/src/apm_cli/integration/agent_integrator.py
+++ b/src/apm_cli/integration/agent_integrator.py
@@ -255,7 +255,12 @@ class AgentIntegrator(BaseIntegrator):
                 )
                 links_resolved = 0
             elif mapping.format_id == "github_agent":
-                links_resolved = self._copy_github_agent(source_file, target_path)
+                links_resolved = self._copy_github_agent(
+                    source_file,
+                    target_path,
+                    diagnostics=diagnostics,
+                    package_name=package_info.package.name,
+                )
             else:
                 if mapping.format_id == "opencode_agent":
                     self._warn_opencode_frontmatter(
@@ -388,7 +393,13 @@ class AgentIntegrator(BaseIntegrator):
         fm_text = yaml_to_str(fm)
         return f"---\n{fm_text}---\n{body}"
 
-    def _copy_github_agent(self, source: Path, target: Path) -> int:
+    def _copy_github_agent(
+        self,
+        source: Path,
+        target: Path,
+        diagnostics: DiagnosticCollector | None = None,
+        package_name: str = "",
+    ) -> int:
         """Copy a github_agent file, rewriting deprecated tool names.
 
         Like :meth:`copy_agent` but applies
@@ -396,9 +407,14 @@ class AgentIntegrator(BaseIntegrator):
         that deployed ``*.agent.md`` files use the current VSCode namespaced
         tool identifiers.
 
+        When ``diagnostics`` is supplied and renames occur, an info-level
+        diagnostic is emitted naming the file and the count of rewrites.
+
         Args:
             source: Source ``.agent.md`` file path.
             target: Destination path under ``.github/agents/``.
+            diagnostics: Optional collector for user-visible messages.
+            package_name: Package name for diagnostic context.
 
         Returns:
             int: Number of context links resolved.
@@ -406,8 +422,17 @@ class AgentIntegrator(BaseIntegrator):
         if source.is_symlink():
             raise ValueError(f"Refusing to read symlink source: {source}")
         content = source.read_text(encoding="utf-8")
-        content = self._apply_github_agent_tool_renames(content)
-        content, links_resolved = self.resolve_links(content, source, target)
+        renamed = self._apply_github_agent_tool_renames(content)
+        if renamed is not content and diagnostics is not None:
+            count = sum(1 for old in GITHUB_AGENT_TOOL_RENAMES if old in content)
+            diagnostics.info(
+                message=(
+                    f"{source.name}: rewrote {count} deprecated"
+                    f" VSCode tool name(s) to namespaced form"
+                ),
+                package=printable_ascii_text(package_name),
+            )
+        content, links_resolved = self.resolve_links(renamed, source, target)
         write_text_lf(target, content)
         return links_resolved
 
@@ -811,7 +836,12 @@ class AgentIntegrator(BaseIntegrator):
                 ):
                     files_skipped += 1
                     continue
-                links_resolved = self._copy_github_agent(source_file, target_path)
+                links_resolved = self._copy_github_agent(
+                    source_file,
+                    target_path,
+                    diagnostics=diagnostics,
+                    package_name=package_info.package.name,
+                )
                 total_links_resolved += links_resolved
                 files_integrated += 1
                 target_paths.append(target_path)

--- a/src/apm_cli/integration/agent_integrator.py
+++ b/src/apm_cli/integration/agent_integrator.py
@@ -378,10 +378,9 @@ class AgentIntegrator(BaseIntegrator):
 
         Applies GITHUB_AGENT_TOOL_RENAMES to every string entry in the YAML
         frontmatter ``tools:`` list.  Non-string entries (mappings, sequences,
-        etc.) are preserved as-is without coercion.  Other frontmatter field
-        *values* are semantically preserved, but their serialisation formatting
-        (quoting style, key order) may change due to the YAML roundtrip.  The
-        markdown body is byte-for-byte unchanged.  Returns the original
+        etc.) are preserved as-is without coercion. Only the exact scalar
+        ranges for renamed aliases change; all other frontmatter and the
+        markdown body remain byte-for-byte unchanged. Returns the original
         *content* unchanged when:
 
         - the file has no YAML frontmatter
@@ -394,28 +393,52 @@ class AgentIntegrator(BaseIntegrator):
         if not fm_match:
             return content
         try:
-            fm = load_yaml_str(fm_match.group(1)) or {}
+            document = yaml.compose(fm_match.group(1))
         except yaml.YAMLError:
             return content
-        if not isinstance(fm, dict):
+        if not isinstance(document, yaml.MappingNode):
             return content
-        tools_raw = fm.get("tools")
-        if not isinstance(tools_raw, list):
+        tools_node = next(
+            (
+                value
+                for key, value in document.value
+                if isinstance(key, yaml.ScalarNode) and key.value == "tools"
+            ),
+            None,
+        )
+        if not isinstance(tools_node, yaml.SequenceNode):
             return content
-        any_renamed = False
-        renamed = []
-        for t in tools_raw:
-            if isinstance(t, str) and t in GITHUB_AGENT_TOOL_RENAMES:
-                renamed.append(GITHUB_AGENT_TOOL_RENAMES[t])
-                any_renamed = True
-            else:
-                renamed.append(t)
-        if not any_renamed:
+        scalar_tokens = [
+            token for token in yaml.scan(fm_match.group(1)) if isinstance(token, yaml.tokens.ScalarToken)
+        ]
+        replacements: list[tuple[int, int, str]] = []
+        for tool in tools_node.value:
+            if not isinstance(tool, yaml.ScalarNode) or tool.value not in GITHUB_AGENT_TOOL_RENAMES:
+                continue
+            scalar_token = next(
+                (
+                    token
+                    for token in scalar_tokens
+                    if (
+                        token.value == tool.value
+                        and tool.start_mark.index <= token.start_mark.index
+                        and token.end_mark.index <= tool.end_mark.index
+                    )
+                ),
+                None,
+            )
+            if scalar_token is None:
+                continue
+            replacement = GITHUB_AGENT_TOOL_RENAMES[tool.value]
+            if scalar_token.style in {"'", '"'}:
+                replacement = f"{scalar_token.style}{replacement}{scalar_token.style}"
+            replacements.append((scalar_token.start_mark.index, scalar_token.end_mark.index, replacement))
+        if not replacements:
             return content
-        fm["tools"] = renamed
-        body = content[fm_match.end() :]
-        fm_text = yaml_to_str(fm)
-        return f"---\n{fm_text}---\n{body}"
+        frontmatter = fm_match.group(1)
+        for start, end, replacement in reversed(replacements):
+            frontmatter = f"{frontmatter[:start]}{replacement}{frontmatter[end:]}"
+        return f"{content[:fm_match.start(1)]}{frontmatter}{content[fm_match.end(1):]}"
 
     def _render_copilot_agent(
         self,

--- a/src/apm_cli/integration/agent_integrator.py
+++ b/src/apm_cli/integration/agent_integrator.py
@@ -231,12 +231,30 @@ class AgentIntegrator(BaseIntegrator):
                 target_paths.append(target_path)
                 continue
 
-            # Non-kiro path: eager mkdir (existing behavior preserved).
+            rel_path = portable_relpath(target_path, project_root)
+            if mapping.format_id == "github_agent":
+                rendered, links_resolved = self._render_copilot_agent(source_file, target_path)
+                if self.try_adopt_rendered(target_path, rendered, target_paths):
+                    files_adopted += 1
+                    continue
+                if self.check_collision(
+                    target_path, rel_path, managed_files, force, diagnostics=diagnostics
+                ):
+                    files_skipped += 1
+                    continue
+                if not agents_dir_created:
+                    agents_dir.mkdir(parents=True, exist_ok=True)
+                    agents_dir_created = True
+                write_text_lf(target_path, rendered)
+                total_links_resolved += links_resolved
+                files_integrated += 1
+                target_paths.append(target_path)
+                continue
+
+            # Non-Kiro/Copilot paths retain the source-file adoption contract.
             if not agents_dir_created:
                 agents_dir.mkdir(parents=True, exist_ok=True)
                 agents_dir_created = True
-
-            rel_path = portable_relpath(target_path, project_root)
 
             skip, adopted = self._check_adopt_or_skip(
                 target_path, source_file, rel_path, managed_files, force, diagnostics, target_paths
@@ -256,13 +274,6 @@ class AgentIntegrator(BaseIntegrator):
                     package_name=package_info.package.name,
                 )
                 links_resolved = 0
-            elif mapping.format_id == "github_agent":
-                links_resolved = self._copy_github_agent(
-                    source_file,
-                    target_path,
-                    diagnostics=diagnostics,
-                    package_name=package_info.package.name,
-                )
             else:
                 if mapping.format_id == "opencode_agent":
                     self._warn_opencode_frontmatter(
@@ -406,49 +417,29 @@ class AgentIntegrator(BaseIntegrator):
         fm_text = yaml_to_str(fm)
         return f"---\n{fm_text}---\n{body}"
 
-    def _copy_github_agent(
+    def _render_copilot_agent(
         self,
         source: Path,
         target: Path,
-        diagnostics: DiagnosticCollector | None = None,
-        package_name: str = "",
-    ) -> int:
-        """Copy a github_agent file, rewriting deprecated tool names.
+    ) -> tuple[str, int]:
+        """Render the sole Copilot projection for an agent source file.
 
-        Delegates the read/resolve/write pipeline to :meth:`copy_agent` via
-        its ``pre_transform`` hook so that security checks (symlink guard) and
-        link resolution live in exactly one place.
-
-        When ``diagnostics`` is supplied and renames occur, an info-level
-        diagnostic is emitted naming the file and the count of rewrites.
+        The returned artifact is used for both adoption comparison and writing.
+        This keeps a transformed Copilot deployment idempotent while leaving
+        package source bytes and all other target projections untouched.
 
         Args:
             source: Source ``.agent.md`` file path.
             target: Destination path under ``.github/agents/``.
-            diagnostics: Optional collector for user-visible messages.
-            package_name: Package name for diagnostic context.
 
         Returns:
-            int: Number of context links resolved.
+            The rendered content and number of resolved context links.
         """
-        rename_count: list[int] = [0]
-
-        def _transform(content: str) -> str:
-            renamed = self._apply_github_agent_tool_renames(content)
-            if renamed is not content:
-                rename_count[0] = sum(1 for old in GITHUB_AGENT_TOOL_RENAMES if old in content)
-            return renamed
-
-        links_resolved = self.copy_agent(source, target, pre_transform=_transform)
-        if rename_count[0] and diagnostics is not None:
-            diagnostics.info(
-                message=(
-                    f"{printable_ascii_text(source.name)}: rewrote {rename_count[0]} deprecated"
-                    f" VSCode tool name(s) to namespaced form"
-                ),
-                package=printable_ascii_text(package_name),
-            )
-        return links_resolved
+        if source.is_symlink():
+            raise ValueError(f"Refusing to read symlink source: {source}")
+        content = source.read_text(encoding="utf-8")
+        content = self._apply_github_agent_tool_renames(content)
+        return self.resolve_links(content, source, target)
 
     # ------------------------------------------------------------------
     # OpenCode validate-and-warn (Phase 1 of #581)
@@ -840,9 +831,8 @@ class AgentIntegrator(BaseIntegrator):
                 continue
             rel_path = portable_relpath(target_path, project_root)
 
-            if self.try_adopt_identical(
-                target_path, source_file, target_paths, lf_normalized_deploy=True
-            ):
+            rendered, links_resolved = self._render_copilot_agent(source_file, target_path)
+            if self.try_adopt_rendered(target_path, rendered, target_paths):
                 files_adopted += 1
             else:
                 if self.check_collision(
@@ -850,12 +840,7 @@ class AgentIntegrator(BaseIntegrator):
                 ):
                     files_skipped += 1
                     continue
-                links_resolved = self._copy_github_agent(
-                    source_file,
-                    target_path,
-                    diagnostics=diagnostics,
-                    package_name=package_info.package.name,
-                )
+                write_text_lf(target_path, rendered)
                 total_links_resolved += links_resolved
                 files_integrated += 1
                 target_paths.append(target_path)

--- a/src/apm_cli/integration/agent_integrator.py
+++ b/src/apm_cli/integration/agent_integrator.py
@@ -347,16 +347,19 @@ class AgentIntegrator(BaseIntegrator):
     def _apply_github_agent_tool_renames(content: str) -> str:
         """Rewrite deprecated VSCode built-in tool names in a github_agent file.
 
-        Applies GITHUB_AGENT_TOOL_RENAMES to every entry in the YAML
-        frontmatter ``tools:`` list.  All other frontmatter fields and the
-        entire markdown body are left completely unchanged.  Returns the
-        original *content* unchanged when:
+        Applies GITHUB_AGENT_TOOL_RENAMES to every string entry in the YAML
+        frontmatter ``tools:`` list.  Non-string entries (mappings, sequences,
+        etc.) are preserved as-is without coercion.  Other frontmatter field
+        *values* are semantically preserved, but their serialisation formatting
+        (quoting style, key order) may change due to the YAML roundtrip.  The
+        markdown body is byte-for-byte unchanged.  Returns the original
+        *content* unchanged when:
 
         - the file has no YAML frontmatter
         - the frontmatter is unparseable
         - there is no ``tools:`` key
         - ``tools:`` is null or not a list
-        - no entry in the list matches a known rename
+        - no string entry in the list matches a known rename
         """
         fm_match = AgentIntegrator._FRONTMATTER_RE.match(content)
         if not fm_match:
@@ -370,8 +373,15 @@ class AgentIntegrator(BaseIntegrator):
         tools_raw = fm.get("tools")
         if not isinstance(tools_raw, list):
             return content
-        renamed = [GITHUB_AGENT_TOOL_RENAMES.get(str(t), str(t)) for t in tools_raw]
-        if renamed == [str(t) for t in tools_raw]:
+        any_renamed = False
+        renamed = []
+        for t in tools_raw:
+            if isinstance(t, str) and t in GITHUB_AGENT_TOOL_RENAMES:
+                renamed.append(GITHUB_AGENT_TOOL_RENAMES[t])
+                any_renamed = True
+            else:
+                renamed.append(t)
+        if not any_renamed:
             return content
         fm["tools"] = renamed
         body = content[fm_match.end() :]

--- a/src/apm_cli/integration/agent_integrator.py
+++ b/src/apm_cli/integration/agent_integrator.py
@@ -427,7 +427,7 @@ class AgentIntegrator(BaseIntegrator):
             count = sum(1 for old in GITHUB_AGENT_TOOL_RENAMES if old in content)
             diagnostics.info(
                 message=(
-                    f"{source.name}: rewrote {count} deprecated"
+                    f"{printable_ascii_text(source.name)}: rewrote {count} deprecated"
                     f" VSCode tool name(s) to namespaced form"
                 ),
                 package=printable_ascii_text(package_name),

--- a/src/apm_cli/integration/agent_integrator.py
+++ b/src/apm_cli/integration/agent_integrator.py
@@ -409,7 +409,9 @@ class AgentIntegrator(BaseIntegrator):
         if not isinstance(tools_node, yaml.SequenceNode):
             return content
         scalar_tokens = [
-            token for token in yaml.scan(fm_match.group(1)) if isinstance(token, yaml.tokens.ScalarToken)
+            token
+            for token in yaml.scan(fm_match.group(1))
+            if isinstance(token, yaml.tokens.ScalarToken)
         ]
         replacements: list[tuple[int, int, str]] = []
         for tool in tools_node.value:
@@ -432,13 +434,15 @@ class AgentIntegrator(BaseIntegrator):
             replacement = GITHUB_AGENT_TOOL_RENAMES[tool.value]
             if scalar_token.style in {"'", '"'}:
                 replacement = f"{scalar_token.style}{replacement}{scalar_token.style}"
-            replacements.append((scalar_token.start_mark.index, scalar_token.end_mark.index, replacement))
+            replacements.append(
+                (scalar_token.start_mark.index, scalar_token.end_mark.index, replacement)
+            )
         if not replacements:
             return content
         frontmatter = fm_match.group(1)
         for start, end, replacement in reversed(replacements):
             frontmatter = f"{frontmatter[:start]}{replacement}{frontmatter[end:]}"
-        return f"{content[:fm_match.start(1)]}{frontmatter}{content[fm_match.end(1):]}"
+        return f"{content[: fm_match.start(1)]}{frontmatter}{content[fm_match.end(1) :]}"
 
     def _render_copilot_agent(
         self,

--- a/src/apm_cli/integration/agent_integrator.py
+++ b/src/apm_cli/integration/agent_integrator.py
@@ -22,6 +22,8 @@ from apm_cli.utils.paths import portable_relpath
 from apm_cli.utils.yaml_io import load_yaml_str, yaml_to_str
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from apm_cli.integration.targets import TargetProfile
     from apm_cli.utils.diagnostics import DiagnosticCollector
 
@@ -327,19 +329,30 @@ class AgentIntegrator(BaseIntegrator):
             KNOWN_TARGETS["copilot"],
         )
 
-    def copy_agent(self, source: Path, target: Path) -> int:
-        """Copy agent file verbatim, resolving context links.
+    def copy_agent(
+        self,
+        source: Path,
+        target: Path,
+        pre_transform: Callable[[str], str] | None = None,
+    ) -> int:
+        """Copy agent file, resolving context links.
 
         Args:
-            source: Source file path
-            target: Target file path
+            source: Source file path.
+            target: Target file path.
+            pre_transform: Optional callable applied to the raw file content
+                before link resolution.  Use this to inject format-specific
+                transforms (e.g. tool-name rewriting) without duplicating the
+                read/resolve/write body in each format helper.
 
         Returns:
-            int: Number of links resolved
+            int: Number of links resolved.
         """
         if source.is_symlink():
             raise ValueError(f"Refusing to read symlink source: {source}")
         content = source.read_text(encoding="utf-8")
+        if pre_transform is not None:
+            content = pre_transform(content)
         content, links_resolved = self.resolve_links(content, source, target)
         write_text_lf(target, content)
         return links_resolved
@@ -402,10 +415,9 @@ class AgentIntegrator(BaseIntegrator):
     ) -> int:
         """Copy a github_agent file, rewriting deprecated tool names.
 
-        Like :meth:`copy_agent` but applies
-        :meth:`_apply_github_agent_tool_renames` before link resolution so
-        that deployed ``*.agent.md`` files use the current VSCode namespaced
-        tool identifiers.
+        Delegates the read/resolve/write pipeline to :meth:`copy_agent` via
+        its ``pre_transform`` hook so that security checks (symlink guard) and
+        link resolution live in exactly one place.
 
         When ``diagnostics`` is supplied and renames occur, an info-level
         diagnostic is emitted naming the file and the count of rewrites.
@@ -419,21 +431,23 @@ class AgentIntegrator(BaseIntegrator):
         Returns:
             int: Number of context links resolved.
         """
-        if source.is_symlink():
-            raise ValueError(f"Refusing to read symlink source: {source}")
-        content = source.read_text(encoding="utf-8")
-        renamed = self._apply_github_agent_tool_renames(content)
-        if renamed is not content and diagnostics is not None:
-            count = sum(1 for old in GITHUB_AGENT_TOOL_RENAMES if old in content)
+        rename_count: list[int] = [0]
+
+        def _transform(content: str) -> str:
+            renamed = self._apply_github_agent_tool_renames(content)
+            if renamed is not content:
+                rename_count[0] = sum(1 for old in GITHUB_AGENT_TOOL_RENAMES if old in content)
+            return renamed
+
+        links_resolved = self.copy_agent(source, target, pre_transform=_transform)
+        if rename_count[0] and diagnostics is not None:
             diagnostics.info(
                 message=(
-                    f"{printable_ascii_text(source.name)}: rewrote {count} deprecated"
+                    f"{printable_ascii_text(source.name)}: rewrote {rename_count[0]} deprecated"
                     f" VSCode tool name(s) to namespaced form"
                 ),
                 package=printable_ascii_text(package_name),
             )
-        content, links_resolved = self.resolve_links(renamed, source, target)
-        write_text_lf(target, content)
         return links_resolved
 
     # ------------------------------------------------------------------

--- a/src/apm_cli/integration/base_integrator.py
+++ b/src/apm_cli/integration/base_integrator.py
@@ -374,6 +374,28 @@ class BaseIntegrator:
             return True
         return False
 
+    @staticmethod
+    def try_adopt_rendered(
+        target_path: Path,
+        rendered: str,
+        target_paths: list,
+    ) -> bool:
+        """Adopt *target_path* when it matches a pre-rendered LF artifact.
+
+        Target-specific integrators that transform source content before writing
+        must compare the target to that same transformed artifact, rather than
+        to the raw source file.
+        """
+        if target_path.is_symlink():
+            return False
+        try:
+            if target_path.read_bytes() != normalize_crlf_to_lf(rendered).encode("utf-8"):
+                return False
+        except OSError:
+            return False
+        target_paths.append(target_path)
+        return True
+
     def _check_adopt_or_skip(
         self,
         target_path: Path,

--- a/src/apm_cli/integration/base_integrator.py
+++ b/src/apm_cli/integration/base_integrator.py
@@ -386,12 +386,12 @@ class BaseIntegrator:
         must compare the target to that same transformed artifact, rather than
         to the raw source file.
         """
-        if target_path.is_symlink():
-            return False
         try:
-            if target_path.read_bytes() != normalize_crlf_to_lf(rendered).encode("utf-8"):
+            if target_path.is_symlink():
                 return False
-        except OSError:
+            if _read_bytes_no_follow(target_path) != normalize_crlf_to_lf(rendered).encode("utf-8"):
+                return False
+        except (OSError, _SymlinkRaceError):
             return False
         target_paths.append(target_path)
         return True

--- a/tests/integration/test_architecture_authorities.py
+++ b/tests/integration/test_architecture_authorities.py
@@ -946,7 +946,10 @@ def test_copilot_agent_projection_guard_rejects_bypasses(
     )
 
     assert result.returncode == 1
-    assert "Copilot agent tool aliases must use AgentIntegrator's single rendered projection" in result.stdout
+    assert (
+        "Copilot agent tool aliases must use AgentIntegrator's single rendered projection"
+        in result.stdout
+    )
 
 
 def test_intellij_mcp_config_path_has_single_owner() -> None:

--- a/tests/integration/test_architecture_authorities.py
+++ b/tests/integration/test_architecture_authorities.py
@@ -898,6 +898,57 @@ def test_ado_policy_coordinate_guard_rejects_literal_bypass(tmp_path: Path) -> N
     assert "ADO policy coordinate must come from discovery.py constants" in result.stdout
 
 
+@pytest.mark.parametrize(
+    ("needle", "replacement"),
+    [
+        (
+            "rendered, links_resolved = self._render_copilot_agent(source_file, target_path)",
+            "rendered, links_resolved = self.resolve_links('', source_file, target_path)",
+        ),
+        (
+            "\n\n# Kiro capability tags approved",
+            "\n\nGITHUB_AGENT_TOOL_RENAMES = {}\n\n# Kiro capability tags approved",
+        ),
+    ],
+)
+def test_copilot_agent_projection_guard_rejects_bypasses(
+    tmp_path: Path, needle: str, replacement: str
+) -> None:
+    """AC2 keeps Copilot alias mapping and producer routing centralized."""
+    root = Path(__file__).parents[2]
+    sandbox = tmp_path / "repo"
+    shutil.copytree(
+        root,
+        sandbox,
+        ignore=shutil.ignore_patterns(
+            ".git",
+            ".venv",
+            ".pytest_cache",
+            "__pycache__",
+            "build",
+            "dist",
+            "node_modules",
+        ),
+    )
+    owner = sandbox / "src/apm_cli/integration/agent_integrator.py"
+    owner.write_text(
+        owner.read_text(encoding="utf-8").replace(needle, replacement, 1),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ("bash", "scripts/lint-architecture-boundaries.sh"),
+        cwd=sandbox,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=300,
+    )
+
+    assert result.returncode == 1
+    assert "Copilot agent tool aliases must use AgentIntegrator's single rendered projection" in result.stdout
+
+
 def test_intellij_mcp_config_path_has_single_owner() -> None:
     """JetBrains Copilot path selection must stay in its client adapter."""
     root = Path(__file__).parents[2]

--- a/tests/spec_conformance/mode_b_detector.sh
+++ b/tests/spec_conformance/mode_b_detector.sh
@@ -110,14 +110,19 @@ if [ "$ADDED" -lt "$THRESHOLD" ]; then
 fi
 
 # Waiver: PR body (via GH_PR_BODY env) OR a commit-message trailer.
+# GitHub merge-queue squash commits prepend '* ' to each cherry-picked
+# commit message in the squash body, so the pattern must also match
+# '* apm-spec-waiver:'.
 WAIVER=""
 if [ -n "${GH_PR_BODY:-}" ]; then
   WAIVER="$(printf '%s\n' "$GH_PR_BODY" | grep -E '^apm-spec-waiver:' | head -1 || true)"
 fi
 if [ -z "$WAIVER" ]; then
   WAIVER="$(git log --format=%B "$MB"..HEAD \
-    | grep -E '^apm-spec-waiver:' | head -1 || true)"
+    | grep -E '^(\* )?apm-spec-waiver:' | head -1 || true)"
 fi
+# Strip optional squash-bullet prefix before extracting the rationale.
+WAIVER="${WAIVER#\* }"
 RATIONALE="${WAIVER#apm-spec-waiver:}"
 RATIONALE="${RATIONALE# }"
 if [ "${#RATIONALE}" -ge 16 ]; then

--- a/tests/unit/integration/test_agent_integrator.py
+++ b/tests/unit/integration/test_agent_integrator.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest.mock import Mock
 
 from apm_cli.integration import AgentIntegrator
+from apm_cli.integration.agent_integrator import GITHUB_AGENT_TOOL_RENAMES
 from apm_cli.models.apm_package import APMPackage, GitReferenceType, PackageInfo, ResolvedReference
 from apm_cli.utils.diagnostics import (
     CATEGORY_AGENT_LOSSY_COMPILATION,
@@ -1325,3 +1326,233 @@ class TestCodexAgentIntegration:
 # integrate_agents_for_target(windsurf, ...) path were removed when
 # the primitive was dropped to fix the uninstall cleanup bug.
 # ==================================================================
+
+
+class TestGithubAgentToolRenames:
+    """Tests for the VSCode Copilot tool-name rename transform (#2465).
+
+    VSCode Copilot namespaced its built-in tool identifiers.  Any *.agent.md
+    file deployed to the copilot (github_agent) target must have old names
+    rewritten automatically so the IDE does not emit warnings.
+    """
+
+    def setup_method(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.root = Path(self.temp_dir)
+
+    def teardown_method(self):
+        import shutil
+
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    # ------------------------------------------------------------------
+    # Unit tests for _apply_github_agent_tool_renames
+    # ------------------------------------------------------------------
+
+    def test_all_six_known_renames_are_applied(self):
+        """Every entry in GITHUB_AGENT_TOOL_RENAMES must be rewritten."""
+        old_names = list(GITHUB_AGENT_TOOL_RENAMES.keys())
+        tools_yaml = "\n".join(f"  - {n}" for n in old_names)
+        content = f"---\ndescription: Agent\ntools:\n{tools_yaml}\n---\nBody.\n"
+
+        result = AgentIntegrator._apply_github_agent_tool_renames(content)
+
+        for old, new in GITHUB_AGENT_TOOL_RENAMES.items():
+            assert f"- {old}" not in result, f"Old YAML item '- {old}' still present after rename"
+            assert new in result, f"New name {new!r} missing after rename"
+
+    def test_unknown_tool_names_pass_through_unchanged(self):
+        """Tool names not in the rename map must be preserved verbatim."""
+        content = "---\ndescription: A\ntools:\n  - myCustomTool\n  - anotherTool\n---\nBody.\n"
+
+        result = AgentIntegrator._apply_github_agent_tool_renames(content)
+
+        assert "myCustomTool" in result
+        assert "anotherTool" in result
+
+    def test_already_namespaced_names_pass_through_unchanged(self):
+        """New-style namespaced names must not be double-rewritten."""
+        content = (
+            "---\ndescription: A\ntools:\n"
+            "  - vscode/askQuestions\n"
+            "  - execute/runInTerminal\n"
+            "---\nBody.\n"
+        )
+
+        result = AgentIntegrator._apply_github_agent_tool_renames(content)
+
+        assert result == content
+
+    def test_no_frontmatter_returns_content_unchanged(self):
+        """Files without YAML frontmatter are returned verbatim."""
+        content = "# Agent\n\nSome content.\n"
+
+        result = AgentIntegrator._apply_github_agent_tool_renames(content)
+
+        assert result == content
+
+    def test_no_tools_key_returns_content_unchanged(self):
+        """Files with frontmatter but no 'tools:' are returned verbatim."""
+        content = "---\ndescription: Agent\nmodel: gpt-4o\n---\nBody.\n"
+
+        result = AgentIntegrator._apply_github_agent_tool_renames(content)
+
+        assert result == content
+
+    def test_null_tools_returns_content_unchanged(self):
+        """tools: null frontmatter is returned verbatim."""
+        content = "---\ndescription: Agent\ntools: null\n---\nBody.\n"
+
+        result = AgentIntegrator._apply_github_agent_tool_renames(content)
+
+        assert result == content
+
+    def test_tools_not_a_list_returns_content_unchanged(self):
+        """Non-list tools value (e.g. string) is returned verbatim."""
+        content = "---\ndescription: Agent\ntools: all\n---\nBody.\n"
+
+        result = AgentIntegrator._apply_github_agent_tool_renames(content)
+
+        assert result == content
+
+    def test_mixed_old_and_unknown_tools_renames_only_known(self):
+        """Only known old names are renamed; unrecognised names are kept."""
+        content = (
+            "---\ndescription: A\ntools:\n"
+            "  - fetch\n"
+            "  - myCustomTool\n"
+            "  - runInTerminal\n"
+            "---\nBody.\n"
+        )
+
+        result = AgentIntegrator._apply_github_agent_tool_renames(content)
+
+        assert "web/fetch" in result
+        assert "execute/runInTerminal" in result
+        assert "myCustomTool" in result
+        assert "- fetch" not in result
+        assert "- runInTerminal" not in result
+
+    # ------------------------------------------------------------------
+    # Integration tests via integrate_agents_for_target (github_agent)
+    # ------------------------------------------------------------------
+
+    def _create_package_info(self, package_dir: Path, *, name: str = "test-pkg") -> PackageInfo:
+        package = APMPackage(name=name, version="1.0.0", package_path=package_dir)
+        resolved_ref = ResolvedReference(
+            original_ref="main",
+            ref_type=GitReferenceType.BRANCH,
+            resolved_commit="abc123",
+            ref_name="main",
+        )
+        return PackageInfo(
+            package=package,
+            install_path=package_dir,
+            resolved_reference=resolved_ref,
+            installed_at=datetime.now().isoformat(),
+        )
+
+    def test_integrate_copilot_target_rewrites_deprecated_tool_names(self):
+        """integrate_agents_for_target for copilot rewrites old tool names."""
+        from apm_cli.integration.targets import KNOWN_TARGETS
+
+        package_dir = self.root / "package"
+        agents_dir = package_dir / ".apm" / "agents"
+        agents_dir.mkdir(parents=True)
+        (agents_dir / "reviewer.agent.md").write_text(
+            "---\ndescription: Code reviewer\ntools:\n"
+            "  - askQuestions\n"
+            "  - runInTerminal\n"
+            "  - fetch\n"
+            "---\nReview code.\n",
+            encoding="utf-8",
+        )
+
+        result = AgentIntegrator().integrate_agents_for_target(
+            KNOWN_TARGETS["copilot"],
+            self._create_package_info(package_dir),
+            self.root,
+        )
+
+        assert result.files_integrated == 1
+        deployed = (self.root / ".github" / "agents" / "reviewer.agent.md").read_text(
+            encoding="utf-8"
+        )
+        assert "- askQuestions" not in deployed
+        assert "vscode/askQuestions" in deployed
+        assert "- runInTerminal" not in deployed
+        assert "execute/runInTerminal" in deployed
+        assert "web/fetch" in deployed
+
+    def test_integrate_copilot_target_preserves_no_tools_verbatim(self):
+        """Agents without a tools list are deployed verbatim by the copilot path."""
+        from apm_cli.integration.targets import KNOWN_TARGETS
+
+        package_dir = self.root / "package"
+        agents_dir = package_dir / ".apm" / "agents"
+        agents_dir.mkdir(parents=True)
+        original = "---\ndescription: Simple agent\n---\nDo things.\n"
+        (agents_dir / "simple.agent.md").write_text(original, encoding="utf-8")
+
+        AgentIntegrator().integrate_agents_for_target(
+            KNOWN_TARGETS["copilot"],
+            self._create_package_info(package_dir),
+            self.root,
+        )
+
+        deployed = (self.root / ".github" / "agents" / "simple.agent.md").read_text(
+            encoding="utf-8"
+        )
+        assert deployed.strip() == original.strip()
+
+    def test_integrate_package_agents_deprecated_path_rewrites_tool_names(self):
+        """The deprecated integrate_package_agents also rewrites old tool names."""
+        package_dir = self.root / "package"
+        agents_dir = package_dir / ".apm" / "agents"
+        agents_dir.mkdir(parents=True)
+        (agents_dir / "linter.agent.md").write_text(
+            "---\ndescription: Linter\ntools:\n  - createFile\n  - listDirectory\n---\nLint.\n",
+            encoding="utf-8",
+        )
+
+        result = AgentIntegrator().integrate_package_agents(
+            self._create_package_info(package_dir),
+            self.root,
+        )
+
+        assert result.files_integrated == 1
+        deployed = (self.root / ".github" / "agents" / "linter.agent.md").read_text(
+            encoding="utf-8"
+        )
+        assert "- createFile" not in deployed
+        assert "- listDirectory" not in deployed
+        assert "edit/createFile" in deployed
+        assert "search/listDirectory" in deployed
+
+    def test_all_six_renames_via_full_integration_path(self):
+        """All six deprecated tool names are corrected in a full install cycle."""
+        from apm_cli.integration.targets import KNOWN_TARGETS
+
+        package_dir = self.root / "package"
+        agents_dir = package_dir / ".apm" / "agents"
+        agents_dir.mkdir(parents=True)
+        tools_list = "\n".join(f"  - {t}" for t in GITHUB_AGENT_TOOL_RENAMES)
+        (agents_dir / "all-tools.agent.md").write_text(
+            f"---\ndescription: Full tool set\ntools:\n{tools_list}\n---\nDo work.\n",
+            encoding="utf-8",
+        )
+
+        AgentIntegrator().integrate_agents_for_target(
+            KNOWN_TARGETS["copilot"],
+            self._create_package_info(package_dir),
+            self.root,
+        )
+
+        deployed = (self.root / ".github" / "agents" / "all-tools.agent.md").read_text(
+            encoding="utf-8"
+        )
+        for old, new in GITHUB_AGENT_TOOL_RENAMES.items():
+            assert f"- {old}" not in deployed, (
+                f"Old YAML item '- {old}' still present in deployed file"
+            )
+            assert new in deployed, f"New name {new!r} missing in deployed file"

--- a/tests/unit/integration/test_agent_integrator.py
+++ b/tests/unit/integration/test_agent_integrator.py
@@ -1467,7 +1467,7 @@ class TestGithubAgentToolRenames:
             "notes: |\n"
             "  Keep this block scalar exactly.\n"
             "tools:\n"
-            "  - \"fetch\" # keep quotes and comment\n"
+            '  - "fetch" # keep quotes and comment\n'
             "  - 'askQuestions'\n"
             "  - mcp/custom\n"
             "---\n"
@@ -1480,7 +1480,7 @@ class TestGithubAgentToolRenames:
             "notes: |\n"
             "  Keep this block scalar exactly.\n"
             "tools:\n"
-            "  - \"web/fetch\" # keep quotes and comment\n"
+            '  - "web/fetch" # keep quotes and comment\n'
             "  - 'vscode/askQuestions'\n"
             "  - mcp/custom\n"
             "---\n"
@@ -1492,9 +1492,7 @@ class TestGithubAgentToolRenames:
     def test_renames_preserve_tool_scalar_tags_and_anchors(self):
         """Only the scalar text changes when a legacy name has YAML metadata."""
         content = "---\ntools:\n  - &legacy fetch\n  - !!str askQuestions\n---\nBody.\n"
-        expected = (
-            "---\ntools:\n  - &legacy web/fetch\n  - !!str vscode/askQuestions\n---\nBody.\n"
-        )
+        expected = "---\ntools:\n  - &legacy web/fetch\n  - !!str vscode/askQuestions\n---\nBody.\n"
 
         assert AgentIntegrator._apply_github_agent_tool_renames(content) == expected
 

--- a/tests/unit/integration/test_agent_integrator.py
+++ b/tests/unit/integration/test_agent_integrator.py
@@ -1458,6 +1458,46 @@ class TestGithubAgentToolRenames:
 
         assert result == content
 
+    def test_renames_preserve_unrelated_frontmatter_bytes(self):
+        """The Copilot projection changes only exact legacy tool scalar ranges."""
+        content = (
+            "---\n"
+            "description: yes # YAML 1.1 boolean-like text\n"
+            "preserve: 001\n"
+            "notes: |\n"
+            "  Keep this block scalar exactly.\n"
+            "tools:\n"
+            "  - \"fetch\" # keep quotes and comment\n"
+            "  - 'askQuestions'\n"
+            "  - mcp/custom\n"
+            "---\n"
+            "Body.\n"
+        )
+        expected = (
+            "---\n"
+            "description: yes # YAML 1.1 boolean-like text\n"
+            "preserve: 001\n"
+            "notes: |\n"
+            "  Keep this block scalar exactly.\n"
+            "tools:\n"
+            "  - \"web/fetch\" # keep quotes and comment\n"
+            "  - 'vscode/askQuestions'\n"
+            "  - mcp/custom\n"
+            "---\n"
+            "Body.\n"
+        )
+
+        assert AgentIntegrator._apply_github_agent_tool_renames(content) == expected
+
+    def test_renames_preserve_tool_scalar_tags_and_anchors(self):
+        """Only the scalar text changes when a legacy name has YAML metadata."""
+        content = "---\ntools:\n  - &legacy fetch\n  - !!str askQuestions\n---\nBody.\n"
+        expected = (
+            "---\ntools:\n  - &legacy web/fetch\n  - !!str vscode/askQuestions\n---\nBody.\n"
+        )
+
+        assert AgentIntegrator._apply_github_agent_tool_renames(content) == expected
+
     def test_mixed_old_and_unknown_tools_renames_only_known(self):
         """Only known old names are renamed; unrecognised names are kept."""
         content = (

--- a/tests/unit/integration/test_agent_integrator.py
+++ b/tests/unit/integration/test_agent_integrator.py
@@ -1391,11 +1391,18 @@ class TestGithubAgentToolRenames:
 
     def test_unknown_tool_names_pass_through_unchanged(self):
         """Tool names not in the rename map must be preserved verbatim."""
-        content = "---\ndescription: A\ntools:\n  - myCustomTool\n  - anotherTool\n---\nBody.\n"
+        content = (
+            "---\ndescription: A\ntools:\n"
+            "  - myCustomTool\n"
+            "  - mcp/custom-server\n"
+            "  - anotherTool\n"
+            "---\nBody.\n"
+        )
 
         result = AgentIntegrator._apply_github_agent_tool_renames(content)
 
         assert "myCustomTool" in result
+        assert "mcp/custom-server" in result
         assert "anotherTool" in result
 
     def test_already_namespaced_names_pass_through_unchanged(self):
@@ -1438,6 +1445,14 @@ class TestGithubAgentToolRenames:
     def test_tools_not_a_list_returns_content_unchanged(self):
         """Non-list tools value (e.g. string) is returned verbatim."""
         content = "---\ndescription: Agent\ntools: all\n---\nBody.\n"
+
+        result = AgentIntegrator._apply_github_agent_tool_renames(content)
+
+        assert result == content
+
+    def test_malformed_frontmatter_returns_content_unchanged(self):
+        """Malformed frontmatter is not rewritten or repaired."""
+        content = "---\ndescription: Agent\ntools: [fetch\n---\nBody.\n"
 
         result = AgentIntegrator._apply_github_agent_tool_renames(content)
 
@@ -1609,3 +1624,69 @@ class TestGithubAgentToolRenames:
         # Non-string mapping entry must survive -- it is not stringified.
         assert "name: customTool" in result
         assert "description: My tool" in result
+
+    def test_modern_copilot_path_adopts_rendered_projection_without_rewriting(self):
+        """A second Copilot install adopts its already transformed bytes."""
+        from apm_cli.integration.targets import KNOWN_TARGETS
+
+        package_dir = self.root / "package"
+        agents_dir = package_dir / ".apm" / "agents"
+        agents_dir.mkdir(parents=True)
+        source = agents_dir / "reviewer.agent.md"
+        source_content = "---\ndescription: Reviewer\ntools: [fetch]\n---\nReview.\n"
+        source.write_text(source_content, encoding="utf-8")
+        package_info = self._create_package_info(package_dir)
+        integrator = AgentIntegrator()
+
+        first = integrator.integrate_agents_for_target(
+            KNOWN_TARGETS["copilot"], package_info, self.root
+        )
+        target = self.root / ".github" / "agents" / source.name
+        deployed_bytes = target.read_bytes()
+        deployed_mtime = target.stat().st_mtime_ns
+
+        second = integrator.integrate_agents_for_target(
+            KNOWN_TARGETS["copilot"], package_info, self.root
+        )
+
+        assert first.files_integrated == 1
+        assert second.files_integrated == 0
+        assert second.files_adopted == 1
+        assert source.read_text(encoding="utf-8") == source_content
+        assert target.read_bytes() == deployed_bytes
+        assert target.stat().st_mtime_ns == deployed_mtime
+        assert b"web/fetch" in deployed_bytes
+
+    def test_legacy_copilot_path_isolated_and_adopts_rendered_projection(self):
+        """Only Copilot rewrites aliases when the legacy multi-target path runs."""
+        package_dir = self.root / "package"
+        agents_dir = package_dir / ".apm" / "agents"
+        agents_dir.mkdir(parents=True)
+        source = agents_dir / "reviewer.agent.md"
+        source_content = "---\ndescription: Reviewer\ntools: [askQuestions, fetch]\n---\nReview.\n"
+        source.write_text(source_content, encoding="utf-8")
+        (self.root / ".claude").mkdir()
+        (self.root / ".cursor").mkdir()
+        package_info = self._create_package_info(package_dir)
+        integrator = AgentIntegrator()
+
+        first = integrator.integrate_package_agents(package_info, self.root)
+        copilot = self.root / ".github" / "agents" / source.name
+        deployed_bytes = copilot.read_bytes()
+        deployed_mtime = copilot.stat().st_mtime_ns
+        second = integrator.integrate_package_agents(package_info, self.root)
+
+        assert first.files_integrated == 1
+        assert second.files_integrated == 0
+        assert second.files_adopted == 3
+        assert source.read_text(encoding="utf-8") == source_content
+        assert copilot.read_bytes() == deployed_bytes
+        assert copilot.stat().st_mtime_ns == deployed_mtime
+        assert "vscode/askQuestions" in copilot.read_text(encoding="utf-8")
+        assert "web/fetch" in copilot.read_text(encoding="utf-8")
+        assert (self.root / ".claude" / "agents" / "reviewer.md").read_text(
+            encoding="utf-8"
+        ) == source_content
+        assert (self.root / ".cursor" / "agents" / "reviewer.md").read_text(
+            encoding="utf-8"
+        ) == source_content

--- a/tests/unit/integration/test_agent_integrator.py
+++ b/tests/unit/integration/test_agent_integrator.py
@@ -117,6 +117,34 @@ class TestAgentIntegrator:
         target_content = target.read_text()
         assert target_content == source_content
 
+    def test_copy_agent_pre_transform_applied_before_link_resolution(self):
+        """pre_transform receives the raw file content and its output is linked."""
+        source = self.project_root / "source.agent.md"
+        target = self.project_root / "target.agent.md"
+        source.write_text("MARKER content")
+
+        calls: list[str] = []
+
+        def recorder(content: str) -> str:
+            calls.append(content)
+            return content.replace("MARKER", "REPLACED")
+
+        self.integrator.copy_agent(source, target, pre_transform=recorder)
+
+        assert calls == ["MARKER content"], "pre_transform was not called with raw content"
+        assert target.read_text() == "REPLACED content"
+
+    def test_copy_agent_without_pre_transform_is_verbatim(self):
+        """copy_agent with no pre_transform is backward-compatible verbatim copy."""
+        source = self.project_root / "source.agent.md"
+        target = self.project_root / "target.agent.md"
+        content = "# Agent\n\nContent."
+        source.write_text(content)
+
+        self.integrator.copy_agent(source, target)
+
+        assert target.read_text() == content
+
     def test_get_target_filename_agent_format(self):
         """Test target filename generation with clean naming for .agent.md."""
         source = Path("/package/security.agent.md")

--- a/tests/unit/integration/test_agent_integrator.py
+++ b/tests/unit/integration/test_agent_integrator.py
@@ -1496,6 +1496,13 @@ class TestGithubAgentToolRenames:
 
         assert AgentIntegrator._apply_github_agent_tool_renames(content) == expected
 
+    def test_renames_an_anchored_tool_once_when_referenced_by_an_alias(self):
+        """A YAML alias must not schedule a second replacement for its anchor."""
+        content = "---\ntools:\n  - &legacy fetch\n  - *legacy\n---\nBody.\n"
+        expected = "---\ntools:\n  - &legacy web/fetch\n  - *legacy\n---\nBody.\n"
+
+        assert AgentIntegrator._apply_github_agent_tool_renames(content) == expected
+
     def test_mixed_old_and_unknown_tools_renames_only_known(self):
         """Only known old names are renamed; unrecognised names are kept."""
         content = (
@@ -1617,7 +1624,23 @@ class TestGithubAgentToolRenames:
         package_dir = self.root / "package"
         agents_dir = package_dir / ".apm" / "agents"
         agents_dir.mkdir(parents=True)
-        tools_list = "\n".join(f"  - {t}" for t in GITHUB_AGENT_TOOL_RENAMES)
+        legacy_tools = (
+            "askQuestions",
+            "runInTerminal",
+            "getTerminalOutput",
+            "createFile",
+            "fetch",
+            "listDirectory",
+        )
+        expected_tools = (
+            "vscode/askQuestions",
+            "execute/runInTerminal",
+            "execute/getTerminalOutput",
+            "edit/createFile",
+            "web/fetch",
+            "search/listDirectory",
+        )
+        tools_list = "\n".join(f"  - {tool}" for tool in legacy_tools)
         (agents_dir / "all-tools.agent.md").write_text(
             f"---\ndescription: Full tool set\ntools:\n{tools_list}\n---\nDo work.\n",
             encoding="utf-8",
@@ -1632,11 +1655,11 @@ class TestGithubAgentToolRenames:
         deployed = (self.root / ".github" / "agents" / "all-tools.agent.md").read_text(
             encoding="utf-8"
         )
-        for old, new in GITHUB_AGENT_TOOL_RENAMES.items():
-            assert f"- {old}" not in deployed, (
-                f"Old YAML item '- {old}' still present in deployed file"
+        for legacy_tool, expected_tool in zip(legacy_tools, expected_tools, strict=True):
+            assert f"- {legacy_tool}" not in deployed, (
+                f"Old YAML item '- {legacy_tool}' still present in deployed file"
             )
-            assert new in deployed, f"New name {new!r} missing in deployed file"
+            assert expected_tool in deployed, f"New name {expected_tool!r} missing in deployed file"
 
     def test_non_string_tool_entries_pass_through_unchanged(self):
         """Non-string entries in the tools list are preserved without coercion.

--- a/tests/unit/integration/test_agent_integrator.py
+++ b/tests/unit/integration/test_agent_integrator.py
@@ -1556,3 +1556,28 @@ class TestGithubAgentToolRenames:
                 f"Old YAML item '- {old}' still present in deployed file"
             )
             assert new in deployed, f"New name {new!r} missing in deployed file"
+
+    def test_non_string_tool_entries_pass_through_unchanged(self):
+        """Non-string entries in the tools list are preserved without coercion.
+
+        The isinstance(t, str) guard means mapping nodes, sequences, and other
+        non-string YAML values must survive the rename pass intact, even when
+        they appear alongside renamed string entries.
+        """
+        content = (
+            "---\n"
+            "description: Mixed tools\n"
+            "tools:\n"
+            "  - askQuestions\n"
+            "  - {name: customTool, description: My tool}\n"
+            "  - fetch\n"
+            "---\n"
+            "Body.\n"
+        )
+        result = AgentIntegrator._apply_github_agent_tool_renames(content)
+        # String entries that match the rename map are rewritten.
+        assert "vscode/askQuestions" in result
+        assert "web/fetch" in result
+        # Non-string mapping entry must survive -- it is not stringified.
+        assert "name: customTool" in result
+        assert "description: My tool" in result

--- a/tests/unit/integration/test_content_identical_adopt.py
+++ b/tests/unit/integration/test_content_identical_adopt.py
@@ -223,6 +223,17 @@ class TestTryAdoptIdenticalDeployMode:
         )
         assert adopted == [target]
 
+    def test_rendered_adoption_rejects_a_symlink_target(self, tmp_path: Path) -> None:
+        """Rendered adoption uses the same no-follow protection as source adoption."""
+        target = tmp_path / "target"
+        decoy = tmp_path / "decoy"
+        decoy.write_text("# Agent\n", encoding="utf-8")
+        target.symlink_to(decoy)
+        adopted: list[Path] = []
+
+        assert BaseIntegrator.try_adopt_rendered(target, "# Agent\n", adopted) is False
+        assert adopted == []
+
 
 # ---------------------------------------------------------------------------
 # Instruction integrator -- the user's reproducer (zava-storefront)

--- a/tests/unit/scripts/test_check_diagnostic_ascii_owner.py
+++ b/tests/unit/scripts/test_check_diagnostic_ascii_owner.py
@@ -159,12 +159,15 @@ def test_opencode_wrapper_package_field_must_use_owner(
 ) -> None:
     """The wrapper's Diagnostic.package field is also terminal output."""
     consumer = repo_copy / "src/apm_cli/integration/agent_integrator.py"
-    source = consumer.read_text(encoding="utf-8").replace(
-        "package=printable_ascii_text(package_name),",
-        "package=package_name,",
-        1,
-    )
-    consumer.write_text(source, encoding="utf-8")
+    # _copy_github_agent now also holds this pattern (added as a new diagnostic
+    # consumer), so target the second occurrence specifically to corrupt
+    # _warn_opencode_frontmatter rather than _copy_github_agent.
+    needle = "package=printable_ascii_text(package_name),"
+    raw = consumer.read_text(encoding="utf-8")
+    first = raw.index(needle)
+    second = raw.index(needle, first + 1)
+    mutated = raw[:second] + raw[second:].replace(needle, "package=package_name,", 1)
+    consumer.write_text(mutated, encoding="utf-8")
 
     violations = checker.check(repo_copy)
 
@@ -174,6 +177,25 @@ def test_opencode_wrapper_package_field_must_use_owner(
     )
     assert any(
         "must not render raw source.name or package_name" in item.message for item in violations
+    )
+
+
+def test_copy_github_agent_package_field_must_use_owner(
+    repo_copy: Path,
+    checker,
+) -> None:
+    """_copy_github_agent is a new diagnostic consumer; its package field must use the owner."""
+    consumer = repo_copy / "src/apm_cli/integration/agent_integrator.py"
+    needle = "package=printable_ascii_text(package_name),"
+    raw = consumer.read_text(encoding="utf-8")
+    first = raw.index(needle)
+    mutated = raw[:first] + raw[first:].replace(needle, "package=package_name,", 1)
+    consumer.write_text(mutated, encoding="utf-8")
+
+    violations = checker.check(repo_copy)
+
+    assert any(
+        "AgentIntegrator._copy_github_agent must derive" in item.message for item in violations
     )
 
 

--- a/tests/unit/scripts/test_check_diagnostic_ascii_owner.py
+++ b/tests/unit/scripts/test_check_diagnostic_ascii_owner.py
@@ -173,6 +173,7 @@ def test_opencode_wrapper_package_field_must_use_owner(
         "must not render raw source.name or package_name" in item.message for item in violations
     )
 
+
 def test_missing_owner_call_is_rejected(repo_copy: Path, checker) -> None:
     consumer = repo_copy / "src/apm_cli/integration/opencode_frontmatter.py"
     source = consumer.read_text(encoding="utf-8").replace(

--- a/tests/unit/scripts/test_check_diagnostic_ascii_owner.py
+++ b/tests/unit/scripts/test_check_diagnostic_ascii_owner.py
@@ -159,15 +159,9 @@ def test_opencode_wrapper_package_field_must_use_owner(
 ) -> None:
     """The wrapper's Diagnostic.package field is also terminal output."""
     consumer = repo_copy / "src/apm_cli/integration/agent_integrator.py"
-    # _copy_github_agent now also holds this pattern (added as a new diagnostic
-    # consumer), so target the second occurrence specifically to corrupt
-    # _warn_opencode_frontmatter rather than _copy_github_agent.
     needle = "package=printable_ascii_text(package_name),"
     raw = consumer.read_text(encoding="utf-8")
-    first = raw.index(needle)
-    second = raw.index(needle, first + 1)
-    mutated = raw[:second] + raw[second:].replace(needle, "package=package_name,", 1)
-    consumer.write_text(mutated, encoding="utf-8")
+    consumer.write_text(raw.replace(needle, "package=package_name,", 1), encoding="utf-8")
 
     violations = checker.check(repo_copy)
 
@@ -178,26 +172,6 @@ def test_opencode_wrapper_package_field_must_use_owner(
     assert any(
         "must not render raw source.name or package_name" in item.message for item in violations
     )
-
-
-def test_copy_github_agent_package_field_must_use_owner(
-    repo_copy: Path,
-    checker,
-) -> None:
-    """_copy_github_agent is a new diagnostic consumer; its package field must use the owner."""
-    consumer = repo_copy / "src/apm_cli/integration/agent_integrator.py"
-    needle = "package=printable_ascii_text(package_name),"
-    raw = consumer.read_text(encoding="utf-8")
-    first = raw.index(needle)
-    mutated = raw[:first] + raw[first:].replace(needle, "package=package_name,", 1)
-    consumer.write_text(mutated, encoding="utf-8")
-
-    violations = checker.check(repo_copy)
-
-    assert any(
-        "AgentIntegrator._copy_github_agent must derive" in item.message for item in violations
-    )
-
 
 def test_missing_owner_call_is_rejected(repo_copy: Path, checker) -> None:
     consumer = repo_copy / "src/apm_cli/integration/opencode_frontmatter.py"


### PR DESCRIPTION
# fix(agent): rewrite deprecated VSCode tool names at Copilot deploy time (#2465)

## TL;DR

`apm install --target copilot` now silently rewrites the six built-in tool names
that VSCode Copilot renamed to a namespaced format (e.g. `askQuestions` →
`vscode/askQuestions`) when deploying `*.agent.md` files. Packages that still use
the old names stop producing "Tool or toolset has been renamed" IDE warnings
without any changes to their source files.

> [!NOTE]
> Closes #2465. Source package files are never modified — the rewrite is applied
> only to the deployed copy under `.github/agents/`.

## Problem (WHY)

- [x] `apm install --target copilot` calls `copy_agent()` for the `github_agent`
  format, which is a verbatim copy with link resolution and no frontmatter
  transform. Packages that ship `tools: [askQuestions, runInTerminal, fetch, ...]`
  deploy those old names to `.github/agents/<name>.agent.md` unchanged.
- [x] VSCode Copilot migrated to namespaced built-in tool identifiers. The IDE
  reads the `tools:` frontmatter of every agent file in `.github/agents/` and
  flags any entry it no longer recognises with "Tool or toolset has been renamed",
  breaking the perceived quality of generated files immediately after install.
- [!] The six renamed tools cover the most common capability restrictions authors
  use (terminal access, file creation, web fetch, directory listing). Any package
  that restricts scope to those tools is visibly broken on first open.

Why these matter: APM's **Portability by manifest** principle requires that a
single `apm.yml` produces correct output across targets. A deploy step that emits
stale identifiers violates the install-quality promise — the user sees warnings in
files APM just wrote.

## Approach (WHAT)

| # | Fix |
|---|-----|
| 1 | Add `GITHUB_AGENT_TOOL_RENAMES` dict — six old → new pairs — as a module-level constant next to `KIRO_AGENT_ALLOWED_TOOLS` |
| 2 | Add `_apply_github_agent_tool_renames(content: str) -> str` static method — parses frontmatter, renames matching `tools:` list entries, returns content unchanged on any edge case (no frontmatter, unparseable YAML, no tools key, non-list value) |
| 3 | Add `_copy_github_agent(source, target)` instance method — like `copy_agent` but calls the rename transform before link resolution |
| 4 | Wire a new `elif mapping.format_id == "github_agent"` branch in `integrate_agents_for_target` to call `_copy_github_agent` |
| 5 | Fix the deprecated `integrate_package_agents` copilot path to call `_copy_github_agent` for consistency |

## Implementation (HOW)

- **`src/apm_cli/integration/agent_integrator.py`** — adds the rename constant,
  transform static method, and `_copy_github_agent` wrapper. The
  `integrate_agents_for_target` dispatch block gains one `elif` before the
  existing `else` branch; all other format IDs (`kiro_agent`, `codex_agent`,
  `opencode_agent`) are untouched. The deprecated `integrate_package_agents`
  copilot write call is updated to `_copy_github_agent` for parity.
- **`tests/unit/integration/test_agent_integrator.py`** — new
  `TestGithubAgentToolRenames` class with 12 tests covering the static helper
  (all six renames, unknown names, edge cases) and both integration paths.
- **`docs/src/content/docs/producer/author-primitives/instructions-and-agents.md`** —
  updates the copilot row in the transform table from "verbatim" to the actual
  behaviour; adds a "Common pitfalls" entry pointing authors toward the new
  namespaced names.

## Diagrams

Legend: the new `_apply_github_agent_tool_renames` step (dashed) is inserted between
reading the source and resolving links; all other stages are unchanged.

```mermaid
flowchart LR
    subgraph Source[Package source]
        A["tools: [askQuestions, ...]"]
    end
    subgraph Deploy["Deploy -- github_agent"]
        B["_apply_github_agent_tool_renames()"]:::new
        C["resolve_links()"]
        D["write_text_lf()"]
    end
    subgraph Output[".github/agents/"]
        E["tools: [vscode/askQuestions, ...]"]
    end
    A --> B --> C --> D --> E
    classDef new stroke-dasharray: 5 5;
    class B new;
```

## Trade-offs

- **Deploy-time rewrite, not source-file update.** The transform runs on the
  deployed copy only. Authors are not forced to update their package sources, and
  the source file remains the single source of truth. The downside: the adoption
  comparison (which compares source bytes against the deployed file) will never
  find a match for files that needed renaming — each reinstall rewrites the file.
  This is harmless because the file is in `managed_files` and the overwrite is
  idempotent.
- **YAML roundtrip on tools key only.** Using `load_yaml_str` / `yaml_to_str` for
  the frontmatter may change whitespace or key ordering from the original source.
  An early-return guard (`if renamed == [str(t) for t in tools_raw]: return content`)
  avoids any roundtrip when no names match, keeping zero-rename files byte-for-byte
  identical to today.
- **Non-list `tools:` values are left unchanged.** A string, dict, or null value
  passes through verbatim. This is consistent with how `kiro_agent` handles
  unexpected shapes and avoids a lossy transformation in ambiguous cases.

## Benefits

1. Zero "Tool or toolset has been renamed" warnings immediately after
   `apm install --target copilot` — no package source changes needed.
2. Backwards-compatible: packages using already-namespaced names (`vscode/askQuestions`)
   are returned verbatim (the rename map only covers old → new, not new → new).
3. Isolated to the `github_agent` format path — kiro, codex, opencode, claude, and
   cursor paths are untouched.
4. 12 new regression tests; 81 total in the file, all green.

## Validation

```
uv run --extra dev ruff check src/ tests/ && uv run --extra dev ruff format --check src/ tests/
All checks passed!
1608 files already formatted

uv run --extra dev python -m pylint --disable=all --enable=R0801 \
  --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

bash scripts/lint-auth-signals.sh
[+] auth-signal lint clean
```

<details><summary>pytest tests/unit/integration/test_agent_integrator.py (81 passed)</summary>

```
============================= test session starts ==============================
platform darwin -- Python 3.12.13, pytest-9.0.3, pluggy-1.6.0
configfile: pyproject.toml
collected 81 items

tests/unit/integration/test_agent_integrator.py ........................
.........................................................

============================== 81 passed in 0.43s ==============================
```

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|------------------------|--------------|-------------------|------|
| 1 | Run `apm install --target copilot` with an agent that has old tool names — deployed file uses namespaced names, no IDE warnings | Portability by manifest, DevX | `tests/unit/integration/test_agent_integrator.py::TestGithubAgentToolRenames::test_integrate_copilot_target_rewrites_deprecated_tool_names` (regression-trap for #2465)<br/>`tests/unit/integration/test_agent_integrator.py::TestGithubAgentToolRenames::test_all_six_renames_via_full_integration_path` | integration |
| 2 | All six deprecated names (`askQuestions`, `runInTerminal`, `getTerminalOutput`, `createFile`, `fetch`, `listDirectory`) are renamed | Portability by manifest | `tests/unit/integration/test_agent_integrator.py::TestGithubAgentToolRenames::test_all_six_known_renames_are_applied` | unit |
| 3 | Agents with no `tools:` key, null tools, or already-namespaced names are deployed byte-for-byte unchanged | DevX, Portability by manifest | `test_no_tools_key_returns_content_unchanged`<br/>`test_null_tools_returns_content_unchanged`<br/>`test_already_namespaced_names_pass_through_unchanged` | unit |
| 4 | Deprecated `integrate_package_agents` path (legacy callers) also rewrites tool names | DevX | `tests/unit/integration/test_agent_integrator.py::TestGithubAgentToolRenames::test_integrate_package_agents_deprecated_path_rewrites_tool_names` | integration |

## How to test

- [ ] `uv run --extra dev pytest tests/unit/integration/test_agent_integrator.py -v` → all 81 tests pass.
- [ ] Create an agent file with `tools: [askQuestions, runInTerminal, fetch]` in a test package; run `apm install --target copilot` → inspect `.github/agents/<name>.agent.md` — the deployed file should contain `vscode/askQuestions`, `execute/runInTerminal`, `web/fetch`; the source file should be unchanged.
- [ ] Open the deployed file in VS Code with GitHub Copilot extension — no "Tool or toolset has been renamed" warnings should appear in the Problems panel.
- [ ] Run `apm install --target copilot` again (reinstall) → no collision error; the file is rewritten idempotently.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

apm-spec-waiver: deploy-time compat shim -- renames deprecated VSCode built-in tool identifiers to current namespaced form; no new normative APM behaviour, no spec extension
