### PR TITLE
fix(outdated): degrade gracefully when Rich progress rendering fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `apm install --target all` no longer aborts on targets that have no MCP
   client, such as `grok-build`. Non-MCP targets are skipped with a note instead
   of raising `Unsupported client type`. (#2484)
+- `apm outdated` no longer exits 1 when the Rich progress renderer fails. The
+  command now owns its own `Console` instead of borrowing Rich's process-global
+  singleton, and falls back to plain-text progress if rendering still raises.
+  (#2507)
 - `apm init` and install-time auto-bootstrap now reject empty or
   whitespace-only project names, falling back to `my-project` at a filesystem
   root. APM no longer writes an `apm.yml` that every later install, lock, or

--- a/src/apm_cli/commands/outdated.py
+++ b/src/apm_cli/commands/outdated.py
@@ -621,6 +621,7 @@ def _check_deps_with_progress(
     total = len(checkable)
 
     try:
+        from rich.console import Console
         from rich.progress import (
             BarColumn,
             Progress,
@@ -629,12 +630,16 @@ def _check_deps_with_progress(
             TextColumn,
         )
 
+        # Own the Console instead of borrowing Rich's process-global singleton:
+        # a caller (or a leaked test double) that poisons ``rich._console`` must
+        # not be able to crash ``apm outdated``.
         with Progress(
             SpinnerColumn(),
             TextColumn("[cyan]{task.description}[/cyan]"),
             BarColumn(),
             TaskProgressColumn(),
             transient=True,
+            console=Console(),
         ) as progress:
             if parallel_checks > 0 and total > 1:
                 rows = _check_parallel(
@@ -660,8 +665,10 @@ def _check_deps_with_progress(
                         result = _unknown_row(dep)
                     rows.append(result)
                     progress.advance(task_id)
-    except ImportError:
-        # No Rich -- plain text feedback
+    except Exception:
+        # No Rich, or the progress renderer itself blew up -- degrade to plain
+        # text rather than failing the whole command over a display concern.
+        rows = []
         logger.progress(f"Checking {total} dependencies...")
         if parallel_checks > 0 and total > 1:
             rows = _check_parallel_plain(

--- a/tests/integration/test_wave6_outdated_view_coverage.py
+++ b/tests/integration/test_wave6_outdated_view_coverage.py
@@ -672,6 +672,45 @@ class TestOutdatedParallel:
         assert result.exit_code == 0
         assert "unknown" in result.output.lower()
 
+    def test_poisoned_rich_console_singleton_degrades(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A poisoned ``rich._console`` must not fail ``outdated``.
+
+        Regression for a CI-only failure where an earlier test in the same
+        xdist worker left a ``MagicMock`` in Rich's process-global console.
+        Rich progress then compared mock timestamps and raised ``TypeError:
+        '<' not supported between instances of 'MagicMock' and 'MagicMock'``,
+        which propagated out of ``outdated`` as exit 1. Progress rendering is
+        a display concern and must degrade to the plain path instead.
+        """
+        monkeypatch.chdir(tmp_path)
+        _write_apm_yml(tmp_path)
+        sha = "aabbccdd11223344"
+        _write_lockfile(
+            tmp_path,
+            f"  - repo_url: test-org/repo-one\n"
+            f"    resolved_ref: main\n"
+            f"    resolved_commit: {sha}\n"
+            f"  - repo_url: test-org/repo-two\n"
+            f"    resolved_ref: main\n"
+            f"    resolved_commit: {sha}\n",
+        )
+
+        branch_ref = _make_remote_ref("main", GitReferenceType.BRANCH, sha)
+
+        def _list_remote_refs(_downloader: object, _dep_ref: object) -> list[RemoteRef]:
+            return [branch_ref]
+
+        monkeypatch.setattr(rich, "_console", MagicMock(), raising=False)
+        with patch(
+            "apm_cli.deps.github_downloader.GitHubPackageDownloader.list_remote_refs",
+            new=_list_remote_refs,
+        ):
+            result = runner.invoke(cli, ["outdated", "-j", "2"])
+
+        assert result.exit_code == 0
+
 
 # ---------------------------------------------------------------------------
 # outdated -- mixed local+remote deps


### PR DESCRIPTION
## TL;DR

`apm outdated` could exit 1 because of a *progress bar*. This makes the
progress renderer non-fatal and stops the command borrowing Rich's
process-global console. Unblocks the v0.28.0 release run.

## Problem (WHY)

Release run [31083262059](https://github.com/microsoft/apm/actions/runs/31083262059)
failed on exactly one job -- `Integration Tests (ubuntu-24.04, x86_64, linux)` --
with 1 failure out of 8506:

```
FAILED tests/integration/test_wave6_outdated_view_coverage.py::TestOutdatedParallel::test_multiple_deps_one_check_errors_degrades
assert 1 == 0
 +  where 1 = <Result TypeError("'<' not supported between instances of 'MagicMock' and 'MagicMock'")>.exit_code
```

Note the message says `instances of` -- that is CPython's own comparison
error, **not** the `TypeError` the test deliberately raises. The test's
`_check_one_dep` stub is already handled correctly; a *second*, real
`TypeError` was escaping from elsewhere.

Root cause, reproduced locally: `_check_deps_with_progress` builds
`Progress(...)` with no `console=`, so Rich falls back to its
process-global `rich._console`. When an earlier test in the same xdist
worker leaves a `MagicMock` there, Rich progress compares mock
timestamps and raises. The existing `except ImportError:` handler is too
narrow to catch it, so the command exits 1.

Injecting `rich._console = MagicMock()` reproduces the CI signature
byte-for-byte:

```
E   assert 1 == 0
E    +  where 1 = <Result TypeError("'<' not supported between instances of 'MagicMock' and 'MagicMock'")>.exit_code
```

The test double is the trigger, but the defect is real: `apm outdated`
lets a *display* concern decide its exit code, and depends on mutable
global state it does not own.

## Approach (WHAT)

Two narrow changes in `src/apm_cli/commands/outdated.py`:

1. **Own the console.** `Progress(..., console=Console())`. The command
   no longer reads `rich._console`, so nothing another caller does to
   that singleton can reach it.
2. **Make rendering non-fatal.** `except ImportError` widens to
   `except Exception`, resetting `rows` before falling through to the
   plain-text path that already exists for the no-Rich case.

## Implementation (HOW)

```mermaid
flowchart TD
    A["_check_deps_with_progress"] --> B{"import rich.progress<br/>+ build Progress(console=Console())"}
    B -->|ok| C["Rich path<br/>(parallel or sequential)"]
    B -->|"ImportError or<br/>render TypeError"| D["reset rows<br/>logger.progress(...)"]
    D --> E["Plain path<br/>(parallel or sequential)"]
    C --> F["return rows"]
    E --> F
```

`rows` is reset in the handler because the Rich branch may have appended
partial results before raising; without the reset, the plain path would
append duplicates.

## Trade-offs

| Decision | Why | Cost |
| --- | --- | --- |
| Widen to `except Exception` | Progress rendering is cosmetic and must not set the exit code | A genuine renderer bug degrades silently instead of surfacing. Accepted: the plain path still reports every dependency. |
| Construct a fresh `Console()` | Removes the dependency on shared mutable global state | One extra short-lived `Console` per `outdated` invocation. Negligible. |
| Fix the product, not the test | The test only exposed a real fragility | Slightly larger diff than a `conftest` patch would have been. |

I deliberately did **not** hunt the specific polluting test. The command
should not be sensitive to a global it does not own; hardening the
command fixes every future variant of this, not just today's.

## Validation evidence

| Check | Result |
| --- | --- |
| `tests/integration/test_wave6_outdated_view_coverage.py` | 53 passed |
| `tests/unit -k outdated` | 169 passed |
| Mutation-break gate (revert `outdated.py`, keep the test) | `1 failed` -- `assert 1 == 0`, the exact CI signature |
| `ruff check src/ tests/` | All checks passed |
| `ruff format --check src/ tests/` | 1609 files already formatted |
| `pylint R0801` | 10.00/10 |
| `scripts/lint-auth-signals.sh` | `[+] auth-signal lint clean` |

## How to test

```bash
uv run --extra dev python -m pytest \
  tests/integration/test_wave6_outdated_view_coverage.py -q

# Mutation check -- must fail without the fix:
git stash -- src/apm_cli/commands/outdated.py
uv run --extra dev python -m pytest \
  tests/integration/test_wave6_outdated_view_coverage.py -q -k poisoned
git stash pop
```

apm-spec-waiver: display-layer resilience in the outdated command only; no
change to manifest parsing, lockfile schema, resolution, policy, or
install/integration behaviour, so no OpenAPM spec surface is touched.
