### PR TITLE
fix: preserve OpenCode MCP passthrough fields

### DIFF
--- a/.apm/architecture/owners/hooks-integrations.json
+++ b/.apm/architecture/owners/hooks-integrations.json
@@ -37,13 +37,17 @@
     },
     {
       "id": "mcp-package-launcher",
-      "decision": "MCP package launcher selection, argv shape, and passthrough denylist",
+      "decision": "MCP package launcher selection and argv shape (container and non-container)",
       "owner": "adapters/client/base.py (MCPClientAdapter)",
       "selectors": ["src/apm_cli/adapters/client/base.py"],
-      "guards": [
-        "hooks-integrations-mcp-package-launcher",
-        "hooks-integrations-mcp-passthrough-denylist"
-      ]
+      "guards": ["hooks-integrations-mcp-package-launcher"]
+    },
+    {
+      "id": "mcp-passthrough-denylist",
+      "decision": "MCP passthrough modeled-field and harness-alias denylist",
+      "owner": "models/dependency/mcp.py (_EXTRA_DENYLIST)",
+      "selectors": ["src/apm_cli/models/dependency/mcp.py"],
+      "guards": ["hooks-integrations-mcp-passthrough-denylist"]
     },
     {
       "id": "jetbrains-copilot-mcp-config-path",

--- a/.apm/architecture/owners/hooks-integrations.json
+++ b/.apm/architecture/owners/hooks-integrations.json
@@ -37,10 +37,13 @@
     },
     {
       "id": "mcp-package-launcher",
-      "decision": "MCP package launcher selection and argv shape (container and non-container)",
+      "decision": "MCP package launcher selection, argv shape, and passthrough denylist",
       "owner": "adapters/client/base.py (MCPClientAdapter)",
       "selectors": ["src/apm_cli/adapters/client/base.py"],
-      "guards": ["hooks-integrations-mcp-package-launcher"]
+      "guards": [
+        "hooks-integrations-mcp-package-launcher",
+        "hooks-integrations-mcp-passthrough-denylist"
+      ]
     },
     {
       "id": "jetbrains-copilot-mcp-config-path",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   decodes critical hidden characters. `--force` overrides only the critical
   character finding, never malformed YAML; warning-level findings do not block.
   (by @manideep-malyala, #2666)
+- OpenCode MCP generation now preserves safe passthrough fields while preventing
+  custom fields from injecting the modeled `environment` alias. (by @aryansk,
+  fixes #2510) (#2593)
 - `apm pack` now reports unavailable remote package metadata, exposes
   certifiability in JSON, prevents `--check-clean` from certifying degraded
   regeneration, and lets `--strict-metadata` fail before writes. (closes #2524)

--- a/docs/src/content/docs/reference/manifest-schema.md
+++ b/docs/src/content/docs/reference/manifest-schema.md
@@ -610,7 +610,7 @@ Any additional keys not listed above are preserved as **extra passthrough fields
 
 Two guardrails apply:
 
-- **Reserved keys are rejected.** A passthrough key whose name collides with a modeled field above -- `name`, `transport`/`type`, `command`, `url`, `headers`, `env`, `args`, `tools`, `version`, `registry`, `package` (plus the Codex `http_headers` and OpenCode `environment` aliases) -- is dropped with a warning. This prevents a passthrough value from shadowing or redirecting a modeled field. Extra keys also never overwrite a value the target adapter set itself.
+- **Reserved keys are rejected.** A passthrough key whose name collides with a modeled field above -- `name`, `transport`/`type`, `command`, `url`, `headers`, `env`, `args`, `tools`, `version`, `registry`, `package` -- or with an adapter-owned field (`http_headers`, `enabled`, `environment`, `id`) is dropped with a warning. This prevents a passthrough value from shadowing or redirecting a modeled field. Extra keys also never overwrite a value the target adapter set itself.
 - **Extra keys broadcast to every target.** Passthrough keys are written uniformly into the generated config for **all** installed harnesses, not just the one that understands them. A Claude Code `oauth` block (`clientId`/`callbackPort`), for example, is emitted into every target's server entry; harnesses that do not recognise the key ignore it. Per-harness scoping is tracked as a future enhancement (see issue #1806).
 
 > A future release may require passthrough keys to be nested under an explicit `extra:` block and stop auto-capturing bare top-level keys (fail-closed), via a deprecation path. See issue #1806.

--- a/docs/src/content/docs/reference/manifest-schema.md
+++ b/docs/src/content/docs/reference/manifest-schema.md
@@ -610,7 +610,7 @@ Any additional keys not listed above are preserved as **extra passthrough fields
 
 Two guardrails apply:
 
-- **Reserved keys are rejected.** A passthrough key whose name collides with a modeled field above -- `name`, `transport`/`type`, `command`, `url`, `headers`, `env`, `args`, `tools`, `version`, `registry`, `package` (and the Codex `http_headers` alias) -- is dropped with a warning. This prevents a passthrough value from shadowing or redirecting a modeled field. Extra keys also never overwrite a value the target adapter set itself.
+- **Reserved keys are rejected.** A passthrough key whose name collides with a modeled field above -- `name`, `transport`/`type`, `command`, `url`, `headers`, `env`, `args`, `tools`, `version`, `registry`, `package` (plus the Codex `http_headers` and OpenCode `environment` aliases) -- is dropped with a warning. This prevents a passthrough value from shadowing or redirecting a modeled field. Extra keys also never overwrite a value the target adapter set itself.
 - **Extra keys broadcast to every target.** Passthrough keys are written uniformly into the generated config for **all** installed harnesses, not just the one that understands them. A Claude Code `oauth` block (`clientId`/`callbackPort`), for example, is emitted into every target's server entry; harnesses that do not recognise the key ignore it. Per-harness scoping is tracked as a future enhancement (see issue #1806).
 
 > A future release may require passthrough keys to be nested under an explicit `extra:` block and stop auto-capturing bare top-level keys (fail-closed), via a deprecation path. See issue #1806.

--- a/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
@@ -473,8 +473,8 @@ dependencies:
     # Self-defined remote with harness-specific extra keys
     # Unknown keys (e.g. oauth) are passthrough: preserved and written into
     # the generated config for EVERY installed harness. Keys that collide with
-    # a modeled field or target alias (command/url/env/environment/http_headers/...)
-    # are rejected with a warning.
+    # a modeled or adapter-owned field
+    # (command/url/env/enabled/environment/http_headers/id/...) are rejected.
     - name: slack
       registry: false
       transport: http

--- a/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
@@ -474,7 +474,7 @@ dependencies:
     # Unknown keys (e.g. oauth) are passthrough: preserved and written into
     # the generated config for EVERY installed harness. Keys that collide with
     # a modeled or adapter-owned field
-    # (command/url/env/enabled/environment/http_headers/id/...) are rejected.
+    # (command/url/headers/env/enabled/environment/http_headers/id/...) are rejected.
     - name: slack
       registry: false
       transport: http

--- a/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
@@ -473,7 +473,8 @@ dependencies:
     # Self-defined remote with harness-specific extra keys
     # Unknown keys (e.g. oauth) are passthrough: preserved and written into
     # the generated config for EVERY installed harness. Keys that collide with
-    # a modeled field (command/url/headers/env/...) are rejected with a warning.
+    # a modeled field or target alias (command/url/env/environment/http_headers/...)
+    # are rejected with a warning.
     - name: slack
       registry: false
       transport: http

--- a/scripts/architecture_linter/checks/mutation_mcp_target_and_scope.py
+++ b/scripts/architecture_linter/checks/mutation_mcp_target_and_scope.py
@@ -59,6 +59,9 @@ _MCP_SCOPE_OWNER = "src/apm_cli/integration/mcp_config_view.py"
 _MCP_ADAPTER_BASE = "src/apm_cli/adapters/client/base.py"
 
 
+_MCP_MODEL = "src/apm_cli/models/dependency/mcp.py"
+
+
 _MCP_OPENCODE = "src/apm_cli/adapters/client/opencode.py"
 
 
@@ -476,7 +479,7 @@ def _check_mcp_passthrough_denylist(provider: FactsProvider) -> Iterable[Violati
     facts_by_path, failures = _read_required(
         provider,
         rule_id,
-        (_MCP_ADAPTER_BASE, _MCP_OPENCODE),
+        (_MCP_MODEL, _MCP_ADAPTER_BASE, _MCP_OPENCODE),
     )
     findings: list[Violation] = list(failures)
     if failures:
@@ -486,17 +489,31 @@ def _check_mcp_passthrough_denylist(provider: FactsProvider) -> Iterable[Violati
         _require(
             _has_fixed(
                 facts_by_path[_MCP_ADAPTER_BASE],
-                '_EXTRA_DENYLIST = _RESERVED_EXTRA_KEYS | frozenset({"environment", '
-                '"http_headers"})',
+                "from ...models.dependency.mcp import _EXTRA_DENYLIST, TrustedEnvLiteral",
             ),
             rule_id,
             _MCP_ADAPTER_BASE,
-            "base adapter denylist must own modeled fields and harness aliases",
+            "base adapter must import the canonical passthrough denylist",
         )
     )
     findings.extend(
         _require(
-            _has_fixed(facts_by_path[_MCP_OPENCODE], "from .base import _EXTRA_DENYLIST"),
+            _has_fixed(
+                facts_by_path[_MCP_MODEL],
+                '_EXTRA_DENYLIST = _RESERVED_EXTRA_KEYS | frozenset({"environment", '
+                '"http_headers"})',
+            ),
+            rule_id,
+            _MCP_MODEL,
+            "MCP model must own the modeled-field and harness-alias denylist",
+        )
+    )
+    findings.extend(
+        _require(
+            _has_fixed(
+                facts_by_path[_MCP_OPENCODE],
+                "from ...models.dependency.mcp import _EXTRA_DENYLIST",
+            ),
             rule_id,
             _MCP_OPENCODE,
             "OpenCode adapter must import the canonical passthrough denylist",

--- a/scripts/architecture_linter/checks/mutation_mcp_target_and_scope.py
+++ b/scripts/architecture_linter/checks/mutation_mcp_target_and_scope.py
@@ -9,6 +9,8 @@ Ports three of the owner guards recorded in
   scope.
 * ``hooks-integrations-mcp-package-launcher`` -- AC26/AC30/AC32
   MCPClientAdapter launcher selection and argv shape.
+* ``hooks-integrations-mcp-passthrough-denylist`` -- MCP passthrough modeled
+  fields and harness aliases.
 * ``hooks-integrations-jetbrains-mcp-path`` -- AC28 JetBrains Copilot MCP
   path.
 """
@@ -55,6 +57,9 @@ _MCP_SCOPE_OWNER = "src/apm_cli/integration/mcp_config_view.py"
 
 
 _MCP_ADAPTER_BASE = "src/apm_cli/adapters/client/base.py"
+
+
+_MCP_OPENCODE = "src/apm_cli/adapters/client/opencode.py"
 
 
 _MCP_CONTAINER_CONSUMERS: tuple[str, ...] = (
@@ -465,6 +470,52 @@ def _mpl_runtime_variables(
     return tuple(findings)
 
 
+def _check_mcp_passthrough_denylist(provider: FactsProvider) -> Iterable[Violation]:
+    """MCP passthrough filtering must route through the base adapter denylist."""
+    rule_id = "mutation_writes.mcp_passthrough_denylist"
+    facts_by_path, failures = _read_required(
+        provider,
+        rule_id,
+        (_MCP_ADAPTER_BASE, _MCP_OPENCODE),
+    )
+    findings: list[Violation] = list(failures)
+    if failures:
+        return tuple(findings)
+
+    findings.extend(
+        _require(
+            _has_fixed(
+                facts_by_path[_MCP_ADAPTER_BASE],
+                '_EXTRA_DENYLIST = _RESERVED_EXTRA_KEYS | frozenset({"environment", '
+                '"http_headers"})',
+            ),
+            rule_id,
+            _MCP_ADAPTER_BASE,
+            "base adapter denylist must own modeled fields and harness aliases",
+        )
+    )
+    findings.extend(
+        _require(
+            _has_fixed(facts_by_path[_MCP_OPENCODE], "from .base import _EXTRA_DENYLIST"),
+            rule_id,
+            _MCP_OPENCODE,
+            "OpenCode adapter must import the canonical passthrough denylist",
+        )
+    )
+    findings.extend(
+        _require(
+            _has_fixed(
+                facts_by_path[_MCP_OPENCODE],
+                'translated_keys = _EXTRA_DENYLIST | {"enabled", "id"}',
+            ),
+            rule_id,
+            _MCP_OPENCODE,
+            "OpenCode translation must derive exclusions from the canonical denylist",
+        )
+    )
+    return tuple(findings)
+
+
 def _check_jetbrains_mcp_path(provider: FactsProvider) -> Iterable[Violation]:
     """JetBrains Copilot MCP config paths must come from the IntelliJ adapter.
 
@@ -571,6 +622,13 @@ RULES: tuple[Rule, ...] = (
         guard_ids=("hooks-integrations-mcp-package-launcher",),
         description="MCP launcher selection and argv shape must route through MCPClientAdapter.",
         check=_check_mcp_package_launcher,
+    ),
+    Rule(
+        id="mutation_writes.mcp_passthrough_denylist",
+        group=GROUP,
+        guard_ids=("hooks-integrations-mcp-passthrough-denylist",),
+        description="MCP passthrough filtering must route through the base adapter denylist.",
+        check=_check_mcp_passthrough_denylist,
     ),
     Rule(
         id="mutation_writes.jetbrains_mcp_path",

--- a/scripts/architecture_linter/checks/mutation_mcp_target_and_scope.py
+++ b/scripts/architecture_linter/checks/mutation_mcp_target_and_scope.py
@@ -500,12 +500,23 @@ def _check_mcp_passthrough_denylist(provider: FactsProvider) -> Iterable[Violati
         _require(
             _has_fixed(
                 facts_by_path[_MCP_MODEL],
-                '_EXTRA_DENYLIST = _RESERVED_EXTRA_KEYS | frozenset({"environment", '
-                '"http_headers"})',
+                '_HARNESS_EXTRA_ALIASES = frozenset({"enabled", "environment", '
+                '"http_headers", "id"})',
             ),
             rule_id,
             _MCP_MODEL,
-            "MCP model must own the modeled-field and harness-alias denylist",
+            "MCP model must own the harness-alias denylist",
+        )
+    )
+    findings.extend(
+        _require(
+            _has_fixed(
+                facts_by_path[_MCP_MODEL],
+                "_EXTRA_DENYLIST = _RESERVED_EXTRA_KEYS | _HARNESS_EXTRA_ALIASES",
+            ),
+            rule_id,
+            _MCP_MODEL,
+            "MCP model must combine modeled fields and harness aliases",
         )
     )
     findings.extend(
@@ -523,7 +534,7 @@ def _check_mcp_passthrough_denylist(provider: FactsProvider) -> Iterable[Violati
         _require(
             _has_fixed(
                 facts_by_path[_MCP_OPENCODE],
-                'translated_keys = _EXTRA_DENYLIST | {"enabled", "id"}',
+                "translated_keys = _EXTRA_DENYLIST",
             ),
             rule_id,
             _MCP_OPENCODE,

--- a/src/apm_cli/adapters/client/base.py
+++ b/src/apm_cli/adapters/client/base.py
@@ -185,7 +185,7 @@ def _docker_image_repository(reference: str) -> str:
 # not be injectable via passthrough. Enforced unconditionally per adapter path
 # (NOT guarded by "key absent from config"), so it also closes paths that do not
 # pre-set the key. Security boundary for PR #1765 / issue #1670.
-_EXTRA_DENYLIST = _RESERVED_EXTRA_KEYS | frozenset({"http_headers"})
+_EXTRA_DENYLIST = _RESERVED_EXTRA_KEYS | frozenset({"environment", "http_headers"})
 
 
 @dataclass(frozen=True)

--- a/src/apm_cli/adapters/client/base.py
+++ b/src/apm_cli/adapters/client/base.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, ClassVar
 
-from ...models.dependency.mcp import _RESERVED_EXTRA_KEYS, TrustedEnvLiteral
+from ...models.dependency.mcp import _EXTRA_DENYLIST, TrustedEnvLiteral
 from ...utils.console import _rich_error, _rich_warning
 
 _INPUT_VAR_RE = re.compile(r"\$\{input:([^}]+)\}")
@@ -185,9 +185,6 @@ def _docker_image_repository(reference: str) -> str:
 # not be injectable via passthrough. Enforced unconditionally per adapter path
 # (NOT guarded by "key absent from config"), so it also closes paths that do not
 # pre-set the key. Security boundary for PR #1765 / issue #1670.
-_EXTRA_DENYLIST = _RESERVED_EXTRA_KEYS | frozenset({"environment", "http_headers"})
-
-
 @dataclass(frozen=True)
 class _MCPLauncherArgumentGroup:
     """One atomic registry argument and its rendered argv values."""

--- a/src/apm_cli/adapters/client/opencode.py
+++ b/src/apm_cli/adapters/client/opencode.py
@@ -154,7 +154,7 @@ class OpenCodeClientAdapter(CopilotClientAdapter):
         if env:
             entry["environment"] = dict(env)
 
-        translated_keys = _EXTRA_DENYLIST | {"enabled", "id"}
+        translated_keys = _EXTRA_DENYLIST
         for key, value in copilot_entry.items():
             if key not in translated_keys and key not in entry:
                 entry[key] = value

--- a/src/apm_cli/adapters/client/opencode.py
+++ b/src/apm_cli/adapters/client/opencode.py
@@ -30,6 +30,7 @@ import json
 import os
 from pathlib import Path
 
+from .base import _EXTRA_DENYLIST
 from .copilot import CopilotClientAdapter
 
 
@@ -153,17 +154,7 @@ class OpenCodeClientAdapter(CopilotClientAdapter):
         if env:
             entry["environment"] = dict(env)
 
-        translated_keys = {
-            "type",
-            "tools",
-            "id",
-            "command",
-            "args",
-            "env",
-            "url",
-            "headers",
-            "enabled",
-        }
+        translated_keys = _EXTRA_DENYLIST | {"enabled", "id"}
         for key, value in copilot_entry.items():
             if key not in translated_keys and key not in entry:
                 entry[key] = value

--- a/src/apm_cli/adapters/client/opencode.py
+++ b/src/apm_cli/adapters/client/opencode.py
@@ -30,7 +30,7 @@ import json
 import os
 from pathlib import Path
 
-from .base import _EXTRA_DENYLIST
+from ...models.dependency.mcp import _EXTRA_DENYLIST
 from .copilot import CopilotClientAdapter
 
 

--- a/src/apm_cli/adapters/client/opencode.py
+++ b/src/apm_cli/adapters/client/opencode.py
@@ -153,4 +153,19 @@ class OpenCodeClientAdapter(CopilotClientAdapter):
         if env:
             entry["environment"] = dict(env)
 
+        translated_keys = {
+            "type",
+            "tools",
+            "id",
+            "command",
+            "args",
+            "env",
+            "url",
+            "headers",
+            "enabled",
+        }
+        for key, value in copilot_entry.items():
+            if key not in translated_keys and key not in entry:
+                entry[key] = value
+
         return entry

--- a/src/apm_cli/integration/mcp_config_view.py
+++ b/src/apm_cli/integration/mcp_config_view.py
@@ -242,7 +242,7 @@ def _allows_missing_manifest(
     package_type, _ = detect_package_type(package_dir)
     if package_type is PackageType.HOOK_PACKAGE:
         return (
-            dependency_ref.is_virtual_subdirectory()
+            dependency.to_dependency_ref().is_virtual_subdirectory()
             and dependency.package_type == PackageType.HOOK_PACKAGE.value
         )
     return (

--- a/src/apm_cli/models/dependency/mcp.py
+++ b/src/apm_cli/models/dependency/mcp.py
@@ -102,7 +102,8 @@ class MCPDependency:
         """Parse an MCPDependency from a dict.
 
         Handles backward compatibility: 'type' key is mapped to 'transport'.
-        Unknown keys are dropped with a warning naming each discarded key.
+        Safe unknown keys are preserved in ``extra``; modeled fields and harness
+        aliases are rejected with a warning.
         """
         if "name" not in d:
             raise ValueError("MCP dependency dict must contain 'name'")

--- a/src/apm_cli/models/dependency/mcp.py
+++ b/src/apm_cli/models/dependency/mcp.py
@@ -46,7 +46,8 @@ _RESERVED_EXTRA_KEYS = _KNOWN_DICT_KEYS - {"extra"}
 # Harness aliases for modeled fields share the same passthrough boundary. Keeping
 # them beside the manifest vocabulary lets parsing report rejected keys truthfully
 # before every adapter consumes the filtered ``extra`` mapping.
-_EXTRA_DENYLIST = _RESERVED_EXTRA_KEYS | frozenset({"environment", "http_headers"})
+_HARNESS_EXTRA_ALIASES = frozenset({"enabled", "environment", "http_headers", "id"})
+_EXTRA_DENYLIST = _RESERVED_EXTRA_KEYS | _HARNESS_EXTRA_ALIASES
 
 _NAME_REGEX = re.compile(r"^[a-zA-Z0-9@_][a-zA-Z0-9._@/:=-]{0,127}$")
 _ALLOWED_URL_SCHEMES = frozenset({"http", "https"})

--- a/src/apm_cli/models/dependency/mcp.py
+++ b/src/apm_cli/models/dependency/mcp.py
@@ -43,6 +43,11 @@ _KNOWN_DICT_KEYS = frozenset(
 # Security boundary for PR #1765 / issue #1670.
 _RESERVED_EXTRA_KEYS = _KNOWN_DICT_KEYS - {"extra"}
 
+# Harness aliases for modeled fields share the same passthrough boundary. Keeping
+# them beside the manifest vocabulary lets parsing report rejected keys truthfully
+# before every adapter consumes the filtered ``extra`` mapping.
+_EXTRA_DENYLIST = _RESERVED_EXTRA_KEYS | frozenset({"environment", "http_headers"})
+
 _NAME_REGEX = re.compile(r"^[a-zA-Z0-9@_][a-zA-Z0-9._@/:=-]{0,127}$")
 _ALLOWED_URL_SCHEMES = frozenset({"http", "https"})
 
@@ -102,31 +107,34 @@ class MCPDependency:
             raise ValueError("MCP dependency dict must contain 'name'")
 
         unknown = sorted(str(k) for k in d if k not in _KNOWN_DICT_KEYS)
+        reserved_unknown = [key for key in unknown if key in _EXTRA_DENYLIST]
+        passthrough_unknown = [key for key in unknown if key not in _EXTRA_DENYLIST]
         extra: dict[str, Any] | None = None
         # Merge unknown top-level keys with an explicit 'extra:' block
-        if unknown:
-            extra = {str(k): d[k] for k in d if str(k) in unknown}
+        if passthrough_unknown:
+            extra = {str(k): d[k] for k in d if str(k) in passthrough_unknown}
         explicit_extra = d.get("extra")
+        reserved_explicit: list[str] = []
         if isinstance(explicit_extra, dict):
             # Strip reserved modeled-field names from the explicit block so a
             # passthrough value cannot shadow/redirect a modeled field.
-            reserved = sorted(str(k) for k in explicit_extra if str(k) in _RESERVED_EXTRA_KEYS)
-            if reserved:
-                safe_name = ascii(str(d["name"]))[1:-1]
-                safe_reserved = ", ".join(ascii(k)[1:-1] for k in reserved)
-                _rich_warning(
-                    f"MCP dependency '{safe_name}': reserved key(s) ignored in 'extra' "
-                    f"(cannot override a modeled MCP field): {safe_reserved}",
-                    symbol="warning",
-                )
+            reserved_explicit = sorted(str(k) for k in explicit_extra if str(k) in _EXTRA_DENYLIST)
             safe_explicit = {
-                str(k): v for k, v in explicit_extra.items() if str(k) not in _RESERVED_EXTRA_KEYS
+                str(k): v for k, v in explicit_extra.items() if str(k) not in _EXTRA_DENYLIST
             }
             if safe_explicit:
                 extra = {**(extra or {}), **safe_explicit}
-        if unknown:
-            safe_name = ascii(str(d["name"]))[1:-1]
-            safe_keys = ", ".join(ascii(k)[1:-1] for k in unknown)
+        safe_name = ascii(str(d["name"]))[1:-1]
+        reserved = sorted(set(reserved_unknown) | set(reserved_explicit))
+        if reserved:
+            safe_reserved = ", ".join(ascii(k)[1:-1] for k in reserved)
+            _rich_warning(
+                f"MCP dependency '{safe_name}': reserved passthrough key(s) ignored "
+                f"(cannot override a modeled MCP field): {safe_reserved}",
+                symbol="warning",
+            )
+        if passthrough_unknown:
+            safe_keys = ", ".join(ascii(k)[1:-1] for k in passthrough_unknown)
             _rich_warning(
                 f"MCP dependency '{safe_name}': unknown key(s) preserved in extra: {safe_keys}",
                 symbol="warning",

--- a/tests/integration/test_architecture_owner_rule_mutations.py
+++ b/tests/integration/test_architecture_owner_rule_mutations.py
@@ -216,10 +216,10 @@ MUTATIONS: tuple[MutationCase, ...] = (
     MutationCase(
         guard_id="hooks-integrations-mcp-passthrough-denylist",
         rule_id="mutation_writes.mcp_passthrough_denylist",
-        path="src/apm_cli/adapters/client/base.py",
+        path="src/apm_cli/models/dependency/mcp.py",
         old='frozenset({"environment", "http_headers"})',
         new='frozenset({"http_headers"})',
-        intent="Shared adapter stops denying the OpenCode environment alias.",
+        intent="Shared MCP model stops denying the OpenCode environment alias.",
     ),
     MutationCase(
         guard_id="hooks-integrations-mcp-target-selection",

--- a/tests/integration/test_architecture_owner_rule_mutations.py
+++ b/tests/integration/test_architecture_owner_rule_mutations.py
@@ -217,8 +217,8 @@ MUTATIONS: tuple[MutationCase, ...] = (
         guard_id="hooks-integrations-mcp-passthrough-denylist",
         rule_id="mutation_writes.mcp_passthrough_denylist",
         path="src/apm_cli/models/dependency/mcp.py",
-        old='frozenset({"environment", "http_headers"})',
-        new='frozenset({"http_headers"})',
+        old='frozenset({"enabled", "environment", "http_headers", "id"})',
+        new='frozenset({"enabled", "http_headers", "id"})',
         intent="Shared MCP model stops denying the OpenCode environment alias.",
     ),
     MutationCase(

--- a/tests/integration/test_architecture_owner_rule_mutations.py
+++ b/tests/integration/test_architecture_owner_rule_mutations.py
@@ -214,6 +214,14 @@ MUTATIONS: tuple[MutationCase, ...] = (
         intent="Shared adapter loses the canonical OCI-to-docker launcher alias.",
     ),
     MutationCase(
+        guard_id="hooks-integrations-mcp-passthrough-denylist",
+        rule_id="mutation_writes.mcp_passthrough_denylist",
+        path="src/apm_cli/adapters/client/base.py",
+        old='frozenset({"environment", "http_headers"})',
+        new='frozenset({"http_headers"})',
+        intent="Shared adapter stops denying the OpenCode environment alias.",
+    ),
+    MutationCase(
         guard_id="hooks-integrations-mcp-target-selection",
         rule_id="mutation_writes.mcp_target_selection",
         path="src/apm_cli/integration/mcp_integrator_install.py",

--- a/tests/integration/test_mcp_install_flow.py
+++ b/tests/integration/test_mcp_install_flow.py
@@ -273,7 +273,9 @@ def test_install_preserves_safe_opencode_passthrough_fields(tmp_path, monkeypatc
         {
             "oauth": {"clientId": "client", "callbackPort": 3118},
             "myField": "somevalue",
+            "enabled": False,
             "environment": {"NODE_OPTIONS": "--require ./payload.js"},
+            "id": "manifest-supplied-id",
         }
     )
     (tmp_path / "apm.yml").write_text(yaml.safe_dump(manifest), encoding="utf-8")
@@ -284,7 +286,7 @@ def test_install_preserves_safe_opencode_passthrough_fields(tmp_path, monkeypatc
     assert result.exit_code == 0, result.output
     normalized_output = " ".join(result.output.split())
     assert "reserved passthrough key(s) ignored" in normalized_output
-    assert "environment" in normalized_output
+    assert "enabled, environment, id" in normalized_output
     assert "unknown key(s) preserved in extra: myField, oauth" in normalized_output
     config = json.loads((tmp_path / "opencode.json").read_text(encoding="utf-8"))
     rendered = config["mcp"]["loopback-remote"]
@@ -296,7 +298,9 @@ def test_install_preserves_safe_opencode_passthrough_fields(tmp_path, monkeypatc
     )
     assert rendered["oauth"] == {"clientId": "client", "callbackPort": 3118}
     assert rendered["myField"] == "somevalue"
+    assert rendered["enabled"] is True
     assert "environment" not in rendered
+    assert "id" not in rendered
 
 
 def test_install_rejects_nonloopback_http_without_ownership_claim(tmp_path, monkeypatch) -> None:

--- a/tests/integration/test_mcp_install_flow.py
+++ b/tests/integration/test_mcp_install_flow.py
@@ -258,6 +258,43 @@ def test_install_loopback_http_remote_is_byte_idempotent_for_requested_targets(
     assert (codex_config_path.read_bytes(), copilot_config_path.read_bytes()) == first_configs
 
 
+def test_install_preserves_safe_opencode_passthrough_fields(tmp_path, monkeypatch) -> None:
+    """OpenCode writes safe extras without accepting its modeled env alias."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    (tmp_path / ".opencode").mkdir()
+    LockFile().write(tmp_path / "apm.lock.yaml")
+    manifest = _self_defined_remote_manifest(
+        targets=["opencode"],
+        url="https://mcp.slack.com/mcp",
+    )
+    server = manifest["dependencies"]["mcp"][0]
+    server.update(
+        {
+            "oauth": {"clientId": "client", "callbackPort": 3118},
+            "myField": "somevalue",
+            "environment": {"NODE_OPTIONS": "--require ./payload.js"},
+        }
+    )
+    (tmp_path / "apm.yml").write_text(yaml.safe_dump(manifest), encoding="utf-8")
+    clear_apm_yml_cache()
+
+    result = CliRunner().invoke(cli, ["install", "--no-policy"])
+
+    assert result.exit_code == 0, result.output
+    config = json.loads((tmp_path / "opencode.json").read_text(encoding="utf-8"))
+    rendered = config["mcp"]["loopback-remote"]
+    rendered_url = urlparse(rendered["url"])
+    assert (rendered_url.scheme, rendered_url.hostname, rendered_url.path) == (
+        "https",
+        "mcp.slack.com",
+        "/mcp",
+    )
+    assert rendered["oauth"] == {"clientId": "client", "callbackPort": 3118}
+    assert rendered["myField"] == "somevalue"
+    assert "environment" not in rendered
+
+
 def test_install_rejects_nonloopback_http_without_ownership_claim(tmp_path, monkeypatch) -> None:
     """A rejected Codex HTTP remote cannot create target or deployment state."""
     monkeypatch.chdir(tmp_path)

--- a/tests/integration/test_mcp_install_flow.py
+++ b/tests/integration/test_mcp_install_flow.py
@@ -282,6 +282,10 @@ def test_install_preserves_safe_opencode_passthrough_fields(tmp_path, monkeypatc
     result = CliRunner().invoke(cli, ["install", "--no-policy"])
 
     assert result.exit_code == 0, result.output
+    normalized_output = " ".join(result.output.split())
+    assert "reserved passthrough key(s) ignored" in normalized_output
+    assert "environment" in normalized_output
+    assert "unknown key(s) preserved in extra: myField, oauth" in normalized_output
     config = json.loads((tmp_path / "opencode.json").read_text(encoding="utf-8"))
     rendered = config["mcp"]["loopback-remote"]
     rendered_url = urlparse(rendered["url"])

--- a/tests/unit/scripts/test_architecture_runner.py
+++ b/tests/unit/scripts/test_architecture_runner.py
@@ -671,6 +671,7 @@ mutation_writes.hook_command_vocabulary
 mutation_writes.jetbrains_mcp_path
 mutation_writes.mcp_declaration_scope
 mutation_writes.mcp_package_launcher
+mutation_writes.mcp_passthrough_denylist
 mutation_writes.mcp_target_selection
 mutation_writes.neutral_hook_contract
 mutation_writes.user_root_scope

--- a/tests/unit/test_opencode_mcp.py
+++ b/tests/unit/test_opencode_mcp.py
@@ -94,12 +94,14 @@ class TestToOpencodeFormat(unittest.TestCase):
             "id": "registry-id",
             "oauth": {"clientId": "client", "callbackPort": 3118},
             "myField": "somevalue",
+            "environment": {"NODE_OPTIONS": "--require ./payload.js"},
         }
         result = OpenCodeClientAdapter._to_opencode_format(copilot)
         self.assertEqual(result["oauth"], {"clientId": "client", "callbackPort": 3118})
         self.assertEqual(result["myField"], "somevalue")
         self.assertNotIn("tools", result)
         self.assertNotIn("id", result)
+        self.assertNotIn("environment", result)
 
     def test_no_command_no_url(self):
         copilot = {"env": {"KEY": "val"}}

--- a/tests/unit/test_opencode_mcp.py
+++ b/tests/unit/test_opencode_mcp.py
@@ -86,6 +86,21 @@ class TestToOpencodeFormat(unittest.TestCase):
         result["headers"]["new-key"] = "new-val"
         self.assertNotIn("new-key", original_headers)
 
+    def test_passthrough_fields_preserved_without_copilot_only_keys(self):
+        copilot = {
+            "type": "http",
+            "url": "https://example.com/mcp",
+            "tools": ["*"],
+            "id": "registry-id",
+            "oauth": {"clientId": "client", "callbackPort": 3118},
+            "myField": "somevalue",
+        }
+        result = OpenCodeClientAdapter._to_opencode_format(copilot)
+        self.assertEqual(result["oauth"], {"clientId": "client", "callbackPort": 3118})
+        self.assertEqual(result["myField"], "somevalue")
+        self.assertNotIn("tools", result)
+        self.assertNotIn("id", result)
+
     def test_no_command_no_url(self):
         copilot = {"env": {"KEY": "val"}}
         result = OpenCodeClientAdapter._to_opencode_format(copilot)


### PR DESCRIPTION
## Summary

Preserve allowed MCP passthrough fields when translating the normalized server config into OpenCode's schema. OpenCode-specific output still translates command/env/remote fields, while modeled fields and Copilot-only `tools` and `id` keys remain excluded.

## Testing

- Added regression coverage for passthrough fields such as `oauth` and custom keys
- Verified modeled aliases, Copilot-only `tools`, and `id` do not leak into `opencode.json`
- Added a hermetic CLI install/write-path regression and a mutation-backed architecture guard

## Scenario Evidence

| User promise | Principle | Executable test | Tier | Regression trap |
|---|---|---|---|---|
| Installing an MCP server for OpenCode preserves safe custom fields without allowing passthrough to inject modeled environment configuration. | Portability by manifest; Secure by default; Multi-harness support | `tests/integration/test_mcp_install_flow.py::test_install_preserves_safe_opencode_passthrough_fields` | integration-with-fixtures | Yes, for #2510 |

Fixes #2510

<!-- pr-relay-job relay-42-c6198bda99dfd39ca1ce -->
