### PR TITLE
fix: make plugin.json dry-run match non-force pack behavior

### DIFF
--- a/src/apm_cli/core/build_orchestrator.py
+++ b/src/apm_cli/core/build_orchestrator.py
@@ -264,7 +264,7 @@ class PluginManifestProducer:
             PLUGIN_ECOSYSTEM_PATHS,
             PLUGIN_MANIFEST_ECOSYSTEMS,
             build_plugin_manifest,
-            write_plugin_manifest,
+            write_plugin_manifest_with_outcome,
         )
 
         # Read raw apm.yml to obtain targets.
@@ -335,7 +335,7 @@ class PluginManifestProducer:
             )
             rel_path = PLUGIN_ECOSYSTEM_PATHS.get(ecosystem, "")
             target_path = str(options.project_root / rel_path) if rel_path else ecosystem
-            output_path = write_plugin_manifest(
+            write_result = write_plugin_manifest_with_outcome(
                 options.project_root,
                 manifest,
                 ecosystem,
@@ -343,14 +343,12 @@ class PluginManifestProducer:
                 force=options.bundle_force,
                 logger=logger,
             )
-            if options.dry_run:
-                # write returns None in dry-run; the path would have been written.
+            if write_result.action == "dry_run":
                 dry_run_paths.append(target_path)
-            elif output_path is not None:
-                outputs.append(output_path)
-                written.append(str(output_path))
+            elif write_result.action == "written" and write_result.path is not None:
+                outputs.append(write_result.path)
+                written.append(str(write_result.path))
             else:
-                # Non-dry-run None means an existing file was preserved (no --force).
                 skipped.append(target_path)
 
         return ProducerResult(

--- a/src/apm_cli/core/plugin_manifest.py
+++ b/src/apm_cli/core/plugin_manifest.py
@@ -429,11 +429,6 @@ def write_plugin_manifest(
     # .github/ directory pointing outside the project root).
     ensure_path_within(output_path, project_root)
 
-    if dry_run:
-        _msg = f"Would write plugin manifest to {output_path}"
-        _emit("info", _msg, logger, "info")
-        return None
-
     if output_path.exists():
         if not force:
             _skip_warn = (
@@ -447,6 +442,11 @@ def write_plugin_manifest(
             f"Overwriting {output_path} with generated manifest from apm.yml (--force)."
         )
         _emit("warning", _overwrite_warn, logger, "warning")
+
+    if dry_run:
+        _msg = f"Would write plugin manifest to {output_path}"
+        _emit("info", _msg, logger, "info")
+        return None
 
     # Generated content under .github/ is granted elevated trust by GitHub
     # Actions -- surface the write so operators with branch-protection on

--- a/src/apm_cli/core/plugin_manifest.py
+++ b/src/apm_cli/core/plugin_manifest.py
@@ -23,8 +23,9 @@ from __future__ import annotations
 
 import json
 import re
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from ..utils.console import _rich_info, _rich_success, _rich_warning
 from ..utils.path_security import ensure_path_within
@@ -68,6 +69,14 @@ PLUGIN_ECOSYSTEM_PATHS: dict[str, str] = {
     "copilot": ".github/plugin/plugin.json",
 }
 """Output path (relative to project root) for each ecosystem's ``plugin.json``."""
+
+
+@dataclass(frozen=True)
+class PluginManifestWriteResult:
+    """Describe the canonical plugin-manifest write decision."""
+
+    path: Path | None
+    action: Literal["written", "skipped", "dry_run"]
 
 
 # Server-object keys that may carry live credentials. Any key whose lowercased
@@ -389,7 +398,7 @@ def build_plugin_manifest(
 # ---------------------------------------------------------------------------
 
 
-def write_plugin_manifest(
+def write_plugin_manifest_with_outcome(
     project_root: Path,
     manifest: dict,
     ecosystem: str,
@@ -397,8 +406,8 @@ def write_plugin_manifest(
     dry_run: bool = False,
     force: bool = False,
     logger: Any = None,
-) -> Path | None:
-    """Write *manifest* as ``plugin.json`` for *ecosystem* inside *project_root*.
+) -> PluginManifestWriteResult:
+    """Write *manifest* and return its canonical write decision.
 
     The output path is resolved from :data:`PLUGIN_ECOSYSTEM_PATHS`.  Parent
     directories are created automatically.
@@ -414,14 +423,15 @@ def write_plugin_manifest(
     In dry-run mode the function logs what *would* be written and returns
     ``None`` without touching the filesystem.
 
-    Returns the output :class:`~pathlib.Path` on a successful write, or ``None``
-    for an unknown ecosystem, a dry-run, or a skipped overwrite.
+    The result distinguishes a real write, a protected existing file, and a
+    dry-run preview so callers can report the same decision without inferring it
+    from filesystem state.
     """
     rel_path = PLUGIN_ECOSYSTEM_PATHS.get(ecosystem)
     if rel_path is None:
         _warn = f"Unknown plugin ecosystem {ecosystem!r}; skipping plugin.json generation."
         _emit("warning", _warn, logger, "warning")
-        return None
+        return PluginManifestWriteResult(path=None, action="skipped")
 
     output_path = project_root / rel_path
 
@@ -436,17 +446,24 @@ def write_plugin_manifest(
                 "Re-run with --force to overwrite it."
             )
             _emit("warning", _skip_warn, logger, "warning")
-            return None
+            return PluginManifestWriteResult(path=None, action="skipped")
 
+    if dry_run:
+        if output_path.exists():
+            _msg = (
+                f"Would overwrite plugin manifest at {output_path} "
+                "with generated manifest from apm.yml (--force)."
+            )
+        else:
+            _msg = f"Would write plugin manifest to {output_path}"
+        _emit("info", _msg, logger, "info")
+        return PluginManifestWriteResult(path=None, action="dry_run")
+
+    if output_path.exists():
         _overwrite_warn = (
             f"Overwriting {output_path} with generated manifest from apm.yml (--force)."
         )
         _emit("warning", _overwrite_warn, logger, "warning")
-
-    if dry_run:
-        _msg = f"Would write plugin manifest to {output_path}"
-        _emit("info", _msg, logger, "info")
-        return None
 
     # Generated content under .github/ is granted elevated trust by GitHub
     # Actions -- surface the write so operators with branch-protection on
@@ -468,4 +485,24 @@ def write_plugin_manifest(
     _success = f"Generated plugin manifest: {output_path}"
     _emit("success", _success, logger, "check")
 
-    return output_path
+    return PluginManifestWriteResult(path=output_path, action="written")
+
+
+def write_plugin_manifest(
+    project_root: Path,
+    manifest: dict,
+    ecosystem: str,
+    *,
+    dry_run: bool = False,
+    force: bool = False,
+    logger: Any = None,
+) -> Path | None:
+    """Write *manifest* as ``plugin.json`` and return its path when written."""
+    return write_plugin_manifest_with_outcome(
+        project_root,
+        manifest,
+        ecosystem,
+        dry_run=dry_run,
+        force=force,
+        logger=logger,
+    ).path

--- a/src/apm_cli/core/plugin_manifest.py
+++ b/src/apm_cli/core/plugin_manifest.py
@@ -415,13 +415,13 @@ def write_plugin_manifest_with_outcome(
     **Overwrite policy.** If a ``plugin.json`` already exists at the target
     path it is preserved unless *force* is set (threaded from ``apm pack
     --force``). Without ``--force`` the function emits a warning and skips the
-    write, returning ``None`` -- this mirrors the collision contract the rest
+    write with a ``"skipped"`` result -- this mirrors the collision contract the rest
     of ``apm pack`` already honours and prevents a compromised ``.mcp.json``
     from silently replacing a hand-audited file. With ``--force`` the existing
     file is overwritten and a warning records the replacement.
 
-    In dry-run mode the function logs what *would* be written and returns
-    ``None`` without touching the filesystem.
+    In dry-run mode the function logs what *would* be written and returns a
+    ``"dry_run"`` result without touching the filesystem.
 
     The result distinguishes a real write, a protected existing file, and a
     dry-run preview so callers can report the same decision without inferring it

--- a/tests/integration/test_pack_install_flow.py
+++ b/tests/integration/test_pack_install_flow.py
@@ -290,6 +290,18 @@ class TestPackCmd:
         assert envelope2["plugin_manifests"]["dry_run"] == []
         assert out.read_text(encoding="utf-8") == preserved
 
+        forced_dry_run = runner.invoke(
+            pack_cmd, ["--claude-plugin", "--force", "--dry-run", "--json"]
+        )
+        assert forced_dry_run.exit_code == 0
+        forced_dry_run_start = forced_dry_run.output.find("{")
+        assert forced_dry_run_start >= 0, f"No JSON found in output: {forced_dry_run.output!r}"
+        forced_dry_run_envelope = json_mod.loads(forced_dry_run.output[forced_dry_run_start:])
+        assert forced_dry_run_envelope["plugin_manifests"]["written"] == []
+        assert forced_dry_run_envelope["plugin_manifests"]["skipped"] == []
+        assert forced_dry_run_envelope["plugin_manifests"]["dry_run"] == [str(out)]
+        assert out.read_text(encoding="utf-8") == preserved
+
     def test_pack_marketplace_output_flag_removed(self, runner, tmp_path, monkeypatch):
         """The legacy --marketplace-output flag was removed in favour of --marketplace-path."""
         monkeypatch.chdir(tmp_path)

--- a/tests/integration/test_pack_install_flow.py
+++ b/tests/integration/test_pack_install_flow.py
@@ -266,17 +266,29 @@ class TestPackCmd:
         assert any(p.endswith(".claude-plugin/plugin.json") for p in written)
         assert envelope["plugin_manifests"]["skipped"] == []
 
-        # Second run without --force: the existing file is preserved (skipped).
+        out = tmp_path / ".claude-plugin" / "plugin.json"
+        preserved = out.read_text(encoding="utf-8")
+
+        # Dry-run and real non-force pack must agree that the existing file skips.
+        dry_run = runner.invoke(pack_cmd, ["--claude-plugin", "--dry-run", "--json"])
+        assert dry_run.exit_code == 0
+        dry_run_start = dry_run.output.find("{")
+        assert dry_run_start >= 0, f"No JSON found in output: {dry_run.output!r}"
+        dry_run_envelope = json_mod.loads(dry_run.output[dry_run_start:])
+        assert dry_run_envelope["plugin_manifests"]["written"] == []
+        assert dry_run_envelope["plugin_manifests"]["skipped"] == [str(out)]
+        assert dry_run_envelope["plugin_manifests"]["dry_run"] == []
+        assert out.read_text(encoding="utf-8") == preserved
+
         result2 = runner.invoke(pack_cmd, ["--claude-plugin", "--json"])
         assert result2.exit_code == 0
         env2_start = result2.output.find("{")
         assert env2_start >= 0, f"No JSON found in output: {result2.output!r}"
         envelope2 = json_mod.loads(result2.output[env2_start:])
         assert envelope2["plugin_manifests"]["written"] == []
-        assert any(
-            p.endswith(".claude-plugin/plugin.json")
-            for p in envelope2["plugin_manifests"]["skipped"]
-        )
+        assert envelope2["plugin_manifests"]["skipped"] == [str(out)]
+        assert envelope2["plugin_manifests"]["dry_run"] == []
+        assert out.read_text(encoding="utf-8") == preserved
 
     def test_pack_marketplace_output_flag_removed(self, runner, tmp_path, monkeypatch):
         """The legacy --marketplace-output flag was removed in favour of --marketplace-path."""

--- a/tests/unit/core/test_plugin_manifest.py
+++ b/tests/unit/core/test_plugin_manifest.py
@@ -563,9 +563,13 @@ class TestWritePluginManifest:
 
         assert result is None
         assert json.loads(existing.read_text(encoding="utf-8"))["name"] == "old-content"
-        assert len(warnings_emitted) == 1
-        assert "Overwriting" in warnings_emitted[0]
-        assert info_emitted == [f"Would write plugin manifest to {existing}"]
+        assert warnings_emitted == []
+        assert info_emitted == [
+            (
+                f"Would overwrite plugin manifest at {existing} "
+                "with generated manifest from apm.yml (--force)."
+            )
+        ]
 
     def test_unknown_ecosystem_returns_none(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/core/test_plugin_manifest.py
+++ b/tests/unit/core/test_plugin_manifest.py
@@ -506,6 +506,36 @@ class TestWritePluginManifest:
         assert result is None
         assert not expected.exists()
 
+    def test_dry_run_existing_file_reports_non_force_skip(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        existing = tmp_path / ".claude-plugin" / "plugin.json"
+        _write(existing, json.dumps({"name": "old-content"}))
+
+        warnings_emitted: list[str] = []
+        info_emitted: list[str] = []
+        monkeypatch.setattr(
+            "apm_cli.core.plugin_manifest._rich_warning",
+            lambda msg, **kw: warnings_emitted.append(msg),
+        )
+        monkeypatch.setattr(
+            "apm_cli.core.plugin_manifest._rich_info",
+            lambda msg, **kw: info_emitted.append(msg),
+        )
+
+        result = write_plugin_manifest(
+            tmp_path,
+            {"name": "new-content"},
+            "claude",
+            dry_run=True,
+        )
+
+        assert result is None
+        assert json.loads(existing.read_text(encoding="utf-8"))["name"] == "old-content"
+        assert len(warnings_emitted) == 1
+        assert "skipping plugin.json generation" in warnings_emitted[0]
+        assert not any("Would write plugin manifest" in msg for msg in info_emitted)
+
     def test_unknown_ecosystem_returns_none(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/core/test_plugin_manifest.py
+++ b/tests/unit/core/test_plugin_manifest.py
@@ -536,6 +536,37 @@ class TestWritePluginManifest:
         assert "skipping plugin.json generation" in warnings_emitted[0]
         assert not any("Would write plugin manifest" in msg for msg in info_emitted)
 
+    def test_dry_run_existing_file_with_force_previews_overwrite(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        existing = tmp_path / ".claude-plugin" / "plugin.json"
+        _write(existing, json.dumps({"name": "old-content"}))
+
+        warnings_emitted: list[str] = []
+        info_emitted: list[str] = []
+        monkeypatch.setattr(
+            "apm_cli.core.plugin_manifest._rich_warning",
+            lambda msg, **kw: warnings_emitted.append(msg),
+        )
+        monkeypatch.setattr(
+            "apm_cli.core.plugin_manifest._rich_info",
+            lambda msg, **kw: info_emitted.append(msg),
+        )
+
+        result = write_plugin_manifest(
+            tmp_path,
+            {"name": "new-content"},
+            "claude",
+            dry_run=True,
+            force=True,
+        )
+
+        assert result is None
+        assert json.loads(existing.read_text(encoding="utf-8"))["name"] == "old-content"
+        assert len(warnings_emitted) == 1
+        assert "Overwriting" in warnings_emitted[0]
+        assert info_emitted == [f"Would write plugin manifest to {existing}"]
+
     def test_unknown_ecosystem_returns_none(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary

Make `apm pack --dry-run` honor the same existing-file overwrite policy as a real non-force pack.

When `plugin.json` already exists and `--force` is absent, dry-run now reports the skip instead of claiming the manifest would be written.

## Changes

- evaluate the existing-file/`--force` policy before the dry-run write preview
- preserve `--force --dry-run` behavior, which still previews an overwrite
- report the writer's canonical skip or preview outcome in `--json` output
- add regression coverage proving an existing manifest is preserved and no misleading `Would write` message is emitted

## Scenario Evidence

| Scenario | Principle(s) | Test(s) | Type | Regression trap |
| --- | --- | --- | --- | --- |
| Existing plugin manifest, `apm pack --claude-plugin --dry-run --json` | DevX | `tests/integration/test_pack_install_flow.py::TestPackCmd::test_pack_json_reports_plugin_manifest_outcomes` | integration-with-fixtures | #2553: reports `skipped`, keeps `dry_run` empty, and preserves the file. |
| Existing plugin manifest, then non-force `apm pack --claude-plugin --json` | DevX | `tests/integration/test_pack_install_flow.py::TestPackCmd::test_pack_json_reports_plugin_manifest_outcomes` | integration-with-fixtures | #2553: makes the same skip decision and leaves the explicit post-state unchanged. |
| Existing plugin manifest with `--force --dry-run` | DevX | `tests/unit/core/test_plugin_manifest.py::TestWritePluginManifest::test_dry_run_existing_file_with_force_previews_overwrite` | unit | Future-tense `Would overwrite` preview remains non-destructive. |

## Scope

This addresses the dry-run parity facet of #2553. The separate proposal for a version-drift release gate remains intentionally out of scope for this focused change.

Addresses #2553
