### PR TITLE
fix(plugins): accept Copilot-dialect LSP field aliases on plugin intake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (closes #2522, #2654)
 - The lifecycle scripts guide now documents the Windows admin-tier policy path
   alongside the Linux and macOS path. (by @WilliamK112, closes #2621, #2640)
+- Windows binary is now Authenticode-signed in the release workflow, eliminating
+  the `Trojan:Script/Wacatac.H!ml` Windows Defender false positive on unsigned
+  PyInstaller bundles. (#2435)
+- Plugin `.lsp.json` intake now accepts Copilot-dialect `fileExtensions` and
+  `warmupTimeoutMs` aliases, preserving C# LSP setup from dotnet/skills.
+  (closes #2509, #2513)
+- Multi-target `apm compile` now avoids repeating expensive project analysis
+  for each target, making multi-target runs scale like single-target runs
+  without changing generated output. (closes #2482)
+- `deployed-files-present` no longer false-positives on gitignored deploy
+  paths (e.g. `.agents/`), enabling `apm audit --ci` to pass on a fresh
+  checkout when deployed outputs are intentionally not committed. (closes
+  #2452, thanks @sergio-sisternes-epam)
+- YAML expansion guard no longer rejects large anchor-free lockfiles (150K+
+  entries) with a false-positive "billion-laughs" error. APM-generated
+  lockfiles with no anchors or aliases now load without error. (#2389)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Plugin `.lsp.json` intake now accepts Copilot-dialect `fileExtensions` and
   `warmupTimeoutMs` aliases, preserving C# LSP setup from dotnet/skills.
   (closes #2509, #2513)
+  (by @normandev92; closes #2509) (#2513)
+- `apm install --skill <name>` now matches on plugins whose manifest declares
+  the conventional skills container (`"skills": ["./skills/"]`). The declared
+  container was normalized under its own name, burying every skill at
+  `.apm/skills/skills/<name>/` -- one level below the depth `--skill`
+  enumeration, deployment, the `bin/` security scan and primitive counting all
+  read, so selection reported `Available: (none)` even though a bare install
+  deployed those same skills. A declared entry that is itself a skill
+  (`"skills": "./skills/engineering/tdd"`) still lands under its own leaf name
+  instead of spilling a bare `SKILL.md` into the shared skills root.
+  (closes #2530)
+- Root-declared plugin components (Claude Code single-skill shape
+  `"skills": ["./"]`, and the same for agents/commands/hooks) no longer cause
+  infinite recursion or unbounded writes during `apm install`.
+  `docs/src/content/docs/specs/openapm-v0.1.md` now explicitly requires
+  containment of consumer-generated staging output. (closes #2556)
 - Multi-target `apm compile` now avoids repeating expensive project analysis
   for each target, making multi-target runs scale like single-target runs
   without changing generated output. (closes #2482)

--- a/docs/src/content/docs/consumer/install-lsp-servers.md
+++ b/docs/src/content/docs/consumer/install-lsp-servers.md
@@ -171,8 +171,8 @@ a flat server map or a `{ "lspServers": { ... } }` envelope. The
 the absolute plugin path for legacy Claude Code plugin compatibility.
 Plugins authored for Copilot CLI may use `fileExtensions` instead of
 `extensionToLanguage` and `warmupTimeoutMs` instead of `startupTimeout`;
-APM normalizes those aliases before validation, while canonical names win
-when both are present.
+APM normalizes those aliases before validation. A non-null canonical value
+wins when both are present; a null canonical value falls back to its alias.
 
 ## Runtime support
 

--- a/docs/src/content/docs/consumer/install-lsp-servers.md
+++ b/docs/src/content/docs/consumer/install-lsp-servers.md
@@ -169,6 +169,10 @@ wired into the install pipeline. Plugin `.lsp.json` files may use either
 a flat server map or a `{ "lspServers": { ... } }` envelope. The
 `${CLAUDE_PLUGIN_ROOT}` placeholder in server configs is replaced with
 the absolute plugin path for legacy Claude Code plugin compatibility.
+Plugins authored for Copilot CLI may use `fileExtensions` instead of
+`extensionToLanguage` and `warmupTimeoutMs` instead of `startupTimeout`;
+APM normalizes those aliases before validation, while canonical names win
+when both are present.
 
 ## Runtime support
 

--- a/docs/src/content/docs/consumer/install-lsp-servers.md
+++ b/docs/src/content/docs/consumer/install-lsp-servers.md
@@ -174,7 +174,9 @@ Plugins authored for Copilot CLI may use `fileExtensions` instead of
 APM normalizes those aliases before validation. A non-null canonical value
 wins when both are present; a null canonical value falls back to its alias.
 APM ignores the unsupported Copilot `cwd` field and warns that the consumer
-runtime chooses the working directory.
+runtime chooses the working directory. Copilot output uses `fileExtensions`
+and `warmupTimeoutMs`; canonical manifests and lockfiles retain
+`extensionToLanguage` and `startupTimeout`.
 
 ## Runtime support
 

--- a/docs/src/content/docs/consumer/install-lsp-servers.md
+++ b/docs/src/content/docs/consumer/install-lsp-servers.md
@@ -173,6 +173,8 @@ Plugins authored for Copilot CLI may use `fileExtensions` instead of
 `extensionToLanguage` and `warmupTimeoutMs` instead of `startupTimeout`;
 APM normalizes those aliases before validation. A non-null canonical value
 wins when both are present; a null canonical value falls back to its alias.
+APM ignores the unsupported Copilot `cwd` field and warns that the consumer
+runtime chooses the working directory.
 
 ## Runtime support
 

--- a/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
@@ -571,7 +571,9 @@ server map or a `{ "lspServers": { ... } }` envelope. For Copilot-dialect
 plugin input, APM accepts `fileExtensions` as an alias for
 `extensionToLanguage` and `warmupTimeoutMs` as an alias for
 `startupTimeout`; a non-null canonical value wins when both are supplied,
-while a null canonical value falls back to its alias.
+while a null canonical value falls back to its alias. APM ignores the
+unsupported Copilot `cwd` field and warns that the consumer runtime chooses
+the working directory.
 
 ## Version pinning
 

--- a/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
@@ -573,7 +573,9 @@ plugin input, APM accepts `fileExtensions` as an alias for
 `startupTimeout`; a non-null canonical value wins when both are supplied,
 while a null canonical value falls back to its alias. APM ignores the
 unsupported Copilot `cwd` field and warns that the consumer runtime chooses
-the working directory.
+the working directory. Copilot output uses `fileExtensions` and
+`warmupTimeoutMs`; manifests and lockfiles retain `extensionToLanguage` and
+`startupTimeout`.
 
 ## Version pinning
 

--- a/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
@@ -567,7 +567,10 @@ Claude Code uses `.lsp.json` or `~/.claude.json`, and GitHub Copilot CLI
 uses `.github/lsp.json` or `~/.copilot/lsp-config.json`. Copilot CLI
 uses `fileExtensions` on disk; manifests continue to use
 `extensionToLanguage`. Plugin `.lsp.json` files may use either a flat
-server map or a `{ "lspServers": { ... } }` envelope.
+server map or a `{ "lspServers": { ... } }` envelope. For Copilot-dialect
+plugin input, APM accepts `fileExtensions` as an alias for
+`extensionToLanguage` and `warmupTimeoutMs` as an alias for
+`startupTimeout`; the canonical key wins when both are supplied.
 
 ## Version pinning
 

--- a/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
@@ -570,7 +570,8 @@ uses `fileExtensions` on disk; manifests continue to use
 server map or a `{ "lspServers": { ... } }` envelope. For Copilot-dialect
 plugin input, APM accepts `fileExtensions` as an alias for
 `extensionToLanguage` and `warmupTimeoutMs` as an alias for
-`startupTimeout`; the canonical key wins when both are supplied.
+`startupTimeout`; a non-null canonical value wins when both are supplied,
+while a null canonical value falls back to its alias.
 
 ## Version pinning
 

--- a/src/apm_cli/deps/plugin_parser.py
+++ b/src/apm_cli/deps/plugin_parser.py
@@ -36,6 +36,10 @@ _logger = logging.getLogger(__name__)
 # Cap the file size first, then funnel every parse failure into a single
 # ``ValueError`` so callers fail closed with one except type.
 _MAX_PLUGIN_JSON_BYTES = 5 * 1024 * 1024
+_LSP_FIELD_ALIASES = (
+    ("extensionToLanguage", "fileExtensions"),
+    ("startupTimeout", "warmupTimeoutMs"),
+)
 _PLUGIN_SKILL_SOURCES_FILE = ".plugin-skill-sources.json"
 
 
@@ -1032,12 +1036,22 @@ def _lsp_servers_to_apm_deps(
                 dep[key] = cfg[key]
 
         # Copilot-dialect aliases; canonical spelling wins when both exist.
-        for canonical, alias in (
-            ("extensionToLanguage", "fileExtensions"),
-            ("startupTimeout", "warmupTimeoutMs"),
-        ):
-            if canonical not in dep and alias in cfg:
+        for canonical, alias in _LSP_FIELD_ALIASES:
+            if dep.get(canonical) is None and alias in cfg:
                 dep[canonical] = cfg[alias]
+                logger.debug(
+                    "Normalizing LSP server '%s' from plugin '%s': '%s' to '%s'",
+                    name,
+                    plugin_path.name,
+                    alias,
+                    canonical,
+                )
+            elif canonical in dep and alias in cfg:
+                _surface_warning(
+                    f"LSP server '{name}' from plugin '{plugin_path.name}' defines both "
+                    f"'{canonical}' and '{alias}'; using '{canonical}'.",
+                    logger,
+                )
 
         # ``cwd`` has no LSPDependency equivalent: APM-managed servers are
         # started by the consumer runtime in its own working directory.

--- a/src/apm_cli/deps/plugin_parser.py
+++ b/src/apm_cli/deps/plugin_parser.py
@@ -616,6 +616,14 @@ def _lsp_servers_to_apm_deps(servers: dict[str, Any], plugin_path: Path) -> list
     - ``command``: binary to run
     - ``extensionToLanguage``: mapping of file extensions to language IDs
 
+    Copilot-dialect spellings are accepted as aliases (#2509): plugins
+    authored against the Copilot CLI schema -- including the official
+    ``dotnet/skills`` dotnet plugin -- write the extension map as
+    ``fileExtensions`` and the startup budget as ``warmupTimeoutMs``.
+    APM itself emits ``fileExtensions`` when generating Copilot output,
+    so rejecting it on intake would drop servers that every supported
+    consumer runtime accepts. Canonical names win when both are present.
+
     All resulting entries are routed through ``LSPDependency.from_dict()``
     for validation. Entries that fail validation are skipped with a warning.
 
@@ -655,6 +663,24 @@ def _lsp_servers_to_apm_deps(servers: dict[str, Any], plugin_path: Path) -> list
         ):
             if key in cfg:
                 dep[key] = cfg[key]
+
+        # Copilot-dialect aliases; canonical spelling wins when both exist.
+        for canonical, alias in (
+            ("extensionToLanguage", "fileExtensions"),
+            ("startupTimeout", "warmupTimeoutMs"),
+        ):
+            if canonical not in dep and alias in cfg:
+                dep[canonical] = cfg[alias]
+
+        # ``cwd`` has no LSPDependency equivalent: APM-managed servers are
+        # started by the consumer runtime in its own working directory.
+        # Ignore it explicitly rather than letting it look like a typo.
+        if "cwd" in cfg:
+            logger.debug(
+                "LSP server '%s' from plugin '%s': ignoring unsupported 'cwd'",
+                name,
+                plugin_path.name,
+            )
 
         # Route through the validation chokepoint
         try:

--- a/src/apm_cli/deps/plugin_parser.py
+++ b/src/apm_cli/deps/plugin_parser.py
@@ -99,23 +99,11 @@ def _assert_no_symlink_descendants(target: Path) -> None:
 
 
 def _surface_warning(message: str, logger: logging.Logger) -> None:
-    """Emit one warning through logging or the rich-console fallback.
-
-    The ``apm`` stdlib logger has no handlers configured by default, so
-    ``logger.warning`` calls are silently dropped in non-debug runs. For
-    user-visible plugin-parse issues (skipped MCP servers, validation
-    failures), route through ``_rich_warning`` when logging has no output
-    handler. Falls back gracefully if Rich is unavailable.
-    """
-    logger.warning(message)
-    handlers = (*logger.handlers, *logging.getLogger().handlers)
-    if any(not isinstance(handler, logging.NullHandler) for handler in handlers):
-        return
-    try:  # noqa: SIM105
+    """Emit one standard user-facing warning, with logging as fallback."""
+    try:
         _rich_warning(message, symbol="warning")
     except Exception:
-        # Console output is best-effort; never mask the underlying warning.
-        pass
+        logger.warning(message)
 
 
 def _is_within_plugin(candidate: Path, plugin_root: Path, *, component: str) -> bool:
@@ -1051,7 +1039,7 @@ def _lsp_servers_to_apm_deps(
                     alias,
                     canonical,
                 )
-            elif canonical in dep and alias in cfg:
+            elif canonical in dep and alias in cfg and dep[canonical] != cfg[alias]:
                 _surface_warning(
                     f"LSP server '{name}' from plugin '{plugin_path.name}' defines both "
                     f"'{canonical}' and '{alias}'; using '{canonical}'.",

--- a/src/apm_cli/deps/plugin_parser.py
+++ b/src/apm_cli/deps/plugin_parser.py
@@ -99,15 +99,18 @@ def _assert_no_symlink_descendants(target: Path) -> None:
 
 
 def _surface_warning(message: str, logger: logging.Logger) -> None:
-    """Emit a warning to both the stdlib logger and the rich console.
+    """Emit one warning through logging or the rich-console fallback.
 
     The ``apm`` stdlib logger has no handlers configured by default, so
     ``logger.warning`` calls are silently dropped in non-debug runs. For
     user-visible plugin-parse issues (skipped MCP servers, validation
-    failures), also route through ``_rich_warning`` so the user sees them
-    even without ``--verbose``. Falls back gracefully if Rich is unavailable.
+    failures), route through ``_rich_warning`` when logging has no output
+    handler. Falls back gracefully if Rich is unavailable.
     """
     logger.warning(message)
+    handlers = (*logger.handlers, *logging.getLogger().handlers)
+    if any(not isinstance(handler, logging.NullHandler) for handler in handlers):
+        return
     try:  # noqa: SIM105
         _rich_warning(message, symbol="warning")
     except Exception:
@@ -1016,6 +1019,7 @@ def _lsp_servers_to_apm_deps(
             continue
 
         dep: dict[str, Any] = {"name": name}
+        aliases_used: list[tuple[str, str]] = []
 
         # Copy all recognized fields
         for key in (
@@ -1039,6 +1043,7 @@ def _lsp_servers_to_apm_deps(
         for canonical, alias in _LSP_FIELD_ALIASES:
             if dep.get(canonical) is None and alias in cfg:
                 dep[canonical] = cfg[alias]
+                aliases_used.append((alias, canonical))
                 logger.debug(
                     "Normalizing LSP server '%s' from plugin '%s': '%s' to '%s'",
                     name,
@@ -1057,10 +1062,10 @@ def _lsp_servers_to_apm_deps(
         # started by the consumer runtime in its own working directory.
         # Ignore it explicitly rather than letting it look like a typo.
         if "cwd" in cfg:
-            logger.debug(
-                "LSP server '%s' from plugin '%s': ignoring unsupported 'cwd'",
-                name,
-                plugin_path.name,
+            _surface_warning(
+                f"LSP server '{name}' from plugin '{plugin_path.name}' uses unsupported "
+                "'cwd'; the consumer runtime chooses the working directory.",
+                logger,
             )
 
         # Route through the validation chokepoint
@@ -1068,8 +1073,15 @@ def _lsp_servers_to_apm_deps(
             LSPDependency.from_dict(dep)
         except Exception as exc:
             if warn_on_invalid:
+                alias_context = ""
+                if aliases_used:
+                    normalized = ", ".join(
+                        f"'{alias}' to '{canonical}'" for alias, canonical in aliases_used
+                    )
+                    alias_context = f" after normalizing {normalized}"
                 _surface_warning(
-                    f"Skipping invalid LSP server '{name}' from plugin '{plugin_path.name}': {exc}",
+                    f"Skipping invalid LSP server '{name}' from plugin "
+                    f"'{plugin_path.name}'{alias_context}: {exc}",
                     logger,
                 )
             continue

--- a/src/apm_cli/deps/plugin_parser.py
+++ b/src/apm_cli/deps/plugin_parser.py
@@ -982,6 +982,14 @@ def _lsp_servers_to_apm_deps(
     - ``command``: binary to run
     - ``extensionToLanguage``: mapping of file extensions to language IDs
 
+    Copilot-dialect spellings are accepted as aliases (#2509): plugins
+    authored against the Copilot CLI schema -- including the official
+    ``dotnet/skills`` dotnet plugin -- write the extension map as
+    ``fileExtensions`` and the startup budget as ``warmupTimeoutMs``.
+    APM itself emits ``fileExtensions`` when generating Copilot output,
+    so rejecting it on intake would drop servers that every supported
+    consumer runtime accepts. Canonical names win when both are present.
+
     All resulting entries are routed through ``LSPDependency.from_dict()``
     for validation. Entries that fail validation are skipped with a warning.
 
@@ -1022,6 +1030,24 @@ def _lsp_servers_to_apm_deps(
         ):
             if key in cfg:
                 dep[key] = cfg[key]
+
+        # Copilot-dialect aliases; canonical spelling wins when both exist.
+        for canonical, alias in (
+            ("extensionToLanguage", "fileExtensions"),
+            ("startupTimeout", "warmupTimeoutMs"),
+        ):
+            if canonical not in dep and alias in cfg:
+                dep[canonical] = cfg[alias]
+
+        # ``cwd`` has no LSPDependency equivalent: APM-managed servers are
+        # started by the consumer runtime in its own working directory.
+        # Ignore it explicitly rather than letting it look like a typo.
+        if "cwd" in cfg:
+            logger.debug(
+                "LSP server '%s' from plugin '%s': ignoring unsupported 'cwd'",
+                name,
+                plugin_path.name,
+            )
 
         # Route through the validation chokepoint
         try:

--- a/src/apm_cli/integration/lsp_integrator.py
+++ b/src/apm_cli/integration/lsp_integrator.py
@@ -28,6 +28,8 @@ _log = logging.getLogger(__name__)
 _LSP_SERVERS_KEY = "lspServers"
 _CLAUDE_LANGUAGE_KEY = "extensionToLanguage"
 _COPILOT_LANGUAGE_KEY = "fileExtensions"
+_CLAUDE_STARTUP_TIMEOUT_KEY = "startupTimeout"
+_COPILOT_STARTUP_TIMEOUT_KEY = "warmupTimeoutMs"
 _LEGACY_DEFAULT_TARGETS = ("claude",)
 _LSP_TARGET_ORDER = ("copilot", "claude")
 
@@ -40,6 +42,7 @@ class _LSPTargetSpec:
     project_relative_path: tuple[str, ...]
     user_relative_path: tuple[str, ...]
     language_key: str
+    startup_timeout_key: str
     project_servers_key: str | None
     user_servers_key: str | None
     project_label: str
@@ -66,6 +69,7 @@ _LSP_TARGET_SPECS: dict[str, _LSPTargetSpec] = {
         project_relative_path=(".lsp.json",),
         user_relative_path=(".claude.json",),
         language_key=_CLAUDE_LANGUAGE_KEY,
+        startup_timeout_key=_CLAUDE_STARTUP_TIMEOUT_KEY,
         project_servers_key=None,
         user_servers_key=_LSP_SERVERS_KEY,
         project_label=".lsp.json",
@@ -76,6 +80,7 @@ _LSP_TARGET_SPECS: dict[str, _LSPTargetSpec] = {
         project_relative_path=(".github", "lsp.json"),
         user_relative_path=(".copilot", "lsp-config.json"),
         language_key=_COPILOT_LANGUAGE_KEY,
+        startup_timeout_key=_COPILOT_STARTUP_TIMEOUT_KEY,
         project_servers_key=_LSP_SERVERS_KEY,
         user_servers_key=_LSP_SERVERS_KEY,
         project_label=".github/lsp.json",
@@ -203,6 +208,11 @@ class LSPIntegrator:
         language_map = extension_to_language or file_extensions or snake_case_extensions
         if language_map is not None:
             out[spec.language_key] = language_map
+        startup_timeout = out.pop(_CLAUDE_STARTUP_TIMEOUT_KEY, None)
+        warmup_timeout = out.pop(_COPILOT_STARTUP_TIMEOUT_KEY, None)
+        timeout = startup_timeout if startup_timeout is not None else warmup_timeout
+        if timeout is not None:
+            out[spec.startup_timeout_key] = timeout
         if spec.language_key == _COPILOT_LANGUAGE_KEY and "args" not in out:
             out["args"] = []
         return out

--- a/tests/integration/test_plugin_e2e.py
+++ b/tests/integration/test_plugin_e2e.py
@@ -496,6 +496,7 @@ class TestPluginHeroScenarios:
                         "csharp": {
                             "command": "dnx",
                             "args": ["roslyn-language-server", "--stdio"],
+                            "cwd": "${PLUGIN_ROOT}",
                             "fileExtensions": {".cs": "csharp"},
                             "warmupTimeoutMs": 120000,
                         }
@@ -525,6 +526,10 @@ class TestPluginHeroScenarios:
             project,
         )
         assert initial_install.returncode == 0, initial_install.stdout + initial_install.stderr
+        install_output = initial_install.stdout + initial_install.stderr
+        assert install_output.count("uses unsupported 'cwd'") == 1
+        assert "consumer runtime chooses the working directory" in install_output
+        assert "[!] LSP server 'csharp'" in install_output
 
         lock = LockFile.read(project / "apm.lock.yaml")
         assert lock is not None
@@ -543,7 +548,7 @@ class TestPluginHeroScenarios:
             "args": ["roslyn-language-server", "--stdio"],
             "command": "dnx",
             "fileExtensions": {".cs": "csharp"},
-            "startupTimeout": 120000,
+            "warmupTimeoutMs": 120000,
         }
         initial_lock_bytes = (project / "apm.lock.yaml").read_bytes()
         initial_runtime_bytes = runtime_path.read_bytes()

--- a/tests/integration/test_plugin_e2e.py
+++ b/tests/integration/test_plugin_e2e.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 import pytest
 
+from apm_cli.deps.lockfile import LockFile
 from apm_cli.integration.agent_integrator import AgentIntegrator
 from apm_cli.integration.command_integrator import CommandIntegrator
 from apm_cli.integration.prompt_integrator import PromptIntegrator
@@ -472,6 +473,100 @@ class TestPluginHeroScenarios:
         combined = uninstall.stdout + uninstall.stderr
         assert "Uninstall complete" in combined
         assert all(not path.exists() for path in deployed_paths)
+
+    @pytest.mark.requires_apm_binary
+    def test_copilot_dialect_plugin_lsp_survives_install_reinstall_and_audit(
+        self,
+        apm_binary_path: Path,
+        tmp_path: Path,
+    ) -> None:
+        """A plugin's Copilot-dialect LSP config reaches canonical lock and runtime state."""
+        plugin_dir = tmp_path / "copilot-lsp-plugin"
+        plugin_dir.mkdir()
+        manifest_dir = plugin_dir / ".github" / "plugin"
+        manifest_dir.mkdir(parents=True)
+        (manifest_dir / "plugin.json").write_text(
+            json.dumps({"name": "copilot-lsp-plugin", "version": "1.0.0"}),
+            encoding="utf-8",
+        )
+        (plugin_dir / ".lsp.json").write_text(
+            json.dumps(
+                {
+                    "lspServers": {
+                        "csharp": {
+                            "command": "dnx",
+                            "args": ["roslyn-language-server", "--stdio"],
+                            "fileExtensions": {".cs": "csharp"},
+                            "warmupTimeoutMs": 120000,
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        normalized = validate_apm_package(plugin_dir)
+        assert normalized.is_valid, normalized.errors
+
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / "apm.yml").write_text(
+            "name: copilot-lsp-lifecycle\nversion: 1.0.0\ndependencies:\n  apm: []\n",
+            encoding="utf-8",
+        )
+        (project / ".github").mkdir()
+        (project / ".github" / "copilot-instructions.md").write_text(
+            "# Test project\n",
+            encoding="utf-8",
+        )
+
+        initial_install = _run_apm_command(
+            str(apm_binary_path),
+            ["install", str(plugin_dir), "--target", "copilot", "--no-policy"],
+            project,
+        )
+        assert initial_install.returncode == 0, initial_install.stdout + initial_install.stderr
+
+        lock = LockFile.read(project / "apm.lock.yaml")
+        assert lock is not None
+        assert lock.lsp_servers == ["csharp"]
+        assert lock.lsp_configs["csharp"] == {
+            "args": ["roslyn-language-server", "--stdio"],
+            "command": "dnx",
+            "extensionToLanguage": {".cs": "csharp"},
+            "name": "csharp",
+            "startupTimeout": 120000,
+        }
+
+        runtime_path = project / ".github" / "lsp.json"
+        runtime_config = json.loads(runtime_path.read_text(encoding="utf-8"))
+        assert runtime_config["lspServers"]["csharp"] == {
+            "args": ["roslyn-language-server", "--stdio"],
+            "command": "dnx",
+            "fileExtensions": {".cs": "csharp"},
+            "startupTimeout": 120000,
+        }
+        initial_lock_bytes = (project / "apm.lock.yaml").read_bytes()
+        initial_runtime_bytes = runtime_path.read_bytes()
+
+        reinstall = _run_apm_command(
+            str(apm_binary_path),
+            ["install", "--target", "copilot", "--no-policy"],
+            project,
+        )
+        assert reinstall.returncode == 0, reinstall.stdout + reinstall.stderr
+        assert (project / "apm.lock.yaml").read_bytes() == initial_lock_bytes
+        assert runtime_path.read_bytes() == initial_runtime_bytes
+
+        audit = _run_apm_command(
+            str(apm_binary_path),
+            ["audit", "--ci", "--no-policy", "--format", "json"],
+            project,
+        )
+        assert audit.returncode == 0, audit.stdout + audit.stderr
+        assert json.loads(audit.stdout)["passed"] is True
+        assert (project / "apm.lock.yaml").read_bytes() == initial_lock_bytes
+        assert runtime_path.read_bytes() == initial_runtime_bytes
+
 
     @pytest.mark.requires_apm_binary
     def test_root_declared_skill_lifecycle_is_bounded(self, apm_binary_path, tmp_path):

--- a/tests/integration/test_plugin_e2e.py
+++ b/tests/integration/test_plugin_e2e.py
@@ -567,7 +567,6 @@ class TestPluginHeroScenarios:
         assert (project / "apm.lock.yaml").read_bytes() == initial_lock_bytes
         assert runtime_path.read_bytes() == initial_runtime_bytes
 
-
     @pytest.mark.requires_apm_binary
     def test_root_declared_skill_lifecycle_is_bounded(self, apm_binary_path, tmp_path):
         """A root-declared plugin skill installs, reinstalls, and uninstalls cleanly."""

--- a/tests/unit/deps/test_plugin_parser_lsp.py
+++ b/tests/unit/deps/test_plugin_parser_lsp.py
@@ -310,6 +310,37 @@ class TestLspServersToApmDeps:
         assert len(deps) == 1
         assert deps[0]["extensionToLanguage"] == {".py": "python"}
 
+    def test_alias_replaces_null_canonical_value(self, tmp_path):
+        """A null canonical value falls back to the Copilot-dialect alias."""
+        servers = {
+            "null-canonical": {
+                "command": "lsp",
+                "extensionToLanguage": None,
+                "fileExtensions": {".py": "python"},
+            }
+        }
+
+        deps = _lsp_servers_to_apm_deps(servers, tmp_path)
+
+        assert len(deps) == 1
+        assert deps[0]["extensionToLanguage"] == {".py": "python"}
+
+    def test_conflicting_alias_and_canonical_warns(self, tmp_path, caplog):
+        """A plugin author can see that the canonical field takes precedence."""
+        servers = {
+            "dual": {
+                "command": "lsp",
+                "extensionToLanguage": {".py": "python"},
+                "fileExtensions": {".rb": "ruby"},
+            }
+        }
+
+        with caplog.at_level(logging.WARNING, logger="apm"):
+            deps = _lsp_servers_to_apm_deps(servers, tmp_path)
+
+        assert len(deps) == 1
+        assert "defines both 'extensionToLanguage' and 'fileExtensions'" in caplog.text
+
     def test_warmup_timeout_ms_alias_accepted(self, tmp_path):
         servers = {
             "slow": {
@@ -365,6 +396,21 @@ class TestLspServersToApmDeps:
         assert "fileExtensions" not in d
         assert "warmupTimeoutMs" not in d
         assert "cwd" not in d
+
+    def test_invalid_copilot_alias_keeps_default_warning(self, tmp_path, caplog):
+        """Invalid alias values remain visible through the normal warning path."""
+        servers = {
+            "invalid": {
+                "command": "lsp",
+                "fileExtensions": [".cs"],
+            }
+        }
+
+        with caplog.at_level(logging.WARNING, logger="apm"):
+            deps = _lsp_servers_to_apm_deps(servers, tmp_path)
+
+        assert deps == []
+        assert "Skipping invalid LSP server 'invalid'" in caplog.text
 
     def test_wrapped_lsp_json_produces_valid_deps(self, tmp_path):
         """End-to-end: .lsp.json with lspServers wrapper yields valid deps."""

--- a/tests/unit/deps/test_plugin_parser_lsp.py
+++ b/tests/unit/deps/test_plugin_parser_lsp.py
@@ -285,6 +285,87 @@ class TestLspServersToApmDeps:
         assert d["restartOnCrash"] is True
         assert d["maxRestarts"] == 3
 
+    def test_fileextensions_alias_accepted(self, tmp_path):
+        """Copilot-dialect ``fileExtensions`` maps onto ``extensionToLanguage`` (#2509)."""
+        servers = {
+            "csharp": {
+                "command": "csharp-ls",
+                "fileExtensions": {".cs": "csharp"},
+            }
+        }
+        deps = _lsp_servers_to_apm_deps(servers, tmp_path)
+        assert len(deps) == 1
+        assert deps[0]["extensionToLanguage"] == {".cs": "csharp"}
+        assert "fileExtensions" not in deps[0]
+
+    def test_canonical_spelling_wins_over_alias(self, tmp_path):
+        servers = {
+            "dual": {
+                "command": "lsp",
+                "extensionToLanguage": {".py": "python"},
+                "fileExtensions": {".rb": "ruby"},
+            }
+        }
+        deps = _lsp_servers_to_apm_deps(servers, tmp_path)
+        assert len(deps) == 1
+        assert deps[0]["extensionToLanguage"] == {".py": "python"}
+
+    def test_warmup_timeout_ms_alias_accepted(self, tmp_path):
+        servers = {
+            "slow": {
+                "command": "lsp",
+                "extensionToLanguage": {".py": "python"},
+                "warmupTimeoutMs": 120000,
+            }
+        }
+        deps = _lsp_servers_to_apm_deps(servers, tmp_path)
+        assert len(deps) == 1
+        assert deps[0]["startupTimeout"] == 120000
+        assert "warmupTimeoutMs" not in deps[0]
+
+    def test_official_dotnet_plugin_lsp_json_accepted(self, tmp_path):
+        """End-to-end regression for #2509: the exact server config shipped by
+        the official dotnet/skills dotnet plugin must survive intake."""
+        lsp_json = tmp_path / ".lsp.json"
+        lsp_json.write_text(
+            json.dumps(
+                {
+                    "lspServers": {
+                        "csharp": {
+                            "command": "dnx",
+                            "args": [
+                                "roslyn-language-server",
+                                "--yes",
+                                "--prerelease",
+                                "--",
+                                "--stdio",
+                                "--autoLoadProjects",
+                            ],
+                            "cwd": "${PLUGIN_ROOT}",
+                            "fileExtensions": {
+                                ".cs": "csharp",
+                                ".razor": "aspnetcorerazor",
+                                ".cshtml": "aspnetcorerazor",
+                            },
+                            "warmupTimeoutMs": 120000,
+                        }
+                    }
+                }
+            )
+        )
+        servers = _extract_lsp_servers(tmp_path, {})
+        deps = _lsp_servers_to_apm_deps(servers, tmp_path)
+        assert len(deps) == 1
+        d = deps[0]
+        assert d["name"] == "csharp"
+        assert d["command"] == "dnx"
+        assert d["extensionToLanguage"][".razor"] == "aspnetcorerazor"
+        assert d["startupTimeout"] == 120000
+        # Copilot-dialect and unsupported keys must not leak into the dep
+        assert "fileExtensions" not in d
+        assert "warmupTimeoutMs" not in d
+        assert "cwd" not in d
+
     def test_wrapped_lsp_json_produces_valid_deps(self, tmp_path):
         """End-to-end: .lsp.json with lspServers wrapper yields valid deps."""
         lsp_json = tmp_path / ".lsp.json"

--- a/tests/unit/deps/test_plugin_parser_lsp.py
+++ b/tests/unit/deps/test_plugin_parser_lsp.py
@@ -326,7 +326,7 @@ class TestLspServersToApmDeps:
         assert len(deps) == 1
         assert deps[0]["extensionToLanguage"] == {".py": "python"}
 
-    def test_conflicting_alias_and_canonical_warns(self, tmp_path, caplog):
+    def test_conflicting_alias_and_canonical_warns(self, tmp_path):
         """A plugin author can see that the canonical field takes precedence."""
         servers = {
             "dual": {
@@ -336,14 +336,27 @@ class TestLspServersToApmDeps:
             }
         }
 
-        with (
-            caplog.at_level(logging.WARNING, logger="apm"),
-            patch("apm_cli.deps.plugin_parser._rich_warning") as rich_warning,
-        ):
+        with patch("apm_cli.deps.plugin_parser._rich_warning") as rich_warning:
             deps = _lsp_servers_to_apm_deps(servers, tmp_path)
 
         assert len(deps) == 1
-        assert "defines both 'extensionToLanguage' and 'fileExtensions'" in caplog.text
+        warning = rich_warning.call_args.args[0]
+        assert "defines both 'extensionToLanguage' and 'fileExtensions'" in warning
+
+    def test_identical_alias_and_canonical_values_stay_quiet(self, tmp_path):
+        extensions = {".py": "python"}
+        servers = {
+            "dual": {
+                "command": "lsp",
+                "extensionToLanguage": extensions,
+                "fileExtensions": extensions,
+            }
+        }
+
+        with patch("apm_cli.deps.plugin_parser._rich_warning") as rich_warning:
+            deps = _lsp_servers_to_apm_deps(servers, tmp_path)
+
+        assert len(deps) == 1
         rich_warning.assert_not_called()
 
     def test_warmup_timeout_ms_alias_accepted(self, tmp_path):
@@ -359,7 +372,7 @@ class TestLspServersToApmDeps:
         assert deps[0]["startupTimeout"] == 120000
         assert "warmupTimeoutMs" not in deps[0]
 
-    def test_official_dotnet_plugin_lsp_json_accepted(self, tmp_path, caplog):
+    def test_official_dotnet_plugin_lsp_json_accepted(self, tmp_path):
         """End-to-end regression for #2509: the exact server config shipped by
         the official dotnet/skills dotnet plugin must survive intake."""
         lsp_json = tmp_path / ".lsp.json"
@@ -390,7 +403,7 @@ class TestLspServersToApmDeps:
             )
         )
         servers = _extract_lsp_servers(tmp_path, {})
-        with caplog.at_level(logging.WARNING, logger="apm"):
+        with patch("apm_cli.deps.plugin_parser._rich_warning") as rich_warning:
             deps = _lsp_servers_to_apm_deps(servers, tmp_path)
         assert len(deps) == 1
         d = deps[0]
@@ -402,12 +415,11 @@ class TestLspServersToApmDeps:
         assert "fileExtensions" not in d
         assert "warmupTimeoutMs" not in d
         assert "cwd" not in d
-        assert (
-            "uses unsupported 'cwd'; the consumer runtime chooses the working directory"
-            in caplog.text
-        )
+        warning = rich_warning.call_args.args[0]
+        assert "uses unsupported 'cwd'" in warning
+        assert "consumer runtime chooses the working directory" in warning
 
-    def test_invalid_copilot_alias_keeps_default_warning(self, tmp_path, caplog):
+    def test_invalid_copilot_alias_keeps_default_warning(self, tmp_path):
         """Invalid alias values remain visible through the normal warning path."""
         servers = {
             "invalid": {
@@ -416,12 +428,13 @@ class TestLspServersToApmDeps:
             }
         }
 
-        with caplog.at_level(logging.WARNING, logger="apm"):
+        with patch("apm_cli.deps.plugin_parser._rich_warning") as rich_warning:
             deps = _lsp_servers_to_apm_deps(servers, tmp_path)
 
         assert deps == []
-        assert "Skipping invalid LSP server 'invalid'" in caplog.text
-        assert "after normalizing 'fileExtensions' to 'extensionToLanguage'" in caplog.text
+        warning = rich_warning.call_args.args[0]
+        assert "Skipping invalid LSP server 'invalid'" in warning
+        assert "after normalizing 'fileExtensions' to 'extensionToLanguage'" in warning
 
     def test_wrapped_lsp_json_produces_valid_deps(self, tmp_path):
         """End-to-end: .lsp.json with lspServers wrapper yields valid deps."""

--- a/tests/unit/deps/test_plugin_parser_lsp.py
+++ b/tests/unit/deps/test_plugin_parser_lsp.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
+from unittest.mock import patch
 
 import yaml
 
@@ -335,11 +336,15 @@ class TestLspServersToApmDeps:
             }
         }
 
-        with caplog.at_level(logging.WARNING, logger="apm"):
+        with (
+            caplog.at_level(logging.WARNING, logger="apm"),
+            patch("apm_cli.deps.plugin_parser._rich_warning") as rich_warning,
+        ):
             deps = _lsp_servers_to_apm_deps(servers, tmp_path)
 
         assert len(deps) == 1
         assert "defines both 'extensionToLanguage' and 'fileExtensions'" in caplog.text
+        rich_warning.assert_not_called()
 
     def test_warmup_timeout_ms_alias_accepted(self, tmp_path):
         servers = {
@@ -354,7 +359,7 @@ class TestLspServersToApmDeps:
         assert deps[0]["startupTimeout"] == 120000
         assert "warmupTimeoutMs" not in deps[0]
 
-    def test_official_dotnet_plugin_lsp_json_accepted(self, tmp_path):
+    def test_official_dotnet_plugin_lsp_json_accepted(self, tmp_path, caplog):
         """End-to-end regression for #2509: the exact server config shipped by
         the official dotnet/skills dotnet plugin must survive intake."""
         lsp_json = tmp_path / ".lsp.json"
@@ -385,7 +390,8 @@ class TestLspServersToApmDeps:
             )
         )
         servers = _extract_lsp_servers(tmp_path, {})
-        deps = _lsp_servers_to_apm_deps(servers, tmp_path)
+        with caplog.at_level(logging.WARNING, logger="apm"):
+            deps = _lsp_servers_to_apm_deps(servers, tmp_path)
         assert len(deps) == 1
         d = deps[0]
         assert d["name"] == "csharp"
@@ -396,6 +402,10 @@ class TestLspServersToApmDeps:
         assert "fileExtensions" not in d
         assert "warmupTimeoutMs" not in d
         assert "cwd" not in d
+        assert (
+            "uses unsupported 'cwd'; the consumer runtime chooses the working directory"
+            in caplog.text
+        )
 
     def test_invalid_copilot_alias_keeps_default_warning(self, tmp_path, caplog):
         """Invalid alias values remain visible through the normal warning path."""
@@ -411,6 +421,7 @@ class TestLspServersToApmDeps:
 
         assert deps == []
         assert "Skipping invalid LSP server 'invalid'" in caplog.text
+        assert "after normalizing 'fileExtensions' to 'extensionToLanguage'" in caplog.text
 
     def test_wrapped_lsp_json_produces_valid_deps(self, tmp_path):
         """End-to-end: .lsp.json with lspServers wrapper yields valid deps."""

--- a/tests/unit/integration/test_lsp_integrator.py
+++ b/tests/unit/integration/test_lsp_integrator.py
@@ -222,7 +222,7 @@ class TestInstallUserScope:
 
 class TestInstallCopilotTarget:
     def test_writes_project_lsp_json_with_file_extensions(self, tmp_path):
-        deps = [_make_dep("pyright")]
+        deps = [_make_dep("pyright", startup_timeout=120000)]
 
         count = LSPIntegrator.install(
             deps,
@@ -240,6 +240,7 @@ class TestInstallCopilotTarget:
                     "command": "pyright-langserver",
                     "args": [],
                     "fileExtensions": {".py": "python"},
+                    "warmupTimeoutMs": 120000,
                 }
             }
         }

--- a/tests/unit/test_plugin_parser.py
+++ b/tests/unit/test_plugin_parser.py
@@ -1,9 +1,9 @@
 """Unit tests for plugin_parser.py and find_plugin_json helper."""
 
 import json
-import logging
 import os
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 import yaml
@@ -612,7 +612,7 @@ class TestMapPluginArtifacts:
         # Undeclared siblings stay out: the entry is a requirement, not a hint.
         assert not (normalized / "pairing").exists()
 
-    def test_declared_skills_entry_holding_no_skill_warns(self, tmp_path, caplog):
+    def test_declared_skills_entry_holding_no_skill_warns(self, tmp_path):
         """An entry that is neither a skill nor a container must say so.
 
         A container whose skills sit two levels down reaches no deployable
@@ -629,14 +629,15 @@ class TestMapPluginArtifacts:
 
         apm_dir = plugin_dir / ".apm"
         apm_dir.mkdir()
-        with caplog.at_level(logging.WARNING, logger="apm_cli.deps.plugin_parser"):
+        with patch("apm_cli.deps.plugin_parser._rich_warning") as rich_warning:
             _map_plugin_artifacts(plugin_dir, apm_dir, manifest={"skills": ["./skills/"]})
 
-        assert "skills" in caplog.text
-        assert "no SKILL.md" in caplog.text
-        assert "--skill" in caplog.text
+        warning = rich_warning.call_args.args[0]
+        assert "skills" in warning
+        assert "no SKILL.md" in warning
+        assert "--skill" in warning
 
-    def test_declared_skills_container_does_not_warn(self, tmp_path, caplog):
+    def test_declared_skills_container_does_not_warn(self, tmp_path):
         """The healthy shapes stay quiet -- a warning nobody can act on is noise."""
         plugin_dir = tmp_path / "plugin"
         plugin_dir.mkdir()
@@ -646,10 +647,10 @@ class TestMapPluginArtifacts:
 
         apm_dir = plugin_dir / ".apm"
         apm_dir.mkdir()
-        with caplog.at_level(logging.WARNING, logger="apm_cli.deps.plugin_parser"):
+        with patch("apm_cli.deps.plugin_parser._rich_warning") as rich_warning:
             _map_plugin_artifacts(plugin_dir, apm_dir, manifest={"skills": ["./skills/"]})
 
-        assert "no SKILL.md" not in caplog.text
+        rich_warning.assert_not_called()
 
     def test_custom_commands_path(self, tmp_path):
         """Manifest commands field redirects command discovery."""


### PR DESCRIPTION
## TL;DR

Plugin LSP intake rejected servers whose config uses the Copilot CLI spelling `fileExtensions` instead of `extensionToLanguage`, silently dropping them -- including the official dotnet/skills dotnet plugin, whose headline feature is its C# language server. This PR accepts the Copilot-dialect spellings as input aliases.

Closes #2509.

## What changed

- `_lsp_servers_to_apm_deps` applies two aliases when the canonical key is absent or null: `fileExtensions` -> `extensionToLanguage` and `warmupTimeoutMs` -> `startupTimeout`. A non-null canonical spelling wins when both are present; equal dual spellings stay quiet.
- The unsupported `cwd` field is ignored with one default-visible warning that explains the consumer runtime chooses the working directory.
- Invalid alias diagnostics name the authored alias.
- Canonical manifests and lockfiles retain `extensionToLanguage` and `startupTimeout`; Copilot output uses its native `fileExtensions` and `warmupTimeoutMs` keys.
- Unit coverage includes aliases, null fallback, precedence, warning behavior, invalid aliases, and target rendering. A real CLI lifecycle regression proves install, canonical lock state, Copilot output, byte-identical reinstall, and clean `apm audit --ci`.

## Why aliasing (not rejecting) is right

- APM itself emits `fileExtensions` when generating Copilot CLI output (`.github/lsp.json`) -- intake rejected the exact spelling the output path produces.
- Both real-world consumer runtimes accept `fileExtensions`: Copilot CLI natively, and Claude Code in practice (verified against the dotnet plugin installed via its marketplace).

## Validation

| Scenario | Regression proof | Principles |
|---|---|---|
| A Copilot-dialect plugin LSP config reaches canonical lock state and `.github/lsp.json`, emits one actionable `cwd` warning, then survives reinstall and audit unchanged. | `tests/integration/test_plugin_e2e.py::TestPluginHeroScenarios::test_copilot_dialect_plugin_lsp_survives_install_reinstall_and_audit` | Multi-harness support, Governed by policy, DevX |
| Parser aliases, null fallback, conflict precedence, warning behavior, and invalid diagnostics remain deterministic. | `tests/unit/deps/test_plugin_parser_lsp.py` | Multi-harness support, DevX |
| Copilot output uses native language and timeout keys. | `tests/unit/integration/test_lsp_integrator.py::TestInstallCopilotTarget::test_writes_project_lsp_json_with_file_extensions` | Multi-harness support, Portability by manifest |

- Plugin parser and LSP integrator unit tests: 70 passed.
- Exact-head plugin lifecycle tests: 2 passed.
- Full CI: green, including lint, Linux shards, lifecycle smoke, Windows compatibility, CodeQL, spec conformance, CRLF invariance, and merge gate.

apm-spec-waiver: Copilot LSP aliases are compatibility intake for an out-of-scope third-party plugin format.

*Disclosure: developed with AI assistance; changes and tests were run and verified manually.*

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>