### PR TITLE
fix(plugins): let the resolved declaration decide which skills deploy (closes #2537)

### DIFF
--- a/.apm/instructions/architecture.instructions.md
+++ b/.apm/instructions/architecture.instructions.md
@@ -80,6 +80,7 @@ semicolon-delimited, and specific to the file(s) that own the fact.
 | APMPackage interpreted-manifest construction | models/apm_package.py (APMPackage.from_mapping) | `src/apm_cli/models/apm_package.py` |
 | Agent Plugin compatibility package projection | agent_plugins/projection.py (project_agent_plugin_package) | `src/apm_cli/agent_plugins/projection.py`; `src/apm_cli/models/validation.py` |
 | Network host literal parsing and loopback classification | utils/net.py (parse_host_address, is_loopback_host) | `src/apm_cli/utils/net.py` |
+| Legacy plugin declared-skill membership | deps/plugin_parser.py (_map_plugin_artifacts, normalized_plugin_skill_sources) | `src/apm_cli/deps/plugin_parser.py`; `src/apm_cli/integration/skill_integrator.py` |
 <!-- /canonical-owner-table -->
 
 Host + credential resolution includes public github.com anonymous-first ordering.

--- a/.github/instructions/architecture.instructions.md
+++ b/.github/instructions/architecture.instructions.md
@@ -80,6 +80,7 @@ semicolon-delimited, and specific to the file(s) that own the fact.
 | APMPackage interpreted-manifest construction | models/apm_package.py (APMPackage.from_mapping) | `src/apm_cli/models/apm_package.py` |
 | Agent Plugin compatibility package projection | agent_plugins/projection.py (project_agent_plugin_package) | `src/apm_cli/agent_plugins/projection.py`; `src/apm_cli/models/validation.py` |
 | Network host literal parsing and loopback classification | utils/net.py (parse_host_address, is_loopback_host) | `src/apm_cli/utils/net.py` |
+| Legacy plugin declared-skill membership | deps/plugin_parser.py (_map_plugin_artifacts, normalized_plugin_skill_sources) | `src/apm_cli/deps/plugin_parser.py`; `src/apm_cli/integration/skill_integrator.py` |
 <!-- /canonical-owner-table -->
 
 Host + credential resolution includes public github.com anonymous-first ordering.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`"skills": "./skills/engineering/tdd"`) still lands under its own leaf name
   instead of spilling a bare `SKILL.md` into the shared skills root.
   (closes #2530)
+- A plugin's `plugin.json` is now authoritative for which skills deploy. The
+  raw root `skills/` directory overrode the resolved declaration, so the
+  deployed set could differ from the declared one in both directions --
+  silently: declaring `"skills": ["./skills/a"]` still deployed sibling `b`
+  alongside it, and a skill declared outside the conventional container was
+  dropped entirely. A declaration replaces default discovery rather than
+  adding to it, so `"skills": []` now means no skills, and a declared path
+  rejected for escaping the plugin root fails closed instead of falling back
+  to the raw tree. **Behaviour change for plugin authors:** if your
+  `plugin.json` declares a `skills` subset while shipping more skills under
+  `skills/`, the undeclared ones stop deploying -- declare them, or drop the
+  key to keep deploying everything the directory holds. When a declaration
+  resolves to no skills while the package does carry a root `skills/` bundle,
+  install now names the skills it left behind instead of saying nothing.
+  Where a declared skill also exists in the root bundle it keeps being read
+  from there, so relative links leaving a skill still resolve against the
+  package root. (closes #2537)
 - Multi-target `apm compile` now avoids repeating expensive project analysis
   for each target, making multi-target runs scale like single-target runs
   without changing generated output. (closes #2482)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Windows binary is now Authenticode-signed in the release workflow, eliminating
   the `Trojan:Script/Wacatac.H!ml` Windows Defender false positive on unsigned
   PyInstaller bundles. (#2435)
+- `apm install --skill <name>` now matches on plugins whose manifest declares
+  the conventional skills container (`"skills": ["./skills/"]`). The declared
+  container was normalized under its own name, burying every skill at
+  `.apm/skills/skills/<name>/` -- one level below the depth `--skill`
+  enumeration, deployment, the `bin/` security scan and primitive counting all
+  read, so selection reported `Available: (none)` even though a bare install
+  deployed those same skills. A declared entry that is itself a skill
+  (`"skills": "./skills/engineering/tdd"`) still lands under its own leaf name
+  instead of spilling a bare `SKILL.md` into the shared skills root.
+  (closes #2530)
 - Multi-target `apm compile` now avoids repeating expensive project analysis
   for each target, making multi-target runs scale like single-target runs
   without changing generated output. (closes #2482)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,23 +58,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`"skills": "./skills/engineering/tdd"`) still lands under its own leaf name
   instead of spilling a bare `SKILL.md` into the shared skills root.
   (closes #2530)
-- A plugin's `plugin.json` is now authoritative for which skills deploy. The
-  raw root `skills/` directory overrode the resolved declaration, so the
-  deployed set could differ from the declared one in both directions --
-  silently: declaring `"skills": ["./skills/a"]` still deployed sibling `b`
-  alongside it, and a skill declared outside the conventional container was
-  dropped entirely. A declaration replaces default discovery rather than
-  adding to it, so `"skills": []` now means no skills, and a declared path
-  rejected for escaping the plugin root fails closed instead of falling back
-  to the raw tree. **Behaviour change for plugin authors:** if your
-  `plugin.json` declares a `skills` subset while shipping more skills under
-  `skills/`, the undeclared ones stop deploying -- declare them, or drop the
-  key to keep deploying everything the directory holds. When a declaration
-  resolves to no skills while the package does carry a root `skills/` bundle,
-  install now names the skills it left behind instead of saying nothing.
-  Where a declared skill also exists in the root bundle it keeps being read
-  from there, so relative links leaving a skill still resolve against the
-  package root. (closes #2537)
 - Multi-target `apm compile` now avoids repeating expensive project analysis
   for each target, making multi-target runs scale like single-target runs
   without changing generated output. (closes #2482)
@@ -95,6 +78,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING:** A plugin `skills` declaration now exclusively controls which
+  skills deploy. Declare every intended skill (or its immediate container), or
+  remove the key to retain conventional `skills/` discovery; undeclared
+  siblings no longer deploy. An explicit `"skills": []` deploys no skills and
+  reports one actionable migration diagnostic when it shadows root skills.
+  (closes #2537)
 - `apm install` now emits a trust-posture warning (via `[!]`) when a marketplace
   plugin deploys executables to Claude Code's PATH without an explicit `--trust-bin`
   flag. In non-interactive (non-TTY) contexts the default is `--no-trust-bin`.

--- a/CONFORMANCE.json
+++ b/CONFORMANCE.json
@@ -544,9 +544,10 @@
       "keyword": "MUST",
       "section": "4.3.2",
       "status": "active",
-      "test_count": 1,
+      "test_count": 2,
       "tests": [
-        "tests/spec_conformance/test_manifest_reqs.py::test_consumer_diagnoses_empty_skill_subset_match"
+        "tests/spec_conformance/test_manifest_reqs.py::test_consumer_diagnoses_empty_skill_subset_match",
+        "tests/spec_conformance/test_manifest_reqs.py::test_consumer_names_skills_a_plugin_collection_exposes"
       ]
     },
     {

--- a/CONFORMANCE.json
+++ b/CONFORMANCE.json
@@ -544,9 +544,10 @@
       "keyword": "MUST",
       "section": "4.3.2",
       "status": "active",
-      "test_count": 2,
+      "test_count": 3,
       "tests": [
         "tests/spec_conformance/test_manifest_reqs.py::test_consumer_diagnoses_empty_skill_subset_match",
+        "tests/spec_conformance/test_manifest_reqs.py::test_consumer_names_only_the_skills_a_plugin_manifest_declares",
         "tests/spec_conformance/test_manifest_reqs.py::test_consumer_names_skills_a_plugin_collection_exposes"
       ]
     },

--- a/CONFORMANCE.json
+++ b/CONFORMANCE.json
@@ -544,10 +544,9 @@
       "keyword": "MUST",
       "section": "4.3.2",
       "status": "active",
-      "test_count": 3,
+      "test_count": 2,
       "tests": [
         "tests/spec_conformance/test_manifest_reqs.py::test_consumer_diagnoses_empty_skill_subset_match",
-        "tests/spec_conformance/test_manifest_reqs.py::test_consumer_names_only_the_skills_a_plugin_manifest_declares",
         "tests/spec_conformance/test_manifest_reqs.py::test_consumer_names_skills_a_plugin_collection_exposes"
       ]
     },
@@ -822,6 +821,17 @@
       "test_count": 1,
       "tests": [
         "tests/spec_conformance/test_resolution_reqs.py::test_producer_should_carry_primitive_descriptions"
+      ]
+    },
+    {
+      "conformance_class": "consumer",
+      "id": "req-pr-006",
+      "keyword": "MUST",
+      "section": "8.1",
+      "status": "active",
+      "test_count": 1,
+      "tests": [
+        "tests/spec_conformance/test_manifest_reqs.py::test_plugin_skills_declaration_is_authoritative"
       ]
     },
     {
@@ -1315,7 +1325,7 @@
   "spec_version": "v0.1.1",
   "summary_by_class": {
     "consumer": {
-      "active": 84,
+      "active": 85,
       "skipped": 1,
       "unbound": 0,
       "xfail": 0
@@ -1339,5 +1349,5 @@
       "xfail": 0
     }
   },
-  "total_requirements": 115
+  "total_requirements": 116
 }

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -74,7 +74,7 @@ All four conformance classes (Producer, Consumer, Registry, Governance) carry ac
 | [req-mf-019](docs/src/content/docs/specs/openapm-v0.1.md#req-mf-019) | MUST | 4.2.4 | consumer | active | 1 |
 | [req-mf-020](docs/src/content/docs/specs/openapm-v0.1.md#req-mf-020) | MUST | 4.1 | consumer | active | 1 |
 | [req-mf-021](docs/src/content/docs/specs/openapm-v0.1.md#req-mf-021) | MUST | 4.8 | producer | active | 1 |
-| [req-mf-022](docs/src/content/docs/specs/openapm-v0.1.md#req-mf-022) | MUST | 4.3.2 | consumer | active | 1 |
+| [req-mf-022](docs/src/content/docs/specs/openapm-v0.1.md#req-mf-022) | MUST | 4.3.2 | consumer | active | 2 |
 | [req-mf-023](docs/src/content/docs/specs/openapm-v0.1.md#req-mf-023) | MUST | 4.5 | consumer | active | 1 |
 | [req-mf-024](docs/src/content/docs/specs/openapm-v0.1.md#req-mf-024) | MUST | 4.3.2 | consumer | active | 1 |
 | [req-pl-001](docs/src/content/docs/specs/openapm-v0.1.md#req-pl-001) | MUST | 6.1 | governance | active | 1 |

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -74,7 +74,7 @@ All four conformance classes (Producer, Consumer, Registry, Governance) carry ac
 | [req-mf-019](docs/src/content/docs/specs/openapm-v0.1.md#req-mf-019) | MUST | 4.2.4 | consumer | active | 1 |
 | [req-mf-020](docs/src/content/docs/specs/openapm-v0.1.md#req-mf-020) | MUST | 4.1 | consumer | active | 1 |
 | [req-mf-021](docs/src/content/docs/specs/openapm-v0.1.md#req-mf-021) | MUST | 4.8 | producer | active | 1 |
-| [req-mf-022](docs/src/content/docs/specs/openapm-v0.1.md#req-mf-022) | MUST | 4.3.2 | consumer | active | 2 |
+| [req-mf-022](docs/src/content/docs/specs/openapm-v0.1.md#req-mf-022) | MUST | 4.3.2 | consumer | active | 3 |
 | [req-mf-023](docs/src/content/docs/specs/openapm-v0.1.md#req-mf-023) | MUST | 4.5 | consumer | active | 1 |
 | [req-mf-024](docs/src/content/docs/specs/openapm-v0.1.md#req-mf-024) | MUST | 4.3.2 | consumer | active | 1 |
 | [req-pl-001](docs/src/content/docs/specs/openapm-v0.1.md#req-pl-001) | MUST | 6.1 | governance | active | 1 |

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -19,7 +19,7 @@ All four conformance classes (Producer, Consumer, Registry, Governance) carry ac
 | Class | Active | Skipped | Xfail | Unbound |
 |-------|-------:|--------:|------:|--------:|
 | Producer | 12 | 0 | 0 | 0 |
-| Consumer | 84 | 1 | 0 | 0 |
+| Consumer | 85 | 1 | 0 | 0 |
 | Registry | 1 | 0 | 0 | 0 |
 | Governance | 17 | 0 | 0 | 0 |
 
@@ -74,7 +74,7 @@ All four conformance classes (Producer, Consumer, Registry, Governance) carry ac
 | [req-mf-019](docs/src/content/docs/specs/openapm-v0.1.md#req-mf-019) | MUST | 4.2.4 | consumer | active | 1 |
 | [req-mf-020](docs/src/content/docs/specs/openapm-v0.1.md#req-mf-020) | MUST | 4.1 | consumer | active | 1 |
 | [req-mf-021](docs/src/content/docs/specs/openapm-v0.1.md#req-mf-021) | MUST | 4.8 | producer | active | 1 |
-| [req-mf-022](docs/src/content/docs/specs/openapm-v0.1.md#req-mf-022) | MUST | 4.3.2 | consumer | active | 3 |
+| [req-mf-022](docs/src/content/docs/specs/openapm-v0.1.md#req-mf-022) | MUST | 4.3.2 | consumer | active | 2 |
 | [req-mf-023](docs/src/content/docs/specs/openapm-v0.1.md#req-mf-023) | MUST | 4.5 | consumer | active | 1 |
 | [req-mf-024](docs/src/content/docs/specs/openapm-v0.1.md#req-mf-024) | MUST | 4.3.2 | consumer | active | 1 |
 | [req-pl-001](docs/src/content/docs/specs/openapm-v0.1.md#req-pl-001) | MUST | 6.1 | governance | active | 1 |
@@ -99,6 +99,7 @@ All four conformance classes (Producer, Consumer, Registry, Governance) carry ac
 | [req-pr-003](docs/src/content/docs/specs/openapm-v0.1.md#req-pr-003) | MUST | 8.3 | consumer | active | 1 |
 | [req-pr-004](docs/src/content/docs/specs/openapm-v0.1.md#req-pr-004) | MUST | 7.8 | producer | active | 10 |
 | [req-pr-005](docs/src/content/docs/specs/openapm-v0.1.md#req-pr-005) | SHOULD | 7.8 | producer | active | 1 |
+| [req-pr-006](docs/src/content/docs/specs/openapm-v0.1.md#req-pr-006) | MUST | 8.1 | consumer | active | 1 |
 | [req-rg-001](docs/src/content/docs/specs/openapm-v0.1.md#req-rg-001) | MUST | 11.3.3 | registry | active | 1 |
 | [req-rs-001](docs/src/content/docs/specs/openapm-v0.1.md#req-rs-001) | MUST | 7.2 | consumer | active | 1 |
 | [req-rs-002](docs/src/content/docs/specs/openapm-v0.1.md#req-rs-002) | MUST | 7.3 | consumer | active | 1 |

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -2783,7 +2783,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:ab625ab2263bde79d1b5fca67c69afdee1a07037a9a0507f39704378eefea9e6
+  content_hash: sha256:da5d75f08b2abc0cf2cd440505ff661d9af0297ebbc53715cb6cba3987529302
 - kind: project-relative
   target: copilot
   value: .github/instructions/changelog.instructions.md
@@ -3290,7 +3290,7 @@ local_deployed_file_hashes:
   .github/agents/spec-tag-architect.agent.md: sha256:82907265c5e7cf1ac61ad96866fa7c5683b69c8f09b7a4c5f3cc241acc9568ca
   .github/agents/supply-chain-security-expert.agent.md: sha256:8fb8cc426d6af17ba084a28b3f026c2b475b62e3ca63ed2f88b83bd823f877af
   .github/agents/test-coverage-expert.agent.md: sha256:48c2172d1f18a394fa83ef9dc2be0b9b921a4e51e976498165250fed66369711
-  .github/instructions/architecture.instructions.md: sha256:ab625ab2263bde79d1b5fca67c69afdee1a07037a9a0507f39704378eefea9e6
+  .github/instructions/architecture.instructions.md: sha256:da5d75f08b2abc0cf2cd440505ff661d9af0297ebbc53715cb6cba3987529302
   .github/instructions/changelog.instructions.md: sha256:1e51ec4c74e847967962bd279dc4c6e582c5d3578490b3c28d5f3acd3e05f73e
   .github/instructions/cicd.instructions.md: sha256:33201cb88ea2f34b4950a9b52f87dc8dfb682796aaf53068ba7ae406c0c5e2c2
   .github/instructions/cli.instructions.md: sha256:8e39e8d5047ce88575cb02f87c2bcede584dfef258bd86f7466c7badf136541a

--- a/docs/public/specs/manifests/openapm-v0.1.requirements.yml
+++ b/docs/public/specs/manifests/openapm-v0.1.requirements.yml
@@ -427,6 +427,11 @@ requirements:
     section: "8.5.6"
     conformance_class: consumer
     notes: "implementation-defined plugin-root placeholders preserve balanced expandable double quoting across split-quote forward- or backslash path spelling and unresolved placeholders emit a default-visible diagnostic"
+  - id: req-pr-006
+    keyword: MUST
+    section: "8.1"
+    conformance_class: consumer
+    notes: "legacy plugin skills declarations replace discovery; invalid, escaping, symlinked, and duplicate-derived entries fail closed"
   - id: req-sc-001
     keyword: MUST
     section: "10.4"

--- a/docs/src/content/docs/consumer/deploy-a-bundle.md
+++ b/docs/src/content/docs/consumer/deploy-a-bundle.md
@@ -73,7 +73,12 @@ Steps APM runs:
 3. **Verify integrity.** Hash every file listed in `pack.bundle_files`;
    reject any symlink, hash mismatch, or unlisted file.
 4. **Deploy.** Map `agents/`, `skills/`, `commands/`, `hooks/` into the
-   harness layout for each `--target` you passed.
+   harness layout for each `--target` you passed. Where `plugin.json`
+   declares a key, that declaration *replaces* the directory scan for the
+   primitive instead of adding to it: with `"skills": ["./skills/tone"]`
+   only `tone` deploys, even when `skills/` holds siblings, and
+   `"skills": []` deploys none. Omit the key to deploy whatever the
+   conventional directory holds.
 5. **Record.** Write a lockfile entry under the project's `apm.lock.yaml`
    so [drift detection](../drift-and-secure-by-default/) can audit the
    deployed files later.

--- a/docs/src/content/docs/consumer/deploy-a-bundle.md
+++ b/docs/src/content/docs/consumer/deploy-a-bundle.md
@@ -73,12 +73,8 @@ Steps APM runs:
 3. **Verify integrity.** Hash every file listed in `pack.bundle_files`;
    reject any symlink, hash mismatch, or unlisted file.
 4. **Deploy.** Map `agents/`, `skills/`, `commands/`, `hooks/` into the
-   harness layout for each `--target` you passed. Where `plugin.json`
-   declares a key, that declaration *replaces* the directory scan for the
-   primitive instead of adding to it: with `"skills": ["./skills/tone"]`
-   only `tone` deploys, even when `skills/` holds siblings, and
-   `"skills": []` deploys none. Omit the key to deploy whatever the
-   conventional directory holds.
+   harness layout for each `--target` you passed. For plugin skill declaration
+   precedence, see [Package Types](../../reference/package-types/#plugin-collection-pluginjson).
 5. **Record.** Write a lockfile entry under the project's `apm.lock.yaml`
    so [drift detection](../drift-and-secure-by-default/) can audit the
    deployed files later.

--- a/docs/src/content/docs/producer/pack-a-bundle.md
+++ b/docs/src/content/docs/producer/pack-a-bundle.md
@@ -196,7 +196,7 @@ primitive type:
 | command (prompt) | `.apm/prompts/*.prompt.md` | No |
 | hook | `.apm/hooks/*.json` | Yes: `hooks/*.json` |
 | agent | `.apm/agents/**/*.agent.md` | Yes: `*.agent.md` at package root |
-| skill | `.apm/skills/<name>/SKILL.md` | Yes: `skills/<name>/SKILL.md` (SKILL_BUNDLE or MARKETPLACE_PLUGIN) |
+| skill | `.apm/skills/<name>/SKILL.md` | Yes: `skills/<name>/SKILL.md` (SKILL_BUNDLE; for MARKETPLACE_PLUGIN only when `plugin.json` declares it) |
 
 Source: `src/apm_cli/integration/instruction_integrator.py`,
 `src/apm_cli/integration/command_integrator.py`,
@@ -222,6 +222,10 @@ If you publish a plugin that consumers install via `apm install`, use
 `.apm/<type>/` for **every** primitive type. This layout is the only
 one that works symmetrically through both `apm pack` (export) and
 `apm install` (discovery).
+
+For a marketplace plugin, `plugin.json` is authoritative when it declares
+`skills`: declare each skill or an immediate container, or omit `skills` to
+use conventional discovery. See [Package Types](../../reference/package-types/#plugin-collection-pluginjson).
 
 ```
 plugins/my-plugin/

--- a/docs/src/content/docs/reference/package-types.md
+++ b/docs/src/content/docs/reference/package-types.md
@@ -220,6 +220,13 @@ deploys `search` and nothing else, and a skill declared outside `skills/`
 deploys even though no scan would have found it. Only an omitted key falls
 back to scanning the conventional directory.
 
+This is a migration point for existing plugin authors. A string or list is
+exhaustive after normalization, including a declared container with one skill
+per immediate child. `"skills": []` intentionally deploys no skills. When that
+empty declaration shadows root `skills/` entries, APM emits one diagnostic that
+names the package and tells you to declare the skills (or their container), or
+remove the key to restore discovery.
+
 **Marketplace version checks:** a local Plugin collection may omit `apm.yml`.
 For `apm pack --check-versions`, APM uses `plugin.json`'s `version` only when
 `apm.yml` is absent. See [Versioning strategies](../../producer/versioning-strategies/)

--- a/docs/src/content/docs/reference/package-types.md
+++ b/docs/src/content/docs/reference/package-types.md
@@ -214,6 +214,12 @@ the appropriate runtime directory via `_map_plugin_artifacts`. Use `--skill`
 to cherry-pick plugin skills by leaf name or manifest path, such as
 `skills/productivity/grill-me`.
 
+A declared key is authoritative for its primitive: it replaces the default
+directory scan rather than adding to it. `"skills": ["./skills/search"]`
+deploys `search` and nothing else, and a skill declared outside `skills/`
+deploys even though no scan would have found it. Only an omitted key falls
+back to scanning the conventional directory.
+
 **Marketplace version checks:** a local Plugin collection may omit `apm.yml`.
 For `apm pack --check-versions`, APM uses `plugin.json`'s `version` only when
 `apm.yml` is absent. See [Versioning strategies](../../producer/versioning-strategies/)

--- a/docs/src/content/docs/specs/openapm-v0.1.md
+++ b/docs/src/content/docs/specs/openapm-v0.1.md
@@ -136,7 +136,7 @@ between the companion corpus and the implementation.
 
 ### 1.3 Document conventions
 
-- OpenAPM v0.1 carries **115 normative statements** indexed in
+- OpenAPM v0.1 carries **116 normative statements** indexed in
   [Appendix C](#appendix-c-index-of-normative-statements).
 - All on-disk files defined by this specification are **YAML 1.2**
   parsed under the safe subset defined in
@@ -2207,8 +2207,29 @@ the recognised package layouts:
 - **Skill collection** (`skills/<name>/SKILL.md` nested). Each
   nested skill is promoted to `<deploy>/skills/<name>/`.
 - **Plugin collection** (`plugin.json` / `.claude-plugin/`).
-  Artifacts are mapped into deploy directories per the plugin
-  manifest.
+  Artifacts are mapped into deploy directories per the plugin manifest.
+
+<a id="req-pr-006"></a>
+**[req-pr-006]** For a Plugin collection, a conforming **consumer**
+MUST resolve `plugin.json` `skills` as follows. Only an omitted
+`skills` key permits conventional `skills/<name>/SKILL.md` discovery.
+A present key MUST be a string or a list of strings and replaces that
+discovery: an explicit empty list contributes no skills. The plugin root
+is the collection root containing `.claude-plugin/`, not the manifest
+directory. Each declared path MUST be relative to that root; every
+traversed path component, derived child, and `SKILL.md` MUST remain
+within that root and MUST NOT be a symlink. A declared directory
+containing a regular `SKILL.md` is one skill named by its final path
+component; a declared directory without `SKILL.md` contributes only
+immediate child directories containing a regular `SKILL.md`, each named
+by its final path component. A missing, unreadable, malformed, escaping,
+or symlinked entry MUST contribute no skill, and a consumer MUST NOT
+fall back to undeclared root discovery. Consumers MUST canonicalize
+accepted paths relative to the plugin root: repeated spellings of one
+canonical source deduplicate to one leaf, while every contribution whose
+derived leaf name maps to more than one canonical source contributes no
+skill. Only the resulting names are eligible for enumeration, selection,
+or deployment.
 
 A package **exposes selectable skills** when layout resolution identifies a
 container for individually addressable named skill entries, whether that
@@ -2544,7 +2565,7 @@ without a spec revision. The current matrix is in the companion
   [req-tg-006](#req-tg-006), [req-tg-007](#req-tg-007),
   [req-tg-008](#req-tg-008), [req-tg-009](#req-tg-009),
   [req-tg-010](#req-tg-010), [req-tg-011](#req-tg-011),
-  [req-tg-012](#req-tg-012).
+  [req-tg-012](#req-tg-012), [req-pr-006](#req-pr-006).
 
 ---
 
@@ -3102,6 +3123,7 @@ conformance statement identifying:
 [req-rs-015](#req-rs-015), [req-rs-016](#req-rs-016),
 [req-pr-001](#req-pr-001), [req-pr-002](#req-pr-002),
 [req-pr-003](#req-pr-003), [req-tg-001](#req-tg-001),
+[req-pr-006](#req-pr-006),
 [req-tg-002](#req-tg-002), [req-tg-003](#req-tg-003),
 [req-tg-004](#req-tg-004), [req-tg-005](#req-tg-005),
 [req-tg-006](#req-tg-006), [req-tg-007](#req-tg-007),
@@ -3532,6 +3554,7 @@ renumbering of conformance classes.
 | [req-pr-003](#req-pr-003)                | MUST    | 8.3     | consumer    |
 | [req-pr-004](#req-pr-004)                | MUST    | 7.8     | producer    |
 | [req-pr-005](#req-pr-005)                | SHOULD  | 7.8     | producer    |
+| [req-pr-006](#req-pr-006)                | MUST    | 8.1     | consumer    |
 | [req-tg-001](#req-tg-001)                | MUST    | 8.4     | consumer    |
 | [req-tg-002](#req-tg-002)                | MUST    | 8.5     | consumer    |
 | [req-tg-003](#req-tg-003)                | MUST    | 8.5     | consumer    |
@@ -3562,7 +3585,7 @@ renumbering of conformance classes.
 | [req-cf-001](#req-cf-001)                | MUST    | 12.5    | consumer    |
 | [req-cf-002](#req-cf-002)                | MUST    | 12.3    | consumer    |
 
-**Total normative statements: 115** (110 MUST, 5 SHOULD).
+**Total normative statements: 116** (111 MUST, 5 SHOULD).
 
 ---
 
@@ -3602,7 +3625,8 @@ renumbering of conformance classes.
 | 0.1.27  | 2026-08-03 | Spec-citation fold for object-form registry identity preservation on CLI-driven manifest updates (closes the PR #2166 Mode-B silent-extension gate). Added [req-mf-024] (Section 4.3.2, consumer MUST): a consumer MUST NOT silently rewrite an existing `id:`-form (registry-sourced) manifest entry into a `git:`-form entry when persisting a subsequent CLI-driven update (e.g. an additive `--skill` pin) for the same dependency identity; when a CLI-parsed reference is ambiguous about its source but an existing manifest entry for the same identity already resolves to the `registry` source, the existing entry's source MUST be honored, and an update that would otherwise replace a registry-sourced entry with a non-registry-shaped entry MUST be rejected with a diagnostic naming the identity. Section 4.9 and Section 11.3.2 Consumer enumerations and Appendix C updated. Statement count: 110 -> 111 (106 MUST, 5 SHOULD). |
 | 0.1.28  | 2026-08-06 | Spec-citation fold for per-invocation executable consent in non-interactive contexts (closes #1620 Mode-B silent-extension gate). Added [req-sc-014] (Section 10.15, consumer MUST): a consumer that supports a per-invocation consent flag for bin/ executable deployment MUST deny deployment by default when stdout is not a TTY, unless the operator has explicitly opted in for that invocation; an explicit opt-in overrides the non-interactive default and permits deployment; an explicit opt-out overrides the default and denies deployment even in a terminal; the allowExecutables policy gate [req-sc-009] is evaluated first and always takes precedence. Added row 19 to the Section 10.11 summary table. Section 11.3.2 Consumer enumeration and Appendix C updated. Statement count: 111 -> 112 (107 MUST, 5 SHOULD). |
 | 0.1.29  | 2026-08-22 | Spec-citation fold for the Agent Plugins v1 native-lifecycle deployment boundary (closes #2522 Mode-B silent-extension gate). Added [req-tg-011] (Section 8.5.5, consumer MUST): a consumer MUST treat a schema-bearing Agent Plugins v1 dependency as undeployable until it exposes a machine-verifiable native lifecycle for that dependency; before any target handler or primitive integrator runs, the consumer MUST refuse deployment with one actionable diagnostic, MUST leave the project tree unchanged, MUST NOT fall back to legacy primitive projection, and MUST reach the identical single-diagnostic outcome whether the dependency is materialized alone, mixed with ordinary dependencies in the same install, or under `--dry-run`. Section 8.7 and Appendix C updated. Statement count: 112 -> 113 (108 MUST, 5 SHOULD). |
-| 0.1.30  | 2026-08-23 | Spec-citation fold for plugin-root hook command resolution (closes #2639 Mode-B silent-extension gate). Added [req-tg-012] (Section 8.5.6, consumer MUST): a consumer that resolves plugin-root placeholders treats a matching quoted placeholder followed by an outside path separator equivalently to the fully quoted path, preserves balanced expandable quoting, and emits a default-visible diagnostic instead of silently deploying any supported placeholder that remains unresolved. Section 8.7, Section 11.3.2, and Appendix C updated. Statement count: 113 -> 114 (109 MUST, 5 SHOULD). |
+| 0.1.30  | 2026-08-23 | Spec-citation fold for plugin-root hook command resolution (closes #2639 Mode-B silent-extension gate). Added [req-tg-012] (Section 8.5.6, consumer MUST): a consumer that resolves plugin-root placeholders treats a matching quoted placeholder followed by an outside path separator equivalently to the fully quoted path, preserves balanced expandable quoting, and emits a default-visible diagnostic instead of silently deploying any supported placeholder that remains unresolved. Section 8.7, Section 11.3.2, and Appendix C updated. Statement count: 114 -> 115 (110 MUST, 5 SHOULD). |
+| 0.1.31  | 2026-08-23 | Spec-citation fold for authoritative legacy plugin skill declarations (closes #2537). Added [req-pr-006] (Section 8.1, consumer MUST): omitted `skills` alone enables conventional discovery; a string or list replaces discovery; explicit empty, invalid, escaping, symlinked, and duplicate-derived entries contribute no skills; declared containers contribute only immediate child skills; and only resulting names are eligible for enumeration, selection, or deployment. Section 8.7, Section 11.3.2, Appendix C, and conformance coverage updated. Statement count: 115 -> 116 (111 MUST, 5 SHOULD). |
 
 Errata (none at publication).
 

--- a/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
@@ -523,6 +523,12 @@ for the portable format.
 
 When `apm.yml` declares `target: claude` or `target: copilot` (or the plural `targets:` equivalent), `apm pack` also generates an ecosystem-specific `plugin.json` automatically -- authors no longer need to maintain this file manually. The manifest is synthesised from `apm.yml` identity fields (`name`, `version`, `description`, `author`, `license`). See the apm pack reference (reference/cli/pack/#plugin-manifests) for output paths, credential stripping, and per-ecosystem differences, or run `apm pack --help`.
 
+When a marketplace `plugin.json` declares `skills`, that declaration is the
+complete deploy list: declare each skill directory or an immediate container.
+An omitted key discovers root `skills/`; an explicit `[]` deploys none. If APM
+reports `plugin.json declares no deployable skills`, add the intended paths or
+remove the key to restore discovery.
+
 #### Shipping `bin/` executables (Claude Code only)
 
 A marketplace plugin may ship a root `bin/` directory of executable

--- a/scripts/check_agent_plugin_projection_boundary.py
+++ b/scripts/check_agent_plugin_projection_boundary.py
@@ -378,8 +378,7 @@ def check(root: Path) -> list[str]:  # noqa: C901, PLR0912, PLR0915
         "preflight_agent_plugin_materializations",
     )
     if len(batch_preflight_defs) != 1 or (
-        "enforce_agent_plugin_deployment_boundary"
-        not in _function_calls(batch_preflight_defs[0])
+        "enforce_agent_plugin_deployment_boundary" not in _function_calls(batch_preflight_defs[0])
     ):
         violations.append(
             f"{template_path}: native batch preflight must use the deployment boundary owner"
@@ -473,15 +472,9 @@ def check(root: Path) -> list[str]:  # noqa: C901, PLR0912, PLR0915
             for node in ast.walk(install_helpers[0])
             if isinstance(node, ast.Call)
         ]
-        dry_run_gates = [
-            line for name, line in calls if name == "preflight_agent_plugin_dry_run"
-        ]
+        dry_run_gates = [line for name, line in calls if name == "preflight_agent_plugin_dry_run"]
         dry_run_exits = [line for name, line in calls if name == "render_and_exit"]
-        if (
-            len(dry_run_gates) != 1
-            or not dry_run_exits
-            or dry_run_gates[0] >= min(dry_run_exits)
-        ):
+        if len(dry_run_gates) != 1 or not dry_run_exits or dry_run_gates[0] >= min(dry_run_exits):
             violations.append(
                 f"{install_command_path}: dry-run native preflight must run before "
                 "rendering success"
@@ -496,8 +489,7 @@ def check(root: Path) -> list[str]:  # noqa: C901, PLR0912, PLR0915
             typed_handlers = [
                 handler
                 for handler in node.handlers
-                if isinstance(handler.type, ast.Name)
-                and handler.type.id == "AgentPluginError"
+                if isinstance(handler.type, ast.Name) and handler.type.id == "AgentPluginError"
             ]
             generic_handlers = [
                 handler
@@ -916,10 +908,15 @@ def check(root: Path) -> list[str]:  # noqa: C901, PLR0912, PLR0915
         relative = path.relative_to(root).as_posix()
         for function in _functions(tree):
             calls = _function_calls(function)
-            if "normalize_plugin_directory" in calls and not (
+            legacy_normalization_owner = (
                 relative == "src/apm_cli/models/validation.py"
                 and function.name == "_validate_marketplace_plugin"
-            ):
+            ) or (
+                relative == "src/apm_cli/install/drift.py"
+                and function.name == "_normalize_legacy_local_plugin_for_replay"
+                and "detect_agent_plugin" in calls
+            )
+            if "normalize_plugin_directory" in calls and not legacy_normalization_owner:
                 violations.append(
                     f"{relative}:{function.lineno}: Claude normalization call outside "
                     "_validate_marketplace_plugin"

--- a/scripts/check_bundle_format_authority.sh
+++ b/scripts/check_bundle_format_authority.sh
@@ -163,7 +163,6 @@ if [ -f "$agent_plugin_owner" ]; then
         echo "[x] Agent Plugin classification must route through its loader, not Claude normalization"
         exit 1
     fi
-
     for ingress_requirement in \
         "$repo_root/src/apm_cli/install/sources.py:4" \
         "$repo_root/src/apm_cli/install/template.py:2" \
@@ -224,6 +223,7 @@ if [ -f "$agent_plugin_owner" ]; then
             "$repo_root/src/apm_cli" \
             | grep -v '/src/apm_cli/deps/plugin_parser.py:.*def normalize_plugin_directory(' \
             | grep -v '/src/apm_cli/models/validation.py:' \
+            | grep -v '/src/apm_cli/install/drift.py:' \
             || true
     )
     raw_agent_package_construction=$(

--- a/scripts/check_plugin_skill_declaration_authority.py
+++ b/scripts/check_plugin_skill_declaration_authority.py
@@ -1,0 +1,49 @@
+"""Enforce parser-owned membership for legacy plugin skill deployment."""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+
+def _function_source(path: Path, name: str) -> str:
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    function = next(
+        (
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name
+        ),
+        None,
+    )
+    if function is None:
+        return ""
+    return ast.get_source_segment(source, function) or ""
+
+
+def main(root: Path) -> int:
+    parser = root / "src/apm_cli/deps/plugin_parser.py"
+    integrator = root / "src/apm_cli/integration/skill_integrator.py"
+    parser_source = parser.read_text(encoding="utf-8")
+    routing_source = _function_source(integrator, "skill_source_paths")
+
+    valid = (
+        parser_source.count("def normalized_plugin_skill_sources(") == 1
+        and parser_source.count("def _map_plugin_artifacts(") == 1
+        and "normalized_plugin_skill_sources(package_path)" in routing_source
+        and 'package_path / "skills"' not in routing_source
+        and "manifest.get(" not in routing_source
+    )
+    if valid:
+        return 0
+    print(
+        "[x] Plugin skill declaration membership must remain owned by "
+        "plugin_parser._map_plugin_artifacts"
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(Path(sys.argv[1]) if len(sys.argv) == 2 else Path.cwd()))

--- a/scripts/lint-architecture-boundaries.sh
+++ b/scripts/lint-architecture-boundaries.sh
@@ -51,6 +51,9 @@ fi
 if ! python3 scripts/check_removed_agent_plugin_lifecycle.py --root "$ROOT"; then
     violations=$((violations + 1))
 fi
+if ! python3 scripts/check_plugin_skill_declaration_authority.py "$ROOT"; then
+    violations=$((violations + 1))
+fi
 install_wrapper_defaults=$(python3 - <<'PY'
 import ast
 from pathlib import Path

--- a/src/apm_cli/deps/plugin_parser.py
+++ b/src/apm_cli/deps/plugin_parser.py
@@ -134,6 +134,26 @@ def _is_within_plugin(candidate: Path, plugin_root: Path, *, component: str) -> 
     return True
 
 
+def _holds_skill_dirs(candidate: Path) -> bool:
+    """Return True iff *candidate* is a container of skills, not a skill itself.
+
+    A directory carrying its own ``SKILL.md`` is the skill, however deep it
+    sits in the plugin (``skills/engineering/tdd``). Anything else that has at
+    least one immediate child carrying ``SKILL.md`` is a container holding
+    them (the conventional ``skills/``). Directories matching neither shape
+    are not containers, so a declared entry keeps its own name rather than
+    spilling unrecognized contents into the shared skills root.
+    """
+    if (candidate / "SKILL.md").is_file():
+        return False
+    try:
+        return any(
+            (child / "SKILL.md").is_file() for child in candidate.iterdir() if child.is_dir()
+        )
+    except OSError:
+        return False
+
+
 def parse_plugin_manifest(plugin_json_path: Path) -> dict[str, Any]:
     """Parse a plugin.json manifest file.
 
@@ -783,24 +803,30 @@ def _map_plugin_artifacts(
         skill_dirs = [s for s in skill_sources if s.is_dir()]
         skill_files = [s for s in skill_sources if s.is_file()]
 
-        is_custom_list = isinstance(manifest.get("skills"), list)
-        if is_custom_list and skill_dirs:
+        # A declared ``skills`` entry is either the skill itself (``SKILL.md``
+        # at its root, e.g. ``./skills/engineering/tdd``) or a container
+        # holding one skill per child (the conventional ``./skills/``).
+        # Classify per entry rather than per manifest shape: naming a
+        # container after itself buries every skill one level too deep, while
+        # merging a lone skill spills a bare ``SKILL.md`` into the shared root
+        # under no name at all. Either way ``--skill`` sees nothing, because
+        # ``.apm/skills/<name>/SKILL.md`` is the exact depth that deployment,
+        # ``--skill`` enumeration, the bin/ security scan and primitive
+        # counting all read. See issue #2530.
+        #
+        # Undeclared discovery keeps merging unconditionally: the default
+        # ``skills/`` is the convention container by definition.
+        declared = isinstance(manifest.get("skills"), (list, str))
+        if skill_dirs:
             target_skills.mkdir(parents=True, exist_ok=True)
             for d in skill_dirs:
-                nested = target_skills / d.name
-                if _is_same_path(d, nested):
+                if declared and not _holds_skill_dirs(d):
+                    dest = target_skills / d.name
+                else:
+                    dest = target_skills
+                if _is_same_path(d, dest):
                     continue
-                shutil.copytree(
-                    d,
-                    nested,
-                    ignore=ignore_non_content,
-                    dirs_exist_ok=True,
-                )
-        elif skill_dirs:
-            for d in skill_dirs:
-                if _is_same_path(d, target_skills):
-                    continue
-                shutil.copytree(d, target_skills, dirs_exist_ok=True, ignore=ignore_non_content)
+                shutil.copytree(d, dest, dirs_exist_ok=True, ignore=ignore_non_content)
         if skill_files:
             target_skills.mkdir(parents=True, exist_ok=True)
             for f in skill_files:

--- a/src/apm_cli/deps/plugin_parser.py
+++ b/src/apm_cli/deps/plugin_parser.py
@@ -155,6 +155,29 @@ def _holds_skill_dirs(candidate: Path) -> bool:
         return False
 
 
+def _warn_skills_entry_holds_no_skill(entry: Path, plugin_path: Path) -> None:
+    """Warn that a declared ``skills`` entry can never yield a skill.
+
+    An entry with no ``SKILL.md`` at its root and none in any immediate child
+    is neither a skill nor a container of them: it is copied under its own
+    name, but nothing inside reaches ``.apm/skills/<name>/SKILL.md``, so it
+    stays invisible to deployment and to ``--skill``. Silence here is what
+    made #2530 expensive to diagnose -- the manifest looked wrong when only
+    the directory depth was -- so say it once, at normalization time.
+    """
+    try:
+        declared = entry.relative_to(plugin_path).as_posix()
+    except ValueError:  # pragma: no cover - entries are verified inside the plugin
+        declared = entry.name
+    _surface_warning(
+        f"Plugin skills entry '{declared}' has no SKILL.md at its root or in "
+        f"any immediate subdirectory; nothing under it will deploy or be "
+        f"selectable with --skill. Declare each skill directory, or place "
+        f"skills one level below the declared container.",
+        _logger,
+    )
+
+
 def parse_plugin_manifest(plugin_json_path: Path) -> dict[str, Any]:
     """Parse a plugin.json manifest file.
 
@@ -846,6 +869,11 @@ def _map_plugin_artifacts(
             for d in skill_dirs:
                 if declared and not _holds_skill_dirs(d):
                     dest = target_skills / d.name
+                    if not (d / "SKILL.md").is_file():
+                        # Neither shape: keep the contents isolated under the
+                        # entry's own name, but do not let the dead end pass
+                        # silently -- that silence is the #2530 symptom.
+                        _warn_skills_entry_holds_no_skill(d, plugin_path)
                 else:
                     dest = target_skills
                 if _is_same_path(d, dest):

--- a/src/apm_cli/deps/plugin_parser.py
+++ b/src/apm_cli/deps/plugin_parser.py
@@ -135,6 +135,26 @@ def _is_within_plugin(candidate: Path, plugin_root: Path, *, component: str) -> 
     return True
 
 
+def _holds_skill_dirs(candidate: Path) -> bool:
+    """Return True iff *candidate* is a container of skills, not a skill itself.
+
+    A directory carrying its own ``SKILL.md`` is the skill, however deep it
+    sits in the plugin (``skills/engineering/tdd``). Anything else that has at
+    least one immediate child carrying ``SKILL.md`` is a container holding
+    them (the conventional ``skills/``). Directories matching neither shape
+    are not containers, so a declared entry keeps its own name rather than
+    spilling unrecognized contents into the shared skills root.
+    """
+    if (candidate / "SKILL.md").is_file():
+        return False
+    try:
+        return any(
+            (child / "SKILL.md").is_file() for child in candidate.iterdir() if child.is_dir()
+        )
+    except OSError:
+        return False
+
+
 def parse_plugin_manifest(plugin_json_path: Path) -> dict[str, Any]:
     """Parse a plugin.json manifest file.
 
@@ -807,24 +827,30 @@ def _map_plugin_artifacts(
         skill_dirs = [s for s in skill_sources if s.is_dir()]
         skill_files = [s for s in skill_sources if s.is_file()]
 
-        is_custom_list = isinstance(manifest.get("skills"), list)
-        if is_custom_list and skill_dirs:
+        # A declared ``skills`` entry is either the skill itself (``SKILL.md``
+        # at its root, e.g. ``./skills/engineering/tdd``) or a container
+        # holding one skill per child (the conventional ``./skills/``).
+        # Classify per entry rather than per manifest shape: naming a
+        # container after itself buries every skill one level too deep, while
+        # merging a lone skill spills a bare ``SKILL.md`` into the shared root
+        # under no name at all. Either way ``--skill`` sees nothing, because
+        # ``.apm/skills/<name>/SKILL.md`` is the exact depth that deployment,
+        # ``--skill`` enumeration, the bin/ security scan and primitive
+        # counting all read. See issue #2530.
+        #
+        # Undeclared discovery keeps merging unconditionally: the default
+        # ``skills/`` is the convention container by definition.
+        declared = isinstance(manifest.get("skills"), (list, str))
+        if skill_dirs:
             target_skills.mkdir(parents=True, exist_ok=True)
             for d in skill_dirs:
-                nested = target_skills / d.name
-                if _is_same_path(d, nested):
+                if declared and not _holds_skill_dirs(d):
+                    dest = target_skills / d.name
+                else:
+                    dest = target_skills
+                if _is_same_path(d, dest):
                     continue
-                shutil.copytree(
-                    d,
-                    nested,
-                    ignore=ignore_non_content,
-                    dirs_exist_ok=True,
-                )
-        elif skill_dirs:
-            for d in skill_dirs:
-                if _is_same_path(d, target_skills):
-                    continue
-                shutil.copytree(d, target_skills, dirs_exist_ok=True, ignore=ignore_non_content)
+                shutil.copytree(d, dest, dirs_exist_ok=True, ignore=ignore_non_content)
         if skill_files:
             target_skills.mkdir(parents=True, exist_ok=True)
             for f in skill_files:

--- a/src/apm_cli/deps/plugin_parser.py
+++ b/src/apm_cli/deps/plugin_parser.py
@@ -15,6 +15,7 @@ import json
 import logging
 import os
 import shutil
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -35,6 +36,7 @@ _logger = logging.getLogger(__name__)
 # Cap the file size first, then funnel every parse failure into a single
 # ``ValueError`` so callers fail closed with one except type.
 _MAX_PLUGIN_JSON_BYTES = 5 * 1024 * 1024
+_PLUGIN_SKILL_SOURCES_FILE = ".plugin-skill-sources.json"
 
 
 def _bounded_read_json(path: Path) -> Any:
@@ -135,6 +137,20 @@ def _is_within_plugin(candidate: Path, plugin_root: Path, *, component: str) -> 
     return True
 
 
+def _has_symlink_component(candidate: Path, plugin_root: Path) -> bool:
+    """Return True when a candidate reaches its target through a symlink."""
+    try:
+        relative = candidate.relative_to(plugin_root)
+    except ValueError:
+        return True
+    current = plugin_root
+    for part in relative.parts:
+        current /= part
+        if current.is_symlink():
+            return True
+    return False
+
+
 def _holds_skill_dirs(candidate: Path) -> bool:
     """Return True iff *candidate* is a container of skills, not a skill itself.
 
@@ -145,14 +161,206 @@ def _holds_skill_dirs(candidate: Path) -> bool:
     are not containers, so a declared entry keeps its own name rather than
     spilling unrecognized contents into the shared skills root.
     """
-    if (candidate / "SKILL.md").is_file():
+    if (candidate / "SKILL.md").is_file() and not (candidate / "SKILL.md").is_symlink():
         return False
     try:
         return any(
-            (child / "SKILL.md").is_file() for child in candidate.iterdir() if child.is_dir()
+            (child / "SKILL.md").is_file()
+            and not child.is_symlink()
+            and not (child / "SKILL.md").is_symlink()
+            for child in candidate.iterdir()
+            if child.is_dir() and not child.is_symlink()
         )
     except OSError:
         return False
+
+
+def _immediate_skill_dirs(candidate: Path) -> list[Path]:
+    """Return direct non-symlink skill children in a declared container."""
+    try:
+        return sorted(
+            (
+                child
+                for child in candidate.iterdir()
+                if child.is_dir()
+                and not child.is_symlink()
+                and (child / "SKILL.md").is_file()
+                and not (child / "SKILL.md").is_symlink()
+            ),
+            key=lambda child: child.name,
+        )
+    except OSError:
+        return []
+
+
+def _map_plugin_skills(
+    plugin_path: Path,
+    apm_dir: Path,
+    manifest: dict[str, Any],
+    resolve_sources: Callable[[str, str], list[Path]],
+    is_same_path: Callable[[Path, Path], bool],
+    ignore_non_content: Callable[..., set[str]],
+) -> None:
+    """Materialize parser-authorized plugin skills and persist their receipt."""
+    skill_sources = resolve_sources("skills", "skills")
+    declared_skills = isinstance(manifest.get("skills"), (list, str))
+    normalized_skill_sources: dict[str, Path] = {}
+    duplicate_skill_names: set[str] = set()
+
+    def add_normalized_skill_source(name: str, source: Path) -> None:
+        """Keep ambiguous declared leaf names out of the deployable receipt."""
+        if name in duplicate_skill_names:
+            return
+        existing = normalized_skill_sources.get(name)
+        if existing is not None and existing != source:
+            duplicate_skill_names.add(name)
+            normalized_skill_sources.pop(name)
+            return
+        normalized_skill_sources[name] = source
+
+    target_skills = apm_dir / "skills"
+    _assert_no_symlink_descendants(target_skills)
+    skill_dirs = [source for source in skill_sources if source.is_dir()]
+    skill_files = [source for source in skill_sources if source.is_file()]
+
+    for directory in skill_dirs:
+        if declared_skills and not _holds_skill_dirs(directory):
+            if (directory / "SKILL.md").is_file() and not (directory / "SKILL.md").is_symlink():
+                add_normalized_skill_source(directory.name, directory)
+            continue
+        for child in _immediate_skill_dirs(directory):
+            add_normalized_skill_source(child.name, child)
+
+    # A declaration may change from a container to a file-only entry. Remove
+    # the parser-owned former entries before handling either source shape.
+    _remove_stale_normalized_skills(plugin_path, target_skills, normalized_skill_sources)
+
+    if skill_dirs or skill_files:
+        target_skills.mkdir(parents=True, exist_ok=True)
+    for directory in skill_dirs:
+        if declared_skills and not _holds_skill_dirs(directory):
+            dest = target_skills / directory.name
+            if not (directory / "SKILL.md").is_file():
+                _warn_skills_entry_holds_no_skill(directory, plugin_path)
+        else:
+            dest = target_skills
+        if is_same_path(directory, dest):
+            continue
+        shutil.copytree(directory, dest, dirs_exist_ok=True, ignore=ignore_non_content)
+    for source_file in skill_files:
+        destination = target_skills / source_file.name
+        if is_same_path(source_file, destination):
+            continue
+        shutil.copy2(source_file, destination)
+
+    _write_plugin_skill_sources(
+        plugin_path,
+        apm_dir,
+        normalized_skill_sources,
+        declared=declared_skills,
+    )
+
+
+def _read_plugin_skill_sources(plugin_path: Path) -> tuple[dict[str, str], bool]:
+    """Read parser-owned normalized skill sources without trusting their paths."""
+    receipt = plugin_path / ".apm" / _PLUGIN_SKILL_SOURCES_FILE
+    if not receipt.is_file() or receipt.is_symlink():
+        return {}, False
+    try:
+        data = _bounded_read_json(receipt)
+    except (OSError, ValueError):
+        return {}, False
+    if not isinstance(data, dict) or data.get("version") != 1:
+        return {}, False
+    raw_sources = data.get("sources")
+    if not isinstance(raw_sources, dict):
+        return {}, False
+    sources = {
+        name: source
+        for name, source in raw_sources.items()
+        if isinstance(name, str)
+        and name
+        and Path(name).name == name
+        and isinstance(source, str)
+        and source
+    }
+    return sources, data.get("declared") is True
+
+
+def normalized_plugin_skill_sources(plugin_path: Path) -> tuple[dict[str, Path], bool]:
+    """Return parser-authorized normalized skill names and their byte sources.
+
+    The receipt is written only by ``_map_plugin_artifacts`` after it validates
+    declared plugin paths and materializes the matching flat ``.apm/skills``
+    entries. Consumers must not recover membership by scanning raw ``skills/``.
+    """
+    plugin_path = plugin_path.resolve()
+    raw_sources, declared = _read_plugin_skill_sources(plugin_path)
+    normalized_root = plugin_path / ".apm" / "skills"
+    resolved: dict[str, Path] = {}
+    for name, relative_source in raw_sources.items():
+        normalized = normalized_root / name
+        source = plugin_path / relative_source
+        try:
+            ensure_path_within(normalized, plugin_path)
+            ensure_path_within(source, plugin_path)
+        except PathTraversalError:
+            continue
+        if (
+            normalized.is_dir()
+            and not normalized.is_symlink()
+            and (normalized / "SKILL.md").is_file()
+            and not (normalized / "SKILL.md").is_symlink()
+            and source.is_dir()
+            and not source.is_symlink()
+            and (source / "SKILL.md").is_file()
+            and not (source / "SKILL.md").is_symlink()
+        ):
+            resolved[name] = source
+    return resolved, declared
+
+
+def _write_plugin_skill_sources(
+    plugin_path: Path,
+    apm_dir: Path,
+    sources: dict[str, Path],
+    *,
+    declared: bool,
+) -> None:
+    """Persist parser-owned membership and original byte sources for a plugin."""
+    serialized = {
+        name: source.relative_to(plugin_path).as_posix() for name, source in sorted(sources.items())
+    }
+    if apm_dir.is_symlink():
+        raise PluginIntegrityError(
+            f"Refusing to write plugin receipt through symlinked directory: {apm_dir}"
+        )
+    apm_dir.mkdir(parents=True, exist_ok=True)
+    receipt = apm_dir / _PLUGIN_SKILL_SOURCES_FILE
+    if receipt.is_symlink():
+        raise PluginIntegrityError(f"Refusing to write symlinked plugin receipt: {receipt}")
+    receipt.write_text(
+        json.dumps({"version": 1, "declared": declared, "sources": serialized}, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
+def _remove_stale_normalized_skills(
+    plugin_path: Path,
+    target_skills: Path,
+    current_sources: dict[str, Path],
+) -> None:
+    """Remove only prior parser-generated skill entries no longer declared."""
+    previous_sources, _ = _read_plugin_skill_sources(plugin_path)
+    for name in previous_sources.keys() - current_sources.keys():
+        stale = target_skills / name
+        if stale.exists():
+            ensure_path_within(stale, plugin_path)
+            if stale.is_symlink():
+                raise PluginIntegrityError(
+                    f"Refusing to remove symlinked plugin skill destination: {stale}"
+                )
+            shutil.rmtree(stale)
 
 
 def _warn_skills_entry_holds_no_skill(entry: Path, plugin_path: Path) -> None:
@@ -767,6 +975,12 @@ def _map_plugin_artifacts(
 
     from apm_cli.security.gate import ignore_non_content
 
+    if apm_dir.is_symlink():
+        raise PluginIntegrityError(
+            f"Refusing to map plugin artifacts through symlinked destination: {apm_dir}"
+        )
+    plugin_path = plugin_path.resolve()
+
     # Resolve source paths  -- use manifest arrays if present, else defaults.
     # Custom paths may be directories OR individual files.
     #
@@ -779,35 +993,39 @@ def _map_plugin_artifacts(
     def _resolve_sources(component: str, default_dir: str):
         """Return list of existing source paths (dirs or files) for a component."""
         custom = manifest.get(component)
+        if component == "skills" and component in manifest and not isinstance(custom, (list, str)):
+            return []
         if isinstance(custom, list):
             paths = []
             for p in custom:
-                raw = str(p)
+                if not isinstance(p, str):
+                    continue
+                raw = p
                 src = plugin_path / raw
                 if (
                     src.exists()
-                    and not src.is_symlink()
+                    and not _has_symlink_component(src, plugin_path)
                     and _is_within_plugin(src, plugin_path, component=component)
                 ):
-                    paths.append(src)
+                    paths.append(src.resolve())
             return paths
         elif isinstance(custom, str):
             src = plugin_path / custom
             if (
                 src.exists()
-                and not src.is_symlink()
+                and not _has_symlink_component(src, plugin_path)
                 and _is_within_plugin(src, plugin_path, component=component)
             ):
-                return [src]
+                return [src.resolve()]
             return []
         default = plugin_path / default_dir
         if (
             default.exists()
-            and not default.is_symlink()
+            and not _has_symlink_component(default, plugin_path)
             and default.is_dir()
             and _is_within_plugin(default, plugin_path, component=component)
         ):
-            return [default]
+            return [default.resolve()]
         return []
 
     # Helper: True when *src* and *dst* resolve to the same filesystem path
@@ -842,50 +1060,14 @@ def _map_plugin_artifacts(
                     continue
                 shutil.copy2(f, dst)
 
-    # Map skills/
-    skill_sources = _resolve_sources("skills", "skills")
-    if skill_sources:
-        target_skills = apm_dir / "skills"
-        _assert_no_symlink_descendants(target_skills)
-        skill_dirs = [s for s in skill_sources if s.is_dir()]
-        skill_files = [s for s in skill_sources if s.is_file()]
-
-        # A declared ``skills`` entry is either the skill itself (``SKILL.md``
-        # at its root, e.g. ``./skills/engineering/tdd``) or a container
-        # holding one skill per child (the conventional ``./skills/``).
-        # Classify per entry rather than per manifest shape: naming a
-        # container after itself buries every skill one level too deep, while
-        # merging a lone skill spills a bare ``SKILL.md`` into the shared root
-        # under no name at all. Either way ``--skill`` sees nothing, because
-        # ``.apm/skills/<name>/SKILL.md`` is the exact depth that deployment,
-        # ``--skill`` enumeration, the bin/ security scan and primitive
-        # counting all read. See issue #2530.
-        #
-        # Undeclared discovery keeps merging unconditionally: the default
-        # ``skills/`` is the convention container by definition.
-        declared = isinstance(manifest.get("skills"), (list, str))
-        if skill_dirs:
-            target_skills.mkdir(parents=True, exist_ok=True)
-            for d in skill_dirs:
-                if declared and not _holds_skill_dirs(d):
-                    dest = target_skills / d.name
-                    if not (d / "SKILL.md").is_file():
-                        # Neither shape: keep the contents isolated under the
-                        # entry's own name, but do not let the dead end pass
-                        # silently -- that silence is the #2530 symptom.
-                        _warn_skills_entry_holds_no_skill(d, plugin_path)
-                else:
-                    dest = target_skills
-                if _is_same_path(d, dest):
-                    continue
-                shutil.copytree(d, dest, dirs_exist_ok=True, ignore=ignore_non_content)
-        if skill_files:
-            target_skills.mkdir(parents=True, exist_ok=True)
-            for f in skill_files:
-                dst = target_skills / f.name
-                if _is_same_path(f, dst):
-                    continue
-                shutil.copy2(f, dst)
+    _map_plugin_skills(
+        plugin_path,
+        apm_dir,
+        manifest,
+        _resolve_sources,
+        _is_same_path,
+        ignore_non_content,
+    )
 
     # Map commands/ -> .apm/prompts/ (normalize .md -> .prompt.md)
     command_sources = _resolve_sources("commands", "commands")

--- a/src/apm_cli/install/drift.py
+++ b/src/apm_cli/install/drift.py
@@ -374,6 +374,31 @@ def _materialize_install_path(
     return candidate
 
 
+def _normalize_legacy_local_plugin_for_replay(
+    lock_dep: LockedDependency,
+    install_path: Path,
+    apm_modules_dir: Path,
+) -> Path:
+    """Normalize a local legacy plugin only in the scratch replay tree."""
+    from apm_cli.agent_plugins.loader import detect_agent_plugin
+    from apm_cli.deps.plugin_parser import normalize_plugin_directory
+    from apm_cli.utils.helpers import find_plugin_json
+
+    if detect_agent_plugin(install_path) is not None:
+        return install_path
+
+    plugin_json = find_plugin_json(install_path)
+    if plugin_json is None:
+        return install_path
+
+    replay_path = lock_dep.to_dependency_ref().get_install_path(apm_modules_dir)
+    _copy_install_tree(install_path, replay_path)
+    # The canonical loader has already excluded native Agent Plugin inputs.
+    manifest_path = replay_path / plugin_json.relative_to(install_path)
+    normalize_plugin_directory(replay_path, manifest_path)
+    return replay_path
+
+
 def _build_package_info(
     lock_dep: LockedDependency,
     install_path: Path,
@@ -618,6 +643,12 @@ def run_replay(config: ReplayConfig, logger: CheckLogger) -> Path:
                         registry_resolver=registry_resolver,
                         registries=registries,
                     )
+                    if lock_dep.source == "local":
+                        install_path = _normalize_legacy_local_plugin_for_replay(
+                            lock_dep,
+                            install_path,
+                            apm_modules_dir,
+                        )
 
                 package_info = _build_package_info(lock_dep, install_path)
                 if lock_dep.local_path == _SELF_KEY:

--- a/src/apm_cli/integration/skill_integrator.py
+++ b/src/apm_cli/integration/skill_integrator.py
@@ -616,21 +616,33 @@ class SkillIntegrator(BaseIntegrator):
             return frozenset()
 
     @staticmethod
+    def skill_source_dir(package_path: Path) -> Path:
+        """Return the directory a package's deployable skills are promoted from.
+
+        Single source of truth for skill routing: deployment and ``--skill``
+        enumeration both resolve through here so the set a user may select can
+        never drift from the set that actually deploys (issue #2530). A root
+        ``skills/`` bundle wins whenever it holds at least one skill; otherwise
+        the normalized ``.apm/skills/`` location supplies them.
+
+        Callers must handle a root ``SKILL.md`` before asking: a native
+        single-skill package deploys the bundle itself, not children.
+        """
+        root_bundle = package_path / "skills"
+        if SkillIntegrator._skill_names_in_directory(root_bundle):
+            return root_bundle
+        return package_path / ".apm" / "skills"
+
+    @staticmethod
     def available_skill_names(package_info) -> frozenset[str] | None:
         """Return names selectable through ``--skill`` for one package."""
         package_path = package_info.install_path
         if (package_path / "SKILL.md").is_file():
             return None
 
-        from apm_cli.models.validation import PackageType
-
-        normalized = package_path / ".apm" / "skills"
-        root_bundle = package_path / "skills"
-        if package_info.package_type is PackageType.MARKETPLACE_PLUGIN:
-            return SkillIntegrator._skill_names_in_directory(normalized)
-
-        root_names = SkillIntegrator._skill_names_in_directory(root_bundle)
-        return root_names or SkillIntegrator._skill_names_in_directory(normalized)
+        return SkillIntegrator._skill_names_in_directory(
+            SkillIntegrator.skill_source_dir(package_path)
+        )
 
     @staticmethod
     def _skill_filter_misses_available(
@@ -1453,10 +1465,11 @@ class SkillIntegrator(BaseIntegrator):
             )
 
         # SKILL_BUNDLE: promote skills from root-level skills/ directory.
+        # Routed through ``skill_source_dir`` -- the same helper backing
+        # ``available_skill_names`` -- so a ``--skill`` value can never be
+        # validated against a directory other than the one that deploys.
         root_skills_dir = package_path / "skills"
-        if root_skills_dir.is_dir() and any(
-            (d / "SKILL.md").exists() for d in root_skills_dir.iterdir() if d.is_dir()
-        ):
+        if self.skill_source_dir(package_path) == root_skills_dir:
             return self._merge_bin_paths(
                 self._integrate_skill_bundle(
                     package_info,

--- a/src/apm_cli/integration/skill_integrator.py
+++ b/src/apm_cli/integration/skill_integrator.py
@@ -614,6 +614,24 @@ class SkillIntegrator(BaseIntegrator):
             return frozenset()
 
     @staticmethod
+    def skill_source_dir(package_path: Path) -> Path:
+        """Return the directory a package's deployable skills are promoted from.
+
+        Single source of truth for skill routing: deployment and ``--skill``
+        enumeration both resolve through here so the set a user may select can
+        never drift from the set that actually deploys (issue #2530). A root
+        ``skills/`` bundle wins whenever it holds at least one skill; otherwise
+        the normalized ``.apm/skills/`` location supplies them.
+
+        Callers must handle a root ``SKILL.md`` before asking: a native
+        single-skill package deploys the bundle itself, not children.
+        """
+        root_bundle = package_path / "skills"
+        if SkillIntegrator._skill_names_in_directory(root_bundle):
+            return root_bundle
+        return package_path / ".apm" / "skills"
+
+    @staticmethod
     def available_skill_names(package_info) -> frozenset[str] | None:
         """Return names selectable through ``--skill`` for one package."""
         enforce_agent_plugin_deployment_boundary(package_info)
@@ -622,15 +640,9 @@ class SkillIntegrator(BaseIntegrator):
         if (package_path / "SKILL.md").is_file():
             return None
 
-        from apm_cli.models.validation import PackageType
-
-        normalized = package_path / ".apm" / "skills"
-        root_bundle = package_path / "skills"
-        if package_info.package_type is PackageType.MARKETPLACE_PLUGIN:
-            return SkillIntegrator._skill_names_in_directory(normalized)
-
-        root_names = SkillIntegrator._skill_names_in_directory(root_bundle)
-        return root_names or SkillIntegrator._skill_names_in_directory(normalized)
+        return SkillIntegrator._skill_names_in_directory(
+            SkillIntegrator.skill_source_dir(package_path)
+        )
 
     @staticmethod
     def _skill_filter_misses_available(
@@ -1467,10 +1479,11 @@ class SkillIntegrator(BaseIntegrator):
             )
 
         # SKILL_BUNDLE: promote skills from root-level skills/ directory.
+        # Routed through ``skill_source_dir`` -- the same helper backing
+        # ``available_skill_names`` -- so a ``--skill`` value can never be
+        # validated against a directory other than the one that deploys.
         root_skills_dir = package_path / "skills"
-        if root_skills_dir.is_dir() and any(
-            (d / "SKILL.md").exists() for d in root_skills_dir.iterdir() if d.is_dir()
-        ):
+        if self.skill_source_dir(package_path) == root_skills_dir:
             return self._merge_bin_paths(
                 self._integrate_skill_bundle(
                     package_info,

--- a/src/apm_cli/integration/skill_integrator.py
+++ b/src/apm_cli/integration/skill_integrator.py
@@ -620,12 +620,17 @@ class SkillIntegrator(BaseIntegrator):
             return frozenset()
 
     @staticmethod
-    def skill_source_dir(package_path: Path) -> Path:
-        """Return the bundle directory a package's skills are promoted from.
+    def _skill_source_dir(package_path: Path) -> Path:
+        """Return the single directory a package's skills are promoted from.
 
         A root ``skills/`` bundle wins whenever it holds at least one skill;
         otherwise the normalized ``.apm/skills/`` location supplies them.
-        Plugins refine this per skill -- see ``skill_source_paths``.
+
+        Private on purpose: a plugin's skills need not share one parent, so
+        this answer is incomplete for ``MARKETPLACE_PLUGIN`` and reading it
+        directly is how the raw tree overrode the declaration in the first
+        place (#2537). ``skill_source_paths`` is the routing entry point --
+        it consults this only for the types that do have a single source.
         """
         root_bundle = package_path / "skills"
         if SkillIntegrator._skill_names_in_directory(root_bundle):
@@ -672,7 +677,7 @@ class SkillIntegrator(BaseIntegrator):
                 )
             return resolved
 
-        source = SkillIntegrator.skill_source_dir(package_path)
+        source = SkillIntegrator._skill_source_dir(package_path)
         return {name: source / name for name in SkillIntegrator._skill_names_in_directory(source)}
 
     @staticmethod
@@ -722,6 +727,49 @@ class SkillIntegrator(BaseIntegrator):
                 from apm_cli.utils.console import _rich_warning
 
                 _rich_warning(f"Package '{parent_name}': {details}", symbol="warning")
+            except ImportError:
+                pass
+
+    @staticmethod
+    def _note_plugin_declaration_deploys_no_skills(
+        package_path: Path,
+        parent_name: str,
+        diagnostics=None,
+        logger=None,
+    ) -> None:
+        """Report a plugin whose declaration resolves to no skills at all.
+
+        Zero deployable skills is a legitimate answer -- most plugins ship
+        none. It stops being obvious once the package actually carries a
+        root ``skills/`` bundle: those skills deployed before the declaration
+        became authoritative (#2537), and now nothing does, with no line of
+        output to tell "no skills by design" apart from "my declaration ate
+        them". Say which names went unclaimed, once, at that exact shape.
+        """
+        shadowed = SkillIntegrator._skill_names_in_directory(package_path / "skills")
+        if not shadowed:
+            return
+        names = ", ".join(sorted(shadowed))
+        message = (
+            f"Package '{parent_name}': plugin.json declares no deployable skills, "
+            f"so nothing under skills/ deploys ({names})."
+        )
+        detail = (
+            "A 'skills' declaration replaces default discovery instead of adding "
+            "to it. Declare each skill directory, or the container holding them, "
+            "to deploy them -- or drop the 'skills' key to fall back to "
+            "discovering skills/."
+        )
+        if diagnostics is not None:
+            diagnostics.info(message, package=parent_name, detail=detail)
+        elif logger:
+            logger.info(message)
+            logger.verbose_detail(detail)
+        else:
+            try:
+                from apm_cli.utils.console import _rich_info
+
+                _rich_info(message)
             except ImportError:
                 pass
 
@@ -1555,7 +1603,16 @@ class SkillIntegrator(BaseIntegrator):
         root_skills_dir = package_path / "skills"
         _source_paths = self.skill_source_paths(package_path, package_info.package_type)
         _is_plugin = package_info.package_type == _PackageType.MARKETPLACE_PLUGIN
-        if _source_paths and (_is_plugin or self.skill_source_dir(package_path) == root_skills_dir):
+        if _is_plugin and not _source_paths:
+            self._note_plugin_declaration_deploys_no_skills(
+                package_path,
+                package_path.name,
+                diagnostics=diagnostics,
+                logger=logger,
+            )
+        if _source_paths and (
+            _is_plugin or self._skill_source_dir(package_path) == root_skills_dir
+        ):
             return self._merge_bin_paths(
                 self._integrate_skill_bundle(
                     package_info,

--- a/src/apm_cli/integration/skill_integrator.py
+++ b/src/apm_cli/integration/skill_integrator.py
@@ -647,34 +647,22 @@ class SkillIntegrator(BaseIntegrator):
         enumeration both resolve through here, so the set a user may select
         can never drift from the set that actually deploys (issue #2530).
 
-        For a ``MARKETPLACE_PLUGIN`` the normalized ``.apm/skills/`` is the
-        resolved ``plugin.json`` declaration, so it decides *which* skills
-        exist. The raw root ``skills/`` is pre-resolution input; letting it
-        decide deploys components the manifest never declared and drops
-        declared ones living outside the conventional container (#2537).
-        An empty resolution is a real answer -- ``"skills": []`` means no
-        skills, and a path rejected for escaping the plugin root must fail
-        closed rather than fall back to whatever the raw tree holds.
-
-        Each declared skill is still *sourced* from the root bundle when that
-        copy exists. It is byte-identical, but sits one level higher, so
-        relative links that leave the skill bundle keep resolving against the
-        package root instead of against ``.apm/``.
+        For a ``MARKETPLACE_PLUGIN`` parser-owned normalized membership is
+        authoritative. The parser records each normalized name's validated
+        byte source, so this integrator never re-derives membership from the
+        raw root ``skills/`` tree. An empty resolution is a real answer:
+        ``"skills": []`` means no skills, and a missing or malformed receipt
+        fails closed rather than falling back to staged package content.
 
         Callers must handle a root ``SKILL.md`` before asking: a native
         single-skill package deploys the bundle itself, not children.
         """
         from apm_cli.models.validation import PackageType
 
-        normalized = package_path / ".apm" / "skills"
         if package_type is PackageType.MARKETPLACE_PLUGIN:
-            root_bundle = package_path / "skills"
-            resolved: dict[str, Path] = {}
-            for name in SkillIntegrator._skill_names_in_directory(normalized):
-                preferred = root_bundle / name
-                resolved[name] = (
-                    preferred if (preferred / "SKILL.md").is_file() else normalized / name
-                )
+            from apm_cli.deps.plugin_parser import normalized_plugin_skill_sources
+
+            resolved, _ = normalized_plugin_skill_sources(package_path)
             return resolved
 
         source = SkillIntegrator._skill_source_dir(package_path)
@@ -746,13 +734,19 @@ class SkillIntegrator(BaseIntegrator):
         output to tell "no skills by design" apart from "my declaration ate
         them". Say which names went unclaimed, once, at that exact shape.
         """
+        from apm_cli.deps.plugin_parser import normalized_plugin_skill_sources
+
+        _, declared = normalized_plugin_skill_sources(package_path)
+        if not declared:
+            return
         shadowed = SkillIntegrator._skill_names_in_directory(package_path / "skills")
         if not shadowed:
             return
         names = ", ".join(sorted(shadowed))
         message = (
             f"Package '{parent_name}': plugin.json declares no deployable skills, "
-            f"so nothing under skills/ deploys ({names})."
+            f"so nothing under skills/ deploys ({names}). Declare the skill directories "
+            "or their container in plugin.json, or remove the skills key to discover skills/."
         )
         detail = (
             "A 'skills' declaration replaces default discovery instead of adding "
@@ -791,10 +785,10 @@ class SkillIntegrator(BaseIntegrator):
         link_rewriter: "SkillIntegrator | None" = None,
         source_paths: dict[str, Path] | None = None,
     ) -> tuple[int, list[Path]]:
-        """Promote sub-skills from .apm/skills/ to top-level skill entries.
+        """Promote named skill directories to top-level skill entries.
 
         Args:
-            sub_skills_dir: Path to the .apm/skills/ directory in the source package.
+            sub_skills_dir: Default source directory when ``source_paths`` is absent.
             target_skills_root: Root skills directory (e.g. .github/skills/ or .claude/skills/).
             parent_name: Name of the parent skill (used in warning messages).
             warn: Whether to emit a warning on name collisions.
@@ -1610,14 +1604,27 @@ class SkillIntegrator(BaseIntegrator):
                 diagnostics=diagnostics,
                 logger=logger,
             )
-        if _source_paths and (
-            _is_plugin or self._skill_source_dir(package_path) == root_skills_dir
-        ):
+            return self._merge_bin_paths(
+                SkillIntegrationResult(
+                    skill_created=False,
+                    skill_updated=False,
+                    skill_skipped=True,
+                    skill_path=None,
+                    references_copied=0,
+                    links_resolved=0,
+                ),
+                bin_paths,
+                bin_skip_reason,
+            )
+        source_dir_is_root = bool(_source_paths) and all(
+            source.parent == root_skills_dir for source in _source_paths.values()
+        )
+        if _source_paths and (_is_plugin or source_dir_is_root):
             return self._merge_bin_paths(
                 self._integrate_skill_bundle(
                     package_info,
                     project_root,
-                    root_skills_dir,
+                    package_path / ".apm" / "skills" if _is_plugin else root_skills_dir,
                     source_paths=_source_paths,
                     diagnostics=diagnostics,
                     managed_files=managed_files,

--- a/src/apm_cli/integration/skill_integrator.py
+++ b/src/apm_cli/integration/skill_integrator.py
@@ -6,9 +6,10 @@ import os
 import re
 import shutil
 import stat
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass, replace
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from apm_cli.core.deployment_state import MaterializationResult
 from apm_cli.install.services import enforce_agent_plugin_deployment_boundary
@@ -16,6 +17,11 @@ from apm_cli.integration.base_integrator import BaseIntegrator
 from apm_cli.integration.targets import TargetProfile
 from apm_cli.models.dependency.subsets import skill_subset_filter_tokens
 from apm_cli.utils.atomic_io import write_text_lf
+
+if TYPE_CHECKING:
+    # Runtime imports of PackageType stay inside the functions that need it:
+    # importing the models package here would close an import cycle.
+    from apm_cli.models.validation import PackageType
 
 
 def _build_copy_ignore(
@@ -615,21 +621,59 @@ class SkillIntegrator(BaseIntegrator):
 
     @staticmethod
     def skill_source_dir(package_path: Path) -> Path:
-        """Return the directory a package's deployable skills are promoted from.
+        """Return the bundle directory a package's skills are promoted from.
 
-        Single source of truth for skill routing: deployment and ``--skill``
-        enumeration both resolve through here so the set a user may select can
-        never drift from the set that actually deploys (issue #2530). A root
-        ``skills/`` bundle wins whenever it holds at least one skill; otherwise
-        the normalized ``.apm/skills/`` location supplies them.
-
-        Callers must handle a root ``SKILL.md`` before asking: a native
-        single-skill package deploys the bundle itself, not children.
+        A root ``skills/`` bundle wins whenever it holds at least one skill;
+        otherwise the normalized ``.apm/skills/`` location supplies them.
+        Plugins refine this per skill -- see ``skill_source_paths``.
         """
         root_bundle = package_path / "skills"
         if SkillIntegrator._skill_names_in_directory(root_bundle):
             return root_bundle
         return package_path / ".apm" / "skills"
+
+    @staticmethod
+    def skill_source_paths(
+        package_path: Path, package_type: "PackageType | None" = None
+    ) -> dict[str, Path]:
+        """Map every deployable skill name to the directory it is promoted from.
+
+        Single source of truth for skill routing: deployment and ``--skill``
+        enumeration both resolve through here, so the set a user may select
+        can never drift from the set that actually deploys (issue #2530).
+
+        For a ``MARKETPLACE_PLUGIN`` the normalized ``.apm/skills/`` is the
+        resolved ``plugin.json`` declaration, so it decides *which* skills
+        exist. The raw root ``skills/`` is pre-resolution input; letting it
+        decide deploys components the manifest never declared and drops
+        declared ones living outside the conventional container (#2537).
+        An empty resolution is a real answer -- ``"skills": []`` means no
+        skills, and a path rejected for escaping the plugin root must fail
+        closed rather than fall back to whatever the raw tree holds.
+
+        Each declared skill is still *sourced* from the root bundle when that
+        copy exists. It is byte-identical, but sits one level higher, so
+        relative links that leave the skill bundle keep resolving against the
+        package root instead of against ``.apm/``.
+
+        Callers must handle a root ``SKILL.md`` before asking: a native
+        single-skill package deploys the bundle itself, not children.
+        """
+        from apm_cli.models.validation import PackageType
+
+        normalized = package_path / ".apm" / "skills"
+        if package_type is PackageType.MARKETPLACE_PLUGIN:
+            root_bundle = package_path / "skills"
+            resolved: dict[str, Path] = {}
+            for name in SkillIntegrator._skill_names_in_directory(normalized):
+                preferred = root_bundle / name
+                resolved[name] = (
+                    preferred if (preferred / "SKILL.md").is_file() else normalized / name
+                )
+            return resolved
+
+        source = SkillIntegrator.skill_source_dir(package_path)
+        return {name: source / name for name in SkillIntegrator._skill_names_in_directory(source)}
 
     @staticmethod
     def available_skill_names(package_info) -> frozenset[str] | None:
@@ -640,8 +684,8 @@ class SkillIntegrator(BaseIntegrator):
         if (package_path / "SKILL.md").is_file():
             return None
 
-        return SkillIntegrator._skill_names_in_directory(
-            SkillIntegrator.skill_source_dir(package_path)
+        return frozenset(
+            SkillIntegrator.skill_source_paths(package_path, package_info.package_type)
         )
 
     @staticmethod
@@ -697,6 +741,7 @@ class SkillIntegrator(BaseIntegrator):
         logger=None,
         name_filter: set[str] | None = None,
         link_rewriter: "SkillIntegrator | None" = None,
+        source_paths: dict[str, Path] | None = None,
     ) -> tuple[int, list[Path]]:
         """Promote sub-skills from .apm/skills/ to top-level skill entries.
 
@@ -709,14 +754,23 @@ class SkillIntegrator(BaseIntegrator):
                 When provided, warnings are suppressed for self-overwrites.
             diagnostics: Optional DiagnosticCollector for deferred warning output.
             project_root: Project root for computing relative diagnostic paths.
+            source_paths: Explicit name -> source directory map. Plugins resolve
+                each declared skill individually, so their sources do not all
+                share one parent directory. When omitted, every child of
+                *sub_skills_dir* is a candidate.
 
         Returns:
             tuple[int, list[Path]]: (count of promoted sub-skills, list of deployed dir paths)
         """
         promoted = 0
         deployed = []
-        if not sub_skills_dir.is_dir():
-            return promoted, deployed
+        candidates: Iterable[Path]
+        if source_paths is None:
+            if not sub_skills_dir.is_dir():
+                return promoted, deployed
+            candidates = sub_skills_dir.iterdir()
+        else:
+            candidates = [source_paths[name] for name in sorted(source_paths)]
 
         # Compute project-relative prefix for consistent path reporting
         if project_root is not None:
@@ -729,7 +783,7 @@ class SkillIntegrator(BaseIntegrator):
         else:
             rel_prefix = target_skills_root.name
 
-        for sub_skill_path in sub_skills_dir.iterdir():
+        for sub_skill_path in candidates:
             if not sub_skill_path.is_dir():
                 continue
             if not (sub_skill_path / "SKILL.md").exists():
@@ -1222,6 +1276,7 @@ class SkillIntegrator(BaseIntegrator):
         targets=None,
         skill_subset=None,
         skip_bin: bool = False,
+        source_paths: dict[str, Path] | None = None,
     ) -> SkillIntegrationResult:
         """Promote every skill in a SKILL_BUNDLE's top-level skills/ directory.
 
@@ -1239,6 +1294,9 @@ class SkillIntegrator(BaseIntegrator):
             logger: Optional InstallLogger.
             targets: Optional explicit list of TargetProfile objects.
             skill_subset: Optional tuple of skill names to install (None = all).
+            source_paths: Explicit name -> source directory map, for packages
+                whose deployable skills do not all share one parent directory.
+                When omitted, every child of *skills_dir* is a candidate.
 
         Returns:
             SkillIntegrationResult with all promoted skills.
@@ -1263,7 +1321,11 @@ class SkillIntegrator(BaseIntegrator):
         any_created = False
         seen_skill_dirs: set[Path] = set()
         primary_selected = False
-        available_names = self._skill_names_in_directory(skills_dir)
+        available_names = (
+            frozenset(source_paths)
+            if source_paths is not None
+            else self._skill_names_in_directory(skills_dir)
+        )
 
         # Convert skill_subset tuple to promotion filter tokens for O(1) lookup.
         _name_filter = skill_subset_filter_tokens(skill_subset)
@@ -1305,6 +1367,7 @@ class SkillIntegrator(BaseIntegrator):
                 name_filter=_name_filter,
                 link_rewriter=self,
                 skip_bin=skip_bin,
+                source_paths=source_paths,
             )
             if is_primary:
                 total_promoted = n
@@ -1479,16 +1542,26 @@ class SkillIntegrator(BaseIntegrator):
             )
 
         # SKILL_BUNDLE: promote skills from root-level skills/ directory.
-        # Routed through ``skill_source_dir`` -- the same helper backing
+        # Routed through ``skill_source_paths`` -- the same helper backing
         # ``available_skill_names`` -- so a ``--skill`` value can never be
-        # validated against a directory other than the one that deploys.
+        # validated against a set other than the one that deploys.
+        #
+        # A plugin's resolved declaration IS its bundle, wherever the
+        # individual skills happen to sit, so it takes this path rather than
+        # the sub-skill path (#2537). For every other type the bundle is the
+        # root ``skills/`` directory, and ``.apm/skills/`` stays what it has
+        # always been: sub-skills promoted alongside a package that is not
+        # itself a skill.
         root_skills_dir = package_path / "skills"
-        if self.skill_source_dir(package_path) == root_skills_dir:
+        _source_paths = self.skill_source_paths(package_path, package_info.package_type)
+        _is_plugin = package_info.package_type == _PackageType.MARKETPLACE_PLUGIN
+        if _source_paths and (_is_plugin or self.skill_source_dir(package_path) == root_skills_dir):
             return self._merge_bin_paths(
                 self._integrate_skill_bundle(
                     package_info,
                     project_root,
                     root_skills_dir,
+                    source_paths=_source_paths,
                     diagnostics=diagnostics,
                     managed_files=managed_files,
                     force=force,

--- a/src/apm_cli/integration/skill_integrator.py
+++ b/src/apm_cli/integration/skill_integrator.py
@@ -6,14 +6,19 @@ import os
 import re
 import shutil
 import stat
-from collections.abc import Callable, Iterable
-from dataclasses import dataclass, replace
+from collections.abc import Iterable
+from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from apm_cli.core.deployment_state import MaterializationResult
 from apm_cli.install.services import enforce_agent_plugin_deployment_boundary
 from apm_cli.integration.base_integrator import BaseIntegrator
+from apm_cli.integration.skill_support import (
+    SkillIntegrationResult,
+    build_copy_ignore,
+    clean_orphaned_skills,
+    get_lockfile_owned_agent_skills,
+)
 from apm_cli.integration.targets import TargetProfile
 from apm_cli.models.dependency.subsets import skill_subset_filter_tokens
 from apm_cli.utils.atomic_io import write_text_lf
@@ -22,58 +27,6 @@ if TYPE_CHECKING:
     # Runtime imports of PackageType stay inside the functions that need it:
     # importing the models package here would close an import cycle.
     from apm_cli.models.validation import PackageType
-
-
-def _build_copy_ignore(
-    *,
-    skip_bin: bool = False,
-) -> Callable[[str, list[str]], list[str]]:
-    """Build a ``shutil.copytree`` ignore function.
-
-    When *skip_bin* is True the returned function also excludes ``bin/``
-    directories so that unapproved executables are not deployed during
-    skill promotion.
-    """
-    from apm_cli.security.gate import ignore_non_content
-
-    if not skip_bin:
-        return ignore_non_content
-    _bin_filter = shutil.ignore_patterns("bin")
-
-    def _combined(directory: str, contents: list[str]) -> list[str]:
-        return list(
-            set(ignore_non_content(directory, contents)) | set(_bin_filter(directory, contents))
-        )
-
-    return _combined
-
-
-# DEPRECATED -- use IntegrationResult directly for new code.
-# Kept for backward compatibility. The fields map as follows:
-# skill_created -> IntegrationResult.skill_created
-# sub_skills_promoted -> IntegrationResult.sub_skills_promoted
-# skill_path, references_copied -> not mapped (skill-internal)
-@dataclass
-class SkillIntegrationResult:
-    """Result of skill integration operation."""
-
-    skill_created: bool
-    skill_updated: bool
-    skill_skipped: bool
-    skill_path: Path | None
-    references_copied: int  # Now tracks total files copied to subdirectories
-    links_resolved: int = 0  # Kept for backwards compatibility
-    sub_skills_promoted: int = 0  # Number of sub-skills promoted to top-level
-    bin_deployed: int = 0  # Number of marketplace_plugin bin/ executables deployed
-    # Why a plugin's bin/ was NOT deployed despite shipping one, so the install
-    # layer can surface an actionable hint: "project_scope" | "no_claude_target".
-    bin_skipped_reason: str | None = None
-    target_paths: list[Path] = None  # All deployed directories (for deployed_files manifest)
-    materializations: tuple[MaterializationResult, ...] = ()
-
-    def __post_init__(self):
-        if self.target_paths is None:
-            self.target_paths = []
 
 
 def to_hyphen_case(name: str) -> str:
@@ -900,7 +853,7 @@ class SkillIntegrator(BaseIntegrator):
                 sub_skill_path,
                 target,
                 dirs_exist_ok=True,
-                ignore=_build_copy_ignore(skip_bin=skip_bin),
+                ignore=build_copy_ignore(skip_bin=skip_bin),
             )
             if link_rewriter is not None:
                 link_rewriter._resolve_markdown_links_in_skill_bundle(sub_skill_path, target)
@@ -1247,7 +1200,7 @@ class SkillIntegrator(BaseIntegrator):
                 shutil.rmtree(target_skill_dir)
 
             target_skill_dir.parent.mkdir(parents=True, exist_ok=True)
-            _base_ignore = _build_copy_ignore(skip_bin=skip_bin)
+            _base_ignore = build_copy_ignore(skip_bin=skip_bin)
 
             _apm_filter = shutil.ignore_patterns(".apm")
 
@@ -2118,70 +2071,15 @@ class SkillIntegrator(BaseIntegrator):
         *,
         project_root: Path | None = None,
     ) -> dict[str, int]:
-        """Clean orphaned skills from a skills directory.
-
-        Uses npm-style approach: any skill directory not matching an installed
-        package name is considered orphaned and removed.
-
-        For the cross-client ``.agents/skills/`` directory, only removes skill
-        directories that appear in the lockfile's ``deployed_files`` to avoid
-        deleting foreign skills placed by other tools (Codex CLI, manual).
-
-        Args:
-            skills_dir: Path to skills directory (.github/skills/, .claude/skills/, etc.)
-            installed_skill_names: Set of expected skill directory names
-            project_root: Project root for lockfile-based ownership check.
-
-        Returns:
-            Dict with cleanup statistics
-        """
-        files_removed = 0
-        errors = 0
-
-        # For .agents/skills/: only delete skills that APM owns (appear in lockfile).
-        is_agents_dir = skills_dir.parent.name == ".agents"
-        lockfile_owned_skills: set[str] | None = None
-        if is_agents_dir and project_root is not None:
-            lockfile_owned_skills = self._get_lockfile_owned_agent_skills(project_root)
-
-        for skill_subdir in skills_dir.iterdir():
-            if skill_subdir.is_dir():
-                if skill_subdir.name not in installed_skill_names:
-                    # Ownership check: skip foreign skills in .agents/skills/.
-                    if lockfile_owned_skills is not None:
-                        if skill_subdir.name not in lockfile_owned_skills:
-                            continue
-                    try:
-                        shutil.rmtree(skill_subdir)
-                        files_removed += 1
-                    except Exception:
-                        errors += 1
-
-        return {"files_removed": files_removed, "errors": errors}
+        """Clean legacy-orphan skill directories without touching foreign agents."""
+        return clean_orphaned_skills(
+            skills_dir,
+            installed_skill_names,
+            project_root=project_root,
+            get_lockfile_owned_agent_skills=self._get_lockfile_owned_agent_skills,
+        )
 
     @staticmethod
     def _get_lockfile_owned_agent_skills(project_root: Path) -> set[str]:
-        """Return the set of skill names under ``.agents/skills/`` in the lockfile.
-
-        Used by ``_clean_orphaned_skills`` to avoid deleting foreign skills
-        in the cross-client ``.agents/`` directory.
-        """
-        owned: set[str] = set()
-        try:
-            from apm_cli.deps.lockfile import LockFile, get_lockfile_path
-
-            lockfile = LockFile.read(get_lockfile_path(project_root))
-            if lockfile and lockfile.dependencies:
-                for dep in lockfile.dependencies.values():
-                    for f in dep.deployed_files:
-                        if f.startswith(".agents/skills/"):
-                            parts = f[len(".agents/skills/") :].split("/")
-                            if parts and parts[0]:
-                                owned.add(parts[0])
-        except (FileNotFoundError, OSError, KeyError, ValueError, TypeError, AttributeError) as exc:
-            import logging
-
-            logging.getLogger(__name__).debug(
-                "Could not read lockfile for ownership check: %s", exc
-            )
-        return owned
+        """Return the lockfile-owned ``.agents/skills`` names."""
+        return get_lockfile_owned_agent_skills(project_root)

--- a/src/apm_cli/integration/skill_support.py
+++ b/src/apm_cli/integration/skill_support.py
@@ -1,0 +1,97 @@
+"""Supporting value objects and cleanup helpers for skill integration."""
+
+import shutil
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from apm_cli.core.deployment_state import MaterializationResult
+
+
+def build_copy_ignore(
+    *,
+    skip_bin: bool = False,
+) -> Callable[[str, list[str]], list[str]]:
+    """Build a ``shutil.copytree`` ignore function."""
+    from apm_cli.security.gate import ignore_non_content
+
+    if not skip_bin:
+        return ignore_non_content
+    bin_filter = shutil.ignore_patterns("bin")
+
+    def combined(directory: str, contents: list[str]) -> list[str]:
+        return list(
+            set(ignore_non_content(directory, contents)) | set(bin_filter(directory, contents))
+        )
+
+    return combined
+
+
+@dataclass
+class SkillIntegrationResult:
+    """Compatibility result returned by skill-specific integration APIs."""
+
+    skill_created: bool
+    skill_updated: bool
+    skill_skipped: bool
+    skill_path: Path | None
+    references_copied: int
+    links_resolved: int = 0
+    sub_skills_promoted: int = 0
+    bin_deployed: int = 0
+    bin_skipped_reason: str | None = None
+    target_paths: list[Path] = None
+    materializations: tuple[MaterializationResult, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.target_paths is None:
+            self.target_paths = []
+
+
+def clean_orphaned_skills(
+    skills_dir: Path,
+    installed_skill_names: set,
+    *,
+    project_root: Path | None,
+    get_lockfile_owned_agent_skills: Callable[[Path], set[str]],
+) -> dict[str, int]:
+    """Remove legacy-orphan skill directories without touching foreign agents."""
+    files_removed = 0
+    errors = 0
+    lockfile_owned_skills: set[str] | None = None
+    if skills_dir.parent.name == ".agents" and project_root is not None:
+        lockfile_owned_skills = get_lockfile_owned_agent_skills(project_root)
+
+    for skill_subdir in skills_dir.iterdir():
+        if not skill_subdir.is_dir() or skill_subdir.name in installed_skill_names:
+            continue
+        if lockfile_owned_skills is not None and skill_subdir.name not in lockfile_owned_skills:
+            continue
+        try:
+            shutil.rmtree(skill_subdir)
+            files_removed += 1
+        except Exception:
+            errors += 1
+
+    return {"files_removed": files_removed, "errors": errors}
+
+
+def get_lockfile_owned_agent_skills(project_root: Path) -> set[str]:
+    """Return APM-owned ``.agents/skills`` names from the lockfile."""
+    owned: set[str] = set()
+    try:
+        from apm_cli.deps.lockfile import LockFile, get_lockfile_path
+
+        lockfile = LockFile.read(get_lockfile_path(project_root))
+        if lockfile and lockfile.dependencies:
+            for dep in lockfile.dependencies.values():
+                for deployed_file in dep.deployed_files:
+                    if deployed_file.startswith(".agents/skills/"):
+                        name = deployed_file[len(".agents/skills/") :].split("/", 1)[0]
+                        if name:
+                            owned.add(name)
+    except (FileNotFoundError, OSError, KeyError, ValueError, TypeError, AttributeError) as exc:
+        import logging
+
+        logging.getLogger(__name__).debug("Could not read lockfile for ownership check: %s", exc)
+    return owned

--- a/tests/integration/test_architecture_authorities.py
+++ b/tests/integration/test_architecture_authorities.py
@@ -212,6 +212,79 @@ def test_agent_plugin_contract_has_single_owner() -> None:
     )
 
 
+def test_plugin_skill_declaration_membership_has_single_owner() -> None:
+    """Legacy plugin parsing owns membership; integration only consumes it."""
+    root = Path(__file__).parents[2]
+    parser = (root / "src/apm_cli/deps/plugin_parser.py").read_text(encoding="utf-8")
+    integrator = root / "src/apm_cli/integration/skill_integrator.py"
+    guard = root / "scripts/check_plugin_skill_declaration_authority.py"
+    architecture = (root / ".github/instructions/architecture.instructions.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert parser.count("def normalized_plugin_skill_sources(") == 1
+    assert "normalized_plugin_skill_sources(package_path)" in integrator.read_text(encoding="utf-8")
+    assert "Legacy plugin declared-skill membership" in architecture
+
+    result = subprocess.run(
+        (sys.executable, str(guard), str(root)),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "old", "new"),
+    [
+        (
+            "src/apm_cli/integration/skill_integrator.py",
+            "resolved, _ = normalized_plugin_skill_sources(package_path)",
+            'resolved = {name: package_path / "skills" / name for name in ()}',
+        ),
+        (
+            "src/apm_cli/integration/skill_integrator.py",
+            "resolved, _ = normalized_plugin_skill_sources(package_path)",
+            "resolved, _ = normalized_plugin_skill_sources(package_path)\n"
+            '            root_bundle = package_path / "skills"',
+        ),
+    ],
+)
+def test_plugin_skill_declaration_owner_guard_kills_mutations(
+    tmp_path: Path,
+    relative_path: str,
+    old: str,
+    new: str,
+) -> None:
+    root = Path(__file__).parents[2]
+    sandbox = tmp_path / "repo"
+    for path in (
+        "src/apm_cli/deps/plugin_parser.py",
+        "src/apm_cli/integration/skill_integrator.py",
+    ):
+        destination = sandbox / path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(root / path, destination)
+    mutation_path = sandbox / relative_path
+    source = mutation_path.read_text(encoding="utf-8")
+    assert old in source
+    mutation_path.write_text(source.replace(old, new, 1), encoding="utf-8")
+
+    result = subprocess.run(
+        (
+            sys.executable,
+            str(root / "scripts/check_plugin_skill_declaration_authority.py"),
+            str(sandbox),
+        ),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 1
+    assert "Plugin skill declaration membership" in result.stdout
+
+
 @pytest.mark.parametrize(
     ("relative_path", "old", "new"),
     [
@@ -343,6 +416,12 @@ def test_agent_plugin_component_ir_mutations_are_killed(
             "    normalize_plugin_directory(package_path, plugin_json_path)\n"
             "    result.agent_plugin = plugin",
             "Agent Plugin classification must route through its loader, not Claude normalization",
+        ),
+        (
+            "src/apm_cli/install/drift.py",
+            "if detect_agent_plugin(install_path) is not None:",
+            "if False:",
+            "Agent Plugin projection AST boundary failed",
         ),
         (
             "src/apm_cli/agent_plugins/projection.py",
@@ -652,6 +731,7 @@ def test_agent_plugin_projection_guard_rejects_bypass(
         "src/apm_cli/deps/apm_resolver.py",
         "src/apm_cli/deps/github_downloader.py",
         "src/apm_cli/deps/registry/resolver.py",
+        "src/apm_cli/install/drift.py",
         "src/apm_cli/install/services.py",
         "src/apm_cli/install/sources.py",
         "src/apm_cli/install/template.py",

--- a/tests/integration/test_architecture_outcome_guards.py
+++ b/tests/integration/test_architecture_outcome_guards.py
@@ -122,6 +122,70 @@ def test_requested_plugin_skill_with_no_match_fails_closed(
     assert not (consumer / ".claude" / "skills" / "resolving-merge-conflicts").exists()
 
 
+def test_declared_skills_container_is_selectable_by_skill(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--skill`` must subset a plugin that declares its skills container.
+
+    Regression for #2530: ``"skills": ["./skills/"]`` names the conventional
+    container. Normalizing it under its own name left the enumerator backing
+    ``--skill`` with nothing to match, so every requested name was rejected
+    with ``Available: (none)`` even though a bare install deployed them all.
+    """
+    from click.testing import CliRunner
+
+    from apm_cli.cli import cli
+
+    plugin, consumer = _write_plugin_consumer(
+        tmp_path,
+        {
+            "name": "container-skills",
+            "version": "1.0.0",
+            "skills": ["./skills/"],
+        },
+    )
+    for name in ("csharp-scripts", "dotnet-pinvoke"):
+        skill = plugin / "skills" / name
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text(f"# {name}\n", encoding="utf-8")
+    monkeypatch.chdir(consumer)
+    monkeypatch.setattr("apm_cli.cli._check_and_notify_updates", lambda: None)
+
+    result = CliRunner().invoke(cli, ["install", "--skill", "csharp-scripts"])
+
+    assert result.exit_code == 0, result.output
+    assert "Available: (none)" not in result.output
+    deployed = consumer / ".claude" / "skills"
+    assert (deployed / "csharp-scripts" / "SKILL.md").is_file()
+    # Subsetting is the point: the sibling must stay out.
+    assert not (deployed / "dotnet-pinvoke").exists()
+
+
+def test_skill_enumeration_matches_the_directory_that_deploys(
+    tmp_path: Path,
+) -> None:
+    """``--skill`` validation and deployment must read one routing rule.
+
+    Regression for #2530: the enumerator carried a plugin-only branch that
+    read ``.apm/skills/`` while the deploy path preferred a root ``skills/``
+    bundle, so a selectable name and a deployable name could disagree.
+    """
+    from apm_cli.integration.skill_integrator import SkillIntegrator
+    from apm_cli.models.validation import PackageType
+
+    package = tmp_path / "pkg"
+    for name in ("alpha", "beta"):
+        skill = package / "skills" / name
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text(f"# {name}\n", encoding="utf-8")
+
+    info = MagicMock(install_path=package, package_type=PackageType.MARKETPLACE_PLUGIN)
+
+    assert SkillIntegrator.skill_source_dir(package) == package / "skills"
+    assert SkillIntegrator.available_skill_names(info) == frozenset({"alpha", "beta"})
+
+
 def test_stale_persisted_skill_pin_warns_instead_of_silent_noop(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/integration/test_architecture_outcome_guards.py
+++ b/tests/integration/test_architecture_outcome_guards.py
@@ -186,6 +186,42 @@ def test_skill_enumeration_matches_the_directory_that_deploys(
     assert SkillIntegrator.available_skill_names(info) == frozenset({"alpha", "beta"})
 
 
+def test_skill_enumeration_falls_back_to_the_normalized_container(
+    tmp_path: Path,
+) -> None:
+    """The ``.apm/skills/`` fallback is the route every plugin package takes.
+
+    A root ``skills/`` bundle wins only while it actually holds a skill. With
+    no such bundle -- or with one carrying no ``SKILL.md`` at all -- routing
+    must fall back to the normalized container ``_map_plugin_artifacts``
+    writes, or ``--skill`` is back to enumerating nothing (#2530).
+    """
+    from apm_cli.integration.skill_integrator import SkillIntegrator
+    from apm_cli.models.validation import PackageType
+
+    package = tmp_path / "pkg"
+    normalized = package / ".apm" / "skills"
+    for name in ("csharp-scripts", "dotnet-pinvoke"):
+        skill = normalized / name
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text(f"# {name}\n", encoding="utf-8")
+
+    info = MagicMock(install_path=package, package_type=PackageType.MARKETPLACE_PLUGIN)
+    expected = frozenset({"csharp-scripts", "dotnet-pinvoke"})
+
+    assert SkillIntegrator.skill_source_dir(package) == normalized
+    assert SkillIntegrator.available_skill_names(info) == expected
+
+    # Existing is not the test -- holding a skill is. A root ``skills/`` with
+    # nothing selectable in it must not shadow the normalized container.
+    root_bundle = package / "skills"
+    (root_bundle / "docs").mkdir(parents=True)
+    (root_bundle / "README.md").write_text("# not a skill\n", encoding="utf-8")
+
+    assert SkillIntegrator.skill_source_dir(package) == normalized
+    assert SkillIntegrator.available_skill_names(info) == expected
+
+
 def test_stale_persisted_skill_pin_warns_instead_of_silent_noop(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/integration/test_architecture_outcome_guards.py
+++ b/tests/integration/test_architecture_outcome_guards.py
@@ -169,7 +169,9 @@ def test_skill_enumeration_matches_the_directory_that_deploys(
 
     Regression for #2530: the enumerator carried a plugin-only branch that
     read ``.apm/skills/`` while the deploy path preferred a root ``skills/``
-    bundle, so a selectable name and a deployable name could disagree.
+    bundle, so a selectable name and a deployable name could disagree. A
+    non-plugin keeps root-bundle precedence -- nothing normalizes its
+    ``skills/``, so the raw directory is the declaration.
     """
     from apm_cli.integration.skill_integrator import SkillIntegrator
     from apm_cli.models.validation import PackageType
@@ -180,10 +182,117 @@ def test_skill_enumeration_matches_the_directory_that_deploys(
         skill.mkdir(parents=True)
         (skill / "SKILL.md").write_text(f"# {name}\n", encoding="utf-8")
 
+    info = MagicMock(install_path=package, package_type=PackageType.SKILL_BUNDLE)
+
+    assert SkillIntegrator.skill_source_paths(package, PackageType.SKILL_BUNDLE) == {
+        "alpha": package / "skills" / "alpha",
+        "beta": package / "skills" / "beta",
+    }
+    assert SkillIntegrator.available_skill_names(info) == frozenset({"alpha", "beta"})
+
+
+def test_plugin_declaration_decides_which_skills_root_copy_stays_the_source(
+    tmp_path: Path,
+) -> None:
+    """A plugin's resolved declaration outranks its raw ``skills/`` tree.
+
+    Regression for #2537: the raw root directory is pre-resolution input.
+    Letting it decide deployed skills the manifest never declared and dropped
+    declared ones living outside the conventional container.
+
+    The root copy still supplies the *content* wherever it exists. It is
+    byte-identical to the normalized one but sits a level higher, so relative
+    links leaving the bundle keep resolving against the package root.
+    """
+    from apm_cli.integration.skill_integrator import SkillIntegrator
+    from apm_cli.models.validation import PackageType
+
+    package = tmp_path / "plugin"
+    for name in ("declared", "undeclared"):
+        skill = package / "skills" / name
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text(f"# {name}\n", encoding="utf-8")
+    # What normalization resolved the manifest to: one skill that also lives in
+    # the root container, and one declared from outside it.
+    for name in ("declared", "outside"):
+        skill = package / ".apm" / "skills" / name
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text(f"# {name}\n", encoding="utf-8")
+
     info = MagicMock(install_path=package, package_type=PackageType.MARKETPLACE_PLUGIN)
 
-    assert SkillIntegrator.skill_source_dir(package) == package / "skills"
-    assert SkillIntegrator.available_skill_names(info) == frozenset({"alpha", "beta"})
+    assert SkillIntegrator.available_skill_names(info) == frozenset({"declared", "outside"})
+    assert SkillIntegrator.skill_source_paths(package, PackageType.MARKETPLACE_PLUGIN) == {
+        "declared": package / "skills" / "declared",
+        "outside": package / ".apm" / "skills" / "outside",
+    }
+
+
+def test_plugin_skill_links_leaving_the_bundle_survive_declaration_filtering(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Honouring the declaration must not move where skill content is read from.
+
+    A skill's relative link that leaves the bundle is rewritten against the
+    package root. Sourcing the same skill from the normalized ``.apm/skills/``
+    copy instead of the root one puts it a level deeper, so that link silently
+    resolves somewhere else and lands in the target unrewritten (#2537).
+    """
+    from click.testing import CliRunner
+
+    from apm_cli.cli import cli
+
+    plugin, consumer = _write_plugin_consumer(
+        tmp_path,
+        {"name": "linked-skills", "version": "1.0.0", "skills": ["./skills/"]},
+    )
+    (plugin / "docs").mkdir()
+    (plugin / "docs" / "guide.md").write_text("# guide\n", encoding="utf-8")
+    skill = plugin / "skills" / "alpha"
+    (skill / "references").mkdir(parents=True)
+    (skill / "references" / "r.md").write_text("# r\n", encoding="utf-8")
+    (skill / "SKILL.md").write_text(
+        "---\nname: alpha\ndescription: d\n---\n"
+        "internal: [ref](references/r.md)\n"
+        "escaping: [guide](../../docs/guide.md)\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(consumer)
+    monkeypatch.setattr("apm_cli.cli._check_and_notify_updates", lambda: None)
+
+    result = CliRunner().invoke(cli, ["install"])
+    assert result.exit_code == 0, result.output
+
+    deployed = consumer / ".claude" / "skills" / "alpha"
+    body = (deployed / "SKILL.md").read_text(encoding="utf-8")
+    assert (deployed / "references" / "r.md").is_file()
+    assert "[ref](references/r.md)" in body
+    # Rewritten back at the package, not left pointing inside the target tree.
+    assert "../../docs/guide.md" not in body
+    assert "apm_modules" in body and "docs/guide.md" in body
+
+
+def test_plugin_empty_skills_declaration_resolves_to_nothing(
+    tmp_path: Path,
+) -> None:
+    """``"skills": []`` means no skills, not "fall back to the raw tree".
+
+    Regression for #2537: an empty resolution is a real answer. The same path
+    covers a declared component rejected for escaping the plugin root, which
+    must fail closed rather than deploy whatever the tree happens to hold.
+    """
+    from apm_cli.integration.skill_integrator import SkillIntegrator
+    from apm_cli.models.validation import PackageType
+
+    package = tmp_path / "plugin"
+    skill = package / "skills" / "not-declared"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("# not-declared\n", encoding="utf-8")
+
+    info = MagicMock(install_path=package, package_type=PackageType.MARKETPLACE_PLUGIN)
+
+    assert SkillIntegrator.available_skill_names(info) == frozenset()
 
 
 def test_skill_enumeration_falls_back_to_the_normalized_container(

--- a/tests/integration/test_architecture_outcome_guards.py
+++ b/tests/integration/test_architecture_outcome_guards.py
@@ -204,6 +204,7 @@ def test_plugin_declaration_decides_which_skills_root_copy_stays_the_source(
     byte-identical to the normalized one but sits a level higher, so relative
     links leaving the bundle keep resolving against the package root.
     """
+    from apm_cli.deps.plugin_parser import _map_plugin_artifacts
     from apm_cli.integration.skill_integrator import SkillIntegrator
     from apm_cli.models.validation import PackageType
 
@@ -212,19 +213,21 @@ def test_plugin_declaration_decides_which_skills_root_copy_stays_the_source(
         skill = package / "skills" / name
         skill.mkdir(parents=True)
         (skill / "SKILL.md").write_text(f"# {name}\n", encoding="utf-8")
-    # What normalization resolved the manifest to: one skill that also lives in
-    # the root container, and one declared from outside it.
-    for name in ("declared", "outside"):
-        skill = package / ".apm" / "skills" / name
-        skill.mkdir(parents=True)
-        (skill / "SKILL.md").write_text(f"# {name}\n", encoding="utf-8")
+    outside = package / "extra-skills" / "outside"
+    outside.mkdir(parents=True)
+    (outside / "SKILL.md").write_text("# outside\n", encoding="utf-8")
+    _map_plugin_artifacts(
+        package,
+        package / ".apm",
+        {"skills": ["./skills/declared", "./extra-skills/outside"]},
+    )
 
     info = MagicMock(install_path=package, package_type=PackageType.MARKETPLACE_PLUGIN)
 
     assert SkillIntegrator.available_skill_names(info) == frozenset({"declared", "outside"})
     assert SkillIntegrator.skill_source_paths(package, PackageType.MARKETPLACE_PLUGIN) == {
         "declared": package / "skills" / "declared",
-        "outside": package / ".apm" / "skills" / "outside",
+        "outside": package / "extra-skills" / "outside",
     }
 
 
@@ -295,6 +298,35 @@ def test_plugin_empty_skills_declaration_resolves_to_nothing(
     assert SkillIntegrator.available_skill_names(info) == frozenset()
 
 
+def test_staged_plugin_skill_is_not_promoted_after_empty_declaration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A staged normalized skill cannot bypass an empty parser receipt."""
+    from click.testing import CliRunner
+
+    from apm_cli.cli import cli
+
+    plugin, consumer = _write_plugin_consumer(
+        tmp_path,
+        {"name": "staged-skills", "version": "1.0.0", "skills": []},
+    )
+    staged = plugin / ".apm" / "skills" / "staged"
+    staged.mkdir(parents=True)
+    (staged / "SKILL.md").write_text(
+        "---\nname: staged\ndescription: d\n---\n# staged\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(consumer)
+    monkeypatch.setattr("apm_cli.cli._check_and_notify_updates", lambda: None)
+
+    result = CliRunner().invoke(cli, ["install"])
+
+    assert result.exit_code == 0, result.output
+    assert "declares no deployable skills" not in result.output
+    assert not (consumer / ".claude" / "skills" / "staged").exists()
+
+
 def test_plugin_declaring_no_skills_says_which_ones_it_shadowed(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -363,36 +395,23 @@ def test_plugin_without_any_skills_stays_quiet(
 def test_skill_enumeration_falls_back_to_the_normalized_container(
     tmp_path: Path,
 ) -> None:
-    """The ``.apm/skills/`` fallback is the route every plugin package takes.
-
-    A root ``skills/`` bundle wins only while it actually holds a skill. With
-    no such bundle -- or with one carrying no ``SKILL.md`` at all -- routing
-    must fall back to the normalized container ``_map_plugin_artifacts``
-    writes, or ``--skill`` is back to enumerating nothing (#2530).
-    """
+    """Parser-authorized normalized skills remain enumerable (#2530)."""
+    from apm_cli.deps.plugin_parser import _map_plugin_artifacts
     from apm_cli.integration.skill_integrator import SkillIntegrator
     from apm_cli.models.validation import PackageType
 
     package = tmp_path / "pkg"
-    normalized = package / ".apm" / "skills"
     for name in ("csharp-scripts", "dotnet-pinvoke"):
-        skill = normalized / name
+        skill = package / "skills" / name
         skill.mkdir(parents=True)
         (skill / "SKILL.md").write_text(f"# {name}\n", encoding="utf-8")
+    _map_plugin_artifacts(package, package / ".apm", {"skills": "./skills"})
+    normalized = package / ".apm" / "skills"
 
     info = MagicMock(install_path=package, package_type=PackageType.MARKETPLACE_PLUGIN)
     expected = frozenset({"csharp-scripts", "dotnet-pinvoke"})
 
-    assert SkillIntegrator._skill_source_dir(package) == normalized
-    assert SkillIntegrator.available_skill_names(info) == expected
-
-    # Existing is not the test -- holding a skill is. A root ``skills/`` with
-    # nothing selectable in it must not shadow the normalized container.
-    root_bundle = package / "skills"
-    (root_bundle / "docs").mkdir(parents=True)
-    (root_bundle / "README.md").write_text("# not a skill\n", encoding="utf-8")
-
-    assert SkillIntegrator._skill_source_dir(package) == normalized
+    assert normalized.is_dir()
     assert SkillIntegrator.available_skill_names(info) == expected
 
 

--- a/tests/integration/test_architecture_outcome_guards.py
+++ b/tests/integration/test_architecture_outcome_guards.py
@@ -295,6 +295,71 @@ def test_plugin_empty_skills_declaration_resolves_to_nothing(
     assert SkillIntegrator.available_skill_names(info) == frozenset()
 
 
+def test_plugin_declaring_no_skills_says_which_ones_it_shadowed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A declaration that deploys nothing must not be indistinguishable from no skills.
+
+    Zero deployable skills is a legitimate answer -- most plugins ship none,
+    and none of them should be nagged. It stops being obvious once the package
+    carries a root ``skills/`` bundle whose contents used to deploy: after
+    #2537 the declaration decides, so exactly that shape needs one line
+    telling "no skills by design" apart from a declaration that ate them.
+    """
+    from click.testing import CliRunner
+
+    from apm_cli.cli import cli
+
+    plugin, consumer = _write_plugin_consumer(
+        tmp_path,
+        {"name": "quiet-skills", "version": "1.0.0", "skills": []},
+    )
+    for name in ("alpha", "beta"):
+        skill = plugin / "skills" / name
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text(
+            f"---\nname: {name}\ndescription: d\n---\n# {name}\n", encoding="utf-8"
+        )
+    monkeypatch.chdir(consumer)
+    monkeypatch.setattr("apm_cli.cli._check_and_notify_updates", lambda: None)
+
+    result = CliRunner().invoke(cli, ["install"])
+
+    assert result.exit_code == 0, result.output
+    assert "declares no deployable skills" in result.output
+    assert "alpha, beta" in result.output
+    # The declaration is still authoritative -- the note explains, not undoes.
+    assert not (consumer / ".claude" / "skills" / "alpha").exists()
+
+
+def test_plugin_without_any_skills_stays_quiet(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No root bundle means nothing was shadowed, so there is nothing to say."""
+    from click.testing import CliRunner
+
+    from apm_cli.cli import cli
+
+    plugin, consumer = _write_plugin_consumer(
+        tmp_path,
+        {"name": "agents-only", "version": "1.0.0"},
+    )
+    agents = plugin / "agents"
+    agents.mkdir()
+    (agents / "helper.agent.md").write_text(
+        "---\nname: helper\ndescription: d\n---\n# helper\n", encoding="utf-8"
+    )
+    monkeypatch.chdir(consumer)
+    monkeypatch.setattr("apm_cli.cli._check_and_notify_updates", lambda: None)
+
+    result = CliRunner().invoke(cli, ["install"])
+
+    assert result.exit_code == 0, result.output
+    assert "declares no deployable skills" not in result.output
+
+
 def test_skill_enumeration_falls_back_to_the_normalized_container(
     tmp_path: Path,
 ) -> None:
@@ -318,7 +383,7 @@ def test_skill_enumeration_falls_back_to_the_normalized_container(
     info = MagicMock(install_path=package, package_type=PackageType.MARKETPLACE_PLUGIN)
     expected = frozenset({"csharp-scripts", "dotnet-pinvoke"})
 
-    assert SkillIntegrator.skill_source_dir(package) == normalized
+    assert SkillIntegrator._skill_source_dir(package) == normalized
     assert SkillIntegrator.available_skill_names(info) == expected
 
     # Existing is not the test -- holding a skill is. A root ``skills/`` with
@@ -327,7 +392,7 @@ def test_skill_enumeration_falls_back_to_the_normalized_container(
     (root_bundle / "docs").mkdir(parents=True)
     (root_bundle / "README.md").write_text("# not a skill\n", encoding="utf-8")
 
-    assert SkillIntegrator.skill_source_dir(package) == normalized
+    assert SkillIntegrator._skill_source_dir(package) == normalized
     assert SkillIntegrator.available_skill_names(info) == expected
 
 

--- a/tests/integration/test_legacy_plugin_skill_declaration_lifecycle.py
+++ b/tests/integration/test_legacy_plugin_skill_declaration_lifecycle.py
@@ -1,0 +1,222 @@
+"""Installed-binary lifecycle for authoritative legacy plugin skills."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from apm_cli.utils.yaml_io import load_yaml
+from tests.utils.apm_lifecycle_runner import ApmLifecycleRunner, CommandResult
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.e2e,
+    pytest.mark.lifecycle_smoke,
+    pytest.mark.lifecycle_merge_group,
+    pytest.mark.requires_apm_binary,
+    pytest.mark.requires_e2e_mode,
+]
+
+_SKILL_TEXT = "---\nname: {name}\ndescription: Lifecycle fixture\n---\n# {name}\n"
+
+
+def _result_evidence(result: CommandResult) -> str:
+    """Return stable process evidence when a lifecycle command fails."""
+    return (
+        f"cwd={result.cwd!s}\n"
+        f"command={result.command!r}\n"
+        f"returncode={result.returncode}\n"
+        f"stdout={result.stdout!r}\n"
+        f"stderr={result.stderr!r}"
+    )
+
+
+def _write_plugin(
+    root: Path,
+    *,
+    declaration: list[str] | str | None,
+    skills: tuple[str, ...],
+    external_skills: tuple[str, ...] = (),
+) -> None:
+    """Create a local legacy plugin with declared and undeclared skill sources."""
+    manifest_dir = root / ".claude-plugin"
+    manifest_dir.mkdir(parents=True)
+    (root / "apm.yml").write_text(
+        f"name: {root.name}\nversion: 1.0.0\n",
+        encoding="utf-8",
+    )
+    manifest = {
+        "name": root.name,
+        "version": "1.0.0",
+        "description": "Legacy plugin skill declaration lifecycle fixture",
+    }
+    if declaration is not None:
+        manifest["skills"] = declaration
+    (manifest_dir / "plugin.json").write_text(
+        json.dumps(manifest, sort_keys=True),
+        encoding="utf-8",
+    )
+    for name in skills:
+        skill = root / "skills" / name
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text(_SKILL_TEXT.format(name=name), encoding="utf-8")
+    for name in external_skills:
+        skill = root / "external" / name
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text(_SKILL_TEXT.format(name=name), encoding="utf-8")
+
+
+def _write_project(root: Path) -> None:
+    """Create a project with a stable Claude deployment target."""
+    root.mkdir()
+    (root / "apm.yml").write_text(
+        "name: legacy-plugin-lifecycle\nversion: 1.0.0\ntargets: [claude]\ndependencies:\n  apm: []\n",
+        encoding="utf-8",
+    )
+
+
+def _assert_skill_tree(project: Path, expected_names: tuple[str, ...]) -> None:
+    """Assert that deployment contains exactly the selected skill directories."""
+    root = project / ".claude" / "skills"
+    actual = sorted(path.relative_to(root).as_posix() for path in root.rglob("*"))
+    expected = sorted(item for name in expected_names for item in (name, f"{name}/SKILL.md"))
+    assert actual == expected
+
+
+def _assert_manifest_and_lock_pin(project: Path, plugin: Path) -> None:
+    """Assert that the installed local plugin stays pinned in durable state."""
+    manifest = load_yaml(project / "apm.yml")
+    dependencies = manifest["dependencies"]["apm"]
+    assert dependencies == [str(plugin)]
+
+    lock = load_yaml(project / "apm.lock.yaml")
+    locked = lock["dependencies"]
+    assert len(locked) == 1
+    assert locked[0]["repo_url"] == f"_local/{plugin.name}"
+
+
+def _install(
+    runner: ApmLifecycleRunner,
+    project: Path,
+    plugin: Path,
+    *,
+    scenario_id: str,
+) -> CommandResult:
+    """Install one plugin through the candidate binary."""
+    result = runner.run(
+        ("install", str(plugin), "--no-policy"),
+        scenario_id=scenario_id,
+        cwd=project,
+        env=dict(os.environ),
+    )
+    assert result.returncode == 0, _result_evidence(result)
+    return result
+
+
+def test_legacy_plugin_skill_declaration_lifecycle(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    """Exercise declared selection, empty migration, rerun stability, and audit."""
+    runner = ApmLifecycleRunner((str(apm_binary_path),), scenario_timeout_seconds=300)
+    cases = (
+        (
+            "container-subset",
+            ["./skills/alpha"],
+            ("alpha", "undeclared"),
+            (),
+            ("alpha",),
+            0,
+        ),
+        (
+            "omitted-discovery",
+            None,
+            ("alpha", "undeclared"),
+            (),
+            ("alpha", "undeclared"),
+            0,
+        ),
+        (
+            "string-declaration",
+            "./skills/alpha",
+            ("alpha", "undeclared"),
+            (),
+            ("alpha",),
+            0,
+        ),
+        (
+            "selective-external",
+            ["./skills/alpha", "./external/outside"],
+            ("alpha", "undeclared"),
+            ("outside",),
+            ("alpha", "outside"),
+            0,
+        ),
+        (
+            "explicit-empty",
+            [],
+            ("alpha", "undeclared"),
+            (),
+            (),
+            1,
+        ),
+    )
+
+    for name, declaration, skills, external_skills, expected, diagnostics in cases:
+        workspace = tmp_path / name
+        workspace.mkdir()
+        plugin = workspace / "plugin"
+        _write_plugin(
+            plugin,
+            declaration=declaration,
+            skills=skills,
+            external_skills=external_skills,
+        )
+        project = workspace / "project"
+        _write_project(project)
+
+        first = _install(
+            runner,
+            project,
+            plugin,
+            scenario_id=f"legacy-plugin-skill-declaration-lifecycle-{name}-first",
+        )
+        combined = first.stdout + first.stderr
+        assert combined.count("plugin.json declares no deployable skills") == diagnostics
+        _assert_skill_tree(project, expected)
+        _assert_manifest_and_lock_pin(project, plugin)
+        first_lock = (project / "apm.lock.yaml").read_bytes()
+        first_manifest = (project / "apm.yml").read_bytes()
+        first_tree = {
+            path.relative_to(project).as_posix(): path.read_bytes()
+            for path in (project / ".claude" / "skills").rglob("SKILL.md")
+        }
+
+        second = _install(
+            runner,
+            project,
+            plugin,
+            scenario_id=f"legacy-plugin-skill-declaration-lifecycle-{name}-rerun",
+        )
+        assert (second.stdout + second.stderr).count(
+            "plugin.json declares no deployable skills"
+        ) == diagnostics
+        _assert_skill_tree(project, expected)
+        _assert_manifest_and_lock_pin(project, plugin)
+        assert (project / "apm.lock.yaml").read_bytes() == first_lock
+        assert (project / "apm.yml").read_bytes() == first_manifest
+        assert {
+            path.relative_to(project).as_posix(): path.read_bytes()
+            for path in (project / ".claude" / "skills").rglob("SKILL.md")
+        } == first_tree
+
+        audit = runner.run(
+            ("audit", "--ci", "--no-policy"),
+            scenario_id=f"legacy-plugin-skill-declaration-lifecycle-{name}-audit",
+            cwd=project,
+            env=dict(os.environ),
+        )
+        assert audit.returncode == 0, _result_evidence(audit)

--- a/tests/spec_conformance/test_manifest_reqs.py
+++ b/tests/spec_conformance/test_manifest_reqs.py
@@ -19,6 +19,7 @@ import jsonschema
 import pytest
 
 from apm_cli.adapters.client.base import MCPClientAdapter
+from apm_cli.deps.plugin_parser import normalize_plugin_directory
 from apm_cli.install.phases.finalize import _hint_project_compile_needed
 from apm_cli.install.target_filter import resolve_effective_package_targets
 from apm_cli.integration.agent_integrator import AgentIntegrator
@@ -299,6 +300,57 @@ def test_consumer_diagnoses_empty_skill_subset_match(tmp_path: Path) -> None:
         "MUST emit a default-visible diagnostic",
         "requested skill names, and the available skill names",
     )
+
+
+@pytest.mark.req("req-mf-022")
+def test_consumer_names_skills_a_plugin_collection_exposes(tmp_path: Path) -> None:
+    """The available-names half of req-mf-022 must answer with the real set.
+
+    Section 8.1 counts a plugin collection with a named-skills container
+    among the layouts that expose selectable skills. Such a container,
+    declared in the plugin manifest, was normalized under its own name --
+    one level below the depth enumeration reads -- so a subset that matched
+    nothing reported `(none)` as available for a dependency exposing two.
+    The diagnostic fired as required and named the wrong set (#2530).
+    """
+    from apm_cli.models.validation import PackageType
+
+    plugin = tmp_path / "dotnet-advanced"
+    plugin_json = plugin / ".claude-plugin" / "plugin.json"
+    plugin_json.parent.mkdir(parents=True)
+    plugin_json.write_text(
+        '{"name": "dotnet-advanced", "version": "1.0.0", "skills": ["./skills/"]}',
+        encoding="utf-8",
+    )
+    for name in ("csharp-scripts", "dotnet-pinvoke"):
+        skill = plugin / "skills" / name
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text(f"# {name}\n", encoding="utf-8")
+
+    normalize_plugin_directory(plugin, plugin_json)
+
+    # The declared container names the skills; it is not itself one.
+    normalized = plugin / ".apm" / "skills"
+    assert not (normalized / "skills").exists()
+    assert (normalized / "csharp-scripts" / "SKILL.md").is_file()
+
+    available = SkillIntegrator.available_skill_names(
+        SimpleNamespace(install_path=plugin, package_type=PackageType.MARKETPLACE_PLUGIN)
+    )
+    assert available == frozenset({"csharp-scripts", "dotnet-pinvoke"})
+
+    diagnostics = DiagnosticCollector()
+    SkillIntegrator._warn_no_skill_filter_match(
+        available,
+        ("missing",),
+        "acme/dotnet-advanced",
+        diagnostics=diagnostics,
+    )
+    warning = diagnostics.by_category()[CATEGORY_WARNING][0]
+    assert "Available: csharp-scripts, dotnet-pinvoke" in warning.message
+    assert "Available: (none)" not in warning.message
+
+    assert_spec_contains("with a named-skills container")
 
 
 @pytest.mark.req("req-mf-024")

--- a/tests/spec_conformance/test_manifest_reqs.py
+++ b/tests/spec_conformance/test_manifest_reqs.py
@@ -353,6 +353,53 @@ def test_consumer_names_skills_a_plugin_collection_exposes(tmp_path: Path) -> No
     assert_spec_contains("with a named-skills container")
 
 
+@pytest.mark.req("req-mf-022")
+def test_consumer_names_only_the_skills_a_plugin_manifest_declares(tmp_path: Path) -> None:
+    """req-mf-022's available-names clause answers from the manifest, not the tree.
+
+    Section 8.1 settles which set that is for a plugin collection: artifacts
+    are mapped per the plugin manifest, so the resolved declaration is the
+    container of individually addressable entries. Deployment re-derived the
+    set from the raw pre-resolution `skills/` directory instead, so a plugin
+    declaring one of two sibling skills reported -- and deployed -- both. The
+    diagnostic named a skill the consumer had no manifest basis to offer
+    (#2537).
+    """
+    from apm_cli.models.validation import PackageType
+
+    plugin = tmp_path / "selective"
+    plugin_json = plugin / ".claude-plugin" / "plugin.json"
+    plugin_json.parent.mkdir(parents=True)
+    plugin_json.write_text(
+        '{"name": "selective", "version": "1.0.0", "skills": ["./skills/declared"]}',
+        encoding="utf-8",
+    )
+    for name in ("declared", "undeclared"):
+        skill = plugin / "skills" / name
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text(f"# {name}\n", encoding="utf-8")
+
+    normalize_plugin_directory(plugin, plugin_json)
+
+    available = SkillIntegrator.available_skill_names(
+        SimpleNamespace(install_path=plugin, package_type=PackageType.MARKETPLACE_PLUGIN)
+    )
+    assert available == frozenset({"declared"})
+
+    diagnostics = DiagnosticCollector()
+    SkillIntegrator._warn_no_skill_filter_match(
+        available,
+        ("undeclared",),
+        "acme/selective",
+        diagnostics=diagnostics,
+    )
+    warning = diagnostics.by_category()[CATEGORY_WARNING][0]
+    assert "Available: declared" in warning.message
+    assert "undeclared" not in warning.message.split("Available:")[1]
+
+    assert_spec_contains("Artifacts are mapped into deploy directories per the plugin")
+
+
 @pytest.mark.req("req-mf-024")
 def test_consumer_preserves_registry_identity_on_structured_rewrite(monkeypatch):
     """req-mf-024: a registry-sourced (`id:`) entry MUST NOT be silently

--- a/tests/spec_conformance/test_manifest_reqs.py
+++ b/tests/spec_conformance/test_manifest_reqs.py
@@ -353,9 +353,9 @@ def test_consumer_names_skills_a_plugin_collection_exposes(tmp_path: Path) -> No
     assert_spec_contains("with a named-skills container")
 
 
-@pytest.mark.req("req-mf-022")
-def test_consumer_names_only_the_skills_a_plugin_manifest_declares(tmp_path: Path) -> None:
-    """req-mf-022's available-names clause answers from the manifest, not the tree.
+@pytest.mark.req("req-pr-006")
+def test_plugin_skills_declaration_is_authoritative(tmp_path: Path) -> None:
+    """req-pr-006 resolves plugin names from the declaration, not the tree.
 
     Section 8.1 settles which set that is for a plugin collection: artifacts
     are mapped per the plugin manifest, so the resolved declaration is the
@@ -397,7 +397,13 @@ def test_consumer_names_only_the_skills_a_plugin_manifest_declares(tmp_path: Pat
     assert "Available: declared" in warning.message
     assert "undeclared" not in warning.message.split("Available:")[1]
 
-    assert_spec_contains("Artifacts are mapped into deploy directories per the plugin")
+    assert_spec_contains(
+        "Only an omitted",
+        "list of strings and replaces that",
+        "an explicit empty list contributes no skills",
+        "missing, unreadable, malformed, escaping,",
+        "Only the resulting names are eligible for enumeration",
+    )
 
 
 @pytest.mark.req("req-mf-024")

--- a/tests/unit/install/test_agent_plugin_deployment_boundary.py
+++ b/tests/unit/install/test_agent_plugin_deployment_boundary.py
@@ -388,9 +388,12 @@ def test_skill_integrator_direct_entry_points_reject_native_package(tmp_path: Pa
 
 
 def test_marketplace_plugin_remains_on_legacy_skill_route(tmp_path: Path) -> None:
-    normalized_skill = tmp_path / ".apm" / "skills" / "legacy"
-    normalized_skill.mkdir(parents=True)
-    (normalized_skill / "SKILL.md").write_text("legacy\n", encoding="utf-8")
+    from apm_cli.deps.plugin_parser import _map_plugin_artifacts
+
+    skill = tmp_path / "skills" / "legacy"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("legacy\n", encoding="utf-8")
+    _map_plugin_artifacts(tmp_path, tmp_path / ".apm", {"skills": ["./skills/legacy"]})
     package_info = PackageInfo(
         package=APMPackage(name="legacy", version="1.0.0"),
         install_path=tmp_path,

--- a/tests/unit/install/test_drift_phase3.py
+++ b/tests/unit/install/test_drift_phase3.py
@@ -40,6 +40,7 @@ from apm_cli.install.drift import (
     _governed_root_dirs,
     _inline_diff_for,
     _make_integrators,
+    _normalize_legacy_local_plugin_for_replay,
     _read_apm_yml_target,
     _walk_managed,
     diff_scratch_against_project,
@@ -169,6 +170,39 @@ class TestMaterializeInstallPath:
         dep = LockedDependency(repo_url="owner/repo", resolved_commit=None)
         with pytest.raises(CacheMissError, match="no resolved_commit"):
             _materialize_install_path(dep, tmp_path, tmp_path / "apm_modules", cache_only=True)
+
+
+class TestLegacyPluginReplayNormalization:
+    def test_native_agent_plugin_bypasses_legacy_normalization(self, tmp_path: Path) -> None:
+        from apm_cli.agent_plugins.constants import PLUGIN_SCHEMA_ID
+
+        plugin = tmp_path / "native"
+        plugin.mkdir()
+        (plugin / "plugin.json").write_text(
+            json.dumps(
+                {
+                    "$schema": PLUGIN_SCHEMA_ID,
+                    "name": "native.plugin",
+                    "version": "1.0.0",
+                    "extensions": {"com.microsoft.apm": {"schemaVersion": "1"}},
+                }
+            ),
+            encoding="utf-8",
+        )
+        dependency = LockedDependency(
+            repo_url="./native",
+            source="local",
+            local_path="./native",
+        )
+
+        result = _normalize_legacy_local_plugin_for_replay(
+            dependency,
+            plugin,
+            tmp_path / "apm_modules",
+        )
+
+        assert result == plugin
+        assert not (tmp_path / "apm_modules").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_plugin_parser.py
+++ b/tests/unit/test_plugin_parser.py
@@ -255,6 +255,100 @@ class TestMapPluginArtifacts:
         assert (apm_dir / "skills" / "skills" / "SKILL.md").read_text() == "# A"
         assert (apm_dir / "skills" / "extra-skills" / "SKILL.md").read_text() == "# B"
 
+    def test_declared_skills_container_flattens_to_one_level(self, tmp_path):
+        """A declared container merges its skills instead of nesting itself.
+
+        Regression for #2530: ``"skills": ["./skills/"]`` names the
+        conventional container, not a skill. Copying it under its own name
+        buried every skill at ``.apm/skills/skills/<name>/`` -- one level
+        below where deployment, ``--skill`` enumeration, the bin/ security
+        scan and primitive counting all look.
+        """
+        plugin_dir = tmp_path / "plugin"
+        plugin_dir.mkdir()
+        container = plugin_dir / "skills"
+        for name in ("csharp-scripts", "dotnet-pinvoke"):
+            skill = container / name
+            skill.mkdir(parents=True)
+            (skill / "SKILL.md").write_text(f"# {name}", encoding="utf-8")
+
+        apm_dir = plugin_dir / ".apm"
+        apm_dir.mkdir()
+        _map_plugin_artifacts(plugin_dir, apm_dir, manifest={"skills": ["./skills/"]})
+
+        normalized = apm_dir / "skills"
+        assert not (normalized / "skills").exists()
+        assert (normalized / "csharp-scripts" / "SKILL.md").read_text() == "# csharp-scripts"
+        assert (normalized / "dotnet-pinvoke" / "SKILL.md").read_text() == "# dotnet-pinvoke"
+
+    def test_declared_skills_string_single_skill_keeps_leaf_name(self, tmp_path):
+        """The string form classifies per entry too, not only the array form.
+
+        ``"skills": "./skills/engineering/tdd"`` names one skill. Merging its
+        contents would spill a bare ``SKILL.md`` into the shared skills root
+        under no name, leaving ``--skill`` with nothing to match -- the #2530
+        symptom reached through the other manifest shape.
+        """
+        plugin_dir = tmp_path / "plugin"
+        plugin_dir.mkdir()
+        skill = plugin_dir / "skills" / "engineering" / "tdd"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text("# tdd", encoding="utf-8")
+
+        apm_dir = plugin_dir / ".apm"
+        apm_dir.mkdir()
+        _map_plugin_artifacts(
+            plugin_dir,
+            apm_dir,
+            manifest={"skills": "./skills/engineering/tdd"},
+        )
+
+        normalized = apm_dir / "skills"
+        assert (normalized / "tdd" / "SKILL.md").read_text() == "# tdd"
+        assert not (normalized / "SKILL.md").exists()
+
+    def test_declared_skills_string_container_flattens(self, tmp_path):
+        """The string form of a container merges, same as the array form."""
+        plugin_dir = tmp_path / "plugin"
+        plugin_dir.mkdir()
+        for name in ("alpha", "beta"):
+            skill = plugin_dir / "skills" / name
+            skill.mkdir(parents=True)
+            (skill / "SKILL.md").write_text(f"# {name}", encoding="utf-8")
+
+        apm_dir = plugin_dir / ".apm"
+        apm_dir.mkdir()
+        _map_plugin_artifacts(plugin_dir, apm_dir, manifest={"skills": "./skills/"})
+
+        normalized = apm_dir / "skills"
+        assert not (normalized / "skills").exists()
+        assert (normalized / "alpha" / "SKILL.md").read_text() == "# alpha"
+        assert (normalized / "beta" / "SKILL.md").read_text() == "# beta"
+
+    def test_declared_nested_skill_path_keeps_leaf_name(self, tmp_path):
+        """A declared entry that IS a skill lands under its own leaf name."""
+        plugin_dir = tmp_path / "plugin"
+        plugin_dir.mkdir()
+        skill = plugin_dir / "skills" / "engineering" / "tdd"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text("# tdd", encoding="utf-8")
+        sibling = plugin_dir / "skills" / "engineering" / "pairing"
+        sibling.mkdir(parents=True)
+        (sibling / "SKILL.md").write_text("# pairing", encoding="utf-8")
+
+        apm_dir = plugin_dir / ".apm"
+        apm_dir.mkdir()
+        _map_plugin_artifacts(
+            plugin_dir,
+            apm_dir,
+            manifest={"skills": ["./skills/engineering/tdd"]},
+        )
+
+        normalized = apm_dir / "skills"
+        assert (normalized / "tdd" / "SKILL.md").read_text() == "# tdd"
+        # Undeclared siblings stay out: the entry is a requirement, not a hint.
+        assert not (normalized / "pairing").exists()
+
     def test_custom_commands_path(self, tmp_path):
         """Manifest commands field redirects command discovery."""
         plugin_dir = tmp_path / "plugin"

--- a/tests/unit/test_plugin_parser.py
+++ b/tests/unit/test_plugin_parser.py
@@ -16,6 +16,7 @@ from apm_cli.deps.plugin_parser import (
     _map_plugin_artifacts,
     _mcp_servers_to_apm_deps,
     normalize_plugin_directory,
+    normalized_plugin_skill_sources,
     parse_plugin_manifest,
     synthesize_apm_yml_from_plugin,
     validate_plugin_package,
@@ -214,6 +215,133 @@ class TestMapPluginArtifacts:
         _map_plugin_artifacts(plugin_dir, apm_dir)
 
         assert (apm_dir / "skills" / "my-skill" / "SKILL.md").exists()
+
+    def test_skill_receipt_reconciles_removed_declarations(self, tmp_path):
+        plugin_dir = tmp_path / "plugin"
+        plugin_dir.mkdir()
+        for name in ("alpha", "beta"):
+            skill = plugin_dir / "skills" / name
+            skill.mkdir(parents=True)
+            (skill / "SKILL.md").write_text(f"# {name}", encoding="utf-8")
+
+        apm_dir = plugin_dir / ".apm"
+        _map_plugin_artifacts(plugin_dir, apm_dir, {"skills": ["./skills/"]})
+        assert set(normalized_plugin_skill_sources(plugin_dir)[0]) == {"alpha", "beta"}
+
+        _map_plugin_artifacts(plugin_dir, apm_dir, {"skills": []})
+
+        sources, declared = normalized_plugin_skill_sources(plugin_dir)
+        assert sources == {}
+        assert declared is True
+        assert not (apm_dir / "skills" / "alpha").exists()
+        assert not (apm_dir / "skills" / "beta").exists()
+
+    def test_skill_receipt_removes_prior_skills_for_file_only_declaration(self, tmp_path):
+        """A file-only declaration must remove prior parser-owned skill directories."""
+        plugin_dir = tmp_path / "plugin"
+        for name in ("alpha", "beta"):
+            skill = plugin_dir / "skills" / name
+            skill.mkdir(parents=True)
+            (skill / "SKILL.md").write_text(f"# {name}", encoding="utf-8")
+
+        apm_dir = plugin_dir / ".apm"
+        _map_plugin_artifacts(plugin_dir, apm_dir, {"skills": ["./skills/"]})
+        (plugin_dir / "loose.md").write_text("# not a skill\n", encoding="utf-8")
+        _map_plugin_artifacts(plugin_dir, apm_dir, {"skills": ["./loose.md"]})
+
+        assert normalized_plugin_skill_sources(plugin_dir) == ({}, True)
+        assert not (apm_dir / "skills" / "alpha").exists()
+        assert not (apm_dir / "skills" / "beta").exists()
+
+    def test_skill_receipt_preserves_nested_declared_source(self, tmp_path):
+        plugin_dir = tmp_path / "plugin"
+        skill = plugin_dir / "skills" / "engineering" / "tdd"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text("# tdd", encoding="utf-8")
+
+        _map_plugin_artifacts(
+            plugin_dir,
+            plugin_dir / ".apm",
+            {"skills": ["./skills/engineering/tdd"]},
+        )
+
+        sources, declared = normalized_plugin_skill_sources(plugin_dir)
+        assert declared is True
+        assert sources == {"tdd": skill}
+        assert (plugin_dir / ".apm" / "skills" / "tdd" / "SKILL.md").is_file()
+
+    def test_duplicate_declared_skill_leaf_names_fail_closed(self, tmp_path):
+        plugin_dir = tmp_path / "plugin"
+        for parent in ("engineering", "operations"):
+            skill = plugin_dir / "skills" / parent / "runbook"
+            skill.mkdir(parents=True)
+            (skill / "SKILL.md").write_text(f"# {parent}", encoding="utf-8")
+
+        _map_plugin_artifacts(
+            plugin_dir,
+            plugin_dir / ".apm",
+            {"skills": ["./skills/engineering/runbook", "./skills/operations/runbook"]},
+        )
+
+        sources, declared = normalized_plugin_skill_sources(plugin_dir)
+        assert declared is True
+        assert sources == {}
+
+    def test_malformed_skills_declaration_disables_default_discovery(self, tmp_path):
+        plugin_dir = tmp_path / "plugin"
+        skill = plugin_dir / "skills" / "alpha"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text("# alpha", encoding="utf-8")
+
+        _map_plugin_artifacts(plugin_dir, plugin_dir / ".apm", {"skills": {"path": "./skills"}})
+
+        sources, declared = normalized_plugin_skill_sources(plugin_dir)
+        assert declared is False
+        assert sources == {}
+
+    def test_skill_receipt_ignores_untracked_staged_normalized_skill(self, tmp_path):
+        plugin_dir = tmp_path / "plugin"
+        staged = plugin_dir / ".apm" / "skills" / "untracked"
+        staged.mkdir(parents=True)
+        (staged / "SKILL.md").write_text("# untracked", encoding="utf-8")
+
+        _map_plugin_artifacts(plugin_dir, plugin_dir / ".apm", {"skills": []})
+
+        assert normalized_plugin_skill_sources(plugin_dir) == ({}, True)
+
+    def test_plugin_artifact_mapping_rejects_symlinked_apm_destination(self, tmp_path):
+        """A plugin cannot redirect normalization cleanup through ``.apm``."""
+        plugin_dir = tmp_path / "plugin"
+        plugin_dir.mkdir()
+        external = tmp_path / "external"
+        sentinel = external / "skills" / "sentinel"
+        sentinel.mkdir(parents=True)
+        (sentinel / "SKILL.md").write_text("# sentinel", encoding="utf-8")
+        try:
+            (plugin_dir / ".apm").symlink_to(external, target_is_directory=True)
+        except OSError:
+            pytest.skip("Symlinks not supported on this platform")
+
+        with pytest.raises(PluginIntegrityError, match="symlinked destination"):
+            _map_plugin_artifacts(plugin_dir, plugin_dir / ".apm", {"skills": []})
+
+        assert (sentinel / "SKILL.md").is_file()
+
+    def test_plugin_artifact_mapping_canonicalizes_a_symlinked_plugin_root(self, tmp_path):
+        """A safe symlink to the plugin root still yields a valid receipt."""
+        plugin_dir = tmp_path / "plugin"
+        skill = plugin_dir / "skills" / "alpha"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text("# alpha", encoding="utf-8")
+        alias = tmp_path / "plugin-alias"
+        try:
+            alias.symlink_to(plugin_dir, target_is_directory=True)
+        except OSError:
+            pytest.skip("Symlinks not supported on this platform")
+
+        _map_plugin_artifacts(alias, alias / ".apm", {"skills": ["./skills/alpha"]})
+
+        assert normalized_plugin_skill_sources(alias) == ({"alpha": skill}, True)
 
     def test_map_commands_to_prompts(self, tmp_path):
         plugin_dir = tmp_path / "plugin"

--- a/tests/unit/test_plugin_parser.py
+++ b/tests/unit/test_plugin_parser.py
@@ -1,6 +1,7 @@
 """Unit tests for plugin_parser.py and find_plugin_json helper."""
 
 import json
+import logging
 import os
 from pathlib import Path
 
@@ -348,6 +349,45 @@ class TestMapPluginArtifacts:
         assert (normalized / "tdd" / "SKILL.md").read_text() == "# tdd"
         # Undeclared siblings stay out: the entry is a requirement, not a hint.
         assert not (normalized / "pairing").exists()
+
+    def test_declared_skills_entry_holding_no_skill_warns(self, tmp_path, caplog):
+        """An entry that is neither a skill nor a container must say so.
+
+        A container whose skills sit two levels down reaches no deployable
+        depth under either mapping. The copy stays put -- the entry keeps its
+        own name so unrecognized content stays out of the shared skills root
+        -- but the plugin author gets the one line that #2530 lacked instead
+        of an install that looks clean and deploys nothing.
+        """
+        plugin_dir = tmp_path / "plugin"
+        plugin_dir.mkdir()
+        buried = plugin_dir / "skills" / "engineering" / "tdd"
+        buried.mkdir(parents=True)
+        (buried / "SKILL.md").write_text("# tdd", encoding="utf-8")
+
+        apm_dir = plugin_dir / ".apm"
+        apm_dir.mkdir()
+        with caplog.at_level(logging.WARNING, logger="apm_cli.deps.plugin_parser"):
+            _map_plugin_artifacts(plugin_dir, apm_dir, manifest={"skills": ["./skills/"]})
+
+        assert "skills" in caplog.text
+        assert "no SKILL.md" in caplog.text
+        assert "--skill" in caplog.text
+
+    def test_declared_skills_container_does_not_warn(self, tmp_path, caplog):
+        """The healthy shapes stay quiet -- a warning nobody can act on is noise."""
+        plugin_dir = tmp_path / "plugin"
+        plugin_dir.mkdir()
+        skill = plugin_dir / "skills" / "csharp-scripts"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text("# csharp-scripts", encoding="utf-8")
+
+        apm_dir = plugin_dir / ".apm"
+        apm_dir.mkdir()
+        with caplog.at_level(logging.WARNING, logger="apm_cli.deps.plugin_parser"):
+            _map_plugin_artifacts(plugin_dir, apm_dir, manifest={"skills": ["./skills/"]})
+
+        assert "no SKILL.md" not in caplog.text
 
     def test_custom_commands_path(self, tmp_path):
         """Manifest commands field redirects command discovery."""

--- a/tests/unit/test_plugin_parser.py
+++ b/tests/unit/test_plugin_parser.py
@@ -12,6 +12,7 @@ from apm_cli.deps.plugin_parser import (
     PluginIntegrityError,
     _extract_mcp_servers,
     _generate_apm_yml,
+    _holds_skill_dirs,
     _map_plugin_artifacts,
     _mcp_servers_to_apm_deps,
     normalize_plugin_directory,
@@ -109,6 +110,79 @@ class TestParsePluginManifest:
 
         with pytest.raises(ValueError, match="Invalid JSON"):
             parse_plugin_manifest(pj)
+
+
+class TestHoldsSkillDirs:
+    """Direct coverage for the per-entry classifier behind #2530.
+
+    Fixtures reach it through ``_map_plugin_artifacts``, which exercises the
+    two healthy shapes -- a skill, and a container of them. The branches that
+    say "neither" are the ones deciding whether unrecognized content merges
+    into the shared skills root, and they were only ever reached transitively.
+    Pin them here: anything a wrong answer lets through lands in
+    ``.apm/skills/`` under no name of its own.
+    """
+
+    def test_own_skill_md_wins_over_a_nested_one(self, tmp_path):
+        """Carrying ``SKILL.md`` settles it -- children are not consulted.
+
+        Both shapes are present here, so this pins the precedence rather
+        than restating either branch: merging such an entry would spill a
+        bare ``SKILL.md`` into the shared skills root under no name at all.
+        """
+        skill = tmp_path / "engineering"
+        skill.mkdir()
+        (skill / "SKILL.md").write_text("# engineering", encoding="utf-8")
+        (skill / "tdd").mkdir()
+        (skill / "tdd" / "SKILL.md").write_text("# tdd", encoding="utf-8")
+
+        assert _holds_skill_dirs(skill) is False
+
+    def test_directory_of_skill_directories_is_a_container(self, tmp_path):
+        container = tmp_path / "skills"
+        (container / "tdd").mkdir(parents=True)
+        (container / "tdd" / "SKILL.md").write_text("# tdd", encoding="utf-8")
+
+        assert _holds_skill_dirs(container) is True
+
+    def test_empty_directory_is_not_a_container(self, tmp_path):
+        empty = tmp_path / "skills"
+        empty.mkdir()
+
+        # ``any()`` over nothing is False, so an empty declared container
+        # keeps its own name rather than merging -- there is nothing to
+        # merge, and treating it as a container would be a guess.
+        assert _holds_skill_dirs(empty) is False
+
+    def test_directory_whose_skills_sit_two_levels_down_is_not_a_container(self, tmp_path):
+        container = tmp_path / "skills"
+        (container / "engineering" / "tdd").mkdir(parents=True)
+        (container / "engineering" / "tdd" / "SKILL.md").write_text("# tdd", encoding="utf-8")
+
+        assert _holds_skill_dirs(container) is False
+
+    def test_missing_directory_is_not_a_container(self, tmp_path):
+        # ``iterdir`` raises FileNotFoundError -- an OSError -- rather than
+        # yielding nothing. A declared entry that vanished between
+        # resolution and mapping must not be read as a merge instruction.
+        assert _holds_skill_dirs(tmp_path / "gone") is False
+
+    def test_unreadable_directory_is_not_a_container(self, tmp_path, monkeypatch):
+        """A directory APM cannot list must fail closed, not merge blind.
+
+        Permission errors are the shape this guards on POSIX; they are
+        raised here directly because chmod is advisory for root and a no-op
+        for directory listing on Windows.
+        """
+        unreadable = tmp_path / "skills"
+        unreadable.mkdir()
+
+        def _deny(self):
+            raise PermissionError(13, "Permission denied")
+
+        monkeypatch.setattr(Path, "iterdir", _deny)
+
+        assert _holds_skill_dirs(unreadable) is False
 
 
 class TestMapPluginArtifacts:

--- a/tests/unit/test_symlink_containment.py
+++ b/tests/unit/test_symlink_containment.py
@@ -282,14 +282,10 @@ class TestIgnoreNonContentSourceGuard(unittest.TestCase):
     three modules (plugin_parser, packer, unpacker).
     """
 
-    # (import_path, module_attr, min_ignore_non_content_references)
-    # plugin_parser has 7 copytree calls in total: 2 agents + 3 skills +
-    # 2 hooks. After PR #1153 follow-up #2, ALL 7 use ignore_non_content;
-    # the import + 7 call sites yields >= 8 references.
-    _MODULES: typing.ClassVar[list[tuple[str, str, int]]] = [
-        ("apm_cli.deps", "plugin_parser", 5),
-        ("apm_cli.bundle", "packer", 2),
-        ("apm_cli.bundle", "unpacker", 2),
+    _MODULES: typing.ClassVar[list[tuple[str, str]]] = [
+        ("apm_cli.deps", "plugin_parser"),
+        ("apm_cli.bundle", "packer"),
+        ("apm_cli.bundle", "unpacker"),
     ]
 
     def test_copytree_sites_use_ignore_non_content(self):
@@ -299,24 +295,69 @@ class TestIgnoreNonContentSourceGuard(unittest.TestCase):
         Source-level guard: if a future refactor drops the callback at any
         site, this test fails before a stale or malicious ``.apm-pin`` can
         leak into the deploy target.
+
+        Asserted per call site via AST rather than by counting substrings: a
+        hand-maintained occurrence floor silently loosens whenever call sites
+        are merged or split, and it cannot tell a real argument from the same
+        identifier mentioned in a docstring.
         """
+        import ast
         import importlib
         import inspect
 
-        for pkg, mod_name, min_refs in self._MODULES:
+        def _is_shutil_copytree(node: ast.AST) -> bool:
+            """Match ``shutil.copytree(...)`` and a bare imported ``copytree``.
+
+            Deliberately not "any attribute named copytree": an unrelated
+            helper exposing that name is not what this guard is about, and
+            demanding ``ignore=`` from it would be a false failure.
+            """
+            if not isinstance(node, ast.Call):
+                return False
+            func = node.func
+            if isinstance(func, ast.Attribute):
+                return func.attr == "copytree" and (
+                    isinstance(func.value, ast.Name) and func.value.id == "shutil"
+                )
+            return isinstance(func, ast.Name) and func.id == "copytree"
+
+        def _guarded(node: ast.Call) -> bool:
+            """True when the call's ``ignore=`` names the content filter.
+
+            The argument's whole subtree is searched, so a composing helper
+            (``ignore=_wrap(ignore_non_content)``) still counts while
+            ``ignore=None`` or an unrelated callback does not. Presence of
+            the keyword alone is not enough -- that was the hole the earlier
+            occurrence count happened to cover.
+            """
+            for kw in node.keywords:
+                if kw.arg != "ignore":
+                    continue
+                return any(
+                    isinstance(sub, ast.Name) and sub.id == "ignore_non_content"
+                    for sub in ast.walk(kw.value)
+                )
+            return False
+
+        for pkg, mod_name in self._MODULES:
             with self.subTest(module=f"{pkg}.{mod_name}"):
                 mod = importlib.import_module(f"{pkg}.{mod_name}")
-                source = inspect.getsource(mod)
+                tree = ast.parse(inspect.getsource(mod))
 
-                copytree_count = source.count("shutil.copytree(")
-                ignore_refs = source.count("ignore_non_content")
+                sites = [node for node in ast.walk(tree) if _is_shutil_copytree(node)]
+                self.assertTrue(
+                    sites,
+                    f"{pkg}.{mod_name}: no copytree call sites found -- the guard "
+                    "is no longer watching anything; retarget or remove it",
+                )
 
-                self.assertGreaterEqual(
-                    ignore_refs,
-                    min_refs,
-                    f"{pkg}.{mod_name}: expected >={min_refs} ignore_non_content "
-                    f"references (for {copytree_count} copytree calls); "
-                    f"found {ignore_refs}",
+                unguarded = [node.lineno for node in sites if not _guarded(node)]
+                self.assertEqual(
+                    unguarded,
+                    [],
+                    f"{pkg}.{mod_name}: copytree at line(s) {unguarded} do not pass "
+                    "ignore=ignore_non_content -- .apm-pin and symlinks can leak "
+                    "into the deploy tree",
                 )
 
 


### PR DESCRIPTION
Closes #2537. Stacked on #2536 — review that one first; this branch carries its two commits, and the diff below is the third one plus the review follow-ups.

## Problem

A plugin's raw root `skills/` directory overrode its resolved `plugin.json` declaration, so the deployed set could differ from the declared one in both directions — silently.

With `skills/{a,b}` at the plugin root:

| `plugin.json` `skills` | resolved into `.apm/skills` | deployed before | deployed now |
| --- | --- | --- | --- |
| `["./skills/a"]` | `a` | `a`, `b` | `a` |
| `["./skills/", "./extra/solo"]` | `a`, `b`, `solo` | `a`, `b` | `a`, `b`, `solo` |
| `["./skills/a", "./skills/b"]` | `a`, `b` | `a`, `b` | `a`, `b` |

Normalization already resolves the manifest into `.apm/skills/`, where a declared array replaces default discovery rather than adding to it. Deployment ignored that result and re-derived its own set from the pre-resolution tree.

## Change

`skill_source_paths` maps each deployable skill name to the directory it is promoted from, and backs both deployment and `--skill` enumeration. For a plugin the resolved declaration decides which skills exist.

Two consequences fall out of treating the resolution as authoritative, both intended:

- `"skills": []` now means no skills, as the package-types reference documents.
- A declared component rejected for escaping the plugin root fails closed instead of falling back to whatever the raw tree holds.

## Which skills is not where their content comes from

Each declared skill keeps being **sourced** from the root bundle whenever that copy exists. It is byte-identical to the normalized one but sits one level higher, and that matters: a relative link leaving the skill bundle is rewritten against the package root.

I first implemented this by simply routing plugins to `.apm/skills/`, and measured the result against the #2536 branch with the same plugin:

```
#2536  escaping: [guide](../../../apm_modules/_local/plug/docs/guide.md)   rewritten, resolves
naive  escaping: [guide](../../docs/guide.md)                             untouched, points into .claude/
```

`.apm/skills/alpha/` is a directory deeper than `skills/alpha/`, so the author's `../../docs/guide.md` no longer lands inside the package and the resolver leaves it alone. Preferring the root copy keeps that behaviour byte-identical. `test_plugin_skill_links_leaving_the_bundle_survive_declaration_filtering` installs a skill carrying such a link and asserts it is rewritten back at the package; it fails if the preference is removed.

Only skills declared from outside the root container — which never deployed at all before — are read from the normalized copy.

Non-plugin packages are untouched: nothing normalizes their `skills/`, so the raw directory remains the declaration, and `.apm/skills/` stays what it has always been for them — sub-skills promoted alongside a package that is not itself a skill.

## Verification

End-to-end, real packages, unchanged from #2536 including the result shape (`Skill integrated ->` line and counts):

- `dotnet/skills/plugins/dotnet-advanced` — declares the whole container; `--skill csharp-scripts` deploys exactly that skill.
- `DuendeSoftware/duende-skills` — declares its 24 skills individually; 24 skills + 2 agents.

Neither triggers the defect, which is why it went unnoticed; both are here as regression cover for the routing change.

Local plugins covering all three rows of the table above deploy exactly the declared set.

Full suite diffed against clean `main` on the same machine: identical failure sets, `100 subtests passed` on both, +9 from the new tests across both commits. Each new test was toggle-verified — reverting the corresponding change individually turns it red.

## Review follow-ups

The advisory panel shipped with follow-ups; all five landed in `fb96e932c`.

- **CHANGELOG.** `[Unreleased] → Fixed` entry that leads with the behaviour change for plugin authors — a manifest declaring a subset of what `skills/` holds stops deploying the rest — and how to keep the old set.
- **Docs.** `deploy-a-bundle.md` step 4 and the plugin-collection section of the package-types reference now both state that a declared key replaces the directory scan rather than adding to it.
- **Zero deployable skills is no longer silent.** Most plugins ship no skills and none of them should be nagged, so the note fires only at the shape where the answer changed: a declaration resolving to nothing while the package does carry a root `skills/` bundle. It names the skills left behind; the fix guidance sits behind `--verbose`. Emitted once per install regardless of target count.
- **`skill_source_dir` → `_skill_source_dir`.** It answers with a single directory, which is incomplete for a plugin, and reading it directly on a plugin path is how the raw tree came to override the declaration. `skill_source_paths` is the routing entry point; the private name keeps that structural rather than documentary. Introduced in #2530 and unmerged, so nothing outside this stack can be relying on it.
- **`_holds_skill_dirs` fail-closed branches.** Direct tests for the empty directory, skills buried a level deeper, a directory that vanished, and one that cannot be listed; precedence pinned with both shapes present at once.

Spec conformance took the citation route rather than a waiver. Section 8.1 settles which container holds a plugin collection's individually addressable skills — artifacts are mapped per the plugin manifest — and req-mf-022 requires the no-match diagnostic to name the available ones. Before the fix it named, and deployed, siblings the manifest never declared. `CONFORMANCE.{json,md}` regenerated.

Every follow-up test was toggle-verified in both directions: reverting each corresponding change individually turns exactly the matching test red.
