### PR TITLE
fix(agent): rewrite deprecated VSCode tool names at Copilot deploy time (supersedes #2500, closes #2465)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `apm install --target copilot` now rewrites the six deprecated VSCode
+  Copilot built-in tool names (`askQuestions`, `runInTerminal`,
+  `getTerminalOutput`, `createFile`, `fetch`, `listDirectory`) to their
+  current namespaced equivalents in the deployed `.github/agents/` copy.
+  Package source files are never modified. Eliminates "Tool or toolset has
+  been renamed" IDE warnings without any source changes. (by
+  @sergio-sisternes-epam; closes #2465) (#2500)
 - Multi-target `apm compile` now avoids repeating expensive project analysis
   for each target, making multi-target runs scale like single-target runs
   without changing generated output. (closes #2482)

--- a/docs/src/content/docs/producer/author-primitives/instructions-and-agents.md
+++ b/docs/src/content/docs/producer/author-primitives/instructions-and-agents.md
@@ -209,7 +209,7 @@ offending package and field so you can fix the source.
 
 | Target | Output path | Transform |
 |---|---|---|
-| copilot | `.github/agents/<name>.agent.md` | deprecated VSCode built-in tool names renamed to namespaced form; content otherwise verbatim |
+| copilot | `.github/agents/<name>.agent.md` | tool names rewritten; otherwise verbatim |
 | claude | `.claude/agents/<name>.md` | verbatim |
 | grok-build | `.grok/agents/<name>.md` | verbatim |
 | cursor | `.cursor/agents/<name>.md` | verbatim |
@@ -273,13 +273,14 @@ dedicated persona.
   info`). `apm install -t opencode` will warn at install time when
   it detects either shape; the file still deploys but OpenCode will
   refuse to load it.
-- **Old unnamespaced VSCode built-in tool names in a Copilot-targeted
+- **Deprecated VSCode built-in tool names in a Copilot-targeted
   agent.** VSCode Copilot renamed its built-in tools to a namespaced
-  format (e.g. `fetch` became `web/fetch`, `runInTerminal` became
-  `execute/runInTerminal`). APM automatically rewrites the six known
-  old names when deploying to the Copilot target, so you do not need
-  to update existing source files. If you author new agents, prefer
-  the current namespaced names to be explicit:
+  format. APM automatically rewrites the six known old names
+  (`askQuestions`, `runInTerminal`, `getTerminalOutput`, `createFile`,
+  `fetch`, `listDirectory`) when deploying to the Copilot target, so
+  you do not need to update existing source files. The match is
+  exact-string only -- a custom tool named `fetchData` is unaffected.
+  If you author new agents, prefer the current namespaced names:
   `vscode/askQuestions`, `execute/runInTerminal`,
   `execute/getTerminalOutput`, `edit/createFile`, `web/fetch`,
   `search/listDirectory`.

--- a/docs/src/content/docs/producer/author-primitives/instructions-and-agents.md
+++ b/docs/src/content/docs/producer/author-primitives/instructions-and-agents.md
@@ -209,7 +209,7 @@ offending package and field so you can fix the source.
 
 | Target | Output path | Transform |
 |---|---|---|
-| copilot | `.github/agents/<name>.agent.md` | verbatim |
+| copilot | `.github/agents/<name>.agent.md` | deprecated VSCode built-in tool names renamed to namespaced form; content otherwise verbatim |
 | claude | `.claude/agents/<name>.md` | verbatim |
 | grok-build | `.grok/agents/<name>.md` | verbatim |
 | cursor | `.cursor/agents/<name>.md` | verbatim |
@@ -273,6 +273,16 @@ dedicated persona.
   info`). `apm install -t opencode` will warn at install time when
   it detects either shape; the file still deploys but OpenCode will
   refuse to load it.
+- **Old unnamespaced VSCode built-in tool names in a Copilot-targeted
+  agent.** VSCode Copilot renamed its built-in tools to a namespaced
+  format (e.g. `fetch` became `web/fetch`, `runInTerminal` became
+  `execute/runInTerminal`). APM automatically rewrites the six known
+  old names when deploying to the Copilot target, so you do not need
+  to update existing source files. If you author new agents, prefer
+  the current namespaced names to be explicit:
+  `vscode/askQuestions`, `execute/runInTerminal`,
+  `execute/getTerminalOutput`, `edit/createFile`, `web/fetch`,
+  `search/listDirectory`.
 - **Agent body that re-states global instructions.** Agents inherit
   the workspace's compiled context. Restate only what the persona
   needs to *override* or *add*; do not duplicate `python-style`

--- a/scripts/check_diagnostic_ascii_owner.py
+++ b/scripts/check_diagnostic_ascii_owner.py
@@ -29,6 +29,7 @@ AGENT_DIAGNOSTIC_FUNCTIONS = {
     "AgentIntegrator._warn_codex_unverified_scope": True,
     "AgentIntegrator._warn_codex_tools_dropped": True,
     "AgentIntegrator._warn_opencode_frontmatter": False,
+    "AgentIntegrator._copy_github_agent": False,
 }
 ALLOWED_IDENTITY_DELEGATES = {
     "AgentIntegrator._warn_opencode_frontmatter": {"validate_opencode_frontmatter"},
@@ -133,7 +134,7 @@ def _diagnostic_calls(function: ast.AST) -> list[ast.Call]:
         for node in _walk_own_scope(function)
         if isinstance(node, ast.Call)
         and isinstance(node.func, ast.Attribute)
-        and node.func.attr in {"warn", "lossy_agent_compilation"}
+        and node.func.attr in {"warn", "lossy_agent_compilation", "info"}
     ]
 
 

--- a/src/apm_cli/integration/agent_integrator.py
+++ b/src/apm_cli/integration/agent_integrator.py
@@ -25,6 +25,22 @@ if TYPE_CHECKING:
     from apm_cli.integration.targets import TargetProfile
     from apm_cli.utils.diagnostics import DiagnosticCollector
 
+# Renamed VSCode Copilot built-in tool names.
+# VSCode Copilot migrated built-in tool identifiers to a namespaced format.
+# Any *.agent.md file deployed to the copilot target has these old names
+# rewritten automatically so the IDE does not emit "Tool or toolset has been
+# renamed" warnings.  Only the tools list in the YAML frontmatter is affected;
+# the source package file is never modified.
+# Ref: https://github.com/microsoft/apm/issues/2465
+GITHUB_AGENT_TOOL_RENAMES: dict[str, str] = {
+    "askQuestions": "vscode/askQuestions",
+    "runInTerminal": "execute/runInTerminal",
+    "getTerminalOutput": "execute/getTerminalOutput",
+    "createFile": "edit/createFile",
+    "fetch": "web/fetch",
+    "listDirectory": "search/listDirectory",
+}
+
 # Kiro capability tags approved for agent 'tools' frontmatter.
 # Source: https://kiro.dev/docs/custom-agents/ (accessed 2026-08-03)
 # Fail closed: any value not in this set blocks deployment of that agent.
@@ -238,6 +254,8 @@ class AgentIntegrator(BaseIntegrator):
                     package_name=package_info.package.name,
                 )
                 links_resolved = 0
