### PR TITLE
feat: add GitHub Copilot marketplace output

### DIFF
--- a/src/apm_cli/marketplace/output_mappers.py
+++ b/src/apm_cli/marketplace/output_mappers.py
@@ -328,9 +328,71 @@ class CodexMarketplaceMapper(MarketplaceOutputMapper):
         return MapperResult(doc, (), tuple(name_diagnostics))
 
 
+class CopilotMarketplaceMapper(MarketplaceOutputMapper):
+    """Map packages into GitHub Copilot CLI marketplace format."""
+
+    uses_remote_metadata = True
+
+    def compose(
+        self,
+        *,
+        config: MarketplaceConfig,
+        resolved: tuple[ResolvedPackage, ...],
+        remote_metadata: dict[str, dict[str, Any]] | None = None,
+    ) -> MapperResult:
+        remote_metadata = remote_metadata or {}
+        entry_by_name: dict[str, PackageEntry] = {e.name: e for e in config.packages}
+
+        doc: dict[str, Any] = OrderedDict()
+        sanitized, name_diagnostics = _sanitized_name_with_diagnostic(config.name)
+        doc["name"] = sanitized
+        owner: dict[str, Any] = OrderedDict({"name": config.owner.name})
+        if config.owner.email:
+            owner["email"] = config.owner.email
+        doc["owner"] = owner
+
+        metadata: dict[str, Any] = OrderedDict()
+        if config.description:
+            metadata["description"] = config.description
+        if config.version:
+            metadata["version"] = config.version
+        if metadata:
+            doc["metadata"] = metadata
+
+        plugins: list[dict[str, Any]] = []
+        for pkg in resolved:
+            entry = entry_by_name.get(pkg.name)
+            if entry is None:
+                continue
+            plugin: dict[str, Any] = OrderedDict({"name": pkg.name})
+            meta = remote_metadata.get(pkg.name, {})
+            plugin["description"] = entry.description or meta.get("description", "")
+            version = entry.version if entry.is_local else meta.get("version") or entry.version
+            if version:
+                plugin["version"] = version
+            plugin["source"] = _copilot_source(entry, pkg)
+            if entry.author:
+                plugin["author"] = dict(entry.author)
+            if entry.homepage:
+                plugin["homepage"] = entry.homepage
+            if entry.repository:
+                plugin["repository"] = entry.repository
+            if entry.license:
+                plugin["license"] = entry.license
+            if entry.category:
+                plugin["category"] = entry.category
+            if pkg.tags:
+                plugin["tags"] = list(pkg.tags)
+            plugins.append(plugin)
+
+        doc["plugins"] = plugins
+        return MapperResult(doc, (), tuple(name_diagnostics))
+
+
 MARKETPLACE_OUTPUT_MAPPERS: dict[str, MarketplaceOutputMapper] = {
     "claude": ClaudeMarketplaceMapper(),
     "codex": CodexMarketplaceMapper(),
+    "copilot": CopilotMarketplaceMapper(),
 }
 
 
@@ -381,6 +443,28 @@ def _codex_source(entry: PackageEntry, pkg: ResolvedPackage) -> dict[str, Any]:
         source_obj["sha"] = pkg.sha
     _set_effective_tag_pattern(source_obj, pkg)
     return source_obj
