### PR TITLE
fix(install): render LSP dependencies in dry-run preview

### DIFF
--- a/src/apm_cli/commands/install.py
+++ b/src/apm_cli/commands/install.py
@@ -1704,6 +1704,7 @@ def _install_apm_packages(ctx, outcome):
 
     apm_deps = apm_package.get_apm_dependencies()
     dev_apm_deps = apm_package.get_dev_apm_dependencies()
+    lsp_deps = apm_package.get_lsp_dependencies()
     prod_mcp_deps = apm_package.get_mcp_dependencies()
     dev_mcp_deps = apm_package.get_dev_mcp_dependencies()
     mcp_deps = apm_package.get_all_mcp_dependencies()
@@ -1770,6 +1771,7 @@ def _install_apm_packages(ctx, outcome):
             dev_apm_deps=dev_apm_deps,
             should_install_mcp=should_install_mcp,
             update=ctx.update,
+            lsp_deps=lsp_deps,
             only_packages=ctx.only_packages,
             apm_dir=ctx.apm_dir,
         )

--- a/src/apm_cli/install/presentation/dry_run.py
+++ b/src/apm_cli/install/presentation/dry_run.py
@@ -25,6 +25,7 @@ def render_and_exit(
     dev_apm_deps: Sequence[Any],
     should_install_mcp: bool,
     update: bool,
+    lsp_deps: Sequence[Any] | None = None,
     only_packages: Sequence[str] | None = None,
     apm_dir: Path,
 ) -> None:
@@ -49,7 +50,12 @@ def render_and_exit(
         for dep in mcp_deps:
             logger.progress(f"  - {dep}")
 
-    if not apm_deps and not dev_apm_deps and not mcp_deps:
+    if should_install_mcp and lsp_deps:
+        logger.progress(f"LSP dependencies ({len(lsp_deps)}):")
+        for dep in lsp_deps:
+            logger.progress(f"  - {dep}")
+
+    if not apm_deps and not dev_apm_deps and not mcp_deps and not lsp_deps:
         logger.progress("No dependencies found in apm.yml")
 
     # Orphan preview: lockfile + manifest difference -- no integration

--- a/tests/unit/install/test_dry_run_render.py
+++ b/tests/unit/install/test_dry_run_render.py
@@ -38,6 +38,12 @@ def _make_mcp_dep(name: str = "my-server") -> MagicMock:
     return dep
 
 
+def _make_lsp_dep(name: str = "gopls") -> MagicMock:
+    dep = MagicMock()
+    dep.__str__ = lambda self: name
+    return dep
+
+
 # ---------------------------------------------------------------------------
 # APM and MCP dependency rendering
 # ---------------------------------------------------------------------------
@@ -125,6 +131,70 @@ class TestRenderApmDeps:
 
         all_calls = " ".join(str(c) for c in logger.progress.call_args_list)
         assert "MCP dependencies" in all_calls
+
+    def test_lsp_deps_rendered(self, tmp_path: Path) -> None:
+        """LSP deps block is rendered when should_install_mcp=True and lsp_deps non-empty."""
+        logger = _make_logger()
+        dep = _make_lsp_dep("gopls")
+
+        with patch("apm_cli.deps.lockfile.LockFile.read", side_effect=Exception):
+            render_and_exit(
+                logger=logger,
+                should_install_apm=False,
+                apm_deps=[],
+                mcp_deps=[],
+                dev_apm_deps=[],
+                should_install_mcp=True,
+                update=False,
+                lsp_deps=[dep],
+                apm_dir=tmp_path,
+            )
+
+        all_calls = " ".join(str(c) for c in logger.progress.call_args_list)
+        assert "LSP dependencies" in all_calls
+        assert "gopls" in all_calls
+
+    def test_lsp_only_deps_not_reported_empty(self, tmp_path: Path) -> None:
+        """An LSP-only manifest must not report 'No dependencies found in apm.yml'."""
+        logger = _make_logger()
+        dep = _make_lsp_dep("gopls")
+
+        with patch("apm_cli.deps.lockfile.LockFile.read", side_effect=Exception):
+            render_and_exit(
+                logger=logger,
+                should_install_apm=False,
+                apm_deps=[],
+                mcp_deps=[],
+                dev_apm_deps=[],
+                should_install_mcp=True,
+                update=False,
+                lsp_deps=[dep],
+                apm_dir=tmp_path,
+            )
+
+        all_calls = " ".join(str(c) for c in logger.progress.call_args_list)
+        assert "No dependencies" not in all_calls
+
+    def test_lsp_deps_not_rendered_when_mcp_disabled(self, tmp_path: Path) -> None:
+        """LSP block is skipped when should_install_mcp=False (APM-only mode)."""
+        logger = _make_logger()
+        dep = _make_lsp_dep("gopls")
+
+        with patch("apm_cli.deps.lockfile.LockFile.read", side_effect=Exception):
+            render_and_exit(
+                logger=logger,
+                should_install_apm=True,
+                apm_deps=[],
+                mcp_deps=[],
+                dev_apm_deps=[],
+                should_install_mcp=False,
+                update=False,
+                lsp_deps=[dep],
+                apm_dir=tmp_path,
+            )
+
+        all_calls = " ".join(str(c) for c in logger.progress.call_args_list)
+        assert "LSP dependencies" not in all_calls
 
     def test_no_deps_shows_empty_message(self, tmp_path: Path) -> None:
         """When all dep lists are empty the 'No dependencies found' message is shown (line 53)."""


### PR DESCRIPTION
## Problem

`apm install --dry-run` parses LSP dependencies (`dependencies.lsp`) but never passes them to the dry-run renderer. For an LSP-only manifest the preview wrongly reports:

```
[i] Dry run mode - showing what would be installed:
[i] No dependencies found in apm.yml
[*] Dry run complete - no changes made
```

even though the real install would configure the declared LSP servers.

## Approach

- `src/apm_cli/commands/install.py`: read `lsp_deps = apm_package.get_lsp_dependencies()` and pass it to `render_and_exit`.
- `src/apm_cli/install/presentation/dry_run.py`: accept `lsp_deps`, render an `LSP dependencies (N):` block (mirroring the APM/MCP blocks, gated by `should_install_mcp` like the LSP install gate in `service_integration.py`), and include LSP deps in the empty-manifest check so LSP-only manifests no longer report "No dependencies found in apm.yml".

## Validation

- Added 3 unit tests in `tests/unit/install/test_dry_run_render.py` (LSP block rendered, LSP-only manifest not reported empty, LSP block skipped in APM-only mode).
- `uv run pytest tests/unit/install/`: 1974 passed.
- `uv run pytest tests/unit/deps/ tests/unit/models/`: 3316 passed.
- `uv run ruff check` and `uv run ruff format --check`: clean on changed files.
- Manual repro with an LSP-only `apm.yml` now prints `LSP dependencies (1):` + `- go` and no longer reports "No dependencies found"; an empty manifest still reports "No dependencies found in apm.yml".