+            elif mapping.format_id == "github_agent":
+                links_resolved = self._copy_github_agent(source_file, target_path)
             else:
                 if mapping.format_id == "opencode_agent":
                     self._warn_opencode_frontmatter(
@@ -317,6 +335,68 @@ class AgentIntegrator(BaseIntegrator):
         if source.is_symlink():
             raise ValueError(f"Refusing to read symlink source: {source}")
         content = source.read_text(encoding="utf-8")
+        content, links_resolved = self.resolve_links(content, source, target)
+        write_text_lf(target, content)
+        return links_resolved
+
+    # ------------------------------------------------------------------
+    # GitHub (Copilot) agent transformer -- tool name rewrite
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _apply_github_agent_tool_renames(content: str) -> str:
+        """Rewrite deprecated VSCode built-in tool names in a github_agent file.
+
+        Applies GITHUB_AGENT_TOOL_RENAMES to every entry in the YAML
+        frontmatter ``tools:`` list.  All other frontmatter fields and the
+        entire markdown body are left completely unchanged.  Returns the
+        original *content* unchanged when:
+
+        - the file has no YAML frontmatter
+        - the frontmatter is unparseable
+        - there is no ``tools:`` key
+        - ``tools:`` is null or not a list
+        - no entry in the list matches a known rename
+        """
+        fm_match = AgentIntegrator._FRONTMATTER_RE.match(content)
+        if not fm_match:
+            return content
+        try:
+            fm = load_yaml_str(fm_match.group(1)) or {}
+        except yaml.YAMLError:
+            return content
+        if not isinstance(fm, dict):
+            return content
+        tools_raw = fm.get("tools")
+        if not isinstance(tools_raw, list):
+            return content
+        renamed = [GITHUB_AGENT_TOOL_RENAMES.get(str(t), str(t)) for t in tools_raw]
+        if renamed == [str(t) for t in tools_raw]:
+            return content
+        fm["tools"] = renamed
+        body = content[fm_match.end() :]
+        fm_text = yaml_to_str(fm)
+        return f"---\n{fm_text}---\n{body}"
+
+    def _copy_github_agent(self, source: Path, target: Path) -> int:
+        """Copy a github_agent file, rewriting deprecated tool names.
+
+        Like :meth:`copy_agent` but applies
+        :meth:`_apply_github_agent_tool_renames` before link resolution so
+        that deployed ``*.agent.md`` files use the current VSCode namespaced
+        tool identifiers.
+
+        Args:
+            source: Source ``.agent.md`` file path.
+            target: Destination path under ``.github/agents/``.
+
+        Returns:
+            int: Number of context links resolved.
+        """
+        if source.is_symlink():
+            raise ValueError(f"Refusing to read symlink source: {source}")
+        content = source.read_text(encoding="utf-8")
+        content = self._apply_github_agent_tool_renames(content)
         content, links_resolved = self.resolve_links(content, source, target)
         write_text_lf(target, content)
         return links_resolved
@@ -721,7 +801,7 @@ class AgentIntegrator(BaseIntegrator):
                 ):
                     files_skipped += 1
                     continue