+
+
+def _copilot_source(entry: PackageEntry, pkg: ResolvedPackage) -> str | dict[str, Any]:
+    """Return a Copilot CLI source while preserving remote pin information."""
+    if entry.is_local:
+        return entry.source
+
+    source: dict[str, Any] = OrderedDict()
+    remote_url = _remote_source_url(pkg)
+    if remote_url:
+        source["source"] = "url"
+        source["url"] = remote_url
+    else:
+        source["source"] = "github"
+        source["repo"] = pkg.source_repo
+    if pkg.ref:
+        source["ref"] = pkg.ref
+    if pkg.sha:
+        source["sha"] = pkg.sha
+    if pkg.subdir:
+        source["path"] = pkg.subdir
+    return source
 
 
 def _apply_field_with_precedence(

--- a/src/apm_cli/marketplace/output_profiles.py
+++ b/src/apm_cli/marketplace/output_profiles.py
@@ -90,11 +90,20 @@ CODEX_MARKETPLACE_OUTPUT = MarketplaceOutputProfile(
     required_package_fields=("category",),
 )
 
+COPILOT_MARKETPLACE_OUTPUT = MarketplaceOutputProfile(
+    name="copilot",
+    config_attr="copilot",
+    default_output=".github/plugin/marketplace.json",
+    mapper="copilot",
+    path_env_var="APM_MARKETPLACE_COPILOT_PATH",
+)
+
 MARKETPLACE_OUTPUTS: dict[str, MarketplaceOutputProfile] = {
     profile.name: profile
     for profile in (
         DEFAULT_MARKETPLACE_OUTPUT,
         CODEX_MARKETPLACE_OUTPUT,
+        COPILOT_MARKETPLACE_OUTPUT,
     )
 }
 

--- a/tests/unit/marketplace/test_copilot_output_mapper.py
+++ b/tests/unit/marketplace/test_copilot_output_mapper.py
@@ -1,0 +1,96 @@
+from types import SimpleNamespace
+
+from apm_cli.marketplace.output_mappers import CopilotMarketplaceMapper
+from apm_cli.marketplace.output_profiles import MARKETPLACE_OUTPUTS
+from apm_cli.marketplace.yml_schema import MarketplaceConfig, MarketplaceOwner, PackageEntry
+
+
+def _resolved(**overrides):
+    values = {
+        "name": "demo",
+        "source_repo": "acme/demo",
+        "source_url": None,
+        "host": None,
+        "subdir": None,
+        "ref": None,
+        "sha": None,
+        "tags": (),
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _config(entry: PackageEntry) -> MarketplaceConfig:
+    return MarketplaceConfig(
+        name="my-marketplace",
+        description="Curated plugins",
+        version="1.0.0",
+        owner=MarketplaceOwner(name="Acme", email="plugins@acme.test"),
+        outputs=("copilot",),
+        packages=(entry,),
+    )
+
+
+def test_copilot_profile_uses_default_discovery_path():
+    profile = MARKETPLACE_OUTPUTS["copilot"]
+
+    assert profile.default_output == ".github/plugin/marketplace.json"
+    assert profile.mapper == "copilot"
+
+
+def test_copilot_mapper_nests_marketplace_metadata_and_keeps_local_source():
+    entry = PackageEntry(
+        name="demo",
+        source="./plugins/demo",
+        version="2.1.0",
+        description="Demo plugin",
+        is_local=True,
+    )
+
+    result = CopilotMarketplaceMapper().compose(
+        config=_config(entry),
+        resolved=(_resolved(),),
+    )
+
+    assert result.document["metadata"] == {
+        "description": "Curated plugins",
+        "version": "1.0.0",
+    }
+    assert result.document["plugins"] == [
+        {
+            "name": "demo",
+            "description": "Demo plugin",
+            "version": "2.1.0",
+            "source": "./plugins/demo",
+        }
+    ]
+
+
+def test_copilot_mapper_preserves_remote_pin_information():
+    entry = PackageEntry(
+        name="demo",
+        source="acme/demo",
+        ref="main",
+        description="Demo plugin",
+    )
+
+    result = CopilotMarketplaceMapper().compose(
+        config=_config(entry),
+        resolved=(
+            _resolved(
+                ref="v2.1.0",
+                sha="0123456789abcdef0123456789abcdef01234567",
+                subdir="plugins/demo",
+            ),
+        ),
+        remote_metadata={"demo": {"version": "2.1.0"}},
+    )
+
+    plugin = result.document["plugins"][0]
+    assert plugin["source"] == {
+        "source": "github",
+        "repo": "acme/demo",
+        "ref": "v2.1.0",
+        "sha": "0123456789abcdef0123456789abcdef01234567",
+        "path": "plugins/demo",
+    }


### PR DESCRIPTION
Closes #2430

## Summary
- register a `copilot` marketplace output profile with the Copilot CLI default path
- emit Copilot marketplace metadata and plugin entries through a dedicated mapper
- preserve local relative sources and remote pin/ref information
- add unit coverage for the profile path, metadata shape, local sources, and remote pins

## Validation
- patch syntax and application context were checked against current `main`
- repository tests could not be executed in this chat environment; CI should run the project test suite

<!-- pr-relay-job relay-64-e1a58e8740823b949681 -->