### PR TITLE
fix(plugins): stop root-declared components copying the plugin into itself (closes #2556)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of spilling a bare `SKILL.md` into the shared skills root.
   (closes #2530)
 - Root-declared plugin components (Claude Code single-skill shape
-  `skills: ["./"]`, and the same for agents/commands/hooks) no longer cause
+  `"skills": ["./"]`, and the same for agents/commands/hooks) no longer cause
   infinite recursion or unbounded writes during `apm install`. (closes #2556)
 - Multi-target `apm compile` now avoids repeating expensive project analysis
   for each target, making multi-target runs scale like single-target runs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`"skills": "./skills/engineering/tdd"`) still lands under its own leaf name
   instead of spilling a bare `SKILL.md` into the shared skills root.
   (closes #2530)
+- Root-declared plugin components (Claude Code single-skill shape
+  `skills: ["./"]`, and the same for agents/commands/hooks) no longer cause
+  infinite recursion or unbounded writes during `apm install`. (closes #2556)
 - Multi-target `apm compile` now avoids repeating expensive project analysis
   for each target, making multi-target runs scale like single-target runs
   without changing generated output. (closes #2482)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (closes #2530)
 - Root-declared plugin components (Claude Code single-skill shape
   `"skills": ["./"]`, and the same for agents/commands/hooks) no longer cause
-  infinite recursion or unbounded writes during `apm install`. (closes #2556)
+  infinite recursion or unbounded writes during `apm install`.
+  `docs/src/content/docs/specs/openapm-v0.1.md` now explicitly requires
+  containment of consumer-generated staging output. (closes #2556)
 - Multi-target `apm compile` now avoids repeating expensive project analysis
   for each target, making multi-target runs scale like single-target runs
   without changing generated output. (closes #2482)

--- a/CONFORMANCE.json
+++ b/CONFORMANCE.json
@@ -835,6 +835,17 @@
       ]
     },
     {
+      "conformance_class": "consumer",
+      "id": "req-pr-007",
+      "keyword": "MUST",
+      "section": "8.1",
+      "status": "active",
+      "test_count": 1,
+      "tests": [
+        "tests/spec_conformance/test_resolution_reqs.py::test_root_declared_plugin_component_excludes_generated_staging_tree"
+      ]
+    },
+    {
       "conformance_class": "registry",
       "id": "req-rg-001",
       "keyword": "MUST",
@@ -1325,7 +1336,7 @@
   "spec_version": "v0.1.1",
   "summary_by_class": {
     "consumer": {
-      "active": 85,
+      "active": 86,
       "skipped": 1,
       "unbound": 0,
       "xfail": 0
@@ -1349,5 +1360,5 @@
       "xfail": 0
     }
   },
-  "total_requirements": 116
+  "total_requirements": 117
 }

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -19,7 +19,7 @@ All four conformance classes (Producer, Consumer, Registry, Governance) carry ac
 | Class | Active | Skipped | Xfail | Unbound |
 |-------|-------:|--------:|------:|--------:|
 | Producer | 12 | 0 | 0 | 0 |
-| Consumer | 85 | 1 | 0 | 0 |
+| Consumer | 86 | 1 | 0 | 0 |
 | Registry | 1 | 0 | 0 | 0 |
 | Governance | 17 | 0 | 0 | 0 |
 
@@ -100,6 +100,7 @@ All four conformance classes (Producer, Consumer, Registry, Governance) carry ac
 | [req-pr-004](docs/src/content/docs/specs/openapm-v0.1.md#req-pr-004) | MUST | 7.8 | producer | active | 10 |
 | [req-pr-005](docs/src/content/docs/specs/openapm-v0.1.md#req-pr-005) | SHOULD | 7.8 | producer | active | 1 |
 | [req-pr-006](docs/src/content/docs/specs/openapm-v0.1.md#req-pr-006) | MUST | 8.1 | consumer | active | 1 |
+| [req-pr-007](docs/src/content/docs/specs/openapm-v0.1.md#req-pr-007) | MUST | 8.1 | consumer | active | 1 |
 | [req-rg-001](docs/src/content/docs/specs/openapm-v0.1.md#req-rg-001) | MUST | 11.3.3 | registry | active | 1 |
 | [req-rs-001](docs/src/content/docs/specs/openapm-v0.1.md#req-rs-001) | MUST | 7.2 | consumer | active | 1 |
 | [req-rs-002](docs/src/content/docs/specs/openapm-v0.1.md#req-rs-002) | MUST | 7.3 | consumer | active | 1 |

--- a/docs/public/specs/manifests/openapm-v0.1.requirements.yml
+++ b/docs/public/specs/manifests/openapm-v0.1.requirements.yml
@@ -436,7 +436,7 @@ requirements:
     keyword: MUST
     section: "8.1"
     conformance_class: consumer
-    notes: "declared Plugin component copying excludes consumer-generated staging subtrees within its source"
+    notes: "declared Plugin component copying canonicalizes its non-symlink source root and prunes the current operation's materialization subtree"
   - id: req-sc-001
     keyword: MUST
     section: "10.4"

--- a/docs/public/specs/manifests/openapm-v0.1.requirements.yml
+++ b/docs/public/specs/manifests/openapm-v0.1.requirements.yml
@@ -432,6 +432,11 @@ requirements:
     section: "8.1"
     conformance_class: consumer
     notes: "legacy plugin skills declarations replace discovery; invalid, escaping, symlinked, and duplicate-derived entries fail closed"
+  - id: req-pr-007
+    keyword: MUST
+    section: "8.1"
+    conformance_class: consumer
+    notes: "declared Plugin component copying excludes consumer-generated staging subtrees within its source"
   - id: req-sc-001
     keyword: MUST
     section: "10.4"

--- a/docs/src/content/docs/specs/openapm-v0.1.md
+++ b/docs/src/content/docs/specs/openapm-v0.1.md
@@ -136,7 +136,7 @@ between the companion corpus and the implementation.
 
 ### 1.3 Document conventions
 
-- OpenAPM v0.1 carries **116 normative statements** indexed in
+- OpenAPM v0.1 carries **117 normative statements** indexed in
   [Appendix C](#appendix-c-index-of-normative-statements).
 - All on-disk files defined by this specification are **YAML 1.2**
   parsed under the safe subset defined in
@@ -2231,6 +2231,11 @@ derived leaf name maps to more than one canonical source contributes no
 skill. Only the resulting names are eligible for enumeration, selection,
 or deployment.
 
+<a id="req-pr-007"></a>
+**[req-pr-007]** A conforming **consumer** implementation MUST, when
+copying a declared Plugin collection component source, exclude every
+consumer-generated staging subtree within that source.
+
 A package **exposes selectable skills** when layout resolution identifies a
 container for individually addressable named skill entries, whether that
 container currently yields zero or more entries. This includes an APM package
@@ -2565,7 +2570,8 @@ without a spec revision. The current matrix is in the companion
   [req-tg-006](#req-tg-006), [req-tg-007](#req-tg-007),
   [req-tg-008](#req-tg-008), [req-tg-009](#req-tg-009),
   [req-tg-010](#req-tg-010), [req-tg-011](#req-tg-011),
-  [req-tg-012](#req-tg-012), [req-pr-006](#req-pr-006).
+  [req-tg-012](#req-tg-012), [req-pr-006](#req-pr-006),
+  [req-pr-007](#req-pr-007).
 
 ---
 
@@ -3123,7 +3129,7 @@ conformance statement identifying:
 [req-rs-015](#req-rs-015), [req-rs-016](#req-rs-016),
 [req-pr-001](#req-pr-001), [req-pr-002](#req-pr-002),
 [req-pr-003](#req-pr-003), [req-tg-001](#req-tg-001),
-[req-pr-006](#req-pr-006),
+[req-pr-006](#req-pr-006), [req-pr-007](#req-pr-007),
 [req-tg-002](#req-tg-002), [req-tg-003](#req-tg-003),
 [req-tg-004](#req-tg-004), [req-tg-005](#req-tg-005),
 [req-tg-006](#req-tg-006), [req-tg-007](#req-tg-007),
@@ -3555,6 +3561,7 @@ renumbering of conformance classes.
 | [req-pr-004](#req-pr-004)                | MUST    | 7.8     | producer    |
 | [req-pr-005](#req-pr-005)                | SHOULD  | 7.8     | producer    |
 | [req-pr-006](#req-pr-006)                | MUST    | 8.1     | consumer    |
+| [req-pr-007](#req-pr-007)                | MUST    | 8.1     | consumer    |
 | [req-tg-001](#req-tg-001)                | MUST    | 8.4     | consumer    |
 | [req-tg-002](#req-tg-002)                | MUST    | 8.5     | consumer    |
 | [req-tg-003](#req-tg-003)                | MUST    | 8.5     | consumer    |
@@ -3585,7 +3592,7 @@ renumbering of conformance classes.
 | [req-cf-001](#req-cf-001)                | MUST    | 12.5    | consumer    |
 | [req-cf-002](#req-cf-002)                | MUST    | 12.3    | consumer    |
 
-**Total normative statements: 116** (111 MUST, 5 SHOULD).
+**Total normative statements: 117** (112 MUST, 5 SHOULD).
 
 ---
 
@@ -3627,6 +3634,7 @@ renumbering of conformance classes.
 | 0.1.29  | 2026-08-22 | Spec-citation fold for the Agent Plugins v1 native-lifecycle deployment boundary (closes #2522 Mode-B silent-extension gate). Added [req-tg-011] (Section 8.5.5, consumer MUST): a consumer MUST treat a schema-bearing Agent Plugins v1 dependency as undeployable until it exposes a machine-verifiable native lifecycle for that dependency; before any target handler or primitive integrator runs, the consumer MUST refuse deployment with one actionable diagnostic, MUST leave the project tree unchanged, MUST NOT fall back to legacy primitive projection, and MUST reach the identical single-diagnostic outcome whether the dependency is materialized alone, mixed with ordinary dependencies in the same install, or under `--dry-run`. Section 8.7 and Appendix C updated. Statement count: 112 -> 113 (108 MUST, 5 SHOULD). |
 | 0.1.30  | 2026-08-23 | Spec-citation fold for plugin-root hook command resolution (closes #2639 Mode-B silent-extension gate). Added [req-tg-012] (Section 8.5.6, consumer MUST): a consumer that resolves plugin-root placeholders treats a matching quoted placeholder followed by an outside path separator equivalently to the fully quoted path, preserves balanced expandable quoting, and emits a default-visible diagnostic instead of silently deploying any supported placeholder that remains unresolved. Section 8.7, Section 11.3.2, and Appendix C updated. Statement count: 114 -> 115 (110 MUST, 5 SHOULD). |
 | 0.1.31  | 2026-08-23 | Spec-citation fold for authoritative legacy plugin skill declarations (closes #2537). Added [req-pr-006] (Section 8.1, consumer MUST): omitted `skills` alone enables conventional discovery; a string or list replaces discovery; explicit empty, invalid, escaping, symlinked, and duplicate-derived entries contribute no skills; declared containers contribute only immediate child skills; and only resulting names are eligible for enumeration, selection, or deployment. Section 8.7, Section 11.3.2, Appendix C, and conformance coverage updated. Statement count: 115 -> 116 (111 MUST, 5 SHOULD). |
+| 0.1.32  | 2026-08-25 | Spec-citation fold for root-declared Plugin component staging containment (closes #2556). Added [req-pr-007] (Section 8.1, consumer MUST): a consumer copying a declared Plugin collection component source excludes every consumer-generated staging subtree within that source. Section 8.7, Section 11.3.2, Appendix C, and conformance coverage updated. Statement count: 116 -> 117 (112 MUST, 5 SHOULD). |
 
 Errata (none at publication).
 

--- a/docs/src/content/docs/specs/openapm-v0.1.md
+++ b/docs/src/content/docs/specs/openapm-v0.1.md
@@ -2233,8 +2233,11 @@ or deployment.
 
 <a id="req-pr-007"></a>
 **[req-pr-007]** A conforming **consumer** implementation MUST, when
-copying a declared Plugin collection component source, exclude every
-consumer-generated staging subtree within that source.
+copying a declared Plugin collection component source, canonicalize the
+non-symlink source root selected for that component. A consumer-generated
+staging subtree is the materialization root created by the current operation
+and every descendant of that root. The consumer MUST prune every such staging
+subtree before traversing the source.
 
 A package **exposes selectable skills** when layout resolution identifies a
 container for individually addressable named skill entries, whether that
@@ -3634,7 +3637,7 @@ renumbering of conformance classes.
 | 0.1.29  | 2026-08-22 | Spec-citation fold for the Agent Plugins v1 native-lifecycle deployment boundary (closes #2522 Mode-B silent-extension gate). Added [req-tg-011] (Section 8.5.5, consumer MUST): a consumer MUST treat a schema-bearing Agent Plugins v1 dependency as undeployable until it exposes a machine-verifiable native lifecycle for that dependency; before any target handler or primitive integrator runs, the consumer MUST refuse deployment with one actionable diagnostic, MUST leave the project tree unchanged, MUST NOT fall back to legacy primitive projection, and MUST reach the identical single-diagnostic outcome whether the dependency is materialized alone, mixed with ordinary dependencies in the same install, or under `--dry-run`. Section 8.7 and Appendix C updated. Statement count: 112 -> 113 (108 MUST, 5 SHOULD). |
 | 0.1.30  | 2026-08-23 | Spec-citation fold for plugin-root hook command resolution (closes #2639 Mode-B silent-extension gate). Added [req-tg-012] (Section 8.5.6, consumer MUST): a consumer that resolves plugin-root placeholders treats a matching quoted placeholder followed by an outside path separator equivalently to the fully quoted path, preserves balanced expandable quoting, and emits a default-visible diagnostic instead of silently deploying any supported placeholder that remains unresolved. Section 8.7, Section 11.3.2, and Appendix C updated. Statement count: 114 -> 115 (110 MUST, 5 SHOULD). |
 | 0.1.31  | 2026-08-23 | Spec-citation fold for authoritative legacy plugin skill declarations (closes #2537). Added [req-pr-006] (Section 8.1, consumer MUST): omitted `skills` alone enables conventional discovery; a string or list replaces discovery; explicit empty, invalid, escaping, symlinked, and duplicate-derived entries contribute no skills; declared containers contribute only immediate child skills; and only resulting names are eligible for enumeration, selection, or deployment. Section 8.7, Section 11.3.2, Appendix C, and conformance coverage updated. Statement count: 115 -> 116 (111 MUST, 5 SHOULD). |
-| 0.1.32  | 2026-08-25 | Spec-citation fold for root-declared Plugin component staging containment (closes #2556). Added [req-pr-007] (Section 8.1, consumer MUST): a consumer copying a declared Plugin collection component source excludes every consumer-generated staging subtree within that source. Section 8.7, Section 11.3.2, Appendix C, and conformance coverage updated. Statement count: 116 -> 117 (112 MUST, 5 SHOULD). |
+| 0.1.32  | 2026-08-25 | Spec-citation fold for root-declared Plugin component staging containment (closes #2556). Added [req-pr-007] (Section 8.1, consumer MUST): a consumer canonicalizes the non-symlink component-source root and prunes the current operation's materialization subtree before traversal. Section 8.7, Section 11.3.2, Appendix C, and conformance coverage updated. Statement count: 116 -> 117 (112 MUST, 5 SHOULD). |
 
 Errata (none at publication).
 

--- a/src/apm_cli/deps/plugin_parser.py
+++ b/src/apm_cli/deps/plugin_parser.py
@@ -980,9 +980,11 @@ def _map_plugin_artifacts(
             f"Refusing to map plugin artifacts through symlinked destination: {apm_dir}"
         )
     plugin_path = plugin_path.resolve()
+    # Command copying checks every discovered file, so resolve the staging
+    # root once rather than repeating filesystem resolution per path.
     staging_root = apm_dir.resolve()
-    staging_parent = staging_root.parent
-    staging_name = staging_root.name
+    staging_parent = apm_dir.parent.resolve()
+    staging_name = apm_dir.name
 
     def ignore_non_content_and_staging(directory: str, contents: list[str]) -> set[str]:
         """Exclude internal artifacts and the staging root from component copies."""

--- a/src/apm_cli/deps/plugin_parser.py
+++ b/src/apm_cli/deps/plugin_parser.py
@@ -992,7 +992,7 @@ def _map_plugin_artifacts(
         try:
             copying_from_plugin_root = Path(directory).resolve() == staging_parent
         except OSError:
-            copying_from_plugin_root = False
+            copying_from_plugin_root = True
         if copying_from_plugin_root and staging_name in contents:
             ignored.add(staging_name)
         return ignored
@@ -1002,7 +1002,7 @@ def _map_plugin_artifacts(
         try:
             return path.resolve().is_relative_to(staging_root)
         except OSError:
-            return False
+            return True
 
     # Resolve source paths  -- use manifest arrays if present, else defaults.
     # Custom paths may be directories OR individual files.

--- a/src/apm_cli/deps/plugin_parser.py
+++ b/src/apm_cli/deps/plugin_parser.py
@@ -162,7 +162,7 @@ def _iter_command_source_files(
     try:
         source_root = source.resolve()
     except OSError:
-        _logger.warning("Skipping command source with an unresolvable staging boundary")
+        _surface_warning("Skipping command source with an unresolvable staging boundary", _logger)
         return
 
     if source_root == target_root:
@@ -236,7 +236,7 @@ def _map_plugin_skills(
     manifest: dict[str, Any],
     resolve_sources: Callable[[str, str], list[Path]],
     is_same_path: Callable[[Path, Path], bool],
-    ignore_non_content: Callable[..., set[str]],
+    ignore_non_content: Callable[..., list[str]],
 ) -> None:
     """Materialize parser-authorized plugin skills and persist their receipt."""
     skill_sources = resolve_sources("skills", "skills")
@@ -1023,16 +1023,16 @@ def _map_plugin_artifacts(
     staging_parent = apm_dir.parent.resolve()
     staging_name = apm_dir.name
 
-    def ignore_non_content_and_staging(directory: str, contents: list[str]) -> set[str]:
+    def ignore_non_content_and_staging(directory: str, contents: list[str]) -> list[str]:
         """Exclude internal artifacts and the staging root from component copies."""
-        ignored = ignore_non_content(directory, contents)
+        ignored = set(ignore_non_content(directory, contents))
         try:
             copying_from_plugin_root = Path(directory).resolve() == staging_parent
         except OSError:
             copying_from_plugin_root = True
         if copying_from_plugin_root and staging_name in contents:
             ignored.add(staging_name)
-        return ignored
+        return list(ignored)
 
     # Resolve source paths  -- use manifest arrays if present, else defaults.
     # Custom paths may be directories OR individual files.

--- a/src/apm_cli/deps/plugin_parser.py
+++ b/src/apm_cli/deps/plugin_parser.py
@@ -1010,7 +1010,7 @@ def _map_plugin_artifacts(
     if manifest is None:
         manifest = {}
 
-    from apm_cli.security.gate import ignore_non_content
+    from apm_cli.security.gate import ignore_non_content as _ignore_non_content
 
     if apm_dir.is_symlink():
         raise PluginIntegrityError(
@@ -1023,9 +1023,9 @@ def _map_plugin_artifacts(
     staging_parent = apm_dir.parent.resolve()
     staging_name = apm_dir.name
 
-    def ignore_non_content_and_staging(directory: str, contents: list[str]) -> list[str]:
-        """Exclude internal artifacts and the staging root from component copies."""
-        ignored = set(ignore_non_content(directory, contents))
+    def ignore_non_content(directory: str, contents: list[str]) -> list[str]:
+        """Compose the canonical content filter with staging-root containment."""
+        ignored = set(_ignore_non_content(directory, contents))
         try:
             copying_from_plugin_root = Path(directory).resolve() == staging_parent
         except OSError:
@@ -1108,7 +1108,7 @@ def _map_plugin_artifacts(
                 d,
                 target_agents,
                 dirs_exist_ok=True,
-                ignore=ignore_non_content_and_staging,
+                ignore=ignore_non_content,
             )
         if agent_files:
             target_agents.mkdir(parents=True, exist_ok=True)
@@ -1124,7 +1124,7 @@ def _map_plugin_artifacts(
         manifest,
         _resolve_sources,
         _is_same_path,
-        ignore_non_content_and_staging,
+        ignore_non_content,
     )
 
     # Map commands/ -> .apm/prompts/ (normalize .md -> .prompt.md)
@@ -1158,7 +1158,7 @@ def _map_plugin_artifacts(
                     target_prompts_root,
                     staging_root,
                     staging_parent,
-                    ignore_non_content,
+                    _ignore_non_content,
                 ):
                     _copy_command_file(source_file, target_prompts, rel_to=source_root)
 
@@ -1200,7 +1200,7 @@ def _map_plugin_artifacts(
                     d,
                     target_hooks,
                     dirs_exist_ok=True,
-                    ignore=ignore_non_content_and_staging,
+                    ignore=ignore_non_content,
                 )
 
     # Pass-through files required for MCP/LSP plugins to function

--- a/src/apm_cli/deps/plugin_parser.py
+++ b/src/apm_cli/deps/plugin_parser.py
@@ -980,6 +980,27 @@ def _map_plugin_artifacts(
             f"Refusing to map plugin artifacts through symlinked destination: {apm_dir}"
         )
     plugin_path = plugin_path.resolve()
+    staging_root = apm_dir.resolve()
+    staging_parent = staging_root.parent
+    staging_name = staging_root.name
+
+    def ignore_non_content_and_staging(directory: str, contents: list[str]) -> set[str]:
+        """Exclude internal artifacts and the staging root from component copies."""
+        ignored = ignore_non_content(directory, contents)
+        try:
+            copying_from_plugin_root = Path(directory).resolve() == staging_parent
+        except OSError:
+            copying_from_plugin_root = False
+        if copying_from_plugin_root and staging_name in contents:
+            ignored.add(staging_name)
+        return ignored
+
+    def is_staging_content(path: Path) -> bool:
+        """Return whether a command source path belongs to the staging tree."""
+        try:
+            return path.resolve().is_relative_to(staging_root)
+        except OSError:
+            return False
 
     # Resolve source paths  -- use manifest arrays if present, else defaults.
     # Custom paths may be directories OR individual files.
@@ -1051,7 +1072,12 @@ def _map_plugin_artifacts(
         for d in agent_dirs:
             if _is_same_path(d, target_agents):
                 continue
-            shutil.copytree(d, target_agents, dirs_exist_ok=True, ignore=ignore_non_content)
+            shutil.copytree(
+                d,
+                target_agents,
+                dirs_exist_ok=True,
+                ignore=ignore_non_content_and_staging,
+            )
         if agent_files:
             target_agents.mkdir(parents=True, exist_ok=True)
             for f in agent_files:
@@ -1066,7 +1092,7 @@ def _map_plugin_artifacts(
         manifest,
         _resolve_sources,
         _is_same_path,
-        ignore_non_content,
+        ignore_non_content_and_staging,
     )
 
     # Map commands/ -> .apm/prompts/ (normalize .md -> .prompt.md)
@@ -1096,6 +1122,10 @@ def _map_plugin_artifacts(
             elif source.is_dir():
                 for source_file in source.rglob("*"):
                     if not source_file.is_file() or source_file.is_symlink():
+                        continue
+                    if is_staging_content(source_file) or source_file.name in ignore_non_content(
+                        str(source_file.parent), [source_file.name]
+                    ):
                         continue
                     _copy_command_file(source_file, target_prompts, rel_to=source)
 
@@ -1133,7 +1163,12 @@ def _map_plugin_artifacts(
             for d in hook_sources:
                 if _is_same_path(d, target_hooks):
                     continue
-                shutil.copytree(d, target_hooks, dirs_exist_ok=True, ignore=ignore_non_content)
+                shutil.copytree(
+                    d,
+                    target_hooks,
+                    dirs_exist_ok=True,
+                    ignore=ignore_non_content_and_staging,
+                )
 
     # Pass-through files required for MCP/LSP plugins to function
     for passthrough in (".mcp.json", ".lsp.json", "settings.json"):

--- a/src/apm_cli/deps/plugin_parser.py
+++ b/src/apm_cli/deps/plugin_parser.py
@@ -15,7 +15,7 @@ import json
 import logging
 import os
 import shutil
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import Any
 
@@ -149,6 +149,43 @@ def _has_symlink_component(candidate: Path, plugin_root: Path) -> bool:
         if current.is_symlink():
             return True
     return False
+
+
+def _iter_command_source_files(
+    source: Path,
+    target_root: Path,
+    staging_root: Path,
+    staging_parent: Path,
+    ignore_non_content: Callable[[str, list[str]], set[str]],
+) -> Iterator[tuple[Path, Path]]:
+    """Yield regular command files while pruning generated staging output."""
+    try:
+        source_root = source.resolve()
+    except OSError:
+        _logger.warning("Skipping command source with an unresolvable staging boundary")
+        return
+
+    if source_root == target_root:
+        return
+    if source_root == staging_parent:
+        excluded_root = staging_root
+    else:
+        try:
+            target_root.relative_to(source_root)
+        except ValueError:
+            excluded_root = None
+        else:
+            excluded_root = target_root
+
+    for directory, directories, files in os.walk(source_root, topdown=True, followlinks=False):
+        directory_path = Path(directory)
+        if excluded_root is not None and directory_path == excluded_root.parent:
+            directories[:] = [name for name in directories if name != excluded_root.name]
+        ignored = ignore_non_content(directory, files)
+        for name in files:
+            source_file = directory_path / name
+            if name not in ignored and not source_file.is_symlink() and source_file.is_file():
+                yield source_file, source_root
 
 
 def _holds_skill_dirs(candidate: Path) -> bool:
@@ -997,13 +1034,6 @@ def _map_plugin_artifacts(
             ignored.add(staging_name)
         return ignored
 
-    def is_staging_content(path: Path) -> bool:
-        """Return whether a command source path belongs to the staging tree."""
-        try:
-            return path.resolve().is_relative_to(staging_root)
-        except OSError:
-            return True
-
     # Resolve source paths  -- use manifest arrays if present, else defaults.
     # Custom paths may be directories OR individual files.
     #
@@ -1103,6 +1133,7 @@ def _map_plugin_artifacts(
         target_prompts = apm_dir / "prompts"
         _assert_no_symlink_descendants(target_prompts)
         target_prompts.mkdir(parents=True, exist_ok=True)
+        target_prompts_root = target_prompts.resolve()
 
         def _copy_command_file(source_file: Path, dest_dir: Path, rel_to: Path = None):  # noqa: RUF013
             """Copy a command file, normalizing .md -> .prompt.md."""
@@ -1122,14 +1153,14 @@ def _map_plugin_artifacts(
             if source.is_file() and not source.is_symlink():
                 _copy_command_file(source, target_prompts)
             elif source.is_dir():
-                for source_file in source.rglob("*"):
-                    if not source_file.is_file() or source_file.is_symlink():
-                        continue
-                    if is_staging_content(source_file) or source_file.name in ignore_non_content(
-                        str(source_file.parent), [source_file.name]
-                    ):
-                        continue
-                    _copy_command_file(source_file, target_prompts, rel_to=source)
+                for source_file, source_root in _iter_command_source_files(
+                    source,
+                    target_prompts_root,
+                    staging_root,
+                    staging_parent,
+                    ignore_non_content,
+                ):
+                    _copy_command_file(source_file, target_prompts, rel_to=source_root)
 
     # Map hooks/  -- the spec allows a directory path, a config file path,
     # or an inline object.  Handle all three forms.

--- a/src/apm_cli/integration/skill_integrator.py
+++ b/src/apm_cli/integration/skill_integrator.py
@@ -1062,6 +1062,9 @@ class SkillIntegrator(BaseIntegrator):
         """
         self.init_link_resolver(package_info, project_root)
         package_path = package_info.install_path
+        from apm_cli.models.validation import PackageType
+
+        is_plugin = package_info.package_type is PackageType.MARKETPLACE_PLUGIN
 
         # Use the source folder name as the skill name
         # e.g., apm_modules/ComposioHQ/awesome-claude-skills/mcp-builder -> mcp-builder
@@ -1202,15 +1205,18 @@ class SkillIntegrator(BaseIntegrator):
             target_skill_dir.parent.mkdir(parents=True, exist_ok=True)
             _base_ignore = build_copy_ignore(skip_bin=skip_bin)
 
-            _apm_filter = shutil.ignore_patterns(".apm")
+            _internal_filter = shutil.ignore_patterns(
+                ".apm",
+                *(("apm.yml",) if is_plugin else ()),
+            )
 
-            def _ignore_non_content_and_apm(directory, contents):
+            def _ignore_non_content_and_internal(directory, contents):
                 return list(
                     set(_base_ignore(directory, contents))  # noqa: B023
-                    | set(_apm_filter(directory, contents))  # noqa: B023
+                    | set(_internal_filter(directory, contents))  # noqa: B023
                 )
 
-            shutil.copytree(package_path, target_skill_dir, ignore=_ignore_non_content_and_apm)
+            shutil.copytree(package_path, target_skill_dir, ignore=_ignore_non_content_and_internal)
             self._resolve_markdown_links_in_skill_bundle(package_path, target_skill_dir)
             all_target_paths.append(target_skill_dir)
 

--- a/tests/integration/test_architecture_outcome_guards.py
+++ b/tests/integration/test_architecture_outcome_guards.py
@@ -415,42 +415,6 @@ def test_skill_enumeration_falls_back_to_the_normalized_container(
     assert SkillIntegrator.available_skill_names(info) == expected
 
 
-def test_skill_enumeration_falls_back_to_the_normalized_container(
-    tmp_path: Path,
-) -> None:
-    """The ``.apm/skills/`` fallback is the route every plugin package takes.
-
-    A root ``skills/`` bundle wins only while it actually holds a skill. With
-    no such bundle -- or with one carrying no ``SKILL.md`` at all -- routing
-    must fall back to the normalized container ``_map_plugin_artifacts``
-    writes, or ``--skill`` is back to enumerating nothing (#2530).
-    """
-    from apm_cli.integration.skill_integrator import SkillIntegrator
-    from apm_cli.models.validation import PackageType
-
-    package = tmp_path / "pkg"
-    normalized = package / ".apm" / "skills"
-    for name in ("csharp-scripts", "dotnet-pinvoke"):
-        skill = normalized / name
-        skill.mkdir(parents=True)
-        (skill / "SKILL.md").write_text(f"# {name}\n", encoding="utf-8")
-
-    info = MagicMock(install_path=package, package_type=PackageType.MARKETPLACE_PLUGIN)
-    expected = frozenset({"csharp-scripts", "dotnet-pinvoke"})
-
-    assert SkillIntegrator.skill_source_dir(package) == normalized
-    assert SkillIntegrator.available_skill_names(info) == expected
-
-    # Existing is not the test -- holding a skill is. A root ``skills/`` with
-    # nothing selectable in it must not shadow the normalized container.
-    root_bundle = package / "skills"
-    (root_bundle / "docs").mkdir(parents=True)
-    (root_bundle / "README.md").write_text("# not a skill\n", encoding="utf-8")
-
-    assert SkillIntegrator.skill_source_dir(package) == normalized
-    assert SkillIntegrator.available_skill_names(info) == expected
-
-
 def test_stale_persisted_skill_pin_warns_instead_of_silent_noop(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/integration/test_architecture_outcome_guards.py
+++ b/tests/integration/test_architecture_outcome_guards.py
@@ -415,6 +415,42 @@ def test_skill_enumeration_falls_back_to_the_normalized_container(
     assert SkillIntegrator.available_skill_names(info) == expected
 
 
+def test_skill_enumeration_falls_back_to_the_normalized_container(
+    tmp_path: Path,
+) -> None:
+    """The ``.apm/skills/`` fallback is the route every plugin package takes.
+
+    A root ``skills/`` bundle wins only while it actually holds a skill. With
+    no such bundle -- or with one carrying no ``SKILL.md`` at all -- routing
+    must fall back to the normalized container ``_map_plugin_artifacts``
+    writes, or ``--skill`` is back to enumerating nothing (#2530).
+    """
+    from apm_cli.integration.skill_integrator import SkillIntegrator
+    from apm_cli.models.validation import PackageType
+
+    package = tmp_path / "pkg"
+    normalized = package / ".apm" / "skills"
+    for name in ("csharp-scripts", "dotnet-pinvoke"):
+        skill = normalized / name
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text(f"# {name}\n", encoding="utf-8")
+
+    info = MagicMock(install_path=package, package_type=PackageType.MARKETPLACE_PLUGIN)
+    expected = frozenset({"csharp-scripts", "dotnet-pinvoke"})
+
+    assert SkillIntegrator.skill_source_dir(package) == normalized
+    assert SkillIntegrator.available_skill_names(info) == expected
+
+    # Existing is not the test -- holding a skill is. A root ``skills/`` with
+    # nothing selectable in it must not shadow the normalized container.
+    root_bundle = package / "skills"
+    (root_bundle / "docs").mkdir(parents=True)
+    (root_bundle / "README.md").write_text("# not a skill\n", encoding="utf-8")
+
+    assert SkillIntegrator.skill_source_dir(package) == normalized
+    assert SkillIntegrator.available_skill_names(info) == expected
+
+
 def test_stale_persisted_skill_pin_warns_instead_of_silent_noop(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/integration/test_plugin_e2e.py
+++ b/tests/integration/test_plugin_e2e.py
@@ -473,6 +473,63 @@ class TestPluginHeroScenarios:
         assert "Cleaned up 1 integrated agents" in combined
         assert all(not path.exists() for path in deployed_paths)
 
+    @pytest.mark.requires_apm_binary
+    def test_root_declared_skill_lifecycle_is_bounded(self, apm_binary_path, tmp_path):
+        """A root-declared plugin skill installs, reinstalls, and uninstalls cleanly."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        plugin_dir = workspace / "root-skill-plugin"
+        (plugin_dir / ".claude-plugin").mkdir(parents=True)
+        (plugin_dir / "SKILL.md").write_text(
+            "---\nname: root-frontmatter-skill\ndescription: Root skill.\n---\n\n# Root skill\n"
+        )
+        (plugin_dir / ".claude-plugin" / "plugin.json").write_text(
+            json.dumps(
+                {
+                    "name": "root-skill-plugin",
+                    "version": "1.0.0",
+                    "skills": ["./"],
+                }
+            )
+        )
+
+        project = workspace / "project"
+        project.mkdir()
+        (project / "apm.yml").write_text(
+            "name: root-declared-skill-test\nversion: 1.0.0\ndependencies:\n  apm: []\n"
+        )
+        (project / ".github").mkdir()
+        (project / ".github" / "copilot-instructions.md").write_text("# test\n")
+
+        first_install = _run_apm_command(apm_binary_path, ["install", str(plugin_dir)], project)
+        assert first_install.returncode == 0, (
+            f"Root skill install failed:\n{first_install.stdout}\n{first_install.stderr}"
+        )
+
+        deployed_skills = list((project / ".agents" / "skills").rglob("SKILL.md"))
+        assert len(deployed_skills) == 1
+        deployed_skill = deployed_skills[0]
+        assert "name: root-frontmatter-skill" in deployed_skill.read_text()
+        assert not list(deployed_skill.parent.rglob(".apm"))
+        tree_after_install = {
+            path.relative_to(deployed_skill.parent): path.read_text()
+            for path in deployed_skill.parent.rglob("*")
+            if path.is_file()
+        }
+
+        reinstall = _run_apm_command(apm_binary_path, ["install", str(plugin_dir)], project)
+        assert reinstall.returncode == 0, f"Root skill reinstall failed:\n{reinstall.stderr}"
+        tree_after_reinstall = {
+            path.relative_to(deployed_skill.parent): path.read_text()
+            for path in deployed_skill.parent.rglob("*")
+            if path.is_file()
+        }
+        assert tree_after_reinstall == tree_after_install
+
+        uninstall = _run_apm_command(apm_binary_path, ["uninstall", str(plugin_dir)], project)
+        assert uninstall.returncode == 0, f"Root skill uninstall failed:\n{uninstall.stderr}"
+        assert not deployed_skill.exists()
+
 
 # ===========================================================================
 # Class 1b - LOCAL user-scope bin/ permission E2E (no network, sandboxed HOME)

--- a/tests/integration/test_plugin_e2e.py
+++ b/tests/integration/test_plugin_e2e.py
@@ -483,6 +483,7 @@ class TestPluginHeroScenarios:
         (plugin_dir / "SKILL.md").write_text(
             "---\nname: root-frontmatter-skill\ndescription: Root skill.\n---\n\n# Root skill\n"
         )
+        (plugin_dir / ".apm-pin").write_text("internal cache marker\n")
         (plugin_dir / ".claude-plugin" / "plugin.json").write_text(
             json.dumps(
                 {
@@ -501,20 +502,41 @@ class TestPluginHeroScenarios:
         (project / ".github").mkdir()
         (project / ".github" / "copilot-instructions.md").write_text("# test\n")
 
+        dry_run = _run_apm_command(
+            apm_binary_path,
+            ["install", "--dry-run", str(plugin_dir)],
+            project,
+        )
+        assert dry_run.returncode == 0, f"Root skill dry run failed:\n{dry_run.stderr}"
+        assert not (project / "apm.lock.yaml").exists()
+        assert not (project / ".agents" / "skills").exists()
+        assert not (project / ".claude" / "skills").exists()
+        assert not (plugin_dir / ".apm").exists()
+
         first_install = _run_apm_command(apm_binary_path, ["install", str(plugin_dir)], project)
         assert first_install.returncode == 0, (
             f"Root skill install failed:\n{first_install.stdout}\n{first_install.stderr}"
         )
 
-        deployed_skills = list((project / ".agents" / "skills").rglob("SKILL.md"))
+        deployed_skills = [
+            skill
+            for skills_root in (project / ".agents" / "skills", project / ".claude" / "skills")
+            if skills_root.exists()
+            for skill in skills_root.rglob("SKILL.md")
+        ]
         assert len(deployed_skills) == 1
         deployed_skill = deployed_skills[0]
         assert "name: root-frontmatter-skill" in deployed_skill.read_text()
         assert not list(deployed_skill.parent.rglob(".apm"))
+        assert not list(deployed_skill.parent.rglob(".apm-pin"))
         tree_after_install = {
             path.relative_to(deployed_skill.parent): path.read_text()
             for path in deployed_skill.parent.rglob("*")
             if path.is_file()
+        }
+        assert set(tree_after_install) == {
+            Path("SKILL.md"),
+            Path(".claude-plugin/plugin.json"),
         }
 
         reinstall = _run_apm_command(apm_binary_path, ["install", str(plugin_dir)], project)
@@ -529,6 +551,44 @@ class TestPluginHeroScenarios:
         uninstall = _run_apm_command(apm_binary_path, ["uninstall", str(plugin_dir)], project)
         assert uninstall.returncode == 0, f"Root skill uninstall failed:\n{uninstall.stderr}"
         assert not deployed_skill.exists()
+
+    @pytest.mark.requires_apm_binary
+    def test_prepositioned_command_source_deploys_through_local_install(
+        self, apm_binary_path, tmp_path
+    ):
+        """A declared command source under .apm remains usable package input."""
+        workspace = tmp_path / "workspace"
+        plugin_dir = workspace / "prepositioned-commands-plugin"
+        command_dir = plugin_dir / ".apm" / "custom-commands"
+        command_dir.mkdir(parents=True)
+        (command_dir / "run.md").write_text("# Run\n", encoding="utf-8")
+        (plugin_dir / ".claude-plugin").mkdir()
+        (plugin_dir / ".claude-plugin" / "plugin.json").write_text(
+            json.dumps(
+                {
+                    "name": "prepositioned-commands-plugin",
+                    "version": "1.0.0",
+                    "commands": [".apm/custom-commands"],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        project = workspace / "project"
+        project.mkdir()
+        (project / "apm.yml").write_text(
+            "name: prepositioned-commands-test\nversion: 1.0.0\ndependencies:\n  apm: []\n",
+            encoding="utf-8",
+        )
+        (project / ".github").mkdir()
+        (project / ".github" / "copilot-instructions.md").write_text("# test\n", encoding="utf-8")
+
+        install = _run_apm_command(apm_binary_path, ["install", str(plugin_dir)], project)
+
+        assert install.returncode == 0, f"Command plugin install failed:\n{install.stderr}"
+        assert (project / ".github" / "prompts" / "run.prompt.md").read_text(
+            encoding="utf-8"
+        ) == "# Run\n"
 
 
 # ===========================================================================

--- a/tests/spec_conformance/test_resolution_reqs.py
+++ b/tests/spec_conformance/test_resolution_reqs.py
@@ -398,7 +398,9 @@ def test_root_declared_plugin_component_excludes_generated_staging_tree(tmp_path
     assert first_tree == second_tree
     assert_spec_contains(
         "copying a declared Plugin collection component source",
-        "consumer-generated staging subtree within that source",
+        "canonicalize the\nnon-symlink source root",
+        "materialization root created by the current operation",
+        "MUST prune every such staging\nsubtree before traversing the source",
     )
 
 

--- a/tests/spec_conformance/test_resolution_reqs.py
+++ b/tests/spec_conformance/test_resolution_reqs.py
@@ -20,6 +20,7 @@ from pathlib import Path
 import pytest
 
 from apm_cli.cache.url_normalize import normalize_repo_url
+from apm_cli.deps.plugin_parser import _map_plugin_artifacts
 from apm_cli.deps.shared_clone_cache import SharedCloneCache
 from apm_cli.deps.tiered_ref_resolver import (
     L0PerRunCache,
@@ -366,6 +367,38 @@ def test_consumer_rejects_primitive_collisions():
     assert_spec_contains(
         "first declared",
         "MUST NOT replace",
+    )
+
+
+@pytest.mark.req("req-pr-007")
+def test_root_declared_plugin_component_excludes_generated_staging_tree(tmp_path: Path):
+    """A root declaration never re-copies its consumer-generated staging tree."""
+    plugin_root = tmp_path / "plugin"
+    staging_root = plugin_root / ".apm"
+    plugin_root.mkdir()
+    staging_root.mkdir()
+    (plugin_root / "agent.md").write_text("# Agent\n", encoding="ascii")
+    (staging_root / "generated.md").write_text("# Generated\n", encoding="ascii")
+
+    manifest = {"name": "plugin", "agents": ["./"]}
+    _map_plugin_artifacts(plugin_root, staging_root, manifest)
+    first_tree = {
+        path.relative_to(staging_root).as_posix(): path.read_bytes()
+        for path in staging_root.rglob("*")
+        if path.is_file()
+    }
+    _map_plugin_artifacts(plugin_root, staging_root, manifest)
+    second_tree = {
+        path.relative_to(staging_root).as_posix(): path.read_bytes()
+        for path in staging_root.rglob("*")
+        if path.is_file()
+    }
+
+    assert "agents/.apm/generated.md" not in first_tree
+    assert first_tree == second_tree
+    assert_spec_contains(
+        "copying a declared Plugin collection component source",
+        "consumer-generated staging subtree within that source",
     )
 
 

--- a/tests/unit/test_plugin_parser.py
+++ b/tests/unit/test_plugin_parser.py
@@ -363,6 +363,40 @@ class TestMapPluginArtifacts:
         # Already .prompt.md stays unchanged
         assert (prompts / "already.prompt.md").exists()
 
+    def test_prepositioned_apm_command_source_is_preserved(self, tmp_path):
+        """A declared command source under .apm is input, not generated output."""
+        plugin_dir = tmp_path / "plugin"
+        plugin_dir.mkdir()
+        apm_dir = plugin_dir / ".apm"
+        source = apm_dir / "custom-commands"
+        source.mkdir(parents=True)
+        (source / "run.md").write_text("# Run")
+
+        _map_plugin_artifacts(
+            plugin_dir,
+            apm_dir,
+            manifest={"commands": [".apm/custom-commands"]},
+        )
+
+        assert (apm_dir / "prompts" / "run.prompt.md").read_text() == "# Run"
+
+    def test_command_source_skips_fifo(self, tmp_path):
+        """Command mapping must not block while opening a named pipe."""
+        plugin_dir = tmp_path / "plugin"
+        command_dir = plugin_dir / "commands"
+        command_dir.mkdir(parents=True)
+        fifo = command_dir / "wait"
+        try:
+            os.mkfifo(fifo)
+        except (AttributeError, OSError):
+            pytest.skip("Named pipes are not supported on this platform")
+
+        apm_dir = plugin_dir / ".apm"
+        apm_dir.mkdir()
+        _map_plugin_artifacts(plugin_dir, apm_dir, manifest={"commands": "commands"})
+
+        assert not (apm_dir / "prompts" / "wait").exists()
+
     def test_map_hooks_directory(self, tmp_path):
         plugin_dir = tmp_path / "plugin"
         plugin_dir.mkdir()

--- a/tests/unit/test_plugin_parser.py
+++ b/tests/unit/test_plugin_parser.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import traceback
 from pathlib import Path
 
 import pytest
@@ -1830,6 +1831,51 @@ class TestRootDeclaredComponents:
         }
 
         assert second_tree == first_tree
+
+    @staticmethod
+    def _resolve_raises_in_staging_guards(real_resolve):
+        """Return a resolver that fails only for staging containment checks."""
+
+        def flaky_resolve(path: Path, *args, **kwargs):
+            stack = [frame.name for frame in traceback.extract_stack()]
+            if (
+                "ignore_non_content_and_staging" in stack
+                or "is_staging_content" in stack
+            ):
+                raise OSError(63, "File name too long")
+            return real_resolve(path, *args, **kwargs)
+
+        return flaky_resolve
+
+    def test_root_copy_fails_closed_when_staging_parent_cannot_resolve(self, tmp_path) -> None:
+        """An unresolvable staging parent must still be excluded from a copy."""
+        plugin_dir, _ = self._plugin(tmp_path, "skills")
+        apm_dir = plugin_dir / ".apm"
+        apm_dir.mkdir()
+
+        with patch.object(
+            Path,
+            "resolve",
+            self._resolve_raises_in_staging_guards(Path.resolve),
+        ):
+            _map_plugin_artifacts(plugin_dir, apm_dir, {"name": "plug", "skills": ["./"]})
+
+        assert not list((apm_dir / "skills").rglob(".apm"))
+
+    def test_root_commands_fail_closed_when_staging_content_cannot_resolve(self, tmp_path) -> None:
+        """An unresolvable path in the command walk must not restart self-copying."""
+        plugin_dir, _ = self._plugin(tmp_path, "commands")
+        apm_dir = plugin_dir / ".apm"
+        apm_dir.mkdir()
+
+        with patch.object(
+            Path,
+            "resolve",
+            self._resolve_raises_in_staging_guards(Path.resolve),
+        ):
+            _map_plugin_artifacts(plugin_dir, apm_dir, {"name": "plug", "commands": ["./"]})
+
+        assert not list((apm_dir / "prompts").rglob(".apm"))
 
 
 @pytest.mark.windows_compat

--- a/tests/unit/test_plugin_parser.py
+++ b/tests/unit/test_plugin_parser.py
@@ -1749,6 +1749,89 @@ class TestSynthesizePreservesExistingManifest:
         assert result["name"] == "bad-pkg"
 
 
+class TestRootDeclaredComponents:
+    """Root declarations must copy only source content into the component tree."""
+
+    @staticmethod
+    def _plugin(tmp_path, component: str) -> tuple[Path, bool]:
+        plugin_dir = tmp_path / "plug"
+        plugin_dir.mkdir()
+        (plugin_dir / ".claude-plugin").mkdir()
+        (plugin_dir / "SKILL.md").write_text("# hello\n", encoding="utf-8")
+        (plugin_dir / ".claude-plugin" / "plugin.json").write_text(
+            json.dumps({"name": "plug", component: ["./"]}),
+            encoding="utf-8",
+        )
+        (plugin_dir / ".apm-pin").write_text("internal cache marker\n", encoding="utf-8")
+        linked = plugin_dir / "linked.md"
+        try:
+            linked.symlink_to(plugin_dir / "SKILL.md")
+        except OSError:
+            return plugin_dir, False
+        return plugin_dir, True
+
+    @pytest.mark.parametrize(
+        ("component", "expected_files"),
+        [
+            ("agents", {"SKILL.md", ".claude-plugin/plugin.json"}),
+            ("skills", {"SKILL.md", ".claude-plugin/plugin.json"}),
+            ("commands", {"SKILL.prompt.md", ".claude-plugin/plugin.json"}),
+            ("hooks", {"SKILL.md", ".claude-plugin/plugin.json"}),
+        ],
+    )
+    def test_root_component_excludes_internal_and_symlinked_content(
+        self,
+        tmp_path,
+        component: str,
+        expected_files: set[str],
+    ) -> None:
+        """A root declaration has a stable, finite deployment tree."""
+        plugin_dir, has_symlink = self._plugin(tmp_path, component)
+        apm_dir = plugin_dir / ".apm"
+        apm_dir.mkdir()
+
+        _map_plugin_artifacts(plugin_dir, apm_dir, {"name": "plug", component: ["./"]})
+
+        component_root = apm_dir / {
+            "agents": "agents",
+            "skills": "skills/plug",
+            "commands": "prompts",
+            "hooks": "hooks",
+        }[component]
+        deployed_files = {
+            path.relative_to(component_root).as_posix()
+            for path in component_root.rglob("*")
+            if path.is_file()
+        }
+        assert deployed_files == expected_files
+        assert not list(component_root.rglob(".apm"))
+        assert not list(component_root.rglob(".apm-pin"))
+        if has_symlink:
+            assert "linked.md" not in deployed_files
+
+    def test_root_declared_skills_are_idempotent(self, tmp_path) -> None:
+        """Re-materializing a root declaration preserves an identical tree."""
+        plugin_dir, _ = self._plugin(tmp_path, "skills")
+        apm_dir = plugin_dir / ".apm"
+        apm_dir.mkdir()
+        manifest = {"name": "plug", "skills": ["./"]}
+
+        _map_plugin_artifacts(plugin_dir, apm_dir, manifest)
+        first_tree = {
+            path.relative_to(apm_dir).as_posix(): path.read_bytes()
+            for path in apm_dir.rglob("*")
+            if path.is_file()
+        }
+        _map_plugin_artifacts(plugin_dir, apm_dir, manifest)
+        second_tree = {
+            path.relative_to(apm_dir).as_posix(): path.read_bytes()
+            for path in apm_dir.rglob("*")
+            if path.is_file()
+        }
+
+        assert second_tree == first_tree
+
+
 @pytest.mark.windows_compat
 class TestSyntheticManifestLineEndings:
     """apm#2619: synthetic apm.yml bytes must be platform-invariant (LF).

--- a/tests/unit/test_plugin_parser.py
+++ b/tests/unit/test_plugin_parser.py
@@ -3,7 +3,6 @@
 import json
 import logging
 import os
-import traceback
 from pathlib import Path
 
 import pytest
@@ -1831,52 +1830,6 @@ class TestRootDeclaredComponents:
         }
 
         assert second_tree == first_tree
-
-    @staticmethod
-    def _resolve_raises_in_staging_guards(real_resolve):
-        """Return a resolver that fails only for staging containment checks."""
-
-        def flaky_resolve(path: Path, *args, **kwargs):
-            stack = [frame.name for frame in traceback.extract_stack()]
-            if (
-                "ignore_non_content_and_staging" in stack
-                or "is_staging_content" in stack
-            ):
-                raise OSError(63, "File name too long")
-            return real_resolve(path, *args, **kwargs)
-
-        return flaky_resolve
-
-    def test_root_copy_fails_closed_when_staging_parent_cannot_resolve(self, tmp_path) -> None:
-        """An unresolvable staging parent must still be excluded from a copy."""
-        plugin_dir, _ = self._plugin(tmp_path, "skills")
-        apm_dir = plugin_dir / ".apm"
-        apm_dir.mkdir()
-
-        with patch.object(
-            Path,
-            "resolve",
-            self._resolve_raises_in_staging_guards(Path.resolve),
-        ):
-            _map_plugin_artifacts(plugin_dir, apm_dir, {"name": "plug", "skills": ["./"]})
-
-        assert not list((apm_dir / "skills").rglob(".apm"))
-
-    def test_root_commands_fail_closed_when_staging_content_cannot_resolve(self, tmp_path) -> None:
-        """An unresolvable path in the command walk must not restart self-copying."""
-        plugin_dir, _ = self._plugin(tmp_path, "commands")
-        apm_dir = plugin_dir / ".apm"
-        apm_dir.mkdir()
-
-        with patch.object(
-            Path,
-            "resolve",
-            self._resolve_raises_in_staging_guards(Path.resolve),
-        ):
-            _map_plugin_artifacts(plugin_dir, apm_dir, {"name": "plug", "commands": ["./"]})
-
-        assert not list((apm_dir / "prompts").rglob(".apm"))
-
 
 @pytest.mark.windows_compat
 class TestSyntheticManifestLineEndings:

--- a/tests/unit/test_plugin_parser.py
+++ b/tests/unit/test_plugin_parser.py
@@ -1826,12 +1826,15 @@ class TestRootDeclaredComponents:
 
         _map_plugin_artifacts(plugin_dir, apm_dir, {"name": "plug", component: ["./"]})
 
-        component_root = apm_dir / {
-            "agents": "agents",
-            "skills": "skills/plug",
-            "commands": "prompts",
-            "hooks": "hooks",
-        }[component]
+        component_root = (
+            apm_dir
+            / {
+                "agents": "agents",
+                "skills": "skills/plug",
+                "commands": "prompts",
+                "hooks": "hooks",
+            }[component]
+        )
         deployed_files = {
             path.relative_to(component_root).as_posix()
             for path in component_root.rglob("*")
@@ -1864,6 +1867,7 @@ class TestRootDeclaredComponents:
         }
 
         assert second_tree == first_tree
+
 
 @pytest.mark.windows_compat
 class TestSyntheticManifestLineEndings:


### PR DESCRIPTION
Closes #2556.

## Root cause

`"skills": ["./"]` is the documented Claude Code single-skill shape, so APM meets it on any marketplace shipping solo plugins. The staging root `.apm/` lives inside the plugin and every destination in `_map_plugin_artifacts` is under it, so a component declared at the plugin root makes the source an ancestor of its own destination. The copy then walks into the tree it is writing:

```text
plug/                              <- copy FROM here (because "./")
├── SKILL.md
├── .claude-plugin/
└── .apm/skills/
    └── plug/                      <- copy TO here, inside the source
        └── .apm/skills/plug/ ...
```

`_is_same_path` only catches `src == dst`. Here `dst` is a **descendant** of `src`, so the guard never fires. The comment above the helper anticipates only the equal case.

## The issue under-reported the scope

The report covers `skills`. Probing all four component types against clean `main` @ `3aa0365`:

| Component | Behaviour before this PR |
| --------- | ------------------------ |
| `skills` | `RecursionError` — install fails |
| `agents` | `RecursionError` — install fails |
| `hooks` | `RecursionError` — install fails |
| `commands` | **No exception.** Writes without bound — 3301 files and still growing after four minutes, from a two-file plugin |

`commands` is the worse one and the reason the fix is not skills-only: it walks with `rglob` rather than `copytree`, and `rglob` is lazy, so it keeps yielding the files the loop has just written.

## Fix

Exclude the staging root from component copies.

That is sufficient **and** complete: sources are constrained to the plugin root by `_is_within_plugin`, destinations are always under `apm_dir`, so `.apm/` is the only path from a permitted source back down to its own destination. Blocking that one edge makes every case terminate — no temp-dir staging, no move-into-place, no per-component special cases.

- **`ignore_non_content_and_staging`** composes the existing callback and drops the staging directory when copying from its parent. Derived from `apm_dir` rather than hardcoding `.apm`, so it holds if the staging root ever moves.
- **`_under_staging`** gives the `commands` walk an explicit skip, since an ignore-callback cannot reach `rglob`.

No behaviour change for any manifest that does not declare a component at the plugin root: the callback only drops an entry when the directory being copied *is* the staging root's parent.

## Interaction with #2536

#2536 rewrites this function, so worth flagging: from its description, declared entries are classified so that "one carrying its own `SKILL.md` keeps its name" — which is the branch that recurses here, so I do not think #2536 fixes this on its own. If it turns out to, the tests in this PR are still worth keeping as a regression guard. Happy to rebase on top of it in whichever order you prefer.

Also related: #760 established that declared paths must stay inside the plugin root. `"./"` satisfies that check and then breaks on the write, so this is the containment gap on the write side.

## Not addressed here

Two things a root-declared component still does. Both are pre-existing and both feel like they belong with #2537's "which skills win" question rather than with a crash fix — say the word and I will fold either in:

- The staged skill takes its name from the plugin directory (`d.name`), not the frontmatter `name` Claude Code invokes it by.
- Packaging files (`.claude-plugin/`, `apm.yml`) ride along into the staged component, because at the plugin root everything is "content".

## Verification

**New tests** — `TestRootDeclaredComponents`, 7 cases, parameterized across all four component types. Confirmed failing on clean `main`: the six non-hanging cases fail with `RecursionError`; the `commands` case hangs rather than failing, which is called out in the class docstring so nobody is surprised by it later.

```console
$ pytest tests/unit/test_plugin_parser.py -k RootDeclared -q     # on this branch
7 passed

$ pytest tests/unit/test_plugin_parser.py -k "RootDeclared and not commands" -q   # on clean main
6 failed
```

**End to end** — the minimal repro from the issue:

```console
$ apm install ../plug --target claude
  |-- Skill integrated -> .claude/skills/
[*] Installed 1 APM dependency in 0.3s.
```

**No new failures** — `tests/unit/deps tests/unit/install test_plugin_parser test_symlink_containment test_ignore_non_content test_plugin_exporter_schema`: 3347 passed. This Windows box has 42 pre-existing failures in that set; on the first commit the failure list was byte-identical to clean `main` run with the same command, so the diff was zero.

Re-running after the review commit gave 41 — one *fewer*. The difference is `test_direct_dep_failure.py::TestDirectDepFailLoud::test_pipeline_raises_direct_dependency_error`, which passes 3/3 in isolation and is unrelated to anything here; it looks order-dependent or flaky in the full-set run rather than fixed by this PR. Calling it out so the count is not read as an improvement.

**`TestIgnoreNonContentSourceGuard` still passes** — the composing helper keeps each `copytree` site's `ignore_non_content` reference, which is what that AST guard counts.

Environment: Windows 11, Python 3.14, branched from `3aa0365`. I did not run the full suite (it exceeds ten minutes here) or the integration suite — worth a CI pass before merge.

*Disclosure: drafted with AI assistance; every command shown was executed against the versions named above and its output captured verbatim.*