-                links_resolved = self.copy_agent(source_file, target_path)
+                links_resolved = self._copy_github_agent(source_file, target_path)
                 total_links_resolved += links_resolved
                 files_integrated += 1
                 target_paths.append(target_path)

--- a/src/apm_cli/integration/agent_integrator.py
+++ b/src/apm_cli/integration/agent_integrator.py
@@ -255,7 +255,12 @@ class AgentIntegrator(BaseIntegrator):
                 )
                 links_resolved = 0
             elif mapping.format_id == "github_agent":
-                links_resolved = self._copy_github_agent(source_file, target_path)
+                links_resolved = self._copy_github_agent(
+                    source_file,
+                    target_path,
+                    diagnostics=diagnostics,
+                    package_name=package_info.package.name,
+                )
             else:
                 if mapping.format_id == "opencode_agent":
                     self._warn_opencode_frontmatter(
@@ -388,7 +393,13 @@ class AgentIntegrator(BaseIntegrator):
         fm_text = yaml_to_str(fm)
         return f"---\n{fm_text}---\n{body}"
 
-    def _copy_github_agent(self, source: Path, target: Path) -> int:
+    def _copy_github_agent(
+        self,
+        source: Path,
+        target: Path,
+        diagnostics: DiagnosticCollector | None = None,
+        package_name: str = "",
+    ) -> int:
         """Copy a github_agent file, rewriting deprecated tool names.
 
         Like :meth:`copy_agent` but applies
@@ -396,9 +407,14 @@ class AgentIntegrator(BaseIntegrator):
         that deployed ``*.agent.md`` files use the current VSCode namespaced
         tool identifiers.
 
+        When ``diagnostics`` is supplied and renames occur, an info-level
+        diagnostic is emitted naming the file and the count of rewrites.
+
         Args:
             source: Source ``.agent.md`` file path.
             target: Destination path under ``.github/agents/``.
+            diagnostics: Optional collector for user-visible messages.
+            package_name: Package name for diagnostic context.
 
         Returns:
             int: Number of context links resolved.
@@ -406,8 +422,17 @@ class AgentIntegrator(BaseIntegrator):
         if source.is_symlink():
             raise ValueError(f"Refusing to read symlink source: {source}")
         content = source.read_text(encoding="utf-8")
-        content = self._apply_github_agent_tool_renames(content)
-        content, links_resolved = self.resolve_links(content, source, target)
+        renamed = self._apply_github_agent_tool_renames(content)
+        if renamed is not content and diagnostics is not None:
+            count = sum(1 for old in GITHUB_AGENT_TOOL_RENAMES if old in content)
+            diagnostics.info(
+                message=(
+                    f"{source.name}: rewrote {count} deprecated"
+                    f" VSCode tool name(s) to namespaced form"
+                ),
+                package=printable_ascii_text(package_name),
+            )
+        content, links_resolved = self.resolve_links(renamed, source, target)
         write_text_lf(target, content)
         return links_resolved
 
@@ -811,7 +836,12 @@ class AgentIntegrator(BaseIntegrator):
                 ):
                     files_skipped += 1
                     continue
-                links_resolved = self._copy_github_agent(source_file, target_path)
+                links_resolved = self._copy_github_agent(
+                    source_file,
+                    target_path,
+                    diagnostics=diagnostics,
+                    package_name=package_info.package.name,
+                )
                 total_links_resolved += links_resolved
                 files_integrated += 1
                 target_paths.append(target_path)

--- a/src/apm_cli/integration/agent_integrator.py
+++ b/src/apm_cli/integration/agent_integrator.py
@@ -347,16 +347,19 @@ class AgentIntegrator(BaseIntegrator):
     def _apply_github_agent_tool_renames(content: str) -> str:
         """Rewrite deprecated VSCode built-in tool names in a github_agent file.
 
-        Applies GITHUB_AGENT_TOOL_RENAMES to every entry in the YAML
-        frontmatter ``tools:`` list.  All other frontmatter fields and the
-        entire markdown body are left completely unchanged.  Returns the
-        original *content* unchanged when:
+        Applies GITHUB_AGENT_TOOL_RENAMES to every string entry in the YAML
+        frontmatter ``tools:`` list.  Non-string entries (mappings, sequences,
+        etc.) are preserved as-is without coercion.  Other frontmatter field
+        *values* are semantically preserved, but their serialisation formatting
+        (quoting style, key order) may change due to the YAML roundtrip.  The
+        markdown body is byte-for-byte unchanged.  Returns the original
+        *content* unchanged when:
 
         - the file has no YAML frontmatter
         - the frontmatter is unparseable
         - there is no ``tools:`` key
         - ``tools:`` is null or not a list
-        - no entry in the list matches a known rename
+        - no string entry in the list matches a known rename
         """
         fm_match = AgentIntegrator._FRONTMATTER_RE.match(content)
         if not fm_match:
@@ -370,8 +373,15 @@ class AgentIntegrator(BaseIntegrator):
         tools_raw = fm.get("tools")
         if not isinstance(tools_raw, list):
             return content
-        renamed = [GITHUB_AGENT_TOOL_RENAMES.get(str(t), str(t)) for t in tools_raw]
-        if renamed == [str(t) for t in tools_raw]:
+        any_renamed = False
+        renamed = []
+        for t in tools_raw:
+            if isinstance(t, str) and t in GITHUB_AGENT_TOOL_RENAMES:
+                renamed.append(GITHUB_AGENT_TOOL_RENAMES[t])
+                any_renamed = True
+            else:
+                renamed.append(t)
+        if not any_renamed:
             return content
         fm["tools"] = renamed
         body = content[fm_match.end() :]

--- a/src/apm_cli/integration/agent_integrator.py
+++ b/src/apm_cli/integration/agent_integrator.py
@@ -427,7 +427,7 @@ class AgentIntegrator(BaseIntegrator):
             count = sum(1 for old in GITHUB_AGENT_TOOL_RENAMES if old in content)
             diagnostics.info(
                 message=(
-                    f"{source.name}: rewrote {count} deprecated"
+                    f"{printable_ascii_text(source.name)}: rewrote {count} deprecated"
                     f" VSCode tool name(s) to namespaced form"
                 ),
                 package=printable_ascii_text(package_name),

--- a/tests/spec_conformance/mode_b_detector.sh
+++ b/tests/spec_conformance/mode_b_detector.sh
@@ -110,14 +110,19 @@ if [ "$ADDED" -lt "$THRESHOLD" ]; then
 fi
 
 # Waiver: PR body (via GH_PR_BODY env) OR a commit-message trailer.
+# GitHub merge-queue squash commits prepend '* ' to each cherry-picked
+# commit message in the squash body, so the pattern must also match
+# '* apm-spec-waiver:'.
 WAIVER=""
 if [ -n "${GH_PR_BODY:-}" ]; then
   WAIVER="$(printf '%s\n' "$GH_PR_BODY" | grep -E '^apm-spec-waiver:' | head -1 || true)"
 fi
 if [ -z "$WAIVER" ]; then
   WAIVER="$(git log --format=%B "$MB"..HEAD \
-    | grep -E '^apm-spec-waiver:' | head -1 || true)"
+    | grep -E '^(\* )?apm-spec-waiver:' | head -1 || true)"
 fi
+# Strip optional squash-bullet prefix before extracting the rationale.
+WAIVER="${WAIVER#\* }"
 RATIONALE="${WAIVER#apm-spec-waiver:}"
 RATIONALE="${RATIONALE# }"
 if [ "${#RATIONALE}" -ge 16 ]; then

--- a/tests/unit/integration/test_agent_integrator.py
+++ b/tests/unit/integration/test_agent_integrator.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest.mock import Mock
 
 from apm_cli.integration import AgentIntegrator
+from apm_cli.integration.agent_integrator import GITHUB_AGENT_TOOL_RENAMES
 from apm_cli.models.apm_package import APMPackage, GitReferenceType, PackageInfo, ResolvedReference
 from apm_cli.utils.diagnostics import (
     CATEGORY_AGENT_LOSSY_COMPILATION,
@@ -1325,3 +1326,233 @@ class TestCodexAgentIntegration:
 # integrate_agents_for_target(windsurf, ...) path were removed when
 # the primitive was dropped to fix the uninstall cleanup bug.
 # ==================================================================
+
+
+class TestGithubAgentToolRenames:
+    """Tests for the VSCode Copilot tool-name rename transform (#2465).
+
+    VSCode Copilot namespaced its built-in tool identifiers.  Any *.agent.md
+    file deployed to the copilot (github_agent) target must have old names
+    rewritten automatically so the IDE does not emit warnings.
+    """
+
+    def setup_method(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.root = Path(self.temp_dir)
+
+    def teardown_method(self):
+        import shutil
+
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    # ------------------------------------------------------------------
+    # Unit tests for _apply_github_agent_tool_renames
+    # ------------------------------------------------------------------
+
+    def test_all_six_known_renames_are_applied(self):
+        """Every entry in GITHUB_AGENT_TOOL_RENAMES must be rewritten."""
+        old_names = list(GITHUB_AGENT_TOOL_RENAMES.keys())
+        tools_yaml = "\n".join(f"  - {n}" for n in old_names)
+        content = f"---\ndescription: Agent\ntools:\n{tools_yaml}\n---\nBody.\n"
+
+        result = AgentIntegrator._apply_github_agent_tool_renames(content)
+
+        for old, new in GITHUB_AGENT_TOOL_RENAMES.items():
+            assert f"- {old}" not in result, f"Old YAML item '- {old}' still present after rename"
+            assert new in result, f"New name {new!r} missing after rename"
+
+    def test_unknown_tool_names_pass_through_unchanged(self):
+        """Tool names not in the rename map must be preserved verbatim."""
+        content = "---\ndescription: A\ntools:\n  - myCustomTool\n  - anotherTool\n---\nBody.\n"
+
+        result = AgentIntegrator._apply_github_agent_tool_renames(content)
+
+        assert "myCustomTool" in result
+        assert "anotherTool" in result
+
+    def test_already_namespaced_names_pass_through_unchanged(self):
+        """New-style namespaced names must not be double-rewritten."""
+        content = (
+            "---\ndescription: A\ntools:\n"
+            "  - vscode/askQuestions\n"
+            "  - execute/runInTerminal\n"
+            "---\nBody.\n"
+        )
+
+        result = AgentIntegrator._apply_github_agent_tool_renames(content)
+
+        assert result == content
+
+    def test_no_frontmatter_returns_content_unchanged(self):
+        """Files without YAML frontmatter are returned verbatim."""
+        content = "# Agent\n\nSome content.\n"
+
+        result = AgentIntegrator._apply_github_agent_tool_renames(content)
+
+        assert result == content
+
+    def test_no_tools_key_returns_content_unchanged(self):
+        """Files with frontmatter but no 'tools:' are returned verbatim."""
+        content = "---\ndescription: Agent\nmodel: gpt-4o\n---\nBody.\n"
+
+        result = AgentIntegrator._apply_github_agent_tool_renames(content)
+
+        assert result == content
+
+    def test_null_tools_returns_content_unchanged(self):
+        """tools: null frontmatter is returned verbatim."""
+        content = "---\ndescription: Agent\ntools: null\n---\nBody.\n"
+
+        result = AgentIntegrator._apply_github_agent_tool_renames(content)
+
+        assert result == content
+
+    def test_tools_not_a_list_returns_content_unchanged(self):
+        """Non-list tools value (e.g. string) is returned verbatim."""
+        content = "---\ndescription: Agent\ntools: all\n---\nBody.\n"
+
+        result = AgentIntegrator._apply_github_agent_tool_renames(content)
+
+        assert result == content
+
+    def test_mixed_old_and_unknown_tools_renames_only_known(self):
+        """Only known old names are renamed; unrecognised names are kept."""
+        content = (
+            "---\ndescription: A\ntools:\n"
+            "  - fetch\n"
+            "  - myCustomTool\n"
+            "  - runInTerminal\n"
+            "---\nBody.\n"
+        )
+
+        result = AgentIntegrator._apply_github_agent_tool_renames(content)
+
+        assert "web/fetch" in result
+        assert "execute/runInTerminal" in result
+        assert "myCustomTool" in result
+        assert "- fetch" not in result
+        assert "- runInTerminal" not in result
+
+    # ------------------------------------------------------------------
+    # Integration tests via integrate_agents_for_target (github_agent)
+    # ------------------------------------------------------------------
+
+    def _create_package_info(self, package_dir: Path, *, name: str = "test-pkg") -> PackageInfo:
+        package = APMPackage(name=name, version="1.0.0", package_path=package_dir)
+        resolved_ref = ResolvedReference(
+            original_ref="main",
+            ref_type=GitReferenceType.BRANCH,
+            resolved_commit="abc123",
+            ref_name="main",
+        )
+        return PackageInfo(
+            package=package,
+            install_path=package_dir,
+            resolved_reference=resolved_ref,
+            installed_at=datetime.now().isoformat(),
+        )
+
+    def test_integrate_copilot_target_rewrites_deprecated_tool_names(self):
+        """integrate_agents_for_target for copilot rewrites old tool names."""
+        from apm_cli.integration.targets import KNOWN_TARGETS
+
+        package_dir = self.root / "package"
+        agents_dir = package_dir / ".apm" / "agents"
+        agents_dir.mkdir(parents=True)
+        (agents_dir / "reviewer.agent.md").write_text(
+            "---\ndescription: Code reviewer\ntools:\n"
+            "  - askQuestions\n"
+            "  - runInTerminal\n"
+            "  - fetch\n"
+            "---\nReview code.\n",
+            encoding="utf-8",
+        )
+
+        result = AgentIntegrator().integrate_agents_for_target(
+            KNOWN_TARGETS["copilot"],
+            self._create_package_info(package_dir),
+            self.root,
+        )
+
+        assert result.files_integrated == 1
+        deployed = (self.root / ".github" / "agents" / "reviewer.agent.md").read_text(
+            encoding="utf-8"
+        )
+        assert "- askQuestions" not in deployed
+        assert "vscode/askQuestions" in deployed
+        assert "- runInTerminal" not in deployed
+        assert "execute/runInTerminal" in deployed
+        assert "web/fetch" in deployed
+
+    def test_integrate_copilot_target_preserves_no_tools_verbatim(self):
+        """Agents without a tools list are deployed verbatim by the copilot path."""
+        from apm_cli.integration.targets import KNOWN_TARGETS
+
+        package_dir = self.root / "package"
+        agents_dir = package_dir / ".apm" / "agents"
+        agents_dir.mkdir(parents=True)
+        original = "---\ndescription: Simple agent\n---\nDo things.\n"
+        (agents_dir / "simple.agent.md").write_text(original, encoding="utf-8")
+
+        AgentIntegrator().integrate_agents_for_target(
+            KNOWN_TARGETS["copilot"],
+            self._create_package_info(package_dir),
+            self.root,
+        )
+
+        deployed = (self.root / ".github" / "agents" / "simple.agent.md").read_text(
+            encoding="utf-8"
+        )
+        assert deployed.strip() == original.strip()
+
+    def test_integrate_package_agents_deprecated_path_rewrites_tool_names(self):
+        """The deprecated integrate_package_agents also rewrites old tool names."""
+        package_dir = self.root / "package"
+        agents_dir = package_dir / ".apm" / "agents"
+        agents_dir.mkdir(parents=True)
+        (agents_dir / "linter.agent.md").write_text(
+            "---\ndescription: Linter\ntools:\n  - createFile\n  - listDirectory\n---\nLint.\n",
+            encoding="utf-8",
+        )
+
+        result = AgentIntegrator().integrate_package_agents(
+            self._create_package_info(package_dir),
+            self.root,
+        )
+
+        assert result.files_integrated == 1
+        deployed = (self.root / ".github" / "agents" / "linter.agent.md").read_text(
+            encoding="utf-8"
+        )
+        assert "- createFile" not in deployed
+        assert "- listDirectory" not in deployed
+        assert "edit/createFile" in deployed
+        assert "search/listDirectory" in deployed
+
+    def test_all_six_renames_via_full_integration_path(self):
+        """All six deprecated tool names are corrected in a full install cycle."""
+        from apm_cli.integration.targets import KNOWN_TARGETS
+
+        package_dir = self.root / "package"
+        agents_dir = package_dir / ".apm" / "agents"
+        agents_dir.mkdir(parents=True)
+        tools_list = "\n".join(f"  - {t}" for t in GITHUB_AGENT_TOOL_RENAMES)
+        (agents_dir / "all-tools.agent.md").write_text(
+            f"---\ndescription: Full tool set\ntools:\n{tools_list}\n---\nDo work.\n",
+            encoding="utf-8",
+        )
+
+        AgentIntegrator().integrate_agents_for_target(
+            KNOWN_TARGETS["copilot"],
+            self._create_package_info(package_dir),
+            self.root,
+        )
+
+        deployed = (self.root / ".github" / "agents" / "all-tools.agent.md").read_text(
+            encoding="utf-8"
+        )
+        for old, new in GITHUB_AGENT_TOOL_RENAMES.items():
+            assert f"- {old}" not in deployed, (
+                f"Old YAML item '- {old}' still present in deployed file"
+            )
+            assert new in deployed, f"New name {new!r} missing in deployed file"

--- a/tests/unit/integration/test_agent_integrator.py
+++ b/tests/unit/integration/test_agent_integrator.py
@@ -1556,3 +1556,28 @@ class TestGithubAgentToolRenames:
                 f"Old YAML item '- {old}' still present in deployed file"
             )
             assert new in deployed, f"New name {new!r} missing in deployed file"
+
+    def test_non_string_tool_entries_pass_through_unchanged(self):
+        """Non-string entries in the tools list are preserved without coercion.
+
+        The isinstance(t, str) guard means mapping nodes, sequences, and other
+        non-string YAML values must survive the rename pass intact, even when
+        they appear alongside renamed string entries.
+        """
+        content = (
+            "---\n"
+            "description: Mixed tools\n"
+            "tools:\n"
+            "  - askQuestions\n"
+            "  - {name: customTool, description: My tool}\n"
+            "  - fetch\n"
+            "---\n"
+            "Body.\n"
+        )
+        result = AgentIntegrator._apply_github_agent_tool_renames(content)
+        # String entries that match the rename map are rewritten.
+        assert "vscode/askQuestions" in result
+        assert "web/fetch" in result
+        # Non-string mapping entry must survive -- it is not stringified.
+        assert "name: customTool" in result
+        assert "description: My tool" in result

--- a/tests/unit/scripts/test_check_diagnostic_ascii_owner.py
+++ b/tests/unit/scripts/test_check_diagnostic_ascii_owner.py
@@ -159,12 +159,15 @@ def test_opencode_wrapper_package_field_must_use_owner(
 ) -> None:
     """The wrapper's Diagnostic.package field is also terminal output."""
     consumer = repo_copy / "src/apm_cli/integration/agent_integrator.py"
-    source = consumer.read_text(encoding="utf-8").replace(
-        "package=printable_ascii_text(package_name),",
-        "package=package_name,",
-        1,
-    )
-    consumer.write_text(source, encoding="utf-8")
+    # _copy_github_agent now also holds this pattern (added as a new diagnostic
+    # consumer), so target the second occurrence specifically to corrupt
+    # _warn_opencode_frontmatter rather than _copy_github_agent.
+    needle = "package=printable_ascii_text(package_name),"
+    raw = consumer.read_text(encoding="utf-8")
+    first = raw.index(needle)
+    second = raw.index(needle, first + 1)
+    mutated = raw[:second] + raw[second:].replace(needle, "package=package_name,", 1)
+    consumer.write_text(mutated, encoding="utf-8")
 
     violations = checker.check(repo_copy)
 
@@ -174,6 +177,25 @@ def test_opencode_wrapper_package_field_must_use_owner(
     )
     assert any(
         "must not render raw source.name or package_name" in item.message for item in violations
+    )
+
+
+def test_copy_github_agent_package_field_must_use_owner(
+    repo_copy: Path,
+    checker,
+) -> None:
+    """_copy_github_agent is a new diagnostic consumer; its package field must use the owner."""
+    consumer = repo_copy / "src/apm_cli/integration/agent_integrator.py"
+    needle = "package=printable_ascii_text(package_name),"
+    raw = consumer.read_text(encoding="utf-8")
+    first = raw.index(needle)
+    mutated = raw[:first] + raw[first:].replace(needle, "package=package_name,", 1)
+    consumer.write_text(mutated, encoding="utf-8")
+
+    violations = checker.check(repo_copy)
+
+    assert any(
+        "AgentIntegrator._copy_github_agent must derive" in item.message for item in violations
     )
 
 


### PR DESCRIPTION
## TL;DR

This PR rewrites deprecated VSCode Copilot built-in tool identifiers to their current namespaced form when APM deploys GitHub agents, so existing agent content keeps working without requiring source edits. This PR supersedes #2500 authored by @sergio-sisternes-epam. The original change is preserved with full commit authorship. Additional shepherd fold-ins are described below.

Closes #2465

supersedes #2500

apm-spec-waiver: deploy-time compat shim -- renames deprecated VSCode built-in tool identifiers to current namespaced form; no new normative APM behaviour, no spec extension

## Problem (WHY)

- GitHub agent deployment was still emitting deprecated VSCode Copilot tool names, which breaks exact-match tool lookup once the runtime expects only the namespaced identifiers.
- The compatibility fix needed to happen at deploy time so existing checked-in agent content remains unchanged while deployed output is normalized.
- The original PR fixed the rename path, but this superseding branch also had to resolve a separate merge-queue blocker: the Spec conformance waiver detector did not recognize `apm-spec-waiver:` inside GitHub squash commit bodies because GitHub prefixes each squashed commit message line with `* `.
- Without the diagnostic fold-in, rewritten tool names would be silent, making deploy-time mutation harder to observe in the same way other per-format integration helpers already report their transforms.
- Without the extra non-string test, the `isinstance(t, str)` guard would remain uncovered at the tool-list boundary.

## Approach (WHAT)

| Area | Change |
| --- | --- |
| GitHub agent compat | Added a rename map for 6 deprecated VSCode Copilot tool names and applied it while copying GitHub agent files for deployment. |
| Integrator wiring | Routed both `integrate_agents_for_target` and the deprecated `integrate_package_agents` Copilot path through the GitHub-agent copy helper so both deployment paths normalize tool names. |
| Diagnostics | Extended `_copy_github_agent` to accept `diagnostics` and `package_name`, then emit an info-level diagnostic when rewrites occur. |
| Tests | Added the original rename-focused unit coverage plus a new test proving non-string tool entries pass through unchanged. |
| Docs | Updated `instructions-and-agents.md` to list the old names explicitly, shorten the table cell, and call out the exact-match behavior. |
| Changelog | Added an `[Unreleased]` Fixed entry describing the deploy-time compatibility shim. |
| Merge-queue gate | Fixed `mode_b_detector.sh` so squash-commit bodies prefixed with `* ` still match `apm-spec-waiver:` and correctly waive the Spec conformance gate. |

## Implementation (HOW)

- `src/apm_cli/integration/agent_integrator.py`
  - Defines `GITHUB_AGENT_TOOL_RENAMES`.
  - Rewrites YAML frontmatter tool entries via `_apply_github_agent_tool_renames()`.
  - Copies GitHub-agent content through `_copy_github_agent(...)`, now with `diagnostics` and `package_name` so rewrites are reported consistently.
  - Wires the helper into both `integrate_agents_for_target` and the deprecated `integrate_package_agents` Copilot path.

- `tests/unit/integration/test_agent_integrator.py`
  - Covers rename application, deploy-path wiring, unchanged behavior when no deprecated names are present, and the `isinstance(t, str)` guard through `test_non_string_tool_entries_pass_through_unchanged`.

- `docs/src/content/docs/producer/author-primitives/instructions-and-agents.md`
  - Documents the deploy-time rename shim, names the deprecated identifiers explicitly, and explains the exact-match caveat for tool identifiers.

- `CHANGELOG.md`
  - Adds an `[Unreleased]` Fixed entry for the compatibility rewrite.

- `tests/spec_conformance/mode_b_detector.sh`
  - Adjusts waiver detection so merge-queue squash commit bodies that prefix lines with `* ` still satisfy the waiver grep.

## Trade-offs

- This keeps the compatibility shim at deploy time instead of rewriting source content, which minimizes churn in checked-in agent files but preserves a transformation step in deployment.
- The rename map is intentionally narrow: it only covers the known deprecated VSCode built-in identifiers rather than introducing broader fuzzy matching.
- The deprecated `integrate_package_agents` path still receives the fix so older call paths behave correctly, even though that keeps compatibility logic alive in a legacy surface.
- Emitting an info diagnostic adds a little more deploy output, but it makes the mutation observable and aligns this helper with other per-format integrator behavior.

## Validation

| Check | Result |
| --- | --- |
| Ruff lint | `uv run --extra dev ruff check src/ tests/ && uv run --extra dev ruff format --check src/ tests/` -> All checks passed, 1610 files already formatted |
| Targeted unit tests | `uv run pytest tests/unit/integration/test_agent_integrator.py -q` -> 82 passed in 1.66s |
| Mode B detector on branch | `BASE_REF=origin/main bash tests/spec_conformance/mode_b_detector.sh` -> `[!] mode_b: WAIVED (89 substantive added lines)` |
| Mode B detector on squash-commit shape | `BASE_REF=FETCH_HEAD~1 GH_PR_BODY="" bash tests/spec_conformance/mode_b_detector.sh` -> `[!] mode_b: WAIVED` |

## How to test

1. Run `uv run pytest tests/unit/integration/test_agent_integrator.py -q`.
2. Deploy or simulate GitHub-agent integration with agent frontmatter that includes one of the deprecated VSCode tool names and verify the emitted output uses the namespaced identifier instead.
3. Repeat with a tool list containing a non-string entry and verify the non-string value passes through unchanged.
4. Confirm the deploy path emits an info-level diagnostic when a rename occurs.
5. Run `BASE_REF=origin/main bash tests/spec_conformance/mode_b_detector.sh` and then run `BASE_REF=FETCH_HEAD~1 GH_PR_BODY="" bash tests/spec_conformance/mode_b_detector.sh` to verify waiver detection in both cases.

Co-authored-by: sergio-sisternes-epam <sergio-sisternes-epam@users.noreply.github.com>
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
