### PR TITLE
fix(integration): deploy namespaced prompts instead of silently dropping them

### DIFF
--- a/src/apm_cli/integration/base_integrator.py
+++ b/src/apm_cli/integration/base_integrator.py
@@ -12,7 +12,11 @@ from apm_cli.core.deployment_state import MaterializationResult
 from apm_cli.primitives.discovery import discover_primitives
 from apm_cli.utils.atomic_io import normalize_crlf_to_lf
 from apm_cli.utils.console import _rich_warning
-from apm_cli.utils.path_security import PathTraversalError, ensure_path_within
+from apm_cli.utils.path_security import (
+    PathTraversalError,
+    ensure_path_within,
+    validate_path_segments,
+)
 
 
 def _managed_absolute_target_root(candidate: Path, targets: Any) -> Path | None:
@@ -962,3 +966,42 @@ class BaseIntegrator:
                     results.append(f)
 
         return results
+
+    @staticmethod
+    def primitive_namespace(source_file: Path, primitive_dir: Path) -> tuple[str, ...]:
+        """Return the sub-directory components of *source_file* under *primitive_dir*.
+
+        A primitive authored at ``.apm/prompts/opsx/propose.prompt.md`` carries the
+        namespace ``("opsx",)``; one authored flat at ``.apm/prompts/propose.prompt.md``
+        (or in the package root) carries ``()``.  Callers join the namespace onto the
+        deploy directory so the layout an author wrote is the layout the harness sees --
+        Claude Code, for one, reads ``commands/opsx/propose.md`` as ``/opsx:propose``.
+
+        Returns an empty tuple when *source_file* is not under *primitive_dir*, so a
+        caller can always join unconditionally.  Each component is validated: a
+        traversal segment yields ``()`` rather than an escaping path, and
+        ``ensure_path_within`` at the call site remains the second line of defence.
+
+        Args:
+            source_file: Absolute path to the discovered primitive file.
+            primitive_dir: Absolute path to the directory the namespace is relative to.
+
+        Returns:
+            Tuple of directory components, outermost first.
+        """
+        try:
+            relative = source_file.relative_to(primitive_dir)
+        except ValueError:
+            return ()
+
+        parts = relative.parts[:-1]
+        if not parts:
+            return ()
+
+        try:
+            for part in parts:
+                validate_path_segments(part, context="primitive namespace")
+        except PathTraversalError:
+            return ()
+
+        return parts

--- a/src/apm_cli/integration/command_integrator.py
+++ b/src/apm_cli/integration/command_integrator.py
@@ -187,8 +187,17 @@ class CommandIntegrator(BaseIntegrator):
         return True
 
     def find_prompt_files(self, package_path: Path) -> list[Path]:
