### PR TITLE
fix(yaml): skip alias-expansion budget for anchor-free documents (supersedes #2493, closes #2389)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Multi-target `apm compile` now avoids repeating expensive project analysis
   for each target, making multi-target runs scale like single-target runs
   without changing generated output. (closes #2482)
+- YAML expansion guard no longer rejects large anchor-free lockfiles (150K+
+  entries) with a false-positive "billion-laughs" error. APM-generated
+  lockfiles with no anchors or aliases now load without error. (#2389)
 
 ## [0.28.0] - 2026-08-04
 

--- a/src/apm_cli/utils/yaml_io.py
+++ b/src/apm_cli/utils/yaml_io.py
@@ -68,7 +68,7 @@ class _BoundedSafeLoader(yaml.SafeLoader):
     **Two-budget strategy (fix for issue #2389):** ``_guard_expansion`` now
     pre-scans for aliases via ``_has_aliases`` before computing expansion
     weights. Anchor-free documents (no shared node objects in the composed
-    graph) cannot amplify -- their weight equals O(1) of input size -- so the
+    graph) cannot amplify -- their weight scales linearly with input size -- so the
     tight expansion budget is skipped entirely for them. Only documents that
     contain aliases are subjected to the 5M weight cap. The merge-entry and
     depth guards are orthogonal and unaffected.
@@ -144,7 +144,7 @@ class _BoundedSafeLoader(yaml.SafeLoader):
         #
         # Anchor-free documents (no shared node objects in the composed graph)
         # cannot produce alias-expansion amplification -- their total weight
-        # equals O(1) of literal input size.  Applying the tight 5M cap to
+        # scales linearly with literal input size (O(N)).  Applying the tight 5M cap to
         # them produces false-positive rejections of legitimate large lockfiles
         # (APM's own generated output).  We therefore pre-scan with
         # _has_aliases: if the graph is alias-free, return immediately.

--- a/src/apm_cli/utils/yaml_io.py
+++ b/src/apm_cli/utils/yaml_io.py
@@ -64,6 +64,14 @@ class _BoundedSafeLoader(yaml.SafeLoader):
     ``load_yaml`` consumer uniformly, including the non-trust
     ``apm lifecycle validate`` / ``test`` paths that never run
     ``_is_fingerprint_safe``.
+
+    **Two-budget strategy (fix for issue #2389):** ``_guard_expansion`` now
+    pre-scans for aliases via ``_has_aliases`` before computing expansion
+    weights. Anchor-free documents (no shared node objects in the composed
+    graph) cannot amplify -- their weight equals O(1) of input size -- so the
+    tight expansion budget is skipped entirely for them. Only documents that
+    contain aliases are subjected to the 5M weight cap. The merge-entry and
+    depth guards are orthogonal and unaffected.
     """
 
     _MAX_MERGE_ENTRIES = 100_000
@@ -85,36 +93,94 @@ class _BoundedSafeLoader(yaml.SafeLoader):
             getattr(node, "start_mark", None),
         )
 
+    @staticmethod
+    def _has_aliases(root: Any) -> bool:
+        """Return True if the composed node graph contains any shared nodes.
+
+        PyYAML represents every ``*alias`` reference as a pointer to the same
+        node object.  If any node's ``id()`` is encountered more than once
+        during a full graph traversal the document contains aliases (or a
+        self-referential cycle), meaning alias-expansion amplification is
+        possible.  Anchor-free documents are pure trees whose node objects are
+        never shared, so this returns False for them.
+
+        The traversal uses two sets:
+
+        * ``stack`` -- node IDs currently on the active recursion path.  A
+          hit here means a back-edge (cycle / self-referential anchor).
+        * ``seen`` -- node IDs already fully visited from a prior path.  A
+          hit here means a cross-edge (classic alias, reachable from two
+          different parents).
+
+        Both cases mean shared nodes are present; we return True immediately.
+        """
+        seen: set[int] = set()
+        stack: set[int] = set()
+
+        def visit(node: Any) -> bool:
+            nid = id(node)
+            if nid in stack or nid in seen:
+                return True
+            stack.add(nid)
+            found = False
+            if isinstance(node, yaml.nodes.MappingNode):
+                for key_node, value_node in node.value:
+                    if visit(key_node) or visit(value_node):
+                        found = True
+                        break
+            elif isinstance(node, yaml.nodes.SequenceNode):
+                for child in node.value:
+                    if visit(child):
+                        found = True
+                        break
+            stack.discard(nid)
+            seen.add(nid)
+            return found
+
+        return visit(root)
+
     def _guard_expansion(self, root: Any) -> None:
-        # Bound the LOGICAL (alias-expanded) size of the composed node graph
-        # BEFORE construction. PyYAML shares one node object across every
-        # ``*alias`` reference, so a pure-alias billion-laughs graph
-        # (``lN: &lN [*l(N-1), *l(N-1)]``) is only O(N) objects yet expands
-        # to O(2^N) the moment any consumer materializes it (``str()``,
-        # deepcopy, re-serialize). It carries no ``<<`` so the merge-entry
-        # budget never engages, and non-trust consumers
-        # (``apm lifecycle validate`` / ``test``) never run the post-parse
-        # ``_is_fingerprint_safe`` guard -- so without this the bomb wedges
-        # them. We compute a memoized per-node expansion weight (shared nodes
-        # are walked once but summed per occurrence by each parent) and fail
-        # closed as a ``yaml.YAMLError`` the instant the running total crosses
-        # the budget. A self-referential anchor (``a: &a [*a]``) is a cycle in
-        # the node graph; the in-progress sentinel detects it and fails closed
-        # rather than recursing forever. The budget is orders of magnitude
-        # above any legitimate config, so real anchors/aliases still resolve.
+        # Two-budget alias-expansion guard (issue #2389):
+        #
+        # Anchor-free documents (no shared node objects in the composed graph)
+        # cannot produce alias-expansion amplification -- their total weight
+        # equals O(1) of literal input size.  Applying the tight 5M cap to
+        # them produces false-positive rejections of legitimate large lockfiles
+        # (APM's own generated output).  We therefore pre-scan with
+        # _has_aliases: if the graph is alias-free, return immediately.
+        #
+        # Only alias-containing documents proceed to the full weight check:
+        # PyYAML shares one node object across every ``*alias`` reference, so
+        # a pure-alias billion-laughs graph (``lN: &lN [*l(N-1), *l(N-1)]``)
+        # is only O(N) objects yet expands to O(2^N) the moment any consumer
+        # materializes it (``str()``, deepcopy, re-serialize).  It carries no
+        # ``<<`` so the merge-entry budget never engages, and non-trust
+        # consumers (``apm lifecycle validate`` / ``test``) never run the
+        # post-parse ``_is_fingerprint_safe`` guard -- so without this the
+        # bomb wedges them.  We compute a memoized per-node expansion weight
+        # (shared nodes are walked once but summed per occurrence by each
+        # parent) and fail closed as a ``yaml.YAMLError`` the instant the
+        # running total crosses the budget.  A self-referential anchor
+        # (``a: &a [*a]``) is detected as aliases-present by _has_aliases and
+        # then caught by the in-progress sentinel below.
         #
         # Leaf weight is BYTE-AWARE, not a flat 1: PyYAML's representer reports
         # ``ignore_aliases() == True`` for ``str`` / ``int`` / ``float`` /
         # ``bytes`` / ``bool``, so on the dump side (``dump_yaml`` /
         # ``yaml_to_str``) a shared scalar is NOT re-anchored -- its full text
-        # is re-emitted once PER alias occurrence. A single ~50KB anchored
+        # is re-emitted once PER alias occurrence.  A single ~50KB anchored
         # scalar aliased tens of thousands of times therefore composes as only
         # O(N) nodes (passing a node-count guard) yet re-serializes to ~GBs and
         # hangs/OOMs the emitter -- reachable pre-trust on the
-        # ``apm install`` / ``apm uninstall`` apm.yml round-trip. Charging each
-        # scalar occurrence its emitted byte length makes the budget model the
-        # real dump-amplification cost, so the bomb fails closed at parse while
-        # a single large scalar (referenced a handful of times) still resolves.
+        # ``apm install`` / ``apm uninstall`` apm.yml round-trip.  Charging
+        # each scalar occurrence its emitted byte length makes the budget model
+        # the real dump-amplification cost, so the bomb fails closed at parse
+        # while a single large scalar (referenced a handful of times) still
+        # resolves.
+        if not self._has_aliases(root):
+            # Anchor-free document: literal tree, no amplification possible.
+            return
+
         weights: dict[int, int] = {}
 
         def weight(node: Any) -> int:

--- a/src/apm_cli/utils/yaml_io.py
+++ b/src/apm_cli/utils/yaml_io.py
@@ -94,7 +94,7 @@ class _BoundedSafeLoader(yaml.SafeLoader):
         )
 
     @staticmethod
-    def _has_aliases(root: Any) -> bool:
+    def _has_aliases(root: yaml.nodes.Node) -> bool:
         """Return True if the composed node graph contains any shared nodes.
 
         PyYAML represents every ``*alias`` reference as a pointer to the same

--- a/src/apm_cli/utils/yaml_io.py
+++ b/src/apm_cli/utils/yaml_io.py
@@ -104,40 +104,45 @@ class _BoundedSafeLoader(yaml.SafeLoader):
         possible.  Anchor-free documents are pure trees whose node objects are
         never shared, so this returns False for them.
 
-        The traversal uses two sets:
+        The traversal is iterative (no Python recursion) so it is safe for
+        deeply nested anchor-free documents that would otherwise hit the
+        default 1000-frame recursion limit.  It uses two sets:
 
-        * ``stack`` -- node IDs currently on the active recursion path.  A
-          hit here means a back-edge (cycle / self-referential anchor).
-        * ``seen`` -- node IDs already fully visited from a prior path.  A
-          hit here means a cross-edge (classic alias, reachable from two
-          different parents).
+        * ``active`` -- node IDs currently on the active DFS path (pre-order
+          entered, post-order not yet exited).  A hit here means a back-edge
+          (cycle / self-referential anchor).
+        * ``seen`` -- node IDs fully visited from a previous DFS path.  A hit
+          here means a cross-edge (classic alias reachable from two parents).
 
-        Both cases mean shared nodes are present; we return True immediately.
+        Both cases indicate shared nodes; we return True immediately.
         """
         seen: set[int] = set()
-        stack: set[int] = set()
-
-        def visit(node: Any) -> bool:
+        active: set[int] = set()
+        # Work stack entries: (node, entering).
+        #   entering=True  -> first visit; check for alias, push exit + children.
+        #   entering=False -> post-visit; move node from active to seen.
+        work: list[tuple[yaml.nodes.Node, bool]] = [(root, True)]
+        while work:
+            node, entering = work.pop()
             nid = id(node)
-            if nid in stack or nid in seen:
-                return True
-            stack.add(nid)
-            found = False
-            if isinstance(node, yaml.nodes.MappingNode):
-                for key_node, value_node in node.value:
-                    if visit(key_node) or visit(value_node):
-                        found = True
-                        break
-            elif isinstance(node, yaml.nodes.SequenceNode):
-                for child in node.value:
-                    if visit(child):
-                        found = True
-                        break
-            stack.discard(nid)
-            seen.add(nid)
-            return found
-
-        return visit(root)
+            if entering:
+                if nid in active or nid in seen:
+                    return True
+                active.add(nid)
+                # Schedule post-visit before children so it fires after them.
+                work.append((node, False))
+                if isinstance(node, yaml.nodes.MappingNode):
+                    # Push in reverse so leftmost key is processed first.
+                    for key_node, value_node in reversed(node.value):
+                        work.append((value_node, True))
+                        work.append((key_node, True))
+                elif isinstance(node, yaml.nodes.SequenceNode):
+                    for child in reversed(node.value):
+                        work.append((child, True))
+            else:
+                active.discard(nid)
+                seen.add(nid)
+        return False
 
     def _guard_expansion(self, root: Any) -> None:
         # Two-budget alias-expansion guard (issue #2389):

--- a/tests/red_team/parser/test_yaml_bomb.py
+++ b/tests/red_team/parser/test_yaml_bomb.py
@@ -153,8 +153,8 @@ def test_large_anchor_free_lockfile_loads_successfully(tmp_path: Path):
     positive "billion-laughs expansion bomb" error.  After the fix, anchor-free
     documents bypass the tight expansion cap entirely.
 
-    The generated document contains approximately 200,000 scalar bytes across
-    20,000 mapping entries (no anchors, no aliases) -- well above the 5M weight
+    The generated document contains approximately 6,000,000 scalar bytes across
+    150,000 mapping entries (no anchors, no aliases) -- well above the 5M weight
     threshold -- and must load without error.
     """
     from apm_cli.utils.yaml_io import load_yaml

--- a/tests/red_team/parser/test_yaml_bomb.py
+++ b/tests/red_team/parser/test_yaml_bomb.py
@@ -142,3 +142,66 @@ def test_shallow_alias_doc_still_parses_under_budget(tmp_path: Path, levels: int
     assert finished, f"depth={levels}: load did not finish"
     assert exc is None, f"depth={levels}: shallow doc wrongly rejected: {exc!r}"
     assert isinstance(result, dict)
+
+
+def test_large_anchor_free_lockfile_loads_successfully(tmp_path: Path):
+    """Regression for issue #2389: large anchor-free lockfile must not be rejected.
+
+    APM-generated lockfiles can accumulate a YAML node-weight sum that exceeds
+    the 5M alias-expansion budget purely through literal size, with zero anchors
+    or aliases.  Before the two-budget fix ``_guard_expansion`` raised a false-
+    positive "billion-laughs expansion bomb" error.  After the fix, anchor-free
+    documents bypass the tight expansion cap entirely.
+
+    The generated document contains approximately 200,000 scalar bytes across
+    20,000 mapping entries (no anchors, no aliases) -- well above the 5M weight
+    threshold -- and must load without error.
+    """
+    from apm_cli.utils.yaml_io import load_yaml
+
+    # Build a document whose accumulated leaf byte cost exceeds 5_000_000.
+    # Each entry contributes: key (8 bytes) + value (32 bytes hex) = ~40 bytes.
+    # 150_000 entries * 40 bytes = ~6_000_000 -- comfortably above the cap.
+    entry_count = 150_000
+    lines = ["packages:\n"]
+    for i in range(entry_count):
+        # 32-char hex value ensures enough byte weight per leaf.
+        lines.append(f"  pkg{i:06d}: abcdef1234567890abcdef1234567890\n")
+    doc = tmp_path / "apm.lock.yaml"
+    doc.write_text("".join(lines), encoding="utf-8")
+
+    finished, result, exc = run_guarded(lambda: load_yaml(doc), timeout=30.0)
+    assert finished, "load_yaml timed out on large anchor-free lockfile"
+    assert exc is None, f"large anchor-free lockfile wrongly rejected (false positive): {exc!r}"
+    assert isinstance(result, dict)
+    assert len(result["packages"]) == entry_count
+
+
+def test_merge_key_bomb_still_rejected(tmp_path: Path):
+    """Merge-key bomb is rejected by the merge-entry budget regardless of alias check.
+
+    A merge-key chain (``<<: [*a, *a]`` at each level) uses aliases AND the
+    ``<<`` merge key, so both the alias check and the merge-entry guard engage.
+    The merge-entry guard fires first and must raise ``yaml.YAMLError``.
+    This verifies the two-budget refactor did not break the orthogonal
+    ``flatten_mapping`` / merge-entry guard path.
+    """
+    import yaml
+
+    from apm_cli.utils.yaml_io import load_yaml
+
+    # 30 levels of doubling merge: 2**30 > 1_000_000_000 total entries.
+    levels = 30
+    lines = ["a0: &a0\n  x: 1\n"]
+    prev = "a0"
+    for i in range(1, levels + 1):
+        lines.append(f"a{i}: &a{i}\n  <<: [*{prev}, *{prev}]\n  y{i}: {i}\n")
+        prev = f"a{i}"
+    doc = tmp_path / "merge_bomb.yml"
+    doc.write_text("".join(lines), encoding="utf-8")
+
+    finished, _result, exc = run_guarded(lambda: load_yaml(doc), timeout=8.0)
+    assert finished, "load_yaml hung on merge-key bomb"
+    assert isinstance(exc, yaml.YAMLError), (
+        f"merge-key bomb must be rejected with yaml.YAMLError, got {exc!r}"
+    )

--- a/tests/red_team/parser/test_yaml_bomb.py
+++ b/tests/red_team/parser/test_yaml_bomb.py
@@ -182,16 +182,21 @@ def test_merge_key_bomb_still_rejected(tmp_path: Path):
 
     A merge-key chain (``<<: [*a, *a]`` at each level) uses aliases AND the
     ``<<`` merge key, so both the alias check and the merge-entry guard engage.
-    The merge-entry guard fires first and must raise ``yaml.YAMLError``.
-    This verifies the two-budget refactor did not break the orthogonal
-    ``flatten_mapping`` / merge-entry guard path.
+    The level count is chosen so that the per-node expansion weight stays under
+    the 5M alias-expansion budget (levels=17 yields ~2.6M combined weight) while
+    the doubling merge entries (2**17 = 131,072 > 100,000) trigger the
+    merge-entry budget first.  This verifies the two-budget refactor did not
+    break the orthogonal ``flatten_mapping`` / merge-entry guard path.
     """
     import yaml
 
     from apm_cli.utils.yaml_io import load_yaml
 
-    # 30 levels of doubling merge: 2**30 > 1_000_000_000 total entries.
-    levels = 30
+    # 17 levels of doubling merge: 2**17 = 131_072 > _MAX_MERGE_ENTRIES (100_000).
+    # Combined expansion weight is ~2.6M -- below the 5M alias-expansion cap --
+    # so the merge-entry budget fires first and the alias-expansion guard is a
+    # no-op for this case.
+    levels = 17
     lines = ["a0: &a0\n  x: 1\n"]
     prev = "a0"
     for i in range(1, levels + 1):
@@ -204,4 +209,7 @@ def test_merge_key_bomb_still_rejected(tmp_path: Path):
     assert finished, "load_yaml hung on merge-key bomb"
     assert isinstance(exc, yaml.YAMLError), (
         f"merge-key bomb must be rejected with yaml.YAMLError, got {exc!r}"
+    )
+    assert "merge-key expansion exceeded the safe budget" in str(exc), (
+        f"merge-entry guard must fire first, not alias-expansion guard; got {exc!r}"
     )

--- a/tests/unit/utils/test_has_aliases.py
+++ b/tests/unit/utils/test_has_aliases.py
@@ -1,0 +1,120 @@
+"""Direct unit tests for _BoundedSafeLoader._has_aliases.
+
+Covers edge cases that the integration tests in tests/red_team/parser/
+exercise only indirectly: empty mappings, scalar-only documents, a single
+cross-edge alias, a back-edge (self-referential anchor / cycle), and a
+tree with shared scalar leaf objects (which PyYAML reuses for duplicate
+identical scalars in some configurations).
+"""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from apm_cli.utils.yaml_io import _BoundedSafeLoader
+
+_has_aliases = _BoundedSafeLoader._has_aliases
+
+# ---------------------------------------------------------------------------
+# Helpers to build composed node graphs directly without parsing
+# ---------------------------------------------------------------------------
+_STR = "tag:yaml.org,2002:str"
+_MAP = "tag:yaml.org,2002:map"
+_SEQ = "tag:yaml.org,2002:seq"
+
+
+def _scalar(value: str) -> yaml.nodes.ScalarNode:
+    return yaml.nodes.ScalarNode(_STR, value)
+
+
+def _mapping(*pairs: tuple[yaml.nodes.Node, yaml.nodes.Node]) -> yaml.nodes.MappingNode:
+    return yaml.nodes.MappingNode(_MAP, list(pairs))
+
+
+def _sequence(*children: yaml.nodes.Node) -> yaml.nodes.SequenceNode:
+    return yaml.nodes.SequenceNode(_SEQ, list(children))
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_empty_mapping_returns_false() -> None:
+    """An empty mapping has no aliases."""
+    assert _has_aliases(_mapping()) is False
+
+
+def test_scalar_only_returns_false() -> None:
+    """A bare scalar document cannot have aliases."""
+    assert _has_aliases(_scalar("hello")) is False
+
+
+def test_plain_tree_mapping_returns_false() -> None:
+    """A non-trivial mapping with all distinct node objects returns False."""
+    root = _mapping(
+        (_scalar("a"), _scalar("1")),
+        (_scalar("b"), _scalar("2")),
+    )
+    assert _has_aliases(root) is False
+
+
+def test_sequence_of_scalars_returns_false() -> None:
+    """A sequence with all distinct scalar children returns False."""
+    root = _sequence(_scalar("x"), _scalar("y"), _scalar("z"))
+    assert _has_aliases(root) is False
+
+
+def test_single_alias_cross_edge_returns_true() -> None:
+    """A node referenced from two different parents is a cross-edge alias."""
+    shared = _scalar("shared_value")
+    root = _mapping(
+        (_scalar("key1"), shared),
+        (_scalar("key2"), shared),  # same object -> alias
+    )
+    assert _has_aliases(root) is True
+
+
+def test_alias_in_sequence_returns_true() -> None:
+    """Alias detection works inside SequenceNode children."""
+    shared = _scalar("v")
+    root = _sequence(shared, _scalar("other"), shared)
+    assert _has_aliases(root) is True
+
+
+def test_alias_in_nested_mapping_returns_true() -> None:
+    """Alias reachable through nested structure is still detected."""
+    shared = _mapping((_scalar("k"), _scalar("v")))
+    child_a = _mapping((_scalar("x"), shared))
+    child_b = _mapping((_scalar("y"), shared))  # same shared object
+    root = _mapping((_scalar("a"), child_a), (_scalar("b"), child_b))
+    assert _has_aliases(root) is True
+
+
+def test_self_referential_cycle_back_edge_returns_true() -> None:
+    """A self-referential sequence (cycle) is a back-edge alias."""
+    seq = _sequence(_scalar("item"))
+    # Make seq refer to itself: seq.value[0] replaced by seq itself.
+    seq.value[0] = seq  # type: ignore[index]
+    assert _has_aliases(seq) is True
+
+
+@pytest.mark.parametrize(
+    "levels",
+    [1, 5, 50, 1100],
+    ids=["depth-1", "depth-5", "depth-50", "depth-1100-exceeds-recursion-limit"],
+)
+def test_deep_tree_no_aliases_returns_false(levels: int) -> None:
+    """Deep pure-tree documents return False regardless of depth.
+
+    The depth-1100 case specifically guards the iterative implementation
+    against the Python default recursion limit (~1000 frames).  A recursive
+    implementation would raise RecursionError here; the iterative version
+    must return False cleanly.
+    """
+    # Build a chain: {k: {k: {k: ...}}} of the given depth.
+    node: yaml.nodes.Node = _scalar("leaf")
+    for _ in range(levels):
+        node = _mapping((_scalar("k"), node))
+    assert _has_aliases(node) is False


### PR DESCRIPTION
# fix(yaml): skip alias-expansion budget for anchor-free documents

## TL;DR

This superseding PR carries forward #2493's YAML fix onto current
`main` and closes #2389.
`_BoundedSafeLoader._guard_expansion` now does a fast `_has_aliases`
pre-scan and skips the 5M alias-expansion budget for anchor-free
YAML documents.
Alias-containing documents still go through the existing bounded
expansion path, and merge-key guards remain intact.

> [!NOTE]
> Supersedes #2493 by @sergio-sisternes-epam. Closes #2389.
> PR #2493 left the merge queue only because Integration Tests Shard 1
> timed out on a pre-existing failure in `main`
> (`test_multiple_deps_one_check_errors_degrades`), later fixed by
> #2507.

## Problem (WHY)

- [x] `_BoundedSafeLoader._guard_expansion` applied the 5M
  alias-expansion budget to every composed YAML document, even when
  the document had zero anchors and zero aliases.
- [x] APM-generated lockfiles can cross that byte-weighted threshold
  through literal size alone, so a large but ordinary `apm.lock.yaml`
  was rejected with a false-positive
  `YAML alias/anchor expansion exceeded the safe budget` error.
- [x] The failure hit tool-owned output: a lockfile APM had already
  written could stop later reads even though there was no amplification
  vector to defend against.
- [!] The original PR was correct in scope, but it had to be
  re-applied on updated `main` after the merge-queue timeout that was
  fixed independently by #2507.

Why these matter: rejecting APM-generated lockfiles turns a normal
round-trip into a parser failure instead of the reliable behavior
promised by ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/).
The fix stays narrow because ["Add what the agent lacks, omit what it knows"](https://agentskills.io/skill-creation/best-practices): detect
aliases first, then preserve the existing merge-entry and depth
budgets for the cases they already cover.

## Approach (WHAT)

- Add `_has_aliases(root: yaml.nodes.Node)` as an O(N) graph walk over
  the composed node graph, using `seen` and `stack` sets keyed by
  `id(node)`.
- Short-circuit `_guard_expansion` for anchor-free documents, because
  no shared nodes means no alias-driven amplification path exists.
- Keep the existing 5M alias-expansion budget for alias-containing
  documents, including self-referential alias graphs.
- Keep the merge-entry and flatten-depth guards unchanged, and pin the
  merge-key bomb test so it still trips the merge-entry path first.

## Implementation (HOW)

- **`src/apm_cli/utils/yaml_io.py`** -- tightens the `_has_aliases`
  type hint to `yaml.nodes.Node`, adds the alias pre-scan, updates the
  loader docstring to describe the two-budget strategy, and leaves the
  merge-entry and depth guards untouched.
- **`tests/red_team/parser/test_yaml_bomb.py`** -- adds the regression
  that builds a 150,000-entry, roughly 6 MB anchor-free lockfile,
  corrects the entry-count math and the `O(1)` docstring typo, and pins
  the merge-key bomb to 17 levels so the merge-entry guard remains the
  first failing path.
- **`CHANGELOG.md`** -- records the user-visible fix under
  `[Unreleased] -> Fixed`.

## Diagrams

Legend: this flow shows the new decision point in
`_BoundedSafeLoader._guard_expansion` and where the existing merge-key
budget still applies.

```mermaid
flowchart TD
    A[Compose root node]
    B{_has_aliases finds shared nodes}
    C[Skip alias-expansion budget]
    D[Compute alias expansion weight]
    E[Raise yaml YAMLError if weight exceeds 5M]
    F[Construct document]
    G[flatten_mapping still enforces merge-entry and depth budgets]

    A --> B
    B -->|no| C
    C --> F
    B -->|yes| D
    D --> E
    D --> F
    F --> G
```

## Trade-offs

- **One extra graph walk per load.** Chose an O(N) alias pre-scan;
  rejected raising the 5M budget globally because that would weaken the
  bomb defense for the alias-containing documents that actually need it.
- **Two specialized guards instead of one catch-all guard.** Chose to
  preserve the merge-entry budget alongside the alias-expansion budget;
  rejected collapsing them into one generic threshold because ["Favor small, chainable primitives over monolithic frameworks."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/)
  matches the existing split between alias and merge-key amplification.
- **Fresh supersede instead of retrying stale queue state.** Chose to
  reapply the fix on updated `main`; rejected treating the old queue
  timeout as signal about this patch because that failure was already
  fixed by #2507.

## Benefits

1. A 150,000-entry anchor-free lockfile now loads successfully instead
   of failing with a false-positive billion-laughs rejection.
2. Pure alias bombs still fail closed before any downstream consumer
   can materialize the shared-reference graph.
3. Merge-key bombs still raise the dedicated
   `merge-key expansion exceeded the safe budget` error instead of
   silently changing guard precedence.
4. The changelog now states the user-visible regression and fix in the
   same release window as the superseding PR.

## Validation

`uv run pytest tests/red_team/parser/test_yaml_bomb.py -q`:

```text
............                                                             [100%]
12 passed in 5.90s
```

<details><summary>Targeted lint output</summary>

`uv run --extra dev ruff check src/ tests/`:

```text
All checks passed!
```

`uv run --extra dev ruff format --check src/ tests/`:

```text
1610 files already formatted
```

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|------------------------|--------------|--------------------|------|
| 1 | A large APM-generated `apm.lock.yaml` with no anchors or aliases loads successfully instead of tripping the alias budget. | Governed by policy, DevX | `tests/red_team/parser/test_yaml_bomb.py::test_large_anchor_free_lockfile_loads_successfully` (regression-trap for #2389) | unit |
| 2 | A pure alias bomb still fails closed quickly before any consumer can expand it. | Secure by default, Governed by policy | `tests/red_team/parser/test_yaml_bomb.py::test_load_yaml_fails_closed_on_alias_bomb`<br/>`tests/red_team/parser/test_yaml_bomb.py::test_deep_alias_bomb_fails_closed_fast` | unit |
| 3 | A merge-key amplification bomb is still rejected by the dedicated merge-entry guard, not by the new anchor-free fast path. | Secure by default, Governed by policy | `tests/red_team/parser/test_yaml_bomb.py::test_merge_key_bomb_still_rejected` | unit |

## How to test

- [ ] Run `uv run pytest tests/red_team/parser/test_yaml_bomb.py -q`
      and expect `12 passed`.
- [ ] Inspect `test_large_anchor_free_lockfile_loads_successfully` and
      confirm it builds a 150,000-entry anchor-free lockfile that now
      loads without raising `yaml.YAMLError`.
- [ ] Inspect `test_load_yaml_fails_closed_on_alias_bomb` and
      `test_deep_alias_bomb_fails_closed_fast` and confirm alias bombs
      still fail closed quickly.
- [ ] Inspect `test_merge_key_bomb_still_rejected` and confirm the
      asserted message is `merge-key expansion exceeded the safe budget`.

Co-authored-by: sergio-sisternes-epam
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
