### PR TITLE
fix: avoid subpath false positives for .git repository URLs

### DIFF
--- a/.apm/architecture/owners/contracts-tooling.json
+++ b/.apm/architecture/owners/contracts-tooling.json
@@ -3,8 +3,8 @@
   "owners": [
     {
       "id": "dependency-identity-materialization",
-      "decision": "Dependency comparison identity vs display-cased materialization path",
-      "owner": "models/dependency/identity.py + materialization.py + DependencyReference",
+      "decision": "Dependency comparison identity vs display-cased materialization path; embedded git URL subpath validation",
+      "owner": "models/dependency/identity.py + materialization.py + DependencyReference (_check_no_embedded_subpath consumes core/host_providers.py)",
       "selectors": [
         "src/apm_cli/models/dependency/identity.py",
         "src/apm_cli/models/dependency/materialization.py",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   infinite recursion or unbounded writes during `apm install`.
   `docs/src/content/docs/specs/openapm-v0.1.md` now explicitly requires
   containment of consumer-generated staging output. (closes #2556)
+- Explicit GitLab URLs now accept deep repository namespaces whose names match
+  APM primitive directories, while an unambiguous `.git` repository boundary
+  followed by a primitive path still fails before lock, cache, or module writes.
+  (by @aryansk) (#2581)
+- Hook commands such as `"${CLAUDE_PLUGIN_ROOT}"/hooks/probe.py` now rewrite to
+  `"${CLAUDE_PLUGIN_ROOT}/hooks/probe.py"` and warn when a supported plugin-root
+  placeholder remains unresolved instead of silently deploying a dead hook.
+  OpenAPM v0.1 (`docs/src/content/docs/specs/openapm-v0.1.md#req-tg-012`) binds
+  the behavior.
+  (by @MohammedAlkindi; closes #2639) (#2645)
+- `apm uninstall --global` now cleans removed-only target files before deleting their ownership state, while preserving files owned by surviving packages. (#2658)
+- Windows binary is now Authenticode-signed in the release workflow, eliminating
+  the `Trojan:Script/Wacatac.H!ml` Windows Defender false positive on unsigned
+  PyInstaller bundles. (#2435)
 - Multi-target `apm compile` now avoids repeating expensive project analysis
   for each target, making multi-target runs scale like single-target runs
   without changing generated output. (closes #2482)
@@ -125,6 +139,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - YAML expansion guard no longer rejects large anchor-free lockfiles (150K+
   entries) with a false-positive "billion-laughs" error. APM-generated
   lockfiles with no anchors or aliases now load without error. (#2389)
+- `apm install` no longer skips the credential retry on non-English machines.
+  Git localises its diagnostics through gettext, so a translated stderr made an
+  authentication failure unrecognisable and private-repo installs failed with
+  misleading network guidance. Git subprocesses in the authentication retry
+  path now run with `LC_ALL=C` and `LANGUAGE=C`. (by @Naofel-eal, closes #2533)
 
 ### Changed
 

--- a/scripts/architecture_linter/checks/contracts_test_taxonomy.py
+++ b/scripts/architecture_linter/checks/contracts_test_taxonomy.py
@@ -446,7 +446,7 @@ _RESOLVE_PHASE = "src/apm_cli/install/phases/resolve.py"
 
 
 def check_dependency_identity(provider: FactsProvider) -> tuple[Violation, ...]:
-    """Identity may casefold only in identity.py; materialization preserves casing."""
+    """Guard dependency identity, materialization, and embedded-subpath ownership."""
     rule_id = _GUARD_DEPENDENCY_IDENTITY
     identity, identity_fail = _facts_for(provider, _IDENTITY_OWNER, rule_id)
     materialization, mat_fail = _facts_for(provider, _MATERIALIZATION_OWNER, rule_id)
@@ -496,6 +496,42 @@ def check_dependency_identity(provider: FactsProvider) -> tuple[Violation, ...]:
                 rule_id,
                 _IDENTITY_OWNER,
                 "Package identity casing must route through is_github_hostname",
+            )
+        )
+    embedded_subpath_body = _awk_body(
+        reference,
+        re.compile(r"^    def _check_no_embedded_subpath\("),
+        re.compile(r"^    def "),
+    )
+    embedded_subpath_message = (
+        "Embedded git URL subpath validation must use DependencyReference and host_providers"
+    )
+    if not _body_has(
+        embedded_subpath_body, "classify_host_provider("
+    ) or not _body_has(embedded_subpath_body, 'provider.kind == "gitlab"'):
+        findings.append(
+            _summary(
+                rule_id,
+                _REFERENCE_OWNER,
+                embedded_subpath_message,
+            )
+        )
+    primitive_dirs = re.compile(r"_APM_PRIMITIVE_DIRS")
+    for path in _python_paths(provider, _SRC_PREFIX):
+        if path == _REFERENCE_OWNER:
+            continue
+        facts, path_failures = _facts_for(provider, path, rule_id)
+        findings.extend(path_failures)
+        if path_failures:
+            continue
+        findings.extend(
+            _line_findings(
+                facts,
+                path,
+                rule_id,
+                primitive_dirs,
+                embedded_subpath_message,
+                respect_exempt=True,
             )
         )
     return tuple(findings)
@@ -1229,7 +1265,7 @@ RULES: tuple[Rule, ...] = (
     ),
     _owner_rule(
         _GUARD_DEPENDENCY_IDENTITY,
-        "Dependency comparison identity casefolds only in identity.py; materialization preserves casing.",
+        "Dependency identity, materialization, and embedded git URL subpaths have canonical owners.",
         check_dependency_identity,
     ),
     _owner_rule(

--- a/scripts/architecture_linter/checks/contracts_test_taxonomy.py
+++ b/scripts/architecture_linter/checks/contracts_test_taxonomy.py
@@ -506,9 +506,9 @@ def check_dependency_identity(provider: FactsProvider) -> tuple[Violation, ...]:
     embedded_subpath_message = (
         "Embedded git URL subpath validation must use DependencyReference and host_providers"
     )
-    if not _body_has(
-        embedded_subpath_body, "classify_host_provider("
-    ) or not _body_has(embedded_subpath_body, 'provider.kind == "gitlab"'):
+    if not _body_has(embedded_subpath_body, "classify_host_provider(") or not _body_has(
+        embedded_subpath_body, 'provider.kind == "gitlab"'
+    ):
         findings.append(
             _summary(
                 rule_id,

--- a/src/apm_cli/models/dependency/reference.py
+++ b/src/apm_cli/models/dependency/reference.py
@@ -661,10 +661,11 @@ class DependencyReference(ProviderCoordinateMixin):
         else:
             return  # bare shorthand or other form -- not in scope
 
-        # Strip fragment and query string, then remove trailing .git suffix
+        # Strip fragment and query string. A trailing .git is an explicit
+        # repository terminator, so there cannot be an embedded package subpath.
         path_part = path_part.split("#")[0].split("?")[0]
         if path_part.endswith(".git"):
-            path_part = path_part[:-4]
+            return
 
         segments = [s for s in path_part.replace("\\", "/").split("/") if s]
         if len(segments) < 3:

--- a/src/apm_cli/models/dependency/reference.py
+++ b/src/apm_cli/models/dependency/reference.py
@@ -651,6 +651,10 @@ class DependencyReference(ProviderCoordinateMixin):
             return  # bare shorthand or other form -- not in scope
 
         path_part = path_part.split("#")[0].split("?")[0]
+        decoded_path = urllib.parse.unquote(path_part)
+        while decoded_path != path_part:
+            path_part = decoded_path
+            decoded_path = urllib.parse.unquote(path_part)
         segments = [s for s in path_part.replace("\\", "/").split("/") if s]
         if len(segments) < 3:
             return  # too few segments to contain an interior primitive name
@@ -675,9 +679,8 @@ class DependencyReference(ProviderCoordinateMixin):
             # A .git segment followed by an APM primitive is instead an
             # unambiguous embedded subpath, even on GitLab.
             for idx, seg in enumerate(segments[:-1]):
-                if (
-                    seg.endswith(".git")
-                    and segments[idx + 1] in DependencyReference._APM_PRIMITIVE_DIRS
+                if seg.endswith(".git") and any(
+                    tail in DependencyReference._APM_PRIMITIVE_DIRS for tail in segments[idx + 1 :]
                 ):
                     DependencyReference._raise_embedded_subpath_error(raw)
             return

--- a/src/apm_cli/models/dependency/reference.py
+++ b/src/apm_cli/models/dependency/reference.py
@@ -620,7 +620,7 @@ class DependencyReference(ProviderCoordinateMixin):
         return normalized
 
     @staticmethod
-    def _check_no_embedded_subpath(url: str) -> None:
+    def _check_no_embedded_subpath(url: str, *, host_type: str | None = None) -> None:
         """Guard: reject a subpath embedded in an explicit git URL form (#872).
 
         Detects when a user writes, e.g.:
@@ -630,46 +630,36 @@ class DependencyReference(ProviderCoordinateMixin):
         ``fatal: '...' does not appear to be a git repository`` message.
         This guard fires early and points at the supported ``path:`` key.
 
-        The heuristic: for SCP (``git@host:path``), ``ssh://``, or
-        ``https://``/``http://`` URL forms, if any non-last path segment
-        matches a known APM primitive directory name (skills, agents, prompts,
-        etc.), the URL encodes a subpath that belongs in the ``path:`` key.
-
-        GitLab subgroups and Azure DevOps org/project paths do not use APM
-        primitive names (skills, agents, prompts, ...) as segment labels, so
-        the check produces no false positives for those legitimate forms.
-
-        Scoping (issue #1014 follow-up): the embedded-subpath shape is
-        ``org/repo`` followed by ``<primitive>/<name>``, so a primitive
-        segment is only treated as an embedded subpath when it is preceded
-        by a complete ``org/repo`` prefix (segment index >= 2). This avoids
-        a false positive for a GitLab subgroup literally named after a
-        primitive, e.g. ``git@gitlab.com:group/skills/repo.git`` (here
-        ``skills`` is a subgroup at index 1 and ``repo`` is the real
-        repository). A residual ambiguity remains for deep subgroups that
-        embed a primitive name at index >= 2 (e.g.
-        ``group/sub/skills/repo``); that shape is genuinely undecidable
-        without probing the host, so it is still treated as malformed.
+        GitLab repository paths may have arbitrary namespace depth, including
+        namespace names that match APM primitive directories. Fixed-boundary
+        providers instead reserve the path after ``org/repo`` for an APM
+        subpath. The canonical host-provider registry supplies that grammar;
+        this method deliberately performs no network probing.
         """
         raw = url.strip()
 
-        if SCP_LIKE_RE.match(raw):
+        scp_match = SCP_LIKE_RE.match(raw)
+        if scp_match:
             colon_idx = raw.index(":")
             path_part = raw[colon_idx + 1 :]
+            host = scp_match.group("host")
         elif raw.lower().startswith(("ssh://", "https://", "http://")):
-            path_part = urllib.parse.urlparse(raw).path
+            parsed = urllib.parse.urlparse(raw)
+            path_part = parsed.path
+            host = parsed.hostname
         else:
             return  # bare shorthand or other form -- not in scope
 
-        # Strip fragment and query string. A trailing .git is an explicit
-        # repository terminator, so there cannot be an embedded package subpath.
         path_part = path_part.split("#")[0].split("?")[0]
-        if path_part.endswith(".git"):
-            return
-
         segments = [s for s in path_part.replace("\\", "/").split("/") if s]
         if len(segments) < 3:
             return  # too few segments to contain an interior primitive name
+
+        if host is None:
+            return
+        from apm_cli.core.host_providers import classify_host_provider
+
+        provider = classify_host_provider(host, host_type=host_type)
 
         # Azure DevOps repo URLs carry the repository under a `_git` segment
         # and legitimately encode a virtual path after it (e.g.
@@ -680,6 +670,18 @@ class DependencyReference(ProviderCoordinateMixin):
         if "_git" in segments:
             return
 
+        if provider.kind == "gitlab":
+            # A terminal .git segment is an unambiguous repository boundary.
+            # A .git segment followed by an APM primitive is instead an
+            # unambiguous embedded subpath, even on GitLab.
+            for idx, seg in enumerate(segments[:-1]):
+                if (
+                    seg.endswith(".git")
+                    and segments[idx + 1] in DependencyReference._APM_PRIMITIVE_DIRS
+                ):
+                    DependencyReference._raise_embedded_subpath_error(raw)
+            return
+
         # An embedded subpath is `org/repo` + `<primitive>/<name>`, so the
         # primitive directory must be preceded by a complete org/repo prefix
         # (index >= 2). Restricting to index >= 2 keeps the real malformed-URL
@@ -688,14 +690,19 @@ class DependencyReference(ProviderCoordinateMixin):
         # (group/skills/repo, where `repo` is the actual repository).
         for idx, seg in enumerate(segments[:-1]):
             if idx >= 2 and seg in DependencyReference._APM_PRIMITIVE_DIRS:
-                raise ValueError(
-                    "A subpath cannot be embedded in a git URL. "
-                    f"Got: `{raw}`. "
-                    "Use the `path:` key instead: "
-                    "`git: <repo-url>` + `path: <primitive>/<name>` "
-                    "(or the shorthand `org/repo/<primitive>/<name>`). "
-                    "See https://microsoft.github.io/apm/consumer/manage-dependencies/"
-                )
+                DependencyReference._raise_embedded_subpath_error(raw)
+
+    @staticmethod
+    def _raise_embedded_subpath_error(raw: str) -> None:
+        """Raise the canonical recovery error for an embedded primitive path."""
+        raise ValueError(
+            "A subpath cannot be embedded in a git URL. "
+            f"Got: `{raw}`. "
+            "Use the `path:` key instead: "
+            "`git: <repo-url>` + `path: <primitive>/<name>` "
+            "(or the shorthand `org/repo/<primitive>/<name>`). "
+            "See https://microsoft.github.io/apm/consumer/manage-dependencies/"
+        )
 
     @classmethod
     def parse_from_dict(cls, entry: dict) -> "DependencyReference":
@@ -866,7 +873,7 @@ class DependencyReference(ProviderCoordinateMixin):
             validate_path_segments(sub_path, context="path")
 
         # Parse the git URL using the standard parser
-        dep = cls.parse(git_url)
+        dep = cls.parse(git_url, host_type=host_type)
         dep.host_type = host_type
         dep.allow_insecure = allow_insecure
         # Object-form ``- git:`` is an explicit Git resolver pin, even when
@@ -1737,7 +1744,12 @@ class DependencyReference(ProviderCoordinateMixin):
         return None
 
     @classmethod
-    def parse(cls, dependency_str: str) -> "DependencyReference":
+    def parse(
+        cls,
+        dependency_str: str,
+        *,
+        host_type: str | None = None,
+    ) -> "DependencyReference":
         """Parse a dependency string into a DependencyReference.
 
         Supports formats:
@@ -1809,7 +1821,7 @@ class DependencyReference(ProviderCoordinateMixin):
         # Guard: detect a subpath embedded in an explicit git URL form (#872).
         # Fires before virtual-package detection so the user gets an actionable
         # error rather than a cryptic downstream git failure.
-        cls._check_no_embedded_subpath(dependency_str)
+        cls._check_no_embedded_subpath(dependency_str, host_type=host_type)
 
         # Phase 1: detect virtual packages
         is_virtual_package, virtual_path, validated_host = cls._detect_virtual_package(
@@ -1865,6 +1877,7 @@ class DependencyReference(ProviderCoordinateMixin):
         return cls(
             repo_url=repo_url,
             host=host,
+            host_type=host_type,
             port=port,
             explicit_scheme=explicit_scheme,
             reference=reference,

--- a/tests/integration/test_architecture_dependency_reference.py
+++ b/tests/integration/test_architecture_dependency_reference.py
@@ -1,0 +1,47 @@
+"""Architecture coverage for embedded git URL subpath validation."""
+
+from pathlib import Path
+
+import pytest
+
+from scripts.architecture_linter.runner import registered_rules, run_selected_rules
+
+pytestmark = pytest.mark.component
+
+ROOT = Path(__file__).parents[2]
+RULE_ID = "contracts-tooling-dependency-identity"
+REFERENCE = "src/apm_cli/models/dependency/reference.py"
+
+
+def test_embedded_git_url_subpath_has_one_provider_aware_owner() -> None:
+    """The URL guard owns primitive-tail classification through host providers."""
+    reference = (ROOT / REFERENCE).read_text(encoding="utf-8")
+    owner_registry = (ROOT / ".apm/architecture/owners/contracts-tooling.json").read_text(
+        encoding="utf-8"
+    )
+    rule = next(rule for rule in registered_rules() if rule.id == RULE_ID)
+
+    assert reference.count("def _check_no_embedded_subpath(") == 1
+    assert "classify_host_provider(host, host_type=host_type)" in reference
+    assert 'provider.kind == "gitlab"' in reference
+    assert "embedded git URL subpath validation" in owner_registry
+    assert rule.guard_ids == (RULE_ID,)
+
+
+def test_embedded_git_url_subpath_guard_rejects_provider_bypass() -> None:
+    """The registered static guard rejects a universal GitLab bypass mutation."""
+    source = (ROOT / REFERENCE).read_text(encoding="utf-8")
+    mutated = source.replace('provider.kind == "gitlab"', "True", 1)
+    assert mutated != source
+
+    report = run_selected_rules(
+        ROOT,
+        (RULE_ID,),
+        source_overrides={REFERENCE: mutated},
+    )
+
+    assert any(
+        violation.rule_id == RULE_ID
+        and "Embedded git URL subpath validation" in violation.message
+        for violation in report.violations
+    )

--- a/tests/integration/test_architecture_dependency_reference.py
+++ b/tests/integration/test_architecture_dependency_reference.py
@@ -41,7 +41,6 @@ def test_embedded_git_url_subpath_guard_rejects_provider_bypass() -> None:
     )
 
     assert any(
-        violation.rule_id == RULE_ID
-        and "Embedded git URL subpath validation" in violation.message
+        violation.rule_id == RULE_ID and "Embedded git URL subpath validation" in violation.message
         for violation in report.violations
     )

--- a/tests/integration/test_consume_source_ref_cache_matrix.py
+++ b/tests/integration/test_consume_source_ref_cache_matrix.py
@@ -213,9 +213,7 @@ _GITLAB_DEEP_BOUNDARY_ROWS = (
     _MatrixRow(
         id="gitlab-deep-https-string",
         source="https://gitlab.com/ai/platform/collections/consume-matrix.git",
-        rewrite_urls=(
-            "https://gitlab.com/ai/platform/collections/consume-matrix.git",
-        ),
+        rewrite_urls=("https://gitlab.com/ai/platform/collections/consume-matrix.git",),
         expected_host="gitlab.com",
         expected_kind="gitlab",
         expected_repo="ai/platform/collections/consume-matrix",
@@ -225,9 +223,7 @@ _GITLAB_DEEP_BOUNDARY_ROWS = (
     _MatrixRow(
         id="gitlab-deep-scp-string",
         source="git@gitlab.com:ai/platform/collections/consume-matrix.git",
-        rewrite_urls=(
-            "git@gitlab.com:ai/platform/collections/consume-matrix.git",
-        ),
+        rewrite_urls=("git@gitlab.com:ai/platform/collections/consume-matrix.git",),
         expected_host="gitlab.com",
         expected_kind="gitlab",
         expected_repo="ai/platform/collections/consume-matrix",
@@ -237,9 +233,7 @@ _GITLAB_DEEP_BOUNDARY_ROWS = (
     _MatrixRow(
         id="gitlab-deep-https-object",
         source="https://code.example.invalid/ai/platform/collections/consume-matrix.git",
-        rewrite_urls=(
-            "https://code.example.invalid/ai/platform/collections/consume-matrix.git",
-        ),
+        rewrite_urls=("https://code.example.invalid/ai/platform/collections/consume-matrix.git",),
         expected_host="code.example.invalid",
         expected_kind="gitlab",
         expected_repo="ai/platform/collections/consume-matrix",
@@ -249,9 +243,7 @@ _GITLAB_DEEP_BOUNDARY_ROWS = (
     _MatrixRow(
         id="gitlab-deep-scp-object",
         source="git@code.example.invalid:ai/platform/collections/consume-matrix.git",
-        rewrite_urls=(
-            "git@code.example.invalid:ai/platform/collections/consume-matrix.git",
-        ),
+        rewrite_urls=("git@code.example.invalid:ai/platform/collections/consume-matrix.git",),
         expected_host="code.example.invalid",
         expected_kind="gitlab",
         expected_repo="ai/platform/collections/consume-matrix",
@@ -631,6 +623,7 @@ def test_gitlab_deep_repository_boundary(
     (
         "https://github.com/org/repo.git/collections/security",
         {"git": "git@github.com:org/repo/collections/security.git"},
+        "https://gitlab.com/ai/platform/collections/consume-matrix.git/collections/security",
     ),
 )
 def test_embedded_primitive_tail_fails_before_git_state(
@@ -654,7 +647,8 @@ def test_embedded_primitive_tail_fails_before_git_state(
     )
 
     assert result.returncode != 0
-    assert "A subpath cannot be embedded in a git URL" in result.stdout + result.stderr
+    output = " ".join((result.stdout + result.stderr).split())
+    assert "A subpath cannot be embedded in a git URL" in output
     assert not (scenario.project_root / "apm.lock.yaml").exists()
     assert not (scenario.project_root / "apm_modules").exists()
     assert list(scenario.isolated.cache_root.iterdir()) == []

--- a/tests/integration/test_consume_source_ref_cache_matrix.py
+++ b/tests/integration/test_consume_source_ref_cache_matrix.py
@@ -57,6 +57,7 @@ _INSTALL_ARGS = (
     "--parallel-downloads",
     "0",
 )
+_FROZEN_INSTALL_ARGS = (*_INSTALL_ARGS, "--frozen")
 _LOCK_ARGS = (
     "lock",
     "--target",
@@ -92,6 +93,7 @@ class _MatrixRow:
     transition_source: str | None = None
     transition_rewrite_urls: tuple[str, ...] = ()
     expected_port: int | None = None
+    manifest_style: str = "object"
 
 
 _ROWS = (
@@ -207,6 +209,57 @@ _ROWS = (
     ),
 )
 
+_GITLAB_DEEP_BOUNDARY_ROWS = (
+    _MatrixRow(
+        id="gitlab-deep-https-string",
+        source="https://gitlab.com/ai/platform/collections/consume-matrix.git",
+        rewrite_urls=(
+            "https://gitlab.com/ai/platform/collections/consume-matrix.git",
+        ),
+        expected_host="gitlab.com",
+        expected_kind="gitlab",
+        expected_repo="ai/platform/collections/consume-matrix",
+        ref_selector="second-sha",
+        manifest_style="string",
+    ),
+    _MatrixRow(
+        id="gitlab-deep-scp-string",
+        source="git@gitlab.com:ai/platform/collections/consume-matrix.git",
+        rewrite_urls=(
+            "git@gitlab.com:ai/platform/collections/consume-matrix.git",
+        ),
+        expected_host="gitlab.com",
+        expected_kind="gitlab",
+        expected_repo="ai/platform/collections/consume-matrix",
+        ref_selector="second-sha",
+        manifest_style="string",
+    ),
+    _MatrixRow(
+        id="gitlab-deep-https-object",
+        source="https://code.example.invalid/ai/platform/collections/consume-matrix.git",
+        rewrite_urls=(
+            "https://code.example.invalid/ai/platform/collections/consume-matrix.git",
+        ),
+        expected_host="code.example.invalid",
+        expected_kind="gitlab",
+        expected_repo="ai/platform/collections/consume-matrix",
+        ref_selector="second-sha",
+        host_type="gitlab",
+    ),
+    _MatrixRow(
+        id="gitlab-deep-scp-object",
+        source="git@code.example.invalid:ai/platform/collections/consume-matrix.git",
+        rewrite_urls=(
+            "git@code.example.invalid:ai/platform/collections/consume-matrix.git",
+        ),
+        expected_host="code.example.invalid",
+        expected_kind="gitlab",
+        expected_repo="ai/platform/collections/consume-matrix",
+        ref_selector="second-sha",
+        host_type="gitlab",
+    ),
+)
+
 
 @dataclass(frozen=True)
 class _Scenario:
@@ -280,7 +333,9 @@ def _reference_for(
     raise AssertionError(f"Unknown ref selector: {row.ref_selector}")
 
 
-def _manifest_entry(row: _MatrixRow, source: str, reference: str) -> dict[str, str]:
+def _manifest_entry(row: _MatrixRow, source: str, reference: str) -> str | dict[str, str]:
+    if row.manifest_style == "string":
+        return f"{source}#{reference}"
     entry = {"git": source, "ref": reference}
     if row.host_type:
         entry["type"] = row.host_type
@@ -526,6 +581,83 @@ def test_immutable_source_ref_rows_resolve_deploy_audit_and_converge(
     _run_initial_contract(row, scenario, apm_binary_path=apm_binary_path)
     _assert_unchanged_convergence(row, scenario, apm_binary_path=apm_binary_path)
     record_property("scenario_seconds", round(time.monotonic() - started, 3))
+
+
+@pytest.mark.lifecycle_smoke
+@pytest.mark.parametrize("row", _GITLAB_DEEP_BOUNDARY_ROWS, ids=lambda row: row.id)
+def test_gitlab_deep_repository_boundary(
+    tmp_path: Path,
+    apm_binary_path: Path,
+    record_property: Callable[[str, object], None],
+    row: _MatrixRow,
+) -> None:
+    """Deep GitLab paths pack, install, and replay frozen without state drift."""
+    started = time.monotonic()
+    scenario = _create_scenario(tmp_path / row.id, row)
+    _run_initial_contract(row, scenario, apm_binary_path=apm_binary_path)
+    lock_before = (scenario.project_root / "apm.lock.yaml").read_bytes()
+    deployed_before = (scenario.project_root / _SKILL_PATH).read_bytes()
+
+    pack_result = _runner(apm_binary_path).run(
+        ("pack", "--offline"),
+        scenario_id=f"{row.id}-pack",
+        cwd=scenario.project_root,
+        env=scenario.environment,
+    )
+    _assert_success(pack_result)
+    frozen_result = _runner(apm_binary_path).run(
+        _FROZEN_INSTALL_ARGS,
+        scenario_id=f"{row.id}-frozen",
+        cwd=scenario.project_root,
+        env=scenario.environment,
+    )
+    _assert_success(frozen_result)
+    _assert_lock_provenance(
+        row,
+        scenario,
+        expected_source=row.source,
+        expected_ref=scenario.initial_ref,
+        expected_commit=scenario.expected_commit,
+    )
+    _assert_deployment(scenario, expected_skill_bytes=scenario.expected_skill_bytes)
+    assert (scenario.project_root / "apm.lock.yaml").read_bytes() == lock_before
+    assert (scenario.project_root / _SKILL_PATH).read_bytes() == deployed_before
+    record_property("scenario_seconds", round(time.monotonic() - started, 3))
+
+
+@pytest.mark.lifecycle_smoke
+@pytest.mark.parametrize(
+    "dependency",
+    (
+        "https://github.com/org/repo.git/collections/security",
+        {"git": "git@github.com:org/repo/collections/security.git"},
+    ),
+)
+def test_embedded_primitive_tail_fails_before_git_state(
+    tmp_path: Path,
+    apm_binary_path: Path,
+    dependency: str | dict[str, str],
+) -> None:
+    """Malformed explicit paths fail before lock, cache, or module writes."""
+    row = _GITLAB_DEEP_BOUNDARY_ROWS[0]
+    scenario = _create_scenario(tmp_path / "invalid-embedded-tail", row)
+    manifest_path = scenario.project_root / "apm.yml"
+    manifest = load_yaml(manifest_path)
+    manifest["dependencies"]["apm"] = [dependency]
+    dump_yaml(manifest, manifest_path)
+
+    result = _runner(apm_binary_path).run(
+        _LOCK_ARGS,
+        scenario_id="gitlab-deep-repository-boundary-invalid",
+        cwd=scenario.project_root,
+        env=scenario.environment,
+    )
+
+    assert result.returncode != 0
+    assert "A subpath cannot be embedded in a git URL" in result.stdout + result.stderr
+    assert not (scenario.project_root / "apm.lock.yaml").exists()
+    assert not (scenario.project_root / "apm_modules").exists()
+    assert list(scenario.isolated.cache_root.iterdir()) == []
 
 
 def test_warm_cache_only_audit_replays_after_origin_becomes_unavailable(

--- a/tests/unit/test_generic_git_urls.py
+++ b/tests/unit/test_generic_git_urls.py
@@ -59,10 +59,30 @@ class TestGitLabHTTPS:
         assert dep.host == "gitlab.com"
         assert dep.repo_url == "acme/coding-standards"
 
-    def test_gitlab_deep_subgroup_named_primitive_with_git_suffix(self):
-        dep = DependencyReference.parse("https://gitlab.com/ai/collections/core.git")
+    @pytest.mark.parametrize(
+        "url",
+        (
+            "https://gitlab.com/ai/platform/collections/core.git",
+            "git@gitlab.com:ai/platform/collections/core.git",
+        ),
+    )
+    def test_gitlab_deep_subgroup_named_primitive_with_git_suffix(self, url):
+        dep = DependencyReference.parse(url)
         assert dep.host == "gitlab.com"
-        assert dep.repo_url == "ai/collections/core"
+        assert dep.repo_url == "ai/platform/collections/core"
+
+    @pytest.mark.parametrize(
+        "url",
+        (
+            "https://code.example.invalid/ai/platform/collections/core.git",
+            "git@code.example.invalid:ai/platform/collections/core.git",
+        ),
+    )
+    def test_object_gitlab_type_allows_deep_primitive_namespace(self, url):
+        dep = DependencyReference.parse_from_dict({"git": url, "type": "gitlab"})
+        assert dep.host == "code.example.invalid"
+        assert dep.host_type == "gitlab"
+        assert dep.repo_url == "ai/platform/collections/core"
 
     def test_gitlab_https_url_with_ref(self):
         dep = DependencyReference.parse("https://gitlab.com/acme/coding-standards.git#v2.0")
@@ -1355,6 +1375,20 @@ class TestEmbeddedSubpathInGitUrl:
             DependencyReference.parse_from_dict(
                 {"git": "git@github.com:org/repo/skills/hello-world.git"}
             )
+
+    @pytest.mark.parametrize(
+        "url",
+        (
+            "https://github.com/org/repo/collections/core.git",
+            "git@github.com:org/repo/collections/core.git",
+            "ssh://git@github.com/org/repo/collections/core.git",
+            "https://gitlab.com/ai/platform/core.git/collections/security",
+        ),
+    )
+    def test_explicit_primitive_tail_raises_for_fixed_or_git_boundary(self, url) -> None:
+        """A known repository boundary must never permit an embedded primitive tail."""
+        with pytest.raises(ValueError, match=r"A subpath cannot be embedded in a git URL"):
+            DependencyReference.parse(url)
 
     # ------------------------------------------------------------------
     # No-regression cases: supported shapes must still parse fine

--- a/tests/unit/test_generic_git_urls.py
+++ b/tests/unit/test_generic_git_urls.py
@@ -603,14 +603,14 @@ class TestFQDNVirtualPaths:
         assert dep.virtual_path == "prompts/file.prompt.md"
         assert dep.reference == "v2.0"
 
-    def test_https_url_with_path_rejected(self):
-        """HTTPS git URLs can't embed virtual paths -- use dict format with path: instead."""
-        with pytest.raises(ValueError, match=r"A subpath cannot be embedded in a git URL"):
+    def test_https_url_with_virtual_file_path_is_rejected(self) -> None:
+        """HTTPS git URLs cannot embed virtual files."""
+        with pytest.raises(ValueError, match="virtual file extension"):
             DependencyReference.parse("https://gitlab.com/acme/repo/prompts/file.prompt.md")
 
-    def test_ssh_url_with_path_rejected(self):
-        """SSH git URLs can't embed virtual paths -- use dict format with path: instead."""
-        with pytest.raises(ValueError, match=r"A subpath cannot be embedded in a git URL"):
+    def test_ssh_url_with_virtual_file_path_is_rejected(self) -> None:
+        """SSH git URLs cannot embed virtual files."""
+        with pytest.raises(ValueError, match="virtual file extension"):
             DependencyReference.parse("git@gitlab.com:acme/repo/prompts/code-review.prompt.md")
 
 
@@ -1383,6 +1383,9 @@ class TestEmbeddedSubpathInGitUrl:
             "git@github.com:org/repo/collections/core.git",
             "ssh://git@github.com/org/repo/collections/core.git",
             "https://gitlab.com/ai/platform/core.git/collections/security",
+            "git@gitlab.com:ai/platform/core.git/nested/collections/security",
+            "https://github.com/org/repo/%2563ollections/core.git",
+            "https://gitlab.com/ai/platform/core.git/%2563ollections/security",
         ),
     )
     def test_explicit_primitive_tail_raises_for_fixed_or_git_boundary(self, url) -> None:

--- a/tests/unit/test_generic_git_urls.py
+++ b/tests/unit/test_generic_git_urls.py
@@ -59,6 +59,11 @@ class TestGitLabHTTPS:
         assert dep.host == "gitlab.com"
         assert dep.repo_url == "acme/coding-standards"
 
+    def test_gitlab_deep_subgroup_named_primitive_with_git_suffix(self):
+        dep = DependencyReference.parse("https://gitlab.com/ai/collections/core.git")
+        assert dep.host == "gitlab.com"
+        assert dep.repo_url == "ai/collections/core"
+
     def test_gitlab_https_url_with_ref(self):
         dep = DependencyReference.parse("https://gitlab.com/acme/coding-standards.git#v2.0")
         assert dep.host == "gitlab.com"


### PR DESCRIPTION
## Summary

Stop treating a primitive-named GitLab subgroup as an embedded APM subpath when the explicit repository URL already terminates in `.git`.

## Changes

- preserve the `.git` terminator signal in `_check_no_embedded_subpath`
- return before the primitive-directory heuristic for explicit `.git` repository URLs
- add a regression test for `https://gitlab.com/ai/collections/core.git`

## Validation

The new test covers a depth-3 GitLab repository whose subgroup is named `collections`, while existing subpath-guard tests continue to cover shorthand malformed paths.

Fixes #2528

<!-- pr-relay-job relay-5-31439d7fdeea4a73f653 -->