-        """Find all .prompt.md files in a package."""
-        return self.find_files_by_glob(package_path, "*.prompt.md", subdirs=[".apm/prompts"])
+        """Find all .prompt.md files in a package.
+
+        The package root is searched flat; ``.apm/prompts/`` is searched recursively so
+        a namespaced command survives to the target.  See PromptIntegrator for why the
+        two halves differ.
+        """
+        files = self.find_files_by_glob(package_path, "*.prompt.md")
+        apm_prompts = package_path / ".apm" / "prompts"
+        if apm_prompts.exists():
+            files += self.find_files_by_glob(apm_prompts, "**/*.prompt.md")
+        return files
 
     def _transform_prompt_to_command(
         self,
@@ -510,6 +519,7 @@ class CommandIntegrator(BaseIntegrator):
         self.init_link_resolver(package_info, project_root)
 
         commands_dir = target_root / mapping.subdir
+        pkg_prompts_dir = package_info.install_path / ".apm" / "prompts"
         files_integrated = 0
         files_skipped = 0
         files_adopted = 0
@@ -556,7 +566,12 @@ class CommandIntegrator(BaseIntegrator):
                 files_skipped += 1
                 continue
 
-            target_path = commands_dir / f"{base_name}{mapping.extension}"
+            # Preserve the author's sub-directory under .apm/prompts/.  Harnesses that
+            # namespace commands by directory read it back: Claude Code surfaces
+            # commands/opsx/propose.md as /opsx:propose.  A flat prompt yields () and
+            # lands exactly where it always has.
+            namespace = self.primitive_namespace(prompt_file, pkg_prompts_dir)
+            target_path = commands_dir.joinpath(*namespace, f"{base_name}{mapping.extension}")
 
             # Defense-in-depth: assert the resolved target stays inside
             # the commands directory even if validate_path_segments was

--- a/src/apm_cli/integration/prompt_integrator.py
+++ b/src/apm_cli/integration/prompt_integrator.py
@@ -22,8 +22,13 @@ class PromptIntegrator(BaseIntegrator):
         """Find all .prompt.md files in a package.
 
         Searches in:
-        - Package root directory
-        - .apm/prompts/ subdirectory
+        - Package root directory (flat)
+        - .apm/prompts/ subdirectory, recursively
+
+        The recursive half mirrors AgentIntegrator.find_agent_files, which has always
+        used ``**/*.agent.md`` under ``.apm/agents/``.  Prompts were the odd type out:
+        a package authoring ``.apm/prompts/opsx/propose.prompt.md`` had that file
+        silently dropped, never deployed and never reported.
 
         Args:
             package_path: Path to the package directory
@@ -31,7 +36,11 @@ class PromptIntegrator(BaseIntegrator):
         Returns:
             List[Path]: List of absolute paths to .prompt.md files
         """
-        return self.find_files_by_glob(package_path, "*.prompt.md", subdirs=[".apm/prompts"])
+        files = self.find_files_by_glob(package_path, "*.prompt.md")
+        apm_prompts = package_path / ".apm" / "prompts"
+        if apm_prompts.exists():
+            files += self.find_files_by_glob(apm_prompts, "**/*.prompt.md")
+        return files
 
     def copy_prompt(self, source: Path, target: Path) -> int:
         """Copy prompt file verbatim with link resolution.
@@ -284,7 +293,13 @@ class PromptIntegrator(BaseIntegrator):
                 continue
 
             target_filename = self.get_target_filename(source_file, package_info.package.name)
-            target_path = prompts_dir / target_filename
+            # Preserve the author's sub-directory under .apm/prompts/ so a namespaced
+            # prompt keeps its namespace at the target.  Flat prompts get () here and
+            # land exactly where they always have.
+            namespace = self.primitive_namespace(
+                source_file, package_info.install_path / ".apm" / "prompts"
+            )
+            target_path = prompts_dir.joinpath(*namespace, target_filename)
             # Defense-in-depth: target_filename is derived from source
             # file name; assert containment under prompts_dir to mirror
             # the guard already present in command/instruction
@@ -313,6 +328,11 @@ class PromptIntegrator(BaseIntegrator):
                 files_skipped += 1
                 continue
 
+            # Namespaced prompts deploy into a sub-directory that may not exist yet;
+            # write_text_lf requires the parent.  Created only once the file has
+            # cleared adoption and collision checks, so a skipped prompt leaves no
+            # empty directory behind.
+            target_path.parent.mkdir(parents=True, exist_ok=True)
             links_resolved = self.copy_prompt(source_file, target_path)
             total_links_resolved += links_resolved
             files_integrated += 1

--- a/tests/unit/integration/test_command_integrator.py
+++ b/tests/unit/integration/test_command_integrator.py
@@ -1717,3 +1717,72 @@ class TestCursorCommandPanelFindings:
         assert any(i.severity == "critical" for i in sec_items), (
             f"expected critical security diagnostic, got: {[(i.severity, i.message) for i in sec_items]}"
         )
+
+
+class TestNamespacedCommands:
+    """A prompt under .apm/prompts/<ns>/ keeps <ns> at the target.
+
+    Claude Code reads ``commands/opsx/propose.md`` as ``/opsx:propose``.  Before
+    recursive discovery landed, the nested source was never found at all: it was
+    silently dropped, so the namespaced command simply did not exist.
+    """
+
+    @pytest.fixture
+    def temp_project(self):
+        temp_dir = tempfile.mkdtemp()
+        temp_path = Path(temp_dir)
+        (temp_path / ".claude" / "commands").mkdir(parents=True)
+        yield temp_path
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+    @staticmethod
+    def _make_nested_package(project_root):
+        pkg_dir = project_root / "apm_modules" / "test-pkg"
+        prompts_dir = pkg_dir / ".apm" / "prompts"
+        (prompts_dir / "opsx").mkdir(parents=True)
+
+        (prompts_dir / "flat.prompt.md").write_text(
+            "---\ndescription: Flat\n---\n# Flat\n", encoding="utf-8"
+        )
+        (prompts_dir / "opsx" / "propose.prompt.md").write_text(
+            "---\ndescription: Propose a change\n---\n# Propose\n", encoding="utf-8"
+        )
+
+        mock_info = MagicMock()
+        mock_info.install_path = pkg_dir
+        mock_info.resolved_reference = None
+        mock_info.package = MagicMock()
+        mock_info.package.name = "test-pkg"
+        return mock_info
+
+    def test_nested_prompt_keeps_its_namespace(self, temp_project):
+        """.apm/prompts/opsx/propose.prompt.md -> .claude/commands/opsx/propose.md."""
+        from apm_cli.integration.targets import KNOWN_TARGETS
+
+        pkg_info = self._make_nested_package(temp_project)
+        result = CommandIntegrator().integrate_commands_for_target(
+            KNOWN_TARGETS["claude"],
+            pkg_info,
+            temp_project,
+        )
+
+        commands = temp_project / ".claude" / "commands"
+        assert (commands / "opsx" / "propose.md").exists(), "namespaced command was dropped"
+        # The flat prompt is unaffected -- no existing package changes shape.
+        assert (commands / "flat.md").exists()
+        assert result.files_integrated == 2
+
+    def test_nested_prompt_content_is_transformed_normally(self, temp_project):
+        """Namespacing changes the path only, not the command transform."""
+        from apm_cli.integration.targets import KNOWN_TARGETS
+
+        pkg_info = self._make_nested_package(temp_project)
+        CommandIntegrator().integrate_commands_for_target(
+            KNOWN_TARGETS["claude"],
+            pkg_info,
+            temp_project,
+        )
+
+        post = frontmatter.load(temp_project / ".claude" / "commands" / "opsx" / "propose.md")
+        assert post.metadata["description"] == "Propose a change"
+        assert "# Propose" in post.content

--- a/tests/unit/integration/test_prompt_integrator.py
+++ b/tests/unit/integration/test_prompt_integrator.py
@@ -63,6 +63,46 @@ class TestPromptIntegrator:
         assert len(prompts) == 1
         assert prompts[0].name == "workflow.prompt.md"
 
+    def test_find_prompt_files_recurses_into_apm_prompts_subdirs(self):
+        """Namespaced prompts under .apm/prompts/ are discovered, not dropped."""
+        package_dir = self.project_root / "package"
+        apm_prompts = package_dir / ".apm" / "prompts"
+        (apm_prompts / "opsx").mkdir(parents=True)
+
+        (apm_prompts / "flat.prompt.md").write_text("# Flat")
+        (apm_prompts / "opsx" / "propose.prompt.md").write_text("# Propose")
+
+        found = {p.name for p in self.integrator.find_prompt_files(package_dir)}
+        assert found == {"flat.prompt.md", "propose.prompt.md"}
+
+    def test_find_prompt_files_does_not_recurse_package_root(self):
+        """Only .apm/prompts/ recurses -- an arbitrary package subtree must not."""
+        package_dir = self.project_root / "package"
+        (package_dir / "docs" / "examples").mkdir(parents=True)
+
+        (package_dir / "top.prompt.md").write_text("# Top")
+        (package_dir / "docs" / "examples" / "sample.prompt.md").write_text("# Sample")
+
+        found = {p.name for p in self.integrator.find_prompt_files(package_dir)}
+        assert found == {"top.prompt.md"}
+
+    def test_primitive_namespace_components(self):
+        """The namespace is the sub-directory path under the primitive dir."""
+        package_dir = self.project_root / "package"
+        apm_prompts = package_dir / ".apm" / "prompts"
+        (apm_prompts / "opsx" / "deep").mkdir(parents=True)
+
+        flat = apm_prompts / "flat.prompt.md"
+        nested = apm_prompts / "opsx" / "propose.prompt.md"
+        deeper = apm_prompts / "opsx" / "deep" / "dive.prompt.md"
+        outside = package_dir / "root.prompt.md"
+
+        assert self.integrator.primitive_namespace(flat, apm_prompts) == ()
+        assert self.integrator.primitive_namespace(nested, apm_prompts) == ("opsx",)
+        assert self.integrator.primitive_namespace(deeper, apm_prompts) == ("opsx", "deep")
+        # A file outside the primitive dir yields (), so callers can join blindly.
+        assert self.integrator.primitive_namespace(outside, apm_prompts) == ()
+
     def test_copy_prompt_verbatim(self):
         """Test copying prompt file verbatim without metadata injection."""
         source = self.project_root / "source.prompt.md"


### PR DESCRIPTION
## Description

A prompt authored at `.apm/prompts/<ns>/<name>.prompt.md` is never deployed and never
reported. `PromptIntegrator.find_prompt_files` and `CommandIntegrator.find_prompt_files`
both glob `.apm/prompts` exactly one level deep:

```python
# prompt_integrator.py / command_integrator.py -- before
find_files_by_glob(package_path, "*.prompt.md", subdirs=[".apm/prompts"])
```

Anything in a subdirectory is invisible: no warning, no diagnostic, absent from the
lockfile. The install summary just reports a lower count than the package contains.

Agents never had this problem — `AgentIntegrator.find_agent_files` has always searched
`.apm/agents/` with `**/*.agent.md`. Prompts were the odd type out, which is what
suggests an oversight rather than a design stance.

**It also loses content on a supported input path.** `plugin_parser` maps a Claude Code
plugin's `commands/` directory into `.apm/prompts/`, walking it with `rglob("*")` and
preserving subdirectories via `rel_to=source`. Claude plugins routinely namespace
commands that way, so APM faithfully copies `commands/<ns>/x.md` to
`.apm/prompts/<ns>/x.prompt.md` — and then discards it at integration time. Installing
such a plugin silently yields fewer commands than the plugin ships.

Beyond fixing the loss, preserving the subdirectory is what makes namespaced commands
expressible at all: Claude Code reads `commands/opsx/propose.md` as `/opsx:propose`.

### Reproduction

A package with three prompts:

```
.apm/prompts/flat.prompt.md
.apm/prompts/opsx-propose.prompt.md
.apm/prompts/opsx/propose.prompt.md
```

`apm install` against the `claude` target, before this change:

```
2 commands integrated -> .claude/commands/
.claude/commands/flat.md
.claude/commands/opsx-propose.md
```

The third prompt is gone, with nothing said about it. After:

```
3 commands integrated -> .claude/commands/
.claude/commands/flat.md
.claude/commands/opsx-propose.md
.claude/commands/opsx/propose.md
```

The new file is recorded in the lockfile's `deployed_files` with its hash, so uninstall
and `apm audit` track it like any other deployed file.

## Changes

- Search `.apm/prompts/` recursively in both integrators, mirroring `AgentIntegrator`.
  The package root stays a **flat** search, so an unrelated subtree (`docs/`,
  `examples/`) is not swept in — there is a regression test for this.
- Add `BaseIntegrator.primitive_namespace()`, returning the subdirectory components of a
  source file relative to its primitive directory. Every component goes through
  `validate_path_segments`; a file that is flat, or outside the primitive directory,
  yields `()` so callers can join unconditionally. `ensure_path_within` at each call site
  remains the second line of defence.
- Join that namespace onto the deploy directory in both integrators.
- Create the target's parent directory in `PromptIntegrator` before writing —
  `write_text_lf` documents that the caller must ensure the parent exists. The command
  writers (`_write_claude_command`, `_write_gemini_command`) already did this.

### Compatibility

Existing packages are unaffected. A flat prompt yields an empty namespace and lands at
exactly the path it always has. The only files whose behaviour changes are the ones that
were previously dropped, which go from invisible to deployed.

### Deliberately not changed

The copilot-app path deploys workflow rows into SQLite keyed by name rather than files,
where a directory namespace has no meaning. `CopilotAppWorkflowIntegrator` keeps its flat
discovery.

## Open question for maintainers

I preserve the subdirectory for every **file-based** target. That is unambiguously right
for Claude Code (`commands/opsx/propose.md` → `/opsx:propose`). Targets whose prompt
directory has no namespace concept — Copilot's `.github/prompts/`, for instance — will
receive the file nested, where it may not be picked up.

That is still strictly better than today, where the file is not written at all, but a
per-target policy (preserve / flatten-with-separator / reject) is a design call that
belongs to you rather than to this PR. Happy to add a `namespaced: bool` field to the
target registry and gate on it if you prefer that shape.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [x] Added tests for new functionality (if applicable)

Full unit suite as CI runs it (`uv run pytest tests/unit tests/test_console.py`):
**19805 passed, 2 skipped, 21 xfailed**. `ruff check` and `ruff format --check` clean.

Six tests added:

| Test | Covers |
| --- | --- |
| `test_find_prompt_files_recurses_into_apm_prompts_subdirs` | nested discovery |
| `test_find_prompt_files_does_not_recurse_package_root` | guard against over-recursion |
| `test_primitive_namespace_components` | flat, nested, deeper, outside-the-dir |
| `test_nested_prompt_keeps_its_namespace` | end-to-end deploy path |
| `test_nested_prompt_content_is_transformed_normally` | namespacing changes path only |

I reverted `src/` and re-ran them to confirm they are load-bearing: four fail without the
source change. The remaining two are regression guards that pass either way, by design.

## Spec conformance (OpenAPM v0.1)

- [x] N/A -- this PR does not change OpenAPM-observable behaviour.

Reasoning, so you can disagree knowingly rather than assume the box was ticked
carelessly: `req-tg-002` requires deploying only **under** the registered deploy root,
and `.claude/commands/opsx/propose.md` is under `.claude/commands/`. No requirement
mandates a flat layout within a root, and §8.1 says only that primitives are "hoisted
individually into deploy directories" without constraining the resulting path shape.
`req-pr-001` covers source attribution rather than discovery recursion. If you read
§8.5 as fixing the intra-root layout, say so and I will run the three-step ritual.
