### PR TITLE
fix(auth): normalize git message locale so auth failures stay classifiable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - YAML expansion guard no longer rejects large anchor-free lockfiles (150K+
   entries) with a false-positive "billion-laughs" error. APM-generated
   lockfiles with no anchors or aliases now load without error. (#2389)
+- `apm install` no longer skips the credential retry on non-English machines.
+  Git localises its diagnostics through gettext, so a translated stderr made an
+  authentication failure unrecognisable and private-repo installs failed with
+  misleading network guidance. Every git subprocess APM spawns now runs with
+  `LC_ALL=C` and `LANGUAGE=C`. (by @Naofel-eal, closes #2533)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `apm install` no longer skips the credential retry on non-English machines.
   Git localises its diagnostics through gettext, so a translated stderr made an
   authentication failure unrecognisable and private-repo installs failed with
-  misleading network guidance. Every git subprocess APM spawns now runs with
-  `LC_ALL=C` and `LANGUAGE=C`. (by @Naofel-eal, closes #2533)
+  misleading network guidance. Git subprocesses in the authentication retry
+  path now run with `LC_ALL=C` and `LANGUAGE=C`. (by @Naofel-eal, closes #2533)
 
 ### Changed
 

--- a/src/apm_cli/core/auth.py
+++ b/src/apm_cli/core/auth.py
@@ -139,6 +139,16 @@ _GIT_CHILD_TOKEN_ENV_NAMES = frozenset(
 )
 _GIT_CHILD_TOKEN_ENV_PREFIXES = ("GITHUB_APM_PAT_",)
 
+# Git localises its diagnostics through gettext, but APM classifies clone
+# failures by matching English signal strings (see
+# ``AuthResolver.is_public_github_auth_failure``). A translated stderr makes an
+# authentication failure unrecognisable, which suppresses the token retry. The
+# ``C`` locale has no message catalogue, so git emits its untranslated source
+# strings. ``LANGUAGE`` takes precedence over ``LC_ALL`` for translations and
+# must be neutralised too. GitPython already does this for every command it
+# runs; this keeps APM's own subprocess calls consistent with it.
+_GIT_MESSAGE_LOCALE_ENV: dict[str, str] = {"LC_ALL": "C", "LANGUAGE": "C"}
+
 
 # ---------------------------------------------------------------------------
 # Data classes
@@ -1208,6 +1218,7 @@ class AuthResolver:
         AuthResolver._clear_git_auth_env(env)
         env["GIT_TERMINAL_PROMPT"] = "0"
         env["GIT_ASKPASS"] = "echo"
+        env.update(_GIT_MESSAGE_LOCALE_ENV)
         if token and host_kind == "ado" and scheme in {"basic", "bearer"}:
             # ADO credentials use an Authorization header, never argv or
             # GIT_TOKEN. This keeps PATs and bearer JWTs out of process lists.

--- a/src/apm_cli/core/auth.py
+++ b/src/apm_cli/core/auth.py
@@ -35,8 +35,9 @@ import re
 import sys
 import threading
 import traceback
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
+from types import MappingProxyType
 from typing import TYPE_CHECKING, NamedTuple, TypeVar
 
 from apm_cli.core.host_providers import (
@@ -147,7 +148,7 @@ _GIT_CHILD_TOKEN_ENV_PREFIXES = ("GITHUB_APM_PAT_",)
 # strings. ``LANGUAGE`` takes precedence over ``LC_ALL`` for translations and
 # must be neutralised too. GitPython already does this for every command it
 # runs; this keeps APM's own subprocess calls consistent with it.
-_GIT_MESSAGE_LOCALE_ENV: dict[str, str] = {"LC_ALL": "C", "LANGUAGE": "C"}
+_GIT_MESSAGE_LOCALE_ENV: Mapping[str, str] = MappingProxyType({"LC_ALL": "C", "LANGUAGE": "C"})
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_public_github_anonymous_lifecycle_e2e.py
+++ b/tests/integration/test_public_github_anonymous_lifecycle_e2e.py
@@ -246,14 +246,18 @@ def test_all_public_graph_lifecycle_never_resolves_or_leaks_credentials(
         assert all(not observation.authorization_present for observation in repository_requests)
 
 
-def test_private_github_fallback_resolves_once_and_completes_lifecycle(
+def test_private_github_fallback_normalizes_locale_and_completes_lifecycle(
     tmp_path: Path,
     apm_binary_path: Path,
 ) -> None:
-    """One private dependency uses one path-scoped credential fallback."""
+    """A localized private clone retries once with a path-scoped credential."""
     isolated = IsolatedApmEnvironment.create(
         tmp_path / "private-scenario",
-        base_env=dict(os.environ),
+        base_env={
+            **os.environ,
+            "LC_ALL": "id_ID.UTF-8",
+            "LANGUAGE": "id_ID:id",
+        },
     )
     base_environment = isolated.subprocess_env()
     packages = LocalPackageFactory(isolated.package_root)
@@ -323,6 +327,8 @@ def test_private_github_fallback_resolves_once_and_completes_lifecycle(
 
         remote_events = _remote_events(shim)
         assert remote_events
+        assert all(event["lc_all"] == "C" for event in remote_events)
+        assert all(event["language"] == "C" for event in remote_events)
         remote_attempts = [remote for event in remote_events for remote in event["remotes"]]
         assert remote_attempts[0]["authenticated_url"] is False
         assert any(remote["authenticated_url"] is True for remote in remote_attempts)

--- a/tests/unit/core/test_public_github_anonymous_first.py
+++ b/tests/unit/core/test_public_github_anonymous_first.py
@@ -37,6 +37,28 @@ class _HttpStatusError(RuntimeError):
         super().__init__(f"HTTP {status_code}")
 
 
+_UNTRANSLATED_AUTH_STDERR = (
+    "fatal: Authentication failed for 'https://github.com/acme/private.git/'"
+)
+_TRANSLATED_AUTH_STDERR = (
+    "fatal\u00a0: Échec d'authentification pour 'https://github.com/acme/private.git/'"
+)
+
+
+def _localized_git_stderr(env: dict[str, str]) -> str:
+    """Return git's auth failure the way gettext would render it under *env*.
+
+    Git resolves its message catalogue from ``LANGUAGE`` first, then
+    ``LC_ALL``; the ``C`` locale has no catalogue, so the untranslated
+    source string surfaces. Reproducing that precedence here is what makes
+    the retry contract fail when the locale is left inherited.
+    """
+    catalogue = env.get("LANGUAGE") or env.get("LC_ALL") or ""
+    if catalogue.startswith("C"):
+        return _UNTRANSLATED_AUTH_STDERR
+    return _TRANSLATED_AUTH_STDERR
+
+
 def _indexed_git_config(env: dict[str, str]) -> list[tuple[str, str]]:
     """Return process-scoped Git config entries in declared order."""
     count = int(env.get("GIT_CONFIG_COUNT", "0"))
@@ -85,6 +107,8 @@ def _assert_anonymous_attempt_env(env: dict[str, str]) -> None:
     assert env["GIT_TERMINAL_PROMPT"] == "0"
     assert env["GIT_ASKPASS"] == "echo"
     assert env["GIT_CONFIG_NOSYSTEM"] == "1"
+    assert env["LC_ALL"] == "C"
+    assert env["LANGUAGE"] == "C"
     if os.name == "nt":
         assert Path(env["GIT_CONFIG_GLOBAL"]).is_file()
     else:
@@ -455,6 +479,60 @@ def test_public_github_auth_failure_classifier_signal_vocabulary(
 ) -> None:
     """Every documented auth and non-auth signal stays in its intended bucket."""
     assert AuthResolver.is_public_github_auth_failure(failure) is expected
+
+
+@pytest.mark.parametrize(
+    "locale_environment",
+    (
+        {"LC_ALL": "fr_FR.UTF-8", "LANGUAGE": "fr_FR:fr"},
+        {"LANG": "de_DE.UTF-8"},
+        {"LC_MESSAGES": "ja_JP.UTF-8"},
+    ),
+)
+def test_git_message_locale_is_normalized_over_inherited_locale(
+    locale_environment: dict[str, str],
+) -> None:
+    """An inherited locale never reaches git, whichever variable carries it."""
+    with patch.dict(os.environ, locale_environment, clear=True):
+        env = AuthResolver._build_git_env()
+
+    assert env["LC_ALL"] == "C"
+    assert env["LANGUAGE"] == "C"
+
+
+def test_translated_clone_failure_still_retries_with_a_token() -> None:
+    """A localised git stderr stays classifiable, so the token retry happens."""
+    manager = MagicMock(spec=GitHubTokenManager)
+    manager.setup_environment.side_effect = lambda: dict(os.environ)
+    manager.get_token_for_purpose.return_value = None
+    manager.resolve_credential_from_gh_cli.return_value = None
+    manager.resolve_credential_from_git.return_value = "private-token"
+    resolver = AuthResolver(token_manager=manager)
+    dep_ref = DependencyReference.parse("https://github.com/acme/private.git#main")
+    calls: list[tuple[str, dict[str, str]]] = []
+
+    def clone_action(url: str, env: dict[str, str], _target: Path) -> None:
+        calls.append((url, env))
+        if urlparse(url).username is not None:
+            return
+        raise subprocess.CalledProcessError(
+            128,
+            ("git", "clone"),
+            stderr=_localized_git_stderr(env),
+        )
+
+    with patch.dict(os.environ, {"LC_ALL": "fr_FR.UTF-8", "LANGUAGE": "fr_FR:fr"}, clear=True):
+        downloader = _public_downloader(resolver)
+        downloader._execute_transport_plan(
+            dep_ref.repo_url,
+            Path("unused-target"),
+            dep_ref=dep_ref,
+            clone_action=clone_action,
+        )
+
+    assert len(calls) == 2
+    assert urlparse(calls[0][0]).username is None
+    assert urlparse(calls[1][0]).username is not None
 
 
 def test_clear_git_auth_env_only_removes_real_auth_channels() -> None:

--- a/tests/unit/core/test_public_github_anonymous_first.py
+++ b/tests/unit/core/test_public_github_anonymous_first.py
@@ -40,9 +40,7 @@ class _HttpStatusError(RuntimeError):
 _UNTRANSLATED_AUTH_STDERR = (
     "fatal: Authentication failed for 'https://github.com/acme/private.git/'"
 )
-_TRANSLATED_AUTH_STDERR = (
-    "fatal\u00a0: Échec d'authentification pour 'https://github.com/acme/private.git/'"
-)
+_TRANSLATED_AUTH_STDERR = "fatal: Autentikasi gagal untuk 'https://github.com/acme/private.git/'"
 
 
 def _localized_git_stderr(env: dict[str, str]) -> str:
@@ -51,7 +49,9 @@ def _localized_git_stderr(env: dict[str, str]) -> str:
     Git resolves its message catalogue from ``LANGUAGE`` first, then
     ``LC_ALL``; the ``C`` locale has no catalogue, so the untranslated
     source string surfaces. Reproducing that precedence here is what makes
-    the retry contract fail when the locale is left inherited.
+    the retry contract fail when the locale is left inherited. The
+    translated form is git's own ``id`` catalogue entry, chosen because it
+    is a real translation that stays within printable ASCII.
     """
     catalogue = env.get("LANGUAGE") or env.get("LC_ALL") or ""
     if catalogue.startswith("C"):
@@ -484,7 +484,7 @@ def test_public_github_auth_failure_classifier_signal_vocabulary(
 @pytest.mark.parametrize(
     "locale_environment",
     (
-        {"LC_ALL": "fr_FR.UTF-8", "LANGUAGE": "fr_FR:fr"},
+        {"LC_ALL": "id_ID.UTF-8", "LANGUAGE": "id_ID:id"},
         {"LANG": "de_DE.UTF-8"},
         {"LC_MESSAGES": "ja_JP.UTF-8"},
     ),
@@ -521,7 +521,7 @@ def test_translated_clone_failure_still_retries_with_a_token() -> None:
             stderr=_localized_git_stderr(env),
         )
 
-    with patch.dict(os.environ, {"LC_ALL": "fr_FR.UTF-8", "LANGUAGE": "fr_FR:fr"}, clear=True):
+    with patch.dict(os.environ, {"LC_ALL": "id_ID.UTF-8", "LANGUAGE": "id_ID:id"}, clear=True):
         downloader = _public_downloader(resolver)
         downloader._execute_transport_plan(
             dep_ref.repo_url,

--- a/tests/unit/core/test_public_github_anonymous_first.py
+++ b/tests/unit/core/test_public_github_anonymous_first.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 import os
 import subprocess
 from pathlib import Path
+from types import MappingProxyType
 from unittest.mock import MagicMock, call, patch
 from urllib.parse import urlparse
 
 import pytest
 import requests
 
-from apm_cli.core.auth import AuthResolver
+from apm_cli.core.auth import _GIT_MESSAGE_LOCALE_ENV, AuthResolver
 from apm_cli.core.token_manager import GitHubTokenManager
 from apm_cli.deps.github_downloader import GitHubPackageDownloader
 from apm_cli.deps.github_rate_limit import GitHubThrottle, GitHubThrottleError
@@ -498,6 +499,16 @@ def test_git_message_locale_is_normalized_over_inherited_locale(
 
     assert env["LC_ALL"] == "C"
     assert env["LANGUAGE"] == "C"
+
+
+def test_git_message_locale_constant_rejects_mutation() -> None:
+    """The pinned locale cannot be reopened by a caller holding the constant."""
+    assert isinstance(_GIT_MESSAGE_LOCALE_ENV, MappingProxyType)
+
+    with pytest.raises(TypeError):
+        _GIT_MESSAGE_LOCALE_ENV["LC_ALL"] = "id_ID.UTF-8"  # type: ignore[index]
+
+    assert AuthResolver._build_git_env()["LC_ALL"] == "C"
 
 
 def test_translated_clone_failure_still_retries_with_a_token() -> None:

--- a/tests/utils/git_credential_shim.py
+++ b/tests/utils/git_credential_shim.py
@@ -21,6 +21,8 @@ import base64
 from pathlib import Path
 from urllib.parse import urlsplit, urlunsplit
 
+_LOCALIZED_AUTH_FAILURE = "fatal: Autentikasi gagal untuk 'https://github.com/fixture/private.git/'\n"
+
 
 def _config_entries():
     try:
@@ -119,6 +121,11 @@ def _strip_dumb_http_incompatible_options(args):
     return stripped
 
 
+def _uses_non_c_git_message_locale():
+    locale = os.environ.get("LANGUAGE") or os.environ.get("LC_ALL") or ""
+    return not locale.startswith("C")
+
+
 def main():
     args = sys.argv[1:]
     if args[:2] == ["credential", "fill"]:
@@ -162,13 +169,22 @@ def main():
             "credential_interactive": [
                 value for key, value in entries if key.lower() == "credential.interactive"
             ],
+            "lc_all": os.environ.get("LC_ALL"),
+            "language": os.environ.get("LANGUAGE"),
         }
     )
     completed = subprocess.run(
         [os.environ["APM_TEST_REAL_GIT"], *rewritten_args],
         env=os.environ,
         check=False,
+        capture_output=True,
+        text=True,
     )
+    sys.stdout.write(completed.stdout)
+    if completed.returncode and remotes and not authorizations and _uses_non_c_git_message_locale():
+        sys.stderr.write(_LOCALIZED_AUTH_FAILURE)
+    else:
+        sys.stderr.write(completed.stderr)
     return completed.returncode
 
 


### PR DESCRIPTION
## Description

Fixes #2533.

`AuthResolver.is_public_github_auth_failure` classifies a failed clone by matching **English** signal strings against git's stderr (`"authentication failed"`, `"could not read username"`, ...). Git localises those diagnostics through gettext, and APM does not pin a locale for the git subprocesses it spawns itself. On a machine whose locale is not English, an authentication failure becomes unrecognisable.

That is not a message-fidelity problem. The verdict gates the **token retry** in `try_with_fallback` (`core/auth.py:797-802`):

```python
if (
    lazy_public_github
    and path is not None
    and not self.is_public_github_auth_failure(exc)
):
    raise
```

Since `uses_public_github_anonymous_first` makes every github.com access start anonymously, a misclassified failure re-raises before the token is ever tried. A private-repo dependency fails to install, and the user is sent to the wrong place:

```
Could not connect to github.com (network error, not an auth failure).
Check your internet connection and proxy settings.
```

while git actually said "authentication failed".

## Approach

Set `LC_ALL=C` and `LANGUAGE=C` in `AuthResolver._build_git_env` — the single builder that `build_public_github_anonymous_git_env`, `build_noninteractive_git_env` and `git_env_for_context` all route through, so it covers both the anonymous attempt and the authenticated retry. The `C` locale has no message catalogue, so git emits its untranslated source strings.

Both variables are required: `LANGUAGE` takes precedence over `LC_ALL` for translations, so pinning `LC_ALL` alone would still leave the bug for anyone who exports `LANGUAGE`. Verified directly — `LC_ALL=fr_FR.UTF-8 LANGUAGE=C git ...` prints English, while `LC_ALL=C LANGUAGE=fr git ...` also prints English.

GitPython already forces both on every command it runs (`git/cmd.py`), which is exactly why clones issued through it were unaffected while APM's own `subprocess` calls were not. This change makes the two paths consistent rather than introducing a new convention.

Two alternatives I discarded:

- **Widening the classifier's vocabulary with translated strings.** Git ships catalogues for 19 languages today and the strings move between versions. It also fails in a way that is easy to miss: a user whose language has no catalogue (e.g. `ja`) is not affected today, but becomes affected the day that translation lands. Normalising at the source is the stable fix.
- **Patching `git_subprocess_env()`** in `utils/git_env.py`. I tried this first; it does **not** fix the failing path — the shared bare-cache clone does not route through that function. Verified experimentally before settling on `_build_git_env`.

## Scope

The remaining git subprocesses that still inherit the ambient locale are the purely local ones in `deps/bare_cache.py` (`clone --local` from the bare, `config`, `checkout`, sparse-cone). They perform no authentication and their stderr never reaches the classifier, so they are intentionally left alone to keep the diff minimal.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [x] Added tests for new functionality (if applicable)

Added to `tests/unit/core/test_public_github_anonymous_first.py`, the existing home of this contract:

- **`test_git_message_locale_is_normalized_over_inherited_locale`** — parametrised over `LC_ALL`/`LANGUAGE`, `LANG`, and `LC_MESSAGES`, so an inherited locale never reaches git whichever variable carries it.
- **`test_translated_clone_failure_still_retries_with_a_token`** — the regression test. It drives the real transport plan with a `clone_action` whose stderr is rendered through `_localized_git_stderr`, a helper that reproduces gettext's own precedence (`LANGUAGE` first, then `LC_ALL`; `C` yields the untranslated string). It therefore returns the translated form *only if* the locale was left inherited, and asserts the anonymous attempt is followed by an authenticated one. The translated fixture is git's own `id` catalogue entry (`fatal: Autentikasi gagal untuk '<url>'`) — a real gettext output that matches none of the classifier's English signals while staying within printable ASCII, as `.apm/instructions/encoding.instructions.md` requires.
- **`_assert_anonymous_attempt_env`** — the shared assertion for the anonymous call shape now pins the locale alongside `GIT_TERMINAL_PROMPT` and `GIT_ASKPASS`.

Reverting the one-line call site in `_build_git_env` makes 10 tests in that file fail, including both new ones — the tests fail for the intended reason rather than passing vacuously.

End-to-end validation on the real case (private-repo subdirectory package, cold cache, HTTPS forced): fails under `LANG=fr_FR.UTF-8` on `main`, installs successfully with this change. That reproduction used a real French locale on the machine; only the in-source test fixture is ASCII. The A/B across locales is in the issue.

Full CI mirror on Python 3.12, all seven lint gates from `.apm/instructions/linting.instructions.md`:

```
uv run pytest tests/unit tests/test_console.py -x     -> 19807 passed, 2 skipped, 21 xfailed
uv run --extra dev ruff check src/ tests/             -> All checks passed!
uv run --extra dev ruff format --check src/ tests/    -> 1610 files already formatted
pylint --enable=R0801 --min-similarity-lines=10       -> rated at 10.00/10
bash scripts/lint-auth-signals.sh                     -> auth-signal lint clean
YAML I/O guard / file length (<=2450) / relative_to   -> clean
```

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|-------------------------|--------------|--------------------|------|
| 1 | `apm install` of a private github.com dependency succeeds on a non-English machine by retrying once with the resolved credential | Secure by default, DevX | `tests/unit/core/test_public_github_anonymous_first.py::test_translated_clone_failure_still_retries_with_a_token`<br/>`tests/integration/test_public_github_anonymous_lifecycle_e2e.py::test_private_github_fallback_normalizes_locale_and_completes_lifecycle` (regression-trap for #2533) | e2e |

## Spec conformance (OpenAPM v0.1)

- [x] N/A -- this PR does not change OpenAPM-observable behaviour.

No CLI surface, manifest, lockfile or resolution semantics change. The change is confined to the environment handed to git subprocesses; its observable effect is that an authentication failure is now classified as one regardless of the machine's locale.

