### PR TITLE
fix: preserve credential helpers for generic marketplace git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OpenCode MCP generation now preserves safe passthrough fields while preventing
   custom fields from injecting the modeled `environment` alias. (by @aryansk,
   fixes #2510) (#2593)
+- Hook commands such as `"${CLAUDE_PLUGIN_ROOT}"/hooks/probe.py` now rewrite to
+  `"${CLAUDE_PLUGIN_ROOT}/hooks/probe.py"` and warn when a supported plugin-root
+  placeholder remains unresolved instead of silently deploying a dead hook.
+  OpenAPM v0.1 (`docs/src/content/docs/specs/openapm-v0.1.md#req-tg-012`) binds
+  the behavior.
+  (by @MohammedAlkindi; closes #2639) (#2645)
+- `apm uninstall --global` now cleans removed-only target files before deleting their ownership state, while preserving files owned by surviving packages. (#2658)
+- Generic marketplace Git now prevents platform tokens from reaching native
+  credential-helper subprocesses while preserving HTTPS helper access; HTTP and
+  HTTPS-to-HTTP rewrites suppress credentials, and SSH is token-free and
+  noninteractive. - by @aryansk (#2594)
+- Windows binary is now Authenticode-signed in the release workflow, eliminating
+  the `Trojan:Script/Wacatac.H!ml` Windows Defender false positive on unsigned
+  PyInstaller bundles. (#2435)
+- Multi-target `apm compile` now avoids repeating expensive project analysis
+  for each target, making multi-target runs scale like single-target runs
+  without changing generated output. (closes #2482)
+- `deployed-files-present` no longer false-positives on gitignored deploy
+  paths (e.g. `.agents/`), enabling `apm audit --ci` to pass on a fresh
+  checkout when deployed outputs are intentionally not committed. (closes
+  #2452, thanks @sergio-sisternes-epam)
+- YAML expansion guard no longer rejects large anchor-free lockfiles (150K+
+  entries) with a false-positive "billion-laughs" error. APM-generated
+  lockfiles with no anchors or aliases now load without error. (#2389)
+- `apm install` no longer skips the credential retry on non-English machines.
+  Git localises its diagnostics through gettext, so a translated stderr made an
+  authentication failure unrecognisable and private-repo installs failed with
+  misleading network guidance. Git subprocesses in the authentication retry
+  path now run with `LC_ALL=C` and `LANGUAGE=C`. (by @Naofel-eal, closes #2533)
 - `apm pack` now reports unavailable remote package metadata, exposes
   certifiability in JSON, prevents `--check-clean` from certifying degraded
   regeneration, and lets `--strict-metadata` fail before writes. (closes #2524)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the behavior.
   (by @MohammedAlkindi; closes #2639) (#2645)
 - `apm uninstall --global` now cleans removed-only target files before deleting their ownership state, while preserving files owned by surviving packages. (#2658)
+- Generic HTTPS marketplace Git sources now preserve native credential helpers
+  without forwarding platform tokens; HTTP suppresses credentials and SSH is
+  token-free and noninteractive. (by @aryansk, #2594)
 - Windows binary is now Authenticode-signed in the release workflow, eliminating
   the `Trojan:Script/Wacatac.H!ml` Windows Defender false positive on unsigned
   PyInstaller bundles. (#2435)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Generic marketplace Git now prevents platform tokens from reaching native
   credential-helper subprocesses while preserving HTTPS helper access; HTTP and
   HTTPS-to-HTTP rewrites suppress credentials, and SSH is token-free and
-  noninteractive. - by @aryansk (#2594)
+  noninteractive. (by @aryansk, #2594)
 - Windows binary is now Authenticode-signed in the release workflow, eliminating
   the `Trojan:Script/Wacatac.H!ml` Windows Defender false positive on unsigned
   PyInstaller bundles. (#2435)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,8 +127,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (by @MohammedAlkindi; closes #2639) (#2645)
 - `apm uninstall --global` now cleans removed-only target files before deleting their ownership state, while preserving files owned by surviving packages. (#2658)
 - Generic HTTPS marketplace Git sources now preserve native credential helpers
-  without forwarding platform tokens; HTTP suppresses credentials and SSH is
-  token-free and noninteractive. (by @aryansk, #2594)
+  without forwarding platform tokens; HTTP and HTTPS-to-HTTP rewrites suppress
+  credentials, and SSH is token-free and noninteractive. (by @aryansk, #2594)
 - Windows binary is now Authenticode-signed in the release workflow, eliminating
   the `Trojan:Script/Wacatac.H!ml` Windows Defender false positive on unsigned
   PyInstaller bundles. (#2435)

--- a/docs/src/content/docs/getting-started/authentication.md
+++ b/docs/src/content/docs/getting-started/authentication.md
@@ -65,7 +65,7 @@ before that fetch.
 | Remote | Credential posture |
 | --- | --- |
 | Generic HTTPS | Native Git credential helpers are available. |
-| Generic HTTP | Registration rejects plain HTTP. Any attempted Git fetch isolates configuration and suppresses credential helpers. |
+| Generic HTTP | Git fetches isolate configuration and suppress all credential channels. Hosted `marketplace.json` registration requires HTTPS. |
 | Generic SSH | Token-free, with `BatchMode=yes` and `ConnectTimeout=30`. |
 | GitHub, GitLab, ADO | Continue using the hardened provider-specific environment. |
 

--- a/docs/src/content/docs/getting-started/authentication.md
+++ b/docs/src/content/docs/getting-started/authentication.md
@@ -54,6 +54,21 @@ Results are cached per-process. Validation, persistent Git cache population, and
 |----------|--------|-------|
 | 1 | `git credential fill` | Configure credentials for that host in git |
 
+### Generic marketplace Git transport
+
+Marketplace Git fetches use `AuthResolver` host classification with a
+transport-specific credential policy. Generic HTTPS may use its native Git credential helper, while
+APM remains noninteractive (`GIT_TERMINAL_PROMPT=0`). Platform token variables,
+`GIT_TOKEN`, and environment-based authorization-header channels are removed
+before that fetch.
+
+| Remote | Credential posture |
+| --- | --- |
+| Generic HTTPS | Native Git credential helpers are available. |
+| Generic HTTP | Registration rejects plain HTTP. Any attempted Git fetch isolates configuration and suppresses credential helpers. |
+| Generic SSH | Token-free, with `BatchMode=yes` and `ConnectTimeout=30`. |
+| GitHub, GitLab, ADO | Continue using the hardened provider-specific environment. |
+
 For Azure DevOps Services, APM resolves `ADO_APM_PAT`, then an Entra ID
 (AAD) bearer token from Azure CLI (`az`). Azure DevOps Server uses
 `ADO_APM_PAT` only. See [Azure DevOps](#azure-devops).

--- a/docs/src/content/docs/getting-started/authentication.md
+++ b/docs/src/content/docs/getting-started/authentication.md
@@ -69,6 +69,9 @@ before that fetch.
 | Generic SSH | Token-free, with `BatchMode=yes` and `ConnectTimeout=30`. |
 | GitHub, GitLab, ADO | Continue using the hardened provider-specific environment. |
 
+APM rejects an HTTPS Git URL that Git configuration would rewrite to
+`http://` before any credential helper or provider credential is used.
+
 For Azure DevOps Services, APM resolves `ADO_APM_PAT`, then an Entra ID
 (AAD) bearer token from Azure CLI (`az`). Azure DevOps Server uses
 `ADO_APM_PAT` only. See [Azure DevOps](#azure-devops).

--- a/docs/src/content/docs/reference/cli/marketplace.md
+++ b/docs/src/content/docs/reference/cli/marketplace.md
@@ -118,7 +118,8 @@ apm marketplace add file:///srv/marketplaces/agent-forge.git --name agent-forge
 marketplace host is classified as GitHub, GitLab, or Azure DevOps.
 Other git hosts are fetched via subprocess `git` through `GitCache`.
 Generic HTTPS can use a local Git credential helper; plain HTTP suppresses
-credentials and generic SSH is token-free and noninteractive. See the
+credentials, HTTPS-to-HTTP Git URL rewrites are rejected, and generic SSH is
+token-free and noninteractive. See the
 [authentication transport table](../../../getting-started/authentication/#generic-marketplace-git-transport)
 for the full policy. Hosted `marketplace.json`
 URLs are public HTTPS only: APM sends no auth headers. Use a

--- a/docs/src/content/docs/reference/cli/marketplace.md
+++ b/docs/src/content/docs/reference/cli/marketplace.md
@@ -116,9 +116,11 @@ apm marketplace add file:///srv/marketplaces/agent-forge.git --name agent-forge
 **Trust boundary.** APM forwards its authentication tokens
 (`GITHUB_APM_PAT`, `GITLAB_APM_PAT`, `ADO_APM_PAT`) only when the
 marketplace host is classified as GitHub, GitLab, or Azure DevOps.
-Other git hosts -- generic HTTPS, SSH, self-hosted -- are fetched via
-subprocess `git` through `GitCache`, and authentication falls through
-to the host's local git credential helper. Hosted `marketplace.json`
+Other git hosts are fetched via subprocess `git` through `GitCache`.
+Generic HTTPS can use a local Git credential helper; plain HTTP suppresses
+credentials and generic SSH is token-free and noninteractive. See the
+[authentication transport table](../../../getting-started/authentication/#generic-marketplace-git-transport)
+for the full policy. Hosted `marketplace.json`
 URLs are public HTTPS only: APM sends no auth headers. Use a
 git-backed marketplace for private catalogs. When packages are
 installed from a hosted JSON URL, the lockfile records the source URL

--- a/packages/apm-guide/.apm/skills/apm-usage/authentication.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/authentication.md
@@ -41,13 +41,9 @@ dependency. Existing SSH keys keep working instead of the dependency being
 rewritten to HTTPS.
 
 Generic marketplace HTTPS sources may use the native Git credential helper from
-your Git configuration. APM still sets `GIT_TERMINAL_PROMPT=0` and removes
-platform token variables, `GIT_TOKEN`, and environment-based authorization-header
-channels before the fetch. Plain `http://` marketplace registration is rejected;
-any attempted fetch isolates Git configuration and
-suppress helpers; generic SSH sources are token-free and use noninteractive SSH.
-APM rejects HTTPS Git URLs that Git configuration would rewrite to `http://`
-before credentials can be used.
+your Git configuration. Generic HTTP fetches suppress credential channels, HTTPS-
+to-HTTP rewrites are rejected, and generic SSH stays token-free. See the
+[full transport policy](https://microsoft.github.io/apm/getting-started/authentication/#generic-marketplace-git-transport).
 
 ## GitLab hosts
 

--- a/packages/apm-guide/.apm/skills/apm-usage/authentication.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/authentication.md
@@ -40,6 +40,13 @@ registration stays SSH when APM generates the concrete `git:` and `path:`
 dependency. Existing SSH keys keep working instead of the dependency being
 rewritten to HTTPS.
 
+Generic marketplace HTTPS sources may use the native Git credential helper from
+your Git configuration. APM still sets `GIT_TERMINAL_PROMPT=0` and removes
+platform token variables, `GIT_TOKEN`, and environment-based authorization-header
+channels before the fetch. Plain `http://` marketplace registration is rejected;
+any attempted fetch isolates Git configuration and
+suppress helpers; generic SSH sources are token-free and use noninteractive SSH.
+
 ## GitLab hosts
 
 `gitlab.com` is detected automatically. For self-managed GitLab, set

--- a/packages/apm-guide/.apm/skills/apm-usage/authentication.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/authentication.md
@@ -46,6 +46,8 @@ platform token variables, `GIT_TOKEN`, and environment-based authorization-heade
 channels before the fetch. Plain `http://` marketplace registration is rejected;
 any attempted fetch isolates Git configuration and
 suppress helpers; generic SSH sources are token-free and use noninteractive SSH.
+APM rejects HTTPS Git URLs that Git configuration would rewrite to `http://`
+before credentials can be used.
 
 ## GitLab hosts
 

--- a/src/apm_cli/core/auth.py
+++ b/src/apm_cli/core/auth.py
@@ -43,6 +43,8 @@ from typing import TYPE_CHECKING, NamedTuple, TypeVar
 from apm_cli.core.host_providers import (
     HOST_PROVIDERS,
     classify_host_provider,
+    git_transport_cache_key,
+    git_transport_policy,
 )
 from apm_cli.core.token_manager import GitHubTokenManager
 from apm_cli.utils.github_host import (
@@ -229,6 +231,7 @@ class AuthCacheKey(NamedTuple):
     host_type: str  # Empty string represents an absent or canonical host_type.
     org: str
     path: str  # Empty unless credential resolution is repository-scoped.
+    transport: str  # Empty for callers without a concrete remote URL.
 
 
 class AuthResolver:
@@ -284,6 +287,7 @@ class AuthResolver:
         port: int | None = None,
         host_type: str | None = None,
         path: str | None = None,
+        remote_url: str | None = None,
     ) -> bool:
         """Return whether credential resolution already ran for this scope."""
         key = AuthCacheKey(
@@ -292,6 +296,7 @@ class AuthResolver:
             self._cache_host_type(host, host_type),
             org.lower() if org else "",
             path or "",
+            git_transport_cache_key(remote_url),
         )
         with self._lock:
             return key in self._cache
@@ -395,6 +400,7 @@ class AuthResolver:
         port: int | None = None,
         host_type: str | None = None,
         path: str | None = None,
+        remote_url: str | None = None,
     ) -> AuthContext:
         """Resolve auth for a host/org and optional repository path.
 
@@ -410,6 +416,7 @@ class AuthResolver:
             self._cache_host_type(host, host_type),
             org.lower() if org else "",
             path or "",
+            git_transport_cache_key(remote_url),
         )
         with self._lock:
             cached = self._cache.get(key)
@@ -423,13 +430,25 @@ class AuthResolver:
             # Bounded by APM_GIT_CREDENTIAL_TIMEOUT (default 60s). No deadlock
             # risk: single lock, never nested.
             host_info = self.classify_host(host, port=port, host_type=host_type)
+            transport_policy = (
+                git_transport_policy(host_info.kind, remote_url) if remote_url is not None else None
+            )
             if path is None:
-                token, source, scheme = self._resolve_token(host_info, org)
+                token, source, scheme = self._resolve_token(
+                    host_info,
+                    org,
+                    allow_generic_credential_lookup=(
+                        transport_policy is None or transport_policy.allow_native_credential_lookup
+                    ),
+                )
             else:
                 token, source, scheme = self._resolve_token(
                     host_info,
                     org,
                     path=path,
+                    allow_generic_credential_lookup=(
+                        transport_policy is None or transport_policy.allow_native_credential_lookup
+                    ),
                 )
             token_type = self.detect_token_type(token) if token else "unknown"
             git_env = self._build_git_env(token, scheme=scheme, host_kind=host_info.kind)
@@ -444,6 +463,24 @@ class AuthResolver:
             )
             self._cache[key] = ctx
             return ctx
+
+    def resolve_for_remote(
+        self,
+        host: str,
+        remote_url: str,
+        org: str | None = None,
+        *,
+        port: int | None = None,
+        host_type: str | None = None,
+    ) -> AuthContext:
+        """Resolve one context after applying its canonical remote policy."""
+        return self.resolve(
+            host,
+            org,
+            port=port,
+            host_type=host_type,
+            remote_url=remote_url,
+        )
 
     def resolve_for_dep(self, dep_ref: DependencyReference) -> AuthContext:
         """Resolve auth from a ``DependencyReference``.
@@ -1098,6 +1135,7 @@ class AuthResolver:
         org: str | None,
         *,
         path: str | None = None,
+        allow_generic_credential_lookup: bool = True,
     ) -> tuple[str | None, str, str]:
         """Walk the token resolution chain.  Returns (token, source, scheme).
 
@@ -1171,12 +1209,27 @@ class AuthResolver:
             return gh_token, "gh-auth-token", "basic"
 
         # 4. Git credential helper (not for ADO)
-        if host_info.kind not in ("ado",):
+        if host_info.kind not in ("ado",) and (
+            host_info.kind != "generic" or allow_generic_credential_lookup
+        ):
             # Most primary resolution calls remain host-scoped. The public
             # github.com anonymous-first fallback supplies path= after a
             # private-repo-shaped failure so GCM can choose the correct
             # account without an unscoped prompt.
-            if path is None:
+            if path is None and host_info.kind == "generic":
+                credential = self._token_manager.resolve_credential_from_git(
+                    host_info.host,
+                    port=host_info.port,
+                    env=self._generic_credential_lookup_env(),
+                )
+            elif path is not None and host_info.kind == "generic":
+                credential = self._token_manager.resolve_credential_from_git(
+                    host_info.host,
+                    port=host_info.port,
+                    path=path,
+                    env=self._generic_credential_lookup_env(),
+                )
+            elif path is None:
                 credential = self._token_manager.resolve_credential_from_git(
                     host_info.host,
                     port=host_info.port,
@@ -1369,6 +1422,35 @@ class AuthResolver:
             base_env=self.hardened_git_base_env(),
         )
 
+    def git_env_for_remote(self, ctx: AuthContext, remote_url: str) -> dict[str, str]:
+        """Build the canonical noninteractive Git environment for one remote.
+
+        Host and transport policy belongs to the provider registry. This method
+        only applies that selected policy to the resolved context, keeping
+        marketplace and dependency consumers from branching on transport.
+        """
+        policy = git_transport_policy(ctx.host_info.kind, remote_url)
+        if policy.use_resolved_credentials:
+            env = self.hardened_git_env_for_context(ctx)
+        else:
+            env = self.build_noninteractive_git_env(
+                base_env=self.hardened_git_base_env(),
+                host_kind=ctx.host_info.kind,
+                preserve_config_isolation=policy.preserve_config_isolation,
+                suppress_credential_helpers=policy.suppress_credential_helpers,
+            )
+        self._remove_platform_token_env(env)
+        return env
+
+    def _generic_credential_lookup_env(self) -> dict[str, str]:
+        """Build the token-free native-helper environment for generic hosts."""
+        env = self.build_noninteractive_git_env(
+            base_env=self.hardened_git_base_env(),
+            host_kind="generic",
+        )
+        self._remove_platform_token_env(env)
+        return env
+
     @staticmethod
     def _clear_platform_token_env(env: dict) -> None:
         """Neutralize raw platform token sources before spawning git.
@@ -1380,6 +1462,13 @@ class AuthResolver:
         for key in tuple(env):
             if key in _GIT_CHILD_TOKEN_ENV_NAMES or key.startswith(_GIT_CHILD_TOKEN_ENV_PREFIXES):
                 env[key] = ""
+
+    @staticmethod
+    def _remove_platform_token_env(env: dict) -> None:
+        """Remove platform token variables from a complete subprocess env."""
+        for key in tuple(env):
+            if key in _GIT_CHILD_TOKEN_ENV_NAMES or key.startswith(_GIT_CHILD_TOKEN_ENV_PREFIXES):
+                env.pop(key, None)
 
     @staticmethod
     def _clear_git_auth_env(env: dict) -> None:

--- a/src/apm_cli/core/auth.py
+++ b/src/apm_cli/core/auth.py
@@ -1430,15 +1430,21 @@ class AuthResolver:
         marketplace and dependency consumers from branching on transport.
         """
         policy = git_transport_policy(ctx.host_info.kind, remote_url)
+        base_env = self.hardened_git_base_env()
         if policy.use_resolved_credentials:
-            env = self.hardened_git_env_for_context(ctx)
+            env = self.git_env_for_context(ctx, base_env=base_env)
         else:
             env = self.build_noninteractive_git_env(
-                base_env=self.hardened_git_base_env(),
+                base_env=base_env,
                 host_kind=ctx.host_info.kind,
                 preserve_config_isolation=policy.preserve_config_isolation,
                 suppress_credential_helpers=policy.suppress_credential_helpers,
             )
+        if policy.reject_https_downgrade:
+            from ..deps.git_auth_env import GitAuthEnvBuilder
+
+            if GitAuthEnvBuilder.has_https_to_http_url_rewrite(remote_url, env):
+                raise ValueError("HTTPS Git remote is configured to rewrite to insecure HTTP")
         self._remove_platform_token_env(env)
         return env
 

--- a/src/apm_cli/core/auth.py
+++ b/src/apm_cli/core/auth.py
@@ -1216,30 +1216,15 @@ class AuthResolver:
             # github.com anonymous-first fallback supplies path= after a
             # private-repo-shaped failure so GCM can choose the correct
             # account without an unscoped prompt.
-            if path is None and host_info.kind == "generic":
-                credential = self._token_manager.resolve_credential_from_git(
-                    host_info.host,
-                    port=host_info.port,
-                    env=self._generic_credential_lookup_env(),
-                )
-            elif path is not None and host_info.kind == "generic":
-                credential = self._token_manager.resolve_credential_from_git(
-                    host_info.host,
-                    port=host_info.port,
-                    path=path,
-                    env=self._generic_credential_lookup_env(),
-                )
-            elif path is None:
-                credential = self._token_manager.resolve_credential_from_git(
-                    host_info.host,
-                    port=host_info.port,
-                )
-            else:
-                credential = self._token_manager.resolve_credential_from_git(
-                    host_info.host,
-                    port=host_info.port,
-                    path=path,
-                )
+            lookup_kwargs: dict[str, object] = {"port": host_info.port}
+            if path is not None:
+                lookup_kwargs["path"] = path
+            if host_info.kind == "generic":
+                lookup_kwargs["env"] = self._generic_credential_lookup_env()
+            credential = self._token_manager.resolve_credential_from_git(
+                host_info.host,
+                **lookup_kwargs,
+            )
             if credential:
                 return credential, "git-credential-fill", "basic"
 
@@ -1445,7 +1430,7 @@ class AuthResolver:
 
             if GitAuthEnvBuilder.has_https_to_http_url_rewrite(remote_url, env):
                 raise ValueError("HTTPS Git remote is configured to rewrite to insecure HTTP")
-        self._remove_platform_token_env(env)
+        self._clear_platform_token_env(env, remove=True)
         return env
 
     def _generic_credential_lookup_env(self) -> dict[str, str]:
@@ -1454,27 +1439,24 @@ class AuthResolver:
             base_env=self.hardened_git_base_env(),
             host_kind="generic",
         )
-        self._remove_platform_token_env(env)
+        self._clear_platform_token_env(env, remove=True)
         return env
 
     @staticmethod
-    def _clear_platform_token_env(env: dict) -> None:
-        """Neutralize raw platform token sources before spawning git.
+    def _clear_platform_token_env(env: dict, *, remove: bool = False) -> None:
+        """Scrub raw platform token sources before spawning git.
 
         GitPython treats ``env`` as an overlay on the parent process, so
         deleting a key from the overlay leaves the ambient value intact.
-        Empty values mask those sources in GitPython and direct subprocesses.
+        The default empty values mask those sources in GitPython and direct
+        subprocesses. Complete subprocess environments may remove them.
         """
         for key in tuple(env):
             if key in _GIT_CHILD_TOKEN_ENV_NAMES or key.startswith(_GIT_CHILD_TOKEN_ENV_PREFIXES):
-                env[key] = ""
-
-    @staticmethod
-    def _remove_platform_token_env(env: dict) -> None:
-        """Remove platform token variables from a complete subprocess env."""
-        for key in tuple(env):
-            if key in _GIT_CHILD_TOKEN_ENV_NAMES or key.startswith(_GIT_CHILD_TOKEN_ENV_PREFIXES):
-                env.pop(key, None)
+                if remove:
+                    env.pop(key, None)
+                else:
+                    env[key] = ""
 
     @staticmethod
     def _clear_git_auth_env(env: dict) -> None:

--- a/src/apm_cli/core/host_providers.py
+++ b/src/apm_cli/core/host_providers.py
@@ -20,6 +20,16 @@ HostMatcher = Callable[[str], bool]
 
 
 @dataclass(frozen=True)
+class GitTransportPolicy:
+    """Describe the Git credential posture for one resolved remote."""
+
+    use_resolved_credentials: bool
+    allow_native_credential_lookup: bool = True
+    preserve_config_isolation: bool = False
+    suppress_credential_helpers: bool = False
+
+
+@dataclass(frozen=True)
 class HostProviderDescriptor:
     """Describe host classification, credentials, and API capabilities."""
 
@@ -156,6 +166,43 @@ def host_provider_descriptors() -> tuple[HostProviderDescriptor, ...]:
 def accepted_host_types() -> tuple[str, ...]:
     """Return manifest host-type hints accepted by the registry."""
     return tuple(host_type for provider in _HOST_PROVIDERS for host_type in provider.manifest_types)
+
+
+def git_transport_policy(host_kind: str, remote_url: str) -> GitTransportPolicy:
+    """Return the canonical credential policy for a host and Git transport.
+
+    Recognized providers retain APM-managed hardened credentials. Generic HTTPS
+    delegates only to native Git credential helpers, while plaintext HTTP
+    suppresses every credential channel. Generic SSH is token-free and lets
+    AuthResolver preserve its noninteractive SSH command.
+    """
+    scheme = urllib.parse.urlsplit(remote_url).scheme.lower()
+    if host_kind != "generic":
+        return GitTransportPolicy(use_resolved_credentials=True)
+    if scheme == "http":
+        return GitTransportPolicy(
+            use_resolved_credentials=False,
+            allow_native_credential_lookup=False,
+            preserve_config_isolation=True,
+            suppress_credential_helpers=True,
+        )
+    if scheme == "https":
+        return GitTransportPolicy(
+            use_resolved_credentials=False,
+            allow_native_credential_lookup=False,
+        )
+    return GitTransportPolicy(
+        use_resolved_credentials=False,
+        allow_native_credential_lookup=False,
+    )
+
+
+def git_transport_cache_key(remote_url: str | None) -> str:
+    """Return the transport discriminator used by AuthResolver's cache."""
+    if remote_url is None:
+        return ""
+    scheme = urllib.parse.urlsplit(remote_url).scheme.lower()
+    return scheme or "ssh"
 
 
 def classify_host_provider(

--- a/src/apm_cli/core/host_providers.py
+++ b/src/apm_cli/core/host_providers.py
@@ -27,6 +27,7 @@ class GitTransportPolicy:
     allow_native_credential_lookup: bool = True
     preserve_config_isolation: bool = False
     suppress_credential_helpers: bool = False
+    reject_https_downgrade: bool = False
 
 
 @dataclass(frozen=True)
@@ -177,8 +178,6 @@ def git_transport_policy(host_kind: str, remote_url: str) -> GitTransportPolicy:
     AuthResolver preserve its noninteractive SSH command.
     """
     scheme = urllib.parse.urlsplit(remote_url).scheme.lower()
-    if host_kind != "generic":
-        return GitTransportPolicy(use_resolved_credentials=True)
     if scheme == "http":
         return GitTransportPolicy(
             use_resolved_credentials=False,
@@ -186,10 +185,16 @@ def git_transport_policy(host_kind: str, remote_url: str) -> GitTransportPolicy:
             preserve_config_isolation=True,
             suppress_credential_helpers=True,
         )
+    if host_kind != "generic" and scheme == "https":
+        return GitTransportPolicy(
+            use_resolved_credentials=True,
+            reject_https_downgrade=True,
+        )
     if scheme == "https":
         return GitTransportPolicy(
             use_resolved_credentials=False,
             allow_native_credential_lookup=False,
+            reject_https_downgrade=True,
         )
     return GitTransportPolicy(
         use_resolved_credentials=False,

--- a/src/apm_cli/core/token_manager.py
+++ b/src/apm_cli/core/token_manager.py
@@ -189,7 +189,11 @@ class GitHubTokenManager:
 
     @staticmethod
     def resolve_credential_from_git(
-        host: str, port: int | None = None, path: str | None = None
+        host: str,
+        port: int | None = None,
+        path: str | None = None,
+        *,
+        env: dict[str, str] | None = None,
     ) -> str | None:
         """Resolve a credential from the git credential store.
 
@@ -228,7 +232,7 @@ class GitHubTokenManager:
                 encoding="utf-8",
                 timeout=GitHubTokenManager._get_credential_timeout(),
                 env={
-                    **os.environ,
+                    **(os.environ if env is None else env),
                     "GIT_TERMINAL_PROMPT": "0",
                     "GIT_ASKPASS": "" if sys.platform != "win32" else "echo",
                 },

--- a/src/apm_cli/deps/git_auth_env.py
+++ b/src/apm_cli/deps/git_auth_env.py
@@ -25,8 +25,10 @@ from a reference to the surrounding downloader's token manager and
 from __future__ import annotations
 
 import os
+import subprocess
 import sys
 from typing import Any
+from urllib.parse import urlsplit
 
 
 class GitAuthEnvBuilder:
@@ -111,6 +113,53 @@ class GitAuthEnvBuilder:
         env["GIT_CONFIG_VALUE_0"] = ""
 
     @staticmethod
+    def has_https_to_http_url_rewrite(remote_url: str, env: dict[str, str]) -> bool:
+        """Return whether Git configuration would downgrade *remote_url* to HTTP."""
+        if urlsplit(remote_url).scheme.lower() != "https":
+            return False
+
+        from ..utils.git_env import get_git_executable
+
+        try:
+            result = subprocess.run(
+                (
+                    get_git_executable(),
+                    "config",
+                    "--null",
+                    "--get-regexp",
+                    r"^url\..*\.insteadOf$",
+                ),
+                capture_output=True,
+                check=False,
+                env=env,
+                timeout=10,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise ValueError("Unable to verify HTTPS Git rewrite safety") from exc
+        if result.returncode not in {0, 1}:
+            raise ValueError("Unable to verify HTTPS Git rewrite safety")
+
+        for entry in result.stdout.split(b"\0"):
+            if not entry or b"\n" not in entry:
+                continue
+            key, prefix = entry.split(b"\n", 1)
+            try:
+                key_text = key.decode("utf-8")
+                prefix_text = prefix.decode("utf-8")
+            except UnicodeDecodeError:
+                continue
+            normalized_key = key_text.lower()
+            if not normalized_key.startswith("url.") or not normalized_key.endswith(".insteadof"):
+                continue
+            replacement = key_text[4 : -len(".insteadOf")]
+            if (
+                remote_url.startswith(prefix_text)
+                and urlsplit(replacement).scheme.lower() == "http"
+            ):
+                return True
+        return False
+
+    @staticmethod
     def noninteractive_env(
         base_git_env: dict[str, str],
         *,
@@ -143,10 +192,13 @@ class GitAuthEnvBuilder:
 
         if preserve_config_isolation or suppress_credential_helpers:
             env["GIT_CONFIG_NOSYSTEM"] = "1"
-            env.setdefault(
-                "GIT_CONFIG_GLOBAL",
-                GitAuthEnvBuilder.isolated_global_config_path(),
-            )
+            if suppress_credential_helpers:
+                env["GIT_CONFIG_GLOBAL"] = GitAuthEnvBuilder.isolated_global_config_path()
+            else:
+                env.setdefault(
+                    "GIT_CONFIG_GLOBAL",
+                    GitAuthEnvBuilder.isolated_global_config_path(),
+                )
         else:
             env.pop("GIT_CONFIG_GLOBAL", None)
             env.pop("GIT_CONFIG_NOSYSTEM", None)

--- a/src/apm_cli/marketplace/client.py
+++ b/src/apm_cli/marketplace/client.py
@@ -574,12 +574,32 @@ def _fetch_git(
     from ..cache.paths import get_cache_root
 
     org = source.owner or None
-    auth_ctx = (
-        auth_resolver.resolve_for_remote(host_info.host, source.url, org, port=source.port)
-        if source.port is not None
-        else auth_resolver.resolve_for_remote(host_info.host, source.url, org)
-    )
-    git_env = auth_resolver.git_env_for_remote(auth_ctx, source.url)
+    try:
+        auth_ctx = (
+            auth_resolver.resolve_for_remote(host_info.host, source.url, org, port=source.port)
+            if source.port is not None
+            else auth_resolver.resolve_for_remote(host_info.host, source.url, org)
+        )
+        git_env = auth_resolver.git_env_for_remote(auth_ctx, source.url)
+    except ValueError as exc:
+        logger.debug(
+            "Generic-git policy rejected '%s': %s",
+            source.name,
+            type(exc).__name__,
+        )
+        reason = (
+            "HTTPS Git remote was rejected because Git configuration rewrites it to insecure HTTP"
+            if str(exc) == "HTTPS Git remote is configured to rewrite to insecure HTTP"
+            else "unable to verify HTTPS Git rewrite safety"
+        )
+        raise MarketplaceFetchError(
+            source.name,
+            reason,
+            retry_hint=(
+                "Remove the matching Git url.*.insteadOf rewrite, then run "
+                f"'apm marketplace update {source.name}' to retry."
+            ),
+        ) from exc
 
     cache = GitCache(get_cache_root(), refresh=False)
     try:
@@ -601,14 +621,18 @@ def _fetch_git(
         raise MarketplaceFetchError(
             source.name,
             "git fetch failed; verify the remote, configured Git credentials, or SSH key",
-            retry_hint="Correct Git access and rerun the original marketplace command.",
+            retry_hint=(
+                f"Correct Git access, then run 'apm marketplace update {source.name}' to retry."
+            ),
         ) from exc
     except Exception as exc:
         logger.debug("Generic-git fetch failed for '%s': %s", source.name, type(exc).__name__)
         raise MarketplaceFetchError(
             source.name,
             "git fetch failed; verify the remote, configured Git credentials, or SSH key",
-            retry_hint="Correct Git access and rerun the original marketplace command.",
+            retry_hint=(
+                f"Correct Git access, then run 'apm marketplace update {source.name}' to retry."
+            ),
         ) from exc
 
     target = Path(checkout_dir) / file_path

--- a/src/apm_cli/marketplace/client.py
+++ b/src/apm_cli/marketplace/client.py
@@ -600,13 +600,15 @@ def _fetch_git(
             return None
         raise MarketplaceFetchError(
             source.name,
-            "git fetch failed; verify the remote and its configured Git credentials",
+            "git fetch failed; verify the remote, configured Git credentials, or SSH key",
+            retry_hint="Correct Git access and rerun the original marketplace command.",
         ) from exc
     except Exception as exc:
         logger.debug("Generic-git fetch failed for '%s': %s", source.name, type(exc).__name__)
         raise MarketplaceFetchError(
             source.name,
-            "git fetch failed; verify the remote and its configured Git credentials",
+            "git fetch failed; verify the remote, configured Git credentials, or SSH key",
+            retry_hint="Correct Git access and rerun the original marketplace command.",
         ) from exc
 
     target = Path(checkout_dir) / file_path

--- a/src/apm_cli/marketplace/client.py
+++ b/src/apm_cli/marketplace/client.py
@@ -565,27 +565,21 @@ def _fetch_git(
 ) -> dict | None:
     """Fetch marketplace.json from a generic git URL via subprocess + GitCache.
 
-    Sparse-cone clones only the requested manifest path. Uses
-    ``AuthResolver.resolve(host, org).git_env`` to build the git env; for
-    hosts APM doesn't recognise, the env passes through to the user's
-    credential helpers (matches ``apm install`` posture).
+    Sparse-cone clones only the requested manifest path. AuthResolver owns
+    remote-aware credential selection and Git environment policy.
     """
     _validate_ref(source.ref, source.name)
 
-    from ..cache.git_cache import GitCache, _sanitize_url
+    from ..cache.git_cache import GitCache
     from ..cache.paths import get_cache_root
 
     org = source.owner or None
     auth_ctx = (
-        auth_resolver.resolve(host_info.host, org, port=source.port)
+        auth_resolver.resolve_for_remote(host_info.host, source.url, org, port=source.port)
         if source.port is not None
-        else auth_resolver.resolve(host_info.host, org)
+        else auth_resolver.resolve_for_remote(host_info.host, source.url, org)
     )
-    git_env = (
-        auth_ctx.git_env
-        if host_info.kind == "generic"
-        else auth_resolver.hardened_git_env_for_context(auth_ctx)
-    )
+    git_env = auth_resolver.git_env_for_remote(auth_ctx, source.url)
 
     cache = GitCache(get_cache_root(), refresh=False)
     try:
@@ -604,11 +598,16 @@ def _fetch_git(
         stderr_raw = (getattr(exc, "stderr", b"") or b"").decode("utf-8", errors="replace")
         if "not found" in stderr_raw.lower() or "does not exist" in stderr_raw.lower():
             return None
-        stderr = _sanitize_url(stderr_raw)
-        raise MarketplaceFetchError(source.name, f"git fetch failed: {stderr or exc}") from exc
+        raise MarketplaceFetchError(
+            source.name,
+            "git fetch failed; verify the remote and its configured Git credentials",
+        ) from exc
     except Exception as exc:
-        logger.debug("Generic-git fetch failed for '%s'", source.name, exc_info=True)
-        raise MarketplaceFetchError(source.name, _sanitize_url(str(exc))) from exc
+        logger.debug("Generic-git fetch failed for '%s': %s", source.name, type(exc).__name__)
+        raise MarketplaceFetchError(
+            source.name,
+            "git fetch failed; verify the remote and its configured Git credentials",
+        ) from exc
 
     target = Path(checkout_dir) / file_path
     if not target.exists():

--- a/src/apm_cli/marketplace/client.py
+++ b/src/apm_cli/marketplace/client.py
@@ -581,7 +581,11 @@ def _fetch_git(
         if source.port is not None
         else auth_resolver.resolve(host_info.host, org)
     )
-    git_env = auth_resolver.hardened_git_env_for_context(auth_ctx)
+    git_env = (
+        auth_ctx.git_env
+        if host_info.kind == "generic"
+        else auth_resolver.hardened_git_env_for_context(auth_ctx)
+    )
 
     cache = GitCache(get_cache_root(), refresh=False)
     try:

--- a/src/apm_cli/marketplace/errors.py
+++ b/src/apm_cli/marketplace/errors.py
@@ -48,14 +48,16 @@ class MarketplaceYmlError(MarketplaceError):
 class MarketplaceFetchError(MarketplaceError):
     """Raised when fetching marketplace data fails."""
 
-    def __init__(self, name: str, reason: str = ""):
+    def __init__(self, name: str, reason: str = "", *, retry_hint: str | None = None):
         self.name = name
         self.reason = reason
         detail = f": {reason}" if reason else ""
-        super().__init__(
-            f"Failed to fetch marketplace '{name}'{detail}. "
-            f"Run 'apm marketplace update {name}' to retry."
+        retry = (
+            retry_hint
+            if retry_hint is not None
+            else f"Run 'apm marketplace update {name}' to retry."
         )
+        super().__init__(f"Failed to fetch marketplace '{name}'{detail}. {retry}")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_marketplace_generic_https_credential_lifecycle.py
+++ b/tests/integration/test_marketplace_generic_https_credential_lifecycle.py
@@ -175,3 +175,53 @@ def test_generic_https_marketplace_add_uses_native_credential_helper(
     saved = json.loads((isolated.config_root / "marketplaces.json").read_text(encoding="utf-8"))
     assert len(saved["marketplaces"]) == 1
     assert saved["marketplaces"][0]["name"] == "generic-marketplace"
+
+
+def test_generic_https_marketplace_add_rejects_http_rewrite(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    """The installed CLI rejects an HTTPS-to-HTTP Git rewrite safely."""
+    isolated = IsolatedApmEnvironment.create(tmp_path / "scenario", base_env=os.environ)
+    real_git = _real_git()
+    subprocess.run(
+        (
+            str(real_git),
+            "config",
+            "--file",
+            str(isolated.home / ".gitconfig"),
+            "url.http://127.0.0.1:9/.insteadOf",
+            "https://gitea.example.test/",
+        ),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    environment = isolated.subprocess_env()
+    environment.update(
+        {
+            "GITHUB_APM_PAT": "github-apm-sentinel",
+            "GIT_EXEC_PATH": _git_exec_path(real_git),
+        }
+    )
+
+    result = ApmLifecycleRunner((str(apm_binary_path),)).run(
+        (
+            "marketplace",
+            "add",
+            "https://gitea.example.test/org/repo.git",
+            "--name",
+            "downgrade-marketplace",
+        ),
+        scenario_id="marketplace-generic-https-downgrade",
+        cwd=isolated.work_root,
+        env=environment,
+    )
+
+    output = f"{result.stdout}\n{result.stderr}"
+    assert result.returncode == 1
+    assert "Failed to register marketplace" in output
+    assert "rewrite" in output
+    assert "insecure HTTP" in output
+    assert "apm marketplace update downgrade-marketplace" in output
+    assert "github-apm-sentinel" not in output

--- a/tests/integration/test_marketplace_generic_https_credential_lifecycle.py
+++ b/tests/integration/test_marketplace_generic_https_credential_lifecycle.py
@@ -41,6 +41,16 @@ def _real_git() -> Path:
     return Path(executable).resolve()
 
 
+def _git_exec_path(git: Path) -> str:
+    """Return the helper directory paired with the selected Git executable."""
+    return subprocess.run(
+        (str(git), "--exec-path"),
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
 def _write_credential_helper(home: Path, log_path: Path) -> Path:
     """Create a real helper that records only sentinel names, never values."""
     helper = home / "credential-helper.py"
@@ -67,6 +77,37 @@ def _write_credential_helper(home: Path, log_path: Path) -> Path:
     return helper
 
 
+def _write_tls_certificate(root: Path) -> tuple[Path, Path]:
+    """Generate a short-lived loopback certificate for the HTTPS Git fixture."""
+    openssl = shutil.which("openssl")
+    if openssl is None:
+        pytest.skip("openssl is required for the HTTPS Git fixture")
+    certificate = root / "certificate.pem"
+    key = root / "key.pem"
+    subprocess.run(
+        (
+            openssl,
+            "req",
+            "-x509",
+            "-newkey",
+            "rsa:2048",
+            "-nodes",
+            "-keyout",
+            str(key),
+            "-out",
+            str(certificate),
+            "-subj",
+            "/CN=127.0.0.1",
+            "-days",
+            "1",
+        ),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return certificate, key
+
+
 def test_generic_https_marketplace_add_uses_native_credential_helper(
     tmp_path: Path,
     apm_binary_path: Path,
@@ -86,8 +127,11 @@ def test_generic_https_marketplace_add_uses_native_credential_helper(
             "GIT_TOKEN": "git-sentinel",
             "APM_TEST_HELPER_LOG": str(helper_log),
             "GIT_ALLOW_PROTOCOL": "file:http:https",
+            "GIT_SSL_NO_VERIFY": "1",
         }
     )
+    real_git = _real_git()
+    environment["GIT_EXEC_PATH"] = _git_exec_path(real_git)
     repositories = LocalGitRepositoryFactory(isolated.repository_root, env=environment)
     repository = repositories.create("generic-marketplace")
     (repository.worktree / "marketplace.json").write_text(
@@ -97,31 +141,19 @@ def test_generic_https_marketplace_add_uses_native_credential_helper(
     repositories.commit(repository, message="seed marketplace")
     server_factory = LocalGitHttpServerFactory(
         isolated.repository_root,
-        real_git=_real_git(),
+        real_git=real_git,
         env=environment,
     )
+    certificate, key = _write_tls_certificate(isolated.root)
 
     with server_factory.start(
         (repository,),
         password=_HELPER_PASSWORD,
         private_repositories=(repository,),
+        certfile=certificate,
+        keyfile=key,
     ) as server:
-        remote_url = f"https://gitea.example.test/{repository.origin.name}"
-        subprocess.run(
-            (
-                "git",
-                "config",
-                "--file",
-                str(isolated.home / ".gitconfig"),
-                "--add",
-                f"url.{server.proxy_url}/.insteadOf",
-                "https://gitea.example.test/",
-            ),
-            check=True,
-            capture_output=True,
-            text=True,
-            env=environment,
-        )
+        remote_url = server.remote_url(repository)
         runner = ApmLifecycleRunner((str(apm_binary_path),))
         add_result = runner.run(
             ("marketplace", "add", remote_url, "--name", "generic-marketplace"),

--- a/tests/integration/test_marketplace_generic_https_credential_lifecycle.py
+++ b/tests/integration/test_marketplace_generic_https_credential_lifecycle.py
@@ -1,0 +1,145 @@
+"""Installed-CLI lifecycle proof for generic marketplace HTTPS helpers."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.utils.apm_lifecycle_runner import ApmLifecycleRunner
+from tests.utils.isolated_apm_environment import IsolatedApmEnvironment
+from tests.utils.local_git_http_server import LocalGitHttpServerFactory
+from tests.utils.local_git_repository import LocalGitRepositoryFactory
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.e2e,
+    pytest.mark.requires_e2e_mode,
+]
+
+_HELPER_PASSWORD = "fixture-marketplace-password"
+_SENTINEL_NAMES = (
+    "ADO_APM_PAT",
+    "GH_TOKEN",
+    "GITHUB_APM_PAT",
+    "GITHUB_TOKEN",
+    "GIT_HTTP_EXTRAHEADER",
+    "GIT_TOKEN",
+)
+
+
+def _real_git() -> Path:
+    executable = shutil.which("git")
+    if executable is None:
+        pytest.skip("git executable not available")
+    return Path(executable).resolve()
+
+
+def _write_credential_helper(home: Path, log_path: Path) -> Path:
+    """Create a real helper that records only sentinel names, never values."""
+    helper = home / "credential-helper.py"
+    helper.write_text(
+        f"#!{sys.executable}\n"
+        "import json\n"
+        "import os\n"
+        "from pathlib import Path\n"
+        f"names = {list(_SENTINEL_NAMES)!r}\n"
+        "Path(os.environ['APM_TEST_HELPER_LOG']).write_text(\n"
+        "    json.dumps([name for name in names if name in os.environ]), encoding='utf-8'\n"
+        ")\n"
+        "print('username=x-access-token')\n"
+        f"print('password={_HELPER_PASSWORD}')\n",
+        encoding="ascii",
+    )
+    helper.chmod(helper.stat().st_mode | stat.S_IXUSR)
+    subprocess.run(
+        ("git", "config", "--file", str(home / ".gitconfig"), "credential.helper", f"!{helper}"),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return helper
+
+
+def test_generic_https_marketplace_add_uses_native_credential_helper(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    """Add and list one generic HTTPS source through a real Git helper."""
+    isolated = IsolatedApmEnvironment.create(tmp_path / "scenario", base_env=os.environ)
+    helper_log = isolated.root / "credential-helper.json"
+    _write_credential_helper(isolated.home, helper_log)
+    environment = isolated.subprocess_env()
+    environment.update(
+        {
+            "ADO_APM_PAT": "ado-sentinel",
+            "GH_TOKEN": "gh-sentinel",
+            "GITHUB_APM_PAT": "github-apm-sentinel",
+            "GITHUB_TOKEN": "github-sentinel",
+            "GIT_HTTP_EXTRAHEADER": "Authorization: sentinel",
+            "GIT_TOKEN": "git-sentinel",
+            "APM_TEST_HELPER_LOG": str(helper_log),
+            "GIT_ALLOW_PROTOCOL": "file:http:https",
+        }
+    )
+    repositories = LocalGitRepositoryFactory(isolated.repository_root, env=environment)
+    repository = repositories.create("generic-marketplace")
+    (repository.worktree / "marketplace.json").write_text(
+        json.dumps({"name": "generic-marketplace", "plugins": []}),
+        encoding="utf-8",
+    )
+    repositories.commit(repository, message="seed marketplace")
+    server_factory = LocalGitHttpServerFactory(
+        isolated.repository_root,
+        real_git=_real_git(),
+        env=environment,
+    )
+
+    with server_factory.start(
+        (repository,),
+        password=_HELPER_PASSWORD,
+        private_repositories=(repository,),
+    ) as server:
+        remote_url = f"https://gitea.example.test/{repository.origin.name}"
+        subprocess.run(
+            (
+                "git",
+                "config",
+                "--file",
+                str(isolated.home / ".gitconfig"),
+                "--add",
+                f"url.{server.proxy_url}/.insteadOf",
+                "https://gitea.example.test/",
+            ),
+            check=True,
+            capture_output=True,
+            text=True,
+            env=environment,
+        )
+        runner = ApmLifecycleRunner((str(apm_binary_path),))
+        add_result = runner.run(
+            ("marketplace", "add", remote_url, "--name", "generic-marketplace"),
+            scenario_id="marketplace-generic-https-native-helper",
+            cwd=isolated.work_root,
+            env=environment,
+        )
+        list_result = runner.run(
+            ("marketplace", "list"),
+            scenario_id="marketplace-generic-https-native-helper",
+            cwd=isolated.work_root,
+            env=environment,
+        )
+
+    assert add_result.returncode == 0, add_result.stderr
+    assert list_result.returncode == 0, list_result.stderr
+    assert helper_log.exists()
+    assert json.loads(helper_log.read_text(encoding="utf-8")) == []
+    saved = json.loads((isolated.config_root / "marketplaces.json").read_text(encoding="utf-8"))
+    assert len(saved["marketplaces"]) == 1
+    assert saved["marketplaces"][0]["name"] == "generic-marketplace"

--- a/tests/unit/core/test_git_transport_policy.py
+++ b/tests/unit/core/test_git_transport_policy.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import os
+import subprocess
+from pathlib import Path
+
 import pytest
 
 from apm_cli.core.auth import AuthContext, AuthResolver, HostInfo
@@ -29,6 +33,7 @@ class _TokenManager:
             "GIT_CONFIG_GLOBAL": "/dev/null",
             "GIT_CONFIG_NOSYSTEM": "1",
             "GIT_SSH_COMMAND": "ssh -o ConnectTimeout=30 -o BatchMode=yes",
+            "HOME": os.environ.get("HOME", ""),
         }
 
 
@@ -82,6 +87,10 @@ def _context(kind: str) -> AuthContext:
         ("github", "https://github.com/org/repo.git", False, True),
         ("gitlab", "https://gitlab.com/org/repo.git", False, True),
         ("ado", "https://dev.azure.com/org/project/_git/repo", False, True),
+        ("ado", "http://dev.azure.com/org/project/_git/repo", False, True),
+        ("github", "git@github.com:org/repo.git", True, False),
+        ("gitlab", "git@gitlab.com:org/repo.git", True, False),
+        ("ado", "git@ssh.dev.azure.com:v3/org/project/repo", True, False),
     ],
 )
 def test_git_transport_policy_matrix(
@@ -116,6 +125,81 @@ def test_git_transport_policy_matrix(
     if remote_url.startswith("git@"):
         assert "BatchMode=yes" in env["GIT_SSH_COMMAND"]
         assert "ConnectTimeout=30" in env["GIT_SSH_COMMAND"]
+
+
+@pytest.mark.parametrize(
+    ("kind", "remote_url"),
+    [
+        ("generic", "http://gitea.example.test/org/repo.git"),
+        ("github", "http://github.com/org/repo.git"),
+        ("gitlab", "http://gitlab.com/org/repo.git"),
+        ("ado", "http://dev.azure.com/org/project/_git/repo"),
+    ],
+)
+def test_http_transport_never_receives_resolved_credentials(kind: str, remote_url: str) -> None:
+    """Plaintext HTTP suppresses every helper and APM credential channel."""
+    context = _context(kind)
+    context = AuthContext(
+        token="resolved-token",
+        source="test",
+        token_type="unknown",
+        host_info=context.host_info,
+        git_env=context.git_env,
+    )
+
+    env = AuthResolver(token_manager=_TokenManager()).git_env_for_remote(context, remote_url)
+
+    assert "GIT_TOKEN" not in env
+    assert "GIT_HTTP_EXTRAHEADER" not in env
+    assert env["GIT_CONFIG_NOSYSTEM"] == "1"
+    assert env["GIT_CONFIG_KEY_0"] == "credential.helper"
+    assert env["GIT_CONFIG_VALUE_0"] == ""
+
+
+def test_http_transport_replaces_caller_global_config() -> None:
+    """Plaintext HTTP never retains a config file that can inject headers."""
+
+    class _ConfiguredTokenManager(_TokenManager):
+        def setup_environment(self) -> dict[str, str]:
+            return {**super().setup_environment(), "GIT_CONFIG_GLOBAL": "/configured/gitconfig"}
+
+    env = AuthResolver(token_manager=_ConfiguredTokenManager()).git_env_for_remote(
+        _context("generic"),
+        "http://gitea.example.test/org/repo.git",
+    )
+
+    assert env["GIT_CONFIG_GLOBAL"] == os.devnull
+
+
+def test_https_to_http_url_rewrite_is_rejected_before_git_runs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Native helpers cannot follow an HTTPS remote onto plaintext HTTP."""
+    home = tmp_path / "home"
+    home.mkdir()
+    config = home / ".gitconfig"
+    subprocess.run(
+        (
+            "git",
+            "config",
+            "--file",
+            str(config),
+            "url.http://127.0.0.1:8080/.insteadOf",
+            "https://gitea.example.test/",
+        ),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("GIT_CONFIG_GLOBAL", raising=False)
+    monkeypatch.delenv("GIT_CONFIG_NOSYSTEM", raising=False)
+
+    with pytest.raises(ValueError, match="rewrite to insecure HTTP"):
+        AuthResolver().git_env_for_remote(
+            _context("generic"),
+            "https://gitea.example.test/org/repo.git",
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/core/test_git_transport_policy.py
+++ b/tests/unit/core/test_git_transport_policy.py
@@ -224,3 +224,15 @@ def test_generic_remote_policy_controls_native_helper_lookup(
         lookup_env = token_manager.credential_envs[0]
         assert set(_PLATFORM_TOKENS).isdisjoint(lookup_env)
         assert lookup_env["GIT_TERMINAL_PROMPT"] == "0"
+
+
+def test_generic_plain_resolve_strips_platform_tokens_from_helper_lookup() -> None:
+    """Dependency-style resolution never forwards platform tokens to helpers."""
+    token_manager = _RecordingTokenManager()
+
+    AuthResolver(token_manager=token_manager).resolve("gitea.example.test")
+
+    assert len(token_manager.credential_envs) == 1
+    lookup_env = token_manager.credential_envs[0]
+    assert set(_PLATFORM_TOKENS).isdisjoint(lookup_env)
+    assert lookup_env["GIT_TERMINAL_PROMPT"] == "0"

--- a/tests/unit/core/test_git_transport_policy.py
+++ b/tests/unit/core/test_git_transport_policy.py
@@ -1,0 +1,142 @@
+"""Policy matrix for Git subprocess credentials."""
+
+from __future__ import annotations
+
+import pytest
+
+from apm_cli.core.auth import AuthContext, AuthResolver, HostInfo
+
+_PLATFORM_TOKENS = {
+    "ADO_APM_PAT": "ado-sentinel",
+    "GH_TOKEN": "gh-sentinel",
+    "GITHUB_APM_PAT": "github-sentinel",
+    "GITHUB_TOKEN": "actions-sentinel",
+    "GIT_TOKEN": "git-sentinel",
+    "GIT_HTTP_EXTRAHEADER": "Authorization: sentinel",
+    "GIT_CONFIG_COUNT": "1",
+    "GIT_CONFIG_KEY_0": "http.extraheader",
+    "GIT_CONFIG_VALUE_0": "Authorization: sentinel",
+}
+
+
+class _TokenManager:
+    """Provide a deterministic hardened base without resolving credentials."""
+
+    def setup_environment(self) -> dict[str, str]:
+        return {
+            **_PLATFORM_TOKENS,
+            "GIT_ASKPASS": "echo",
+            "GIT_CONFIG_GLOBAL": "/dev/null",
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_SSH_COMMAND": "ssh -o ConnectTimeout=30 -o BatchMode=yes",
+        }
+
+
+class _RecordingTokenManager(_TokenManager):
+    """Record native helper lookups without exposing fixture credentials."""
+
+    def __init__(self) -> None:
+        self.credential_envs: list[dict[str, str]] = []
+
+    def get_token_for_purpose(self, _purpose: str) -> None:
+        return None
+
+    def resolve_credential_from_gh_cli(self, _host: str) -> None:
+        return None
+
+    def resolve_credential_from_git(
+        self,
+        _host: str,
+        port: int | None = None,
+        path: str | None = None,
+        *,
+        env: dict[str, str] | None = None,
+    ) -> None:
+        assert port is None
+        assert path is None
+        assert env is not None
+        self.credential_envs.append(env)
+
+
+def _context(kind: str) -> AuthContext:
+    return AuthContext(
+        token=None,
+        source="none",
+        token_type="unknown",
+        host_info=HostInfo(
+            host=f"{kind}.example.test",
+            kind=kind,
+            has_public_repos=True,
+            api_base="https://example.test/api",
+        ),
+        git_env={},
+    )
+
+
+@pytest.mark.parametrize(
+    ("kind", "remote_url", "expects_helper", "expects_isolation"),
+    [
+        ("generic", "https://gitea.example.test/org/repo.git", True, False),
+        ("generic", "http://gitea.example.test/org/repo.git", False, True),
+        ("generic", "git@gitea.example.test:org/repo.git", True, False),
+        ("github", "https://github.com/org/repo.git", False, True),
+        ("gitlab", "https://gitlab.com/org/repo.git", False, True),
+        ("ado", "https://dev.azure.com/org/project/_git/repo", False, True),
+    ],
+)
+def test_git_transport_policy_matrix(
+    kind: str,
+    remote_url: str,
+    expects_helper: bool,
+    expects_isolation: bool,
+) -> None:
+    """Only generic HTTPS and SSH retain native Git credential configuration."""
+    env = AuthResolver(token_manager=_TokenManager()).git_env_for_remote(_context(kind), remote_url)
+
+    assert env["GIT_TERMINAL_PROMPT"] == "0"
+    assert "GIT_TOKEN" not in env
+    assert "GIT_HTTP_EXTRAHEADER" not in env
+    assert "GITHUB_TOKEN" not in env
+    assert "GITHUB_APM_PAT" not in env
+    assert "GH_TOKEN" not in env
+    assert "ADO_APM_PAT" not in env
+    assert "GIT_CONFIG_PARAMETERS" not in env
+
+    if expects_helper:
+        assert "GIT_ASKPASS" not in env
+        assert "GIT_CONFIG_GLOBAL" not in env
+        assert "GIT_CONFIG_NOSYSTEM" not in env
+    else:
+        assert env["GIT_ASKPASS"] == "echo"
+        assert env["GIT_CONFIG_NOSYSTEM"] == "1"
+
+    if kind == "generic" and expects_isolation:
+        assert env["GIT_CONFIG_KEY_0"] == "credential.helper"
+        assert env["GIT_CONFIG_VALUE_0"] == ""
+    if remote_url.startswith("git@"):
+        assert "BatchMode=yes" in env["GIT_SSH_COMMAND"]
+        assert "ConnectTimeout=30" in env["GIT_SSH_COMMAND"]
+
+
+@pytest.mark.parametrize(
+    ("remote_url", "expected_lookups"),
+    [
+        ("https://gitea.example.test/org/repo.git", 0),
+        ("http://gitea.example.test/org/repo.git", 0),
+        ("git@gitea.example.test:org/repo.git", 0),
+    ],
+)
+def test_generic_remote_policy_controls_native_helper_lookup(
+    remote_url: str, expected_lookups: int
+) -> None:
+    """Remote resolution leaves native helper invocation to Git itself."""
+    token_manager = _RecordingTokenManager()
+    resolver = AuthResolver(token_manager=token_manager)
+
+    resolver.resolve_for_remote("gitea.example.test", remote_url)
+
+    assert len(token_manager.credential_envs) == expected_lookups
+    if token_manager.credential_envs:
+        lookup_env = token_manager.credential_envs[0]
+        assert set(_PLATFORM_TOKENS).isdisjoint(lookup_env)
+        assert lookup_env["GIT_TERMINAL_PROMPT"] == "0"

--- a/tests/unit/marketplace/test_client_git.py
+++ b/tests/unit/marketplace/test_client_git.py
@@ -198,7 +198,26 @@ def test_fetch_git_does_not_render_generic_exception_text(
 
     assert "helper-output-fixture-secret" not in str(raised.value)
     assert "git fetch failed" in str(raised.value)
-    assert "rerun the original marketplace command" in str(raised.value)
+    assert "apm marketplace update acme" in str(raised.value)
+
+
+def test_fetch_git_wraps_https_downgrade_rejection(fake_host_info, fake_auth_resolver) -> None:
+    """Transport-policy rejection keeps the actionable marketplace error shape."""
+    fake_auth_resolver.git_env_for_remote.side_effect = ValueError(
+        "HTTPS Git remote is configured to rewrite to insecure HTTP"
+    )
+
+    with pytest.raises(MarketplaceFetchError) as raised:
+        _fetch_git(
+            _git_source("https://gitea.example.com/org/repo.git"),
+            "marketplace.json",
+            host_info=fake_host_info,
+            auth_resolver=fake_auth_resolver,
+        )
+
+    message = str(raised.value)
+    assert "HTTPS Git remote was rejected" in message
+    assert "apm marketplace update acme" in message
 
 
 def test_fetchers_dispatch_table_routes_kinds_to_correct_callable() -> None:

--- a/tests/unit/marketplace/test_client_git.py
+++ b/tests/unit/marketplace/test_client_git.py
@@ -198,6 +198,7 @@ def test_fetch_git_does_not_render_generic_exception_text(
 
     assert "helper-output-fixture-secret" not in str(raised.value)
     assert "git fetch failed" in str(raised.value)
+    assert "rerun the original marketplace command" in str(raised.value)
 
 
 def test_fetchers_dispatch_table_routes_kinds_to_correct_callable() -> None:

--- a/tests/unit/marketplace/test_client_git.py
+++ b/tests/unit/marketplace/test_client_git.py
@@ -44,7 +44,8 @@ def fake_host_info():
 def fake_auth_resolver():
     resolver = MagicMock()
     resolver.resolve.return_value = SimpleNamespace(git_env={"GIT_TERMINAL_PROMPT": "0"})
-    resolver.hardened_git_env_for_context.side_effect = lambda auth_ctx: auth_ctx.git_env
+    resolver.resolve_for_remote.return_value = resolver.resolve.return_value
+    resolver.git_env_for_remote.side_effect = lambda auth_ctx, _remote_url: auth_ctx.git_env
     return resolver
 
 
@@ -69,10 +70,10 @@ def test_fetch_git_calls_gitcache_with_sparse_path(
         )
 
     assert result == {"name": "acme", "plugins": []}
-    fake_auth_resolver.resolve.assert_called_once()
+    fake_auth_resolver.resolve_for_remote.assert_called_once()
     call_kwargs = gitcache_mock.get_checkout.call_args.kwargs
     assert call_kwargs["env"] == {"GIT_TERMINAL_PROMPT": "0"}
-    fake_auth_resolver.hardened_git_env_for_context.assert_not_called()
+    fake_auth_resolver.git_env_for_remote.assert_called_once()
 
 
 def test_fetch_git_ado_url_routes_via_subprocess(
@@ -96,6 +97,7 @@ def test_fetch_git_ado_url_routes_via_subprocess(
             "GIT_CONFIG_VALUE_0": "AUTHORIZATION: bearer xxx",
         }
     )
+    fake_auth_resolver.resolve_for_remote.return_value = fake_auth_resolver.resolve.return_value
 
     with (
         patch("apm_cli.cache.git_cache.GitCache", return_value=gitcache_mock),
@@ -174,6 +176,28 @@ def test_fetch_git_subprocess_failure_raises_marketplace_fetch_error(
                 host_info=fake_host_info,
                 auth_resolver=fake_auth_resolver,
             )
+
+
+def test_fetch_git_does_not_render_generic_exception_text(
+    tmp_path: Path, fake_host_info, fake_auth_resolver
+) -> None:
+    """A helper or GitCache error cannot leak through the CLI diagnostic."""
+    gitcache_mock = MagicMock()
+    gitcache_mock.get_checkout.side_effect = RuntimeError("helper-output-fixture-secret")
+    with (
+        patch("apm_cli.cache.git_cache.GitCache", return_value=gitcache_mock),
+        patch("apm_cli.cache.paths.get_cache_root", return_value=tmp_path / "cache"),
+    ):
+        with pytest.raises(MarketplaceFetchError) as raised:
+            _fetch_git(
+                _git_source("https://gitea.example.com/org/repo.git"),
+                "marketplace.json",
+                host_info=fake_host_info,
+                auth_resolver=fake_auth_resolver,
+            )
+
+    assert "helper-output-fixture-secret" not in str(raised.value)
+    assert "git fetch failed" in str(raised.value)
 
 
 def test_fetchers_dispatch_table_routes_kinds_to_correct_callable() -> None:

--- a/tests/unit/marketplace/test_client_git.py
+++ b/tests/unit/marketplace/test_client_git.py
@@ -37,7 +37,7 @@ def _git_source(url: str, name: str = "acme", ref: str = "main") -> MarketplaceS
 
 @pytest.fixture
 def fake_host_info():
-    return SimpleNamespace(host="gitea.example.com")
+    return SimpleNamespace(host="gitea.example.com", kind="generic")
 
 
 @pytest.fixture
@@ -72,6 +72,7 @@ def test_fetch_git_calls_gitcache_with_sparse_path(
     fake_auth_resolver.resolve.assert_called_once()
     call_kwargs = gitcache_mock.get_checkout.call_args.kwargs
     assert call_kwargs["env"] == {"GIT_TERMINAL_PROMPT": "0"}
+    fake_auth_resolver.hardened_git_env_for_context.assert_not_called()
 
 
 def test_fetch_git_ado_url_routes_via_subprocess(
@@ -103,7 +104,7 @@ def test_fetch_git_ado_url_routes_via_subprocess(
         result = _fetch_git(
             _git_source("https://dev.azure.com/org/project/_git/repo"),
             "marketplace.json",
-            host_info=SimpleNamespace(host="dev.azure.com"),
+            host_info=SimpleNamespace(host="dev.azure.com", kind="ado"),
             auth_resolver=fake_auth_resolver,
         )
 

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -5,7 +5,7 @@ import logging
 import os
 import time
 from concurrent.futures import ThreadPoolExecutor
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 from urllib.parse import urlparse
 
 import pytest
@@ -273,7 +273,7 @@ class TestResolve:
         """Concurrent resolve() calls for the same key should populate cache once."""
         resolver = AuthResolver()
 
-        def _slow_resolve_token(host_info, org):
+        def _slow_resolve_token(host_info, org, **_kwargs):
             time.sleep(0.05)
             return ("cred-token", "git-credential-fill", "basic")
 
@@ -1221,7 +1221,7 @@ class TestResolvePortDiscrimination:
             resolver = AuthResolver()
             calls: list = []
 
-            def fake_cred(host, port=None):
+            def fake_cred(host, port=None, **_kwargs):
                 calls.append((host, port))
                 return f"tok-{host}-{port}"
 
@@ -1282,7 +1282,7 @@ class TestResolvePortDiscrimination:
 
         assert ctx.host_info.port == 7999
         assert ctx.host_info.display_name == "bitbucket.corp.com:7999"
-        mock_cred.assert_called_once_with("bitbucket.corp.com", port=7999)
+        mock_cred.assert_called_once_with("bitbucket.corp.com", port=7999, env=ANY)
 
     def test_resolve_for_dep_threads_port_from_https_url(self):
         """https://host:port/... also carries the port into the resolver."""
@@ -1299,7 +1299,7 @@ class TestResolvePortDiscrimination:
                 ctx = resolver.resolve_for_dep(dep)
 
         assert ctx.host_info.port == 7990
-        mock_cred.assert_called_once_with("bitbucket.corp.com", port=7990)
+        mock_cred.assert_called_once_with("bitbucket.corp.com", port=7990, env=ANY)
 
     def test_host_info_carries_port(self):
         with patch.dict(os.environ, {"GITHUB_APM_PAT": "t"}, clear=True):

--- a/tests/utils/local_git_http_server.py
+++ b/tests/utils/local_git_http_server.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import functools
+import ssl
 import subprocess
 import threading
 from dataclasses import dataclass
@@ -94,14 +95,15 @@ class _GitHttpHandler(SimpleHTTPRequestHandler):
 class LocalGitHttpServer:
     """Running loopback server for one or more bare Git repositories."""
 
-    def __init__(self, server: _GitHttpServer, thread: threading.Thread) -> None:
+    def __init__(self, server: _GitHttpServer, thread: threading.Thread, *, scheme: str) -> None:
         self._server = server
         self._thread = thread
+        self._scheme = scheme
 
     @property
     def proxy_url(self) -> str:
-        """Return a loopback URL suitable for HTTPS_PROXY."""
-        return f"http://127.0.0.1:{self._server.server_port}"
+        """Return the loopback URL for this fixture."""
+        return f"{self._scheme}://127.0.0.1:{self._server.server_port}"
 
     @property
     def observations(self) -> tuple[GitHttpObservation, ...]:
@@ -149,8 +151,10 @@ class LocalGitHttpServerFactory:
         password: str,
         private_repositories: tuple[LocalGitRepository, ...] = (),
         username: str = "x-access-token",
+        certfile: Path | None = None,
+        keyfile: Path | None = None,
     ) -> LocalGitHttpServer:
-        """Prepare and serve repositories with optional Basic-auth policy."""
+        """Prepare and serve repositories with optional Basic-auth and TLS policy."""
         if not repositories:
             raise ValueError("At least one repository is required")
         private_names = {repository.origin.name for repository in private_repositories}
@@ -182,10 +186,18 @@ class LocalGitHttpServerFactory:
         server.expected_authorization = f"Basic {credentials}"
         server.observations = []
         server.observations_lock = threading.Lock()
+        scheme = "http"
+        if certfile is not None or keyfile is not None:
+            if certfile is None or keyfile is None:
+                raise ValueError("TLS requires both certfile and keyfile")
+            context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+            context.load_cert_chain(certfile=certfile, keyfile=keyfile)
+            server.socket = context.wrap_socket(server.socket, server_side=True)
+            scheme = "https"
         thread = threading.Thread(
             target=server.serve_forever,
             name="local-git-http",
             daemon=True,
         )
         thread.start()
-        return LocalGitHttpServer(server, thread)
+        return LocalGitHttpServer(server, thread, scheme=scheme)

--- a/tests/utils/local_git_http_server.py
+++ b/tests/utils/local_git_http_server.py
@@ -191,6 +191,7 @@ class LocalGitHttpServerFactory:
             if certfile is None or keyfile is None:
                 raise ValueError("TLS requires both certfile and keyfile")
             context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+            context.minimum_version = ssl.TLSVersion.TLSv1_2
             context.load_cert_chain(certfile=certfile, keyfile=keyfile)
             server.socket = context.wrap_socket(server.socket, server_side=True)
             scheme = "https"


### PR DESCRIPTION
## Summary

Preserve the resolver's normal Git environment for generic marketplace hosts so configured credential helpers such as macOS Keychain or libsecret remain available. Known platform paths such as Azure DevOps keep using the hardened Git environment.

## Testing

- Updated generic-host coverage to assert the hardened helper-stripping path is not used
- Added direct token-scrub and HTTPS-to-HTTP downgrade regression coverage
- Kept Azure DevOps coverage on the hardened path

apm-spec-waiver: Internal Git transport hardening; no OpenAPM contract changes.

Fixes #2526

<!-- pr-relay-job relay-41-7d9f01891da16e1e7d4e -->