### PR TITLE
fix(cache): keep git stderr in bare clone error messages

### DIFF
--- a/src/apm_cli/cache/git_cache.py
+++ b/src/apm_cli/cache/git_cache.py
@@ -45,6 +45,10 @@ _log = logging.getLogger(__name__)
 # Full SHA pattern: 40 hex characters
 _SHA_RE = re.compile(r"^[0-9a-f]{40}$", re.IGNORECASE)
 
+# Upper bound on git stderr folded into a clone error message, so a
+# verbose remote cannot flood the terminal.
+_GIT_STDERR_MAX_CHARS = 500
+
 
 def _safe_git_args() -> list[str]:
     """Return hardening ``-c`` args prepended to every git subprocess.
@@ -426,14 +430,16 @@ class GitCache:
                         robust_rmtree(staged, ignore_errors=True)
                         raise RuntimeError(
                             f"Failed to clone {_sanitize_url(url)} "
-                            f"(partial fallback also failed): {exc2}"
+                            f"(partial fallback also failed): {_clone_failure_detail(exc2)}"
                         ) from exc2
                 if not fallback_done:
                     # Clean up staged on failure
                     from ..utils.file_ops import robust_rmtree
 
                     robust_rmtree(staged, ignore_errors=True)
-                    raise RuntimeError(f"Failed to clone {_sanitize_url(url)}: {exc}") from exc
+                    raise RuntimeError(
+                        f"Failed to clone {_sanitize_url(url)}: {_clone_failure_detail(exc)}"
+                    ) from exc
 
             # Atomic land (lock is already held; pass it through so the
             # rename completes under the same critical section).
@@ -815,6 +821,43 @@ def _dir_size(path: Path) -> int:
     except OSError:
         pass
     return total
+
+
+def _sanitize_git_stderr(stderr: str) -> str:
+    """Redact credentials from git stderr before it reaches an error message.
+
+    ``_sanitize_url`` only redacts a URL's password component, so the
+    token-as-username form (``https://<token>@host``) would survive it.
+    Both that form and bare platform tokens are redacted here.
+    """
+    redacted = re.sub(r"(https?://)[^@/\s]+@", r"\1***@", stderr)
+    redacted = re.sub(
+        r"(ghp_|gho_|ghu_|ghs_|ghr_|glpat[_-])[A-Za-z0-9_\-]+",
+        "***",
+        redacted,
+    )
+    return redacted.strip()
+
+
+def _clone_failure_detail(exc: BaseException) -> str:
+    """Render a clone failure with git's own diagnostic included.
+
+    ``CalledProcessError.__str__`` reports only the exit status, so
+    interpolating the exception alone drops git's stderr. Callers that
+    classify failures by message text (``AuthResolver.
+    is_public_github_auth_failure``) then read an auth failure as a
+    network failure, sending users to debug connectivity for what is a
+    credential problem.
+    """
+    stderr = getattr(exc, "stderr", None)
+    if isinstance(stderr, bytes):
+        stderr = stderr.decode("utf-8", errors="replace")
+    if not stderr:
+        return str(exc)
+    detail = _sanitize_git_stderr(stderr)
+    if len(detail) > _GIT_STDERR_MAX_CHARS:
+        detail = f"{detail[:_GIT_STDERR_MAX_CHARS]}..."
+    return f"{exc}: {detail}" if detail else str(exc)
 
 
 def _sanitize_url(url: str) -> str:

--- a/tests/unit/cache/test_git_cache_clone_error_detail.py
+++ b/tests/unit/cache/test_git_cache_clone_error_detail.py
@@ -1,0 +1,168 @@
+"""Clone failures must carry git's own diagnostic, redacted.
+
+``CalledProcessError.__str__`` renders only the exit status, so wrapping
+it with plain interpolation drops git's stderr. That loss is not
+cosmetic: ``AuthResolver.is_public_github_auth_failure`` classifies a
+failure by string-matching the message, so a stripped message turns an
+authentication failure into a reported network failure and sends users
+to check their connectivity and proxy settings for what is a credential
+problem.
+
+These tests pin both halves of the contract: the diagnostic survives the
+wrap so the classifier still recognises it, and credentials that git
+echoes back in that diagnostic are redacted before it reaches a message.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from apm_cli.cache.git_cache import (
+    GitCache,
+    _clone_failure_detail,
+    _sanitize_git_stderr,
+)
+from apm_cli.core.auth import AuthResolver
+
+CLONE_ARGV = ["git", "clone", "--bare", "https://github.com/acme/widgets.git", "/tmp/x"]
+GIT_EXIT_FAILURE = 128
+
+REPO_URL = "https://github.com/acme/widgets.git"
+SHARD_KEY = "1ca76695ff46485c"
+COMMIT_SHA = "0" * 40
+EMPTY_GIT_ENV: dict[str, str] = {}
+
+AUTH_FAILURE_STDERR = (
+    "Cloning into bare repository '/tmp/x'...\n"
+    "fatal: could not read Username for 'https://github.com': terminal prompts disabled\n"
+)
+NETWORK_FAILURE_STDERR = "fatal: unable to access 'https://github.com/': Could not resolve host\n"
+TOKEN_VALUE = "ghp_0123456789abcdefghijklmnopqrstuvwxyz"
+REDACTION_MARKER = "***"
+
+
+def _clone_error(stderr: str | bytes | None) -> subprocess.CalledProcessError:
+    return subprocess.CalledProcessError(GIT_EXIT_FAILURE, CLONE_ARGV, stderr=stderr)
+
+
+class TestCloneFailureDetail:
+    def test_includes_git_stderr(self) -> None:
+        detail = _clone_failure_detail(_clone_error(AUTH_FAILURE_STDERR))
+
+        assert "could not read Username" in detail
+
+    def test_decodes_bytes_stderr(self) -> None:
+        detail = _clone_failure_detail(_clone_error(AUTH_FAILURE_STDERR.encode()))
+
+        assert "could not read Username" in detail
+
+    def test_falls_back_to_exception_text_when_stderr_absent(self) -> None:
+        detail = _clone_failure_detail(_clone_error(None))
+
+        assert str(GIT_EXIT_FAILURE) in detail
+
+    def test_falls_back_to_exception_text_when_stderr_empty(self) -> None:
+        detail = _clone_failure_detail(_clone_error(""))
+
+        assert str(GIT_EXIT_FAILURE) in detail
+
+    def test_handles_exception_without_stderr_attribute(self) -> None:
+        detail = _clone_failure_detail(OSError("disk full"))
+
+        assert "disk full" in detail
+
+    def test_truncates_a_flooding_remote(self) -> None:
+        detail = _clone_failure_detail(_clone_error("remote: " + "y" * 10_000))
+
+        assert len(detail) < 1_000
+        assert detail.endswith("...")
+
+    def test_redacts_token_echoed_in_stderr(self) -> None:
+        stderr = f"fatal: Authentication failed for 'https://{TOKEN_VALUE}@github.com/acme.git'"
+
+        detail = _clone_failure_detail(_clone_error(stderr))
+
+        assert TOKEN_VALUE not in detail
+        assert REDACTION_MARKER in detail
+
+
+class TestAuthFailureStaysClassifiable:
+    """The regression the wrapping caused: auth read as network."""
+
+    def test_wrapped_auth_failure_is_still_an_auth_failure(self) -> None:
+        exc = _clone_error(AUTH_FAILURE_STDERR)
+        assert AuthResolver.is_public_github_auth_failure(exc) is True
+
+        wrapped = RuntimeError(f"Failed to clone URL: {_clone_failure_detail(exc)}")
+
+        assert AuthResolver.is_public_github_auth_failure(wrapped) is True
+
+    def test_bare_interpolation_loses_the_classification(self) -> None:
+        """Pins why the helper exists -- plain f-string drops stderr."""
+        exc = _clone_error(AUTH_FAILURE_STDERR)
+
+        assert AuthResolver.is_public_github_auth_failure(RuntimeError(f"{exc}")) is False
+
+    def test_network_failure_is_not_reclassified_as_auth(self) -> None:
+        wrapped = RuntimeError(_clone_failure_detail(_clone_error(NETWORK_FAILURE_STDERR)))
+
+        assert AuthResolver.is_public_github_auth_failure(wrapped) is False
+
+
+class TestBareCloneFailurePropagatesDetail:
+    """The classifier reads the message ``_ensure_bare_repo`` raises."""
+
+    def _failing_clone(self, tmp_path: Path, *, partial: bool) -> RuntimeError:
+        cache = GitCache(tmp_path)
+
+        def always_fail(*_args: object, **_kwargs: object) -> None:
+            raise _clone_error(AUTH_FAILURE_STDERR)
+
+        with patch("apm_cli.cache.git_cache.subprocess.run", side_effect=always_fail):
+            with pytest.raises(RuntimeError) as raised:
+                cache._ensure_bare_repo(
+                    REPO_URL,
+                    SHARD_KEY,
+                    COMMIT_SHA,
+                    env=EMPTY_GIT_ENV,
+                    partial=partial,
+                )
+        return raised.value
+
+    def test_full_clone_failure_stays_an_auth_failure(self, tmp_path: Path) -> None:
+        error = self._failing_clone(tmp_path, partial=False)
+
+        assert AuthResolver.is_public_github_auth_failure(error) is True
+
+    def test_partial_fallback_failure_stays_an_auth_failure(self, tmp_path: Path) -> None:
+        error = self._failing_clone(tmp_path, partial=True)
+
+        assert AuthResolver.is_public_github_auth_failure(error) is True
+
+
+class TestSanitizeGitStderr:
+    def test_redacts_token_as_username(self) -> None:
+        sanitized = _sanitize_git_stderr(f"https://{TOKEN_VALUE}@github.com/acme.git")
+
+        assert TOKEN_VALUE not in sanitized
+        assert sanitized == f"https://{REDACTION_MARKER}@github.com/acme.git"
+
+    def test_redacts_basic_auth_pair(self) -> None:
+        sanitized = _sanitize_git_stderr(f"https://user:{TOKEN_VALUE}@github.com/acme.git")
+
+        assert TOKEN_VALUE not in sanitized
+
+    def test_redacts_bare_platform_token(self) -> None:
+        sanitized = _sanitize_git_stderr(f"remote: token {TOKEN_VALUE} is not supported")
+
+        assert TOKEN_VALUE not in sanitized
+        assert REDACTION_MARKER in sanitized
+
+    def test_preserves_a_credential_free_message(self) -> None:
+        message = "fatal: repository 'https://github.com/acme/widgets.git' not found"
+
+        assert _sanitize_git_stderr(message) == message


### PR DESCRIPTION
## Description

Fixes #2529.

`GitCache._ensure_bare_repo` wraps a failed `git clone --bare` in a `RuntimeError` built by interpolating the caught exception:

```python
raise RuntimeError(f"Failed to clone {_sanitize_url(url)}: {exc}") from exc
```

`CalledProcessError.__str__` renders only `Command '[...]' returned non-zero exit status 128` — git's stderr lives on `exc.stderr` and is dropped.

That loss is not cosmetic, because `AuthResolver.is_public_github_auth_failure` classifies a failure by string-matching the message text. With stderr gone, the match fails, the failure is filed as `public_github_non_auth_failure`, and the user is told:

```
Could not connect to github.com (network error, not an auth failure).
Check your internet connection and proxy settings.
```

while git actually said `fatal: could not read Username for 'https://github.com': terminal prompts disabled`. The real cause never reaches the terminal, not even under `--verbose`, so the user debugs connectivity and proxy settings for what is a credential problem.

The fix folds git's stderr into the message at both raise sites, through a `_clone_failure_detail` helper. Two details worth calling out:

- **Redaction.** git can echo a credential back in stderr (`fatal: Authentication failed for 'https://<token>@github.com/...'`). The existing `_sanitize_url` only redacts a URL's `password` component, so the token-as-username form would survive it. `_sanitize_git_stderr` redacts that form and bare platform tokens (`ghp_`/`gho_`/`ghu_`/`ghs_`/`ghr_`/`glpat`) before anything reaches a message. Two tests assert the token never survives.
- **Bounding.** The appended text is capped at 500 characters so a verbose remote cannot flood the terminal.

Behaviour when there is no stderr to add (`TimeoutExpired`, `OSError`, empty stderr) is unchanged — the message falls back to `str(exc)` exactly as today.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

New file `tests/unit/cache/test_git_cache_clone_error_detail.py`, 16 tests:

- **`TestCloneFailureDetail`** — stderr is included; `bytes` stderr is decoded; falls back to `str(exc)` when stderr is absent, empty, or the exception has no `stderr` attribute; a flooding remote is truncated; a token echoed in stderr is redacted.
- **`TestBareCloneFailurePropagatesDetail`** — drives `_ensure_bare_repo` with a patched `subprocess.run`, for both the full-clone and the partial-fallback raise site, and asserts the resulting `RuntimeError` is still classified by `is_public_github_auth_failure`. These two are the regression tests: reverting either raise site to plain `{exc}` makes them fail.
- **`TestAuthFailureStaysClassifiable`** — pins both directions of the contract, including that plain interpolation loses the classification (the reason the helper exists) and that a genuine network failure is *not* reclassified as auth.
- **`TestSanitizeGitStderr`** — token-as-username, basic-auth pair, bare platform token, and a credential-free message left untouched.

Verified locally on Python 3.12, mirroring CI:

```
uv run pytest tests/unit tests/test_console.py -x   -> 19819 passed, 2 skipped, 21 xfailed
uv run --extra dev ruff check src/ tests/           -> All checks passed!
uv run --extra dev ruff format --check src/ tests/  -> 1611 files already formatted
```

## Spec conformance

- [x] N/A — this PR does not change OpenAPM-observable behaviour

Only the text of an error message changes; no CLI surface, manifest, lockfile or resolution behaviour is affected. `src/apm_cli/cache/` is not listed in `tests/spec_conformance/critical_paths.txt`, so the Mode B detector does not apply.

## Note

Issue #2529 mentions a second, separate defect found while investigating this one (a private-repo subdirectory package failing because the shared bare-cache clone runs without credentials). It is **not** addressed here — this PR is scoped to the message-fidelity bug alone. The second one still needs its root cause pinned to a line, and I'd rather send it separately.
