### PR TITLE
Fix Copilot CLI project MCP config path

### DIFF
--- a/src/apm_cli/adapters/client/copilot.py
+++ b/src/apm_cli/adapters/client/copilot.py
@@ -106,8 +106,10 @@ class CopilotClientAdapter(MCPClientAdapter):
         """Get the path to the Copilot CLI MCP configuration file.
 
         Returns:
-            str: Path to ~/.copilot/mcp-config.json
+            str: Project .mcp.json or the user-scope ~/.copilot/mcp-config.json.
         """
+        if not self.user_scope:
+            return str(self.project_root / ".mcp.json")
         copilot_dir = Path.home() / ".copilot"
         return str(copilot_dir / "mcp-config.json")
 

--- a/src/apm_cli/integration/mcp_integrator.py
+++ b/src/apm_cli/integration/mcp_integrator.py
@@ -1103,6 +1103,20 @@ class MCPIntegrator:
         )
         from apm_cli.integration.targets import RUNTIME_TO_CANONICAL_TARGET
 
+        # ``copilot`` is a user-facing target shared historically with the
+        # ``vscode`` alias.  For an explicit project-scoped Copilot target,
+        # route the legacy VS Code runtime slot to the Copilot CLI adapter so
+        # MCP configuration lands in the CLI-supported project .mcp.json.
+        explicit_tokens = (
+            [explicit_target]
+            if isinstance(explicit_target, str)
+            else list(explicit_target or [])
+        )
+        if not user_scope and explicit_tokens == ["copilot"]:
+            target_runtimes = list(dict.fromkeys(
+                "copilot" if runtime == "vscode" else runtime for runtime in target_runtimes
+            ))
+
         if target_decision is not None and target_decision.canonical_targets is not None:
             active = set(target_decision.canonical_targets)
             out = [


### PR DESCRIPTION
Fixes #2516

## Summary
- use project .mcp.json for project-scoped Copilot CLI MCP configuration
- retain ~/.copilot/mcp-config.json for user/global scope
- route an explicit project --target copilot through the Copilot adapter without changing the legacy --target vscode behavior

## Testing
Not run locally; draft PR for CI validation.

<!-- pr-relay-job relay-86-ca7abfdb460beb7a845a -->