### PR TITLE
fix: auto-discover org policy on GitLab via valid apm-policy project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- GitLab (gitlab.com and self-managed) org-policy auto-discovery now uses the
-  valid `apm-policy` project convention instead of the GitHub/ADO candidate
-  names (`.github-private`, `.github`, `.apm`, `_apm`), all of which are
-  invalid GitLab project paths. A missing policy project is now a clean
-  "no policy" outcome instead of surfacing a fetch-failure warning on every
-  `apm install` / `apm audit`. Override the project name with
-  `APM_GITLAB_POLICY_REPO`. (#2605)
+- GitLab (gitlab.com and self-managed) org-policy auto-discovery now uses the valid `apm-policy` project convention instead of the GitHub/ADO candidate names (`.github-private`, `.github`, `.apm`, `_apm`), all of which are invalid GitLab project paths. A missing policy project is now a clean "no policy" outcome instead of surfacing a fetch-failure warning on every `apm install` / `apm audit`. Override the project name with `APM_GITLAB_POLICY_REPO`. (#2605)
 - Windows binary is now Authenticode-signed in the release workflow, eliminating
   the `Trojan:Script/Wacatac.H!ml` Windows Defender false positive on unsigned
   PyInstaller bundles. (#2435)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   invalid GitLab project paths. A missing policy project is now a clean
   "no policy" outcome instead of surfacing a fetch-failure warning on every
   `apm install` / `apm audit`. Override the project name with
-  `APM_GITLAB_POLICY_REPO`. (closes #2566)
+  `APM_GITLAB_POLICY_REPO`. (#2605)
 - Windows binary is now Authenticode-signed in the release workflow, eliminating
   the `Trojan:Script/Wacatac.H!ml` Windows Defender false positive on unsigned
   PyInstaller bundles. (#2435)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- GitLab (gitlab.com and self-managed) org-policy auto-discovery now uses the
+  valid `apm-policy` project convention instead of the GitHub/ADO candidate
+  names (`.github-private`, `.github`, `.apm`, `_apm`), all of which are
+  invalid GitLab project paths. A missing policy project is now a clean
+  "no policy" outcome instead of surfacing a fetch-failure warning on every
+  `apm install` / `apm audit`. Override the project name with
+  `APM_GITLAB_POLICY_REPO`. (closes #2566)
 - Windows binary is now Authenticode-signed in the release workflow, eliminating
   the `Trojan:Script/Wacatac.H!ml` Windows Defender false positive on unsigned
   PyInstaller bundles. (#2435)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   consent over marketplace-plugin `bin/` executable deployment. `--trust-bin`
   approves deployment silently; `--no-trust-bin` skips `bin/` even when policy
   permits it. The `allowExecutables` policy gate still takes precedence. (closes #1620)
+- `APM_GITLAB_POLICY_ROOT_GROUP` centralizes GitLab org-policy discovery under one root group on self-managed instances, so a company with many independent root groups can share a single `apm-policy` project instead of needing one per group; ignored on gitlab.com. (#2605)
 
 ### Fixed
 

--- a/CONFORMANCE.json
+++ b/CONFORMANCE.json
@@ -687,8 +687,9 @@
       "keyword": "MUST",
       "section": "6.1.1",
       "status": "active",
-      "test_count": 1,
+      "test_count": 2,
       "tests": [
+        "tests/spec_conformance/test_policy_reqs.py::test_policy_gitlab_discovery_provider_is_a_distinct_convention",
         "tests/spec_conformance/test_policy_reqs.py::test_policy_provides_default_allow_list_shape"
       ]
     },

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -87,7 +87,7 @@ All four conformance classes (Producer, Consumer, Registry, Governance) carry ac
 | [req-pl-008](docs/src/content/docs/specs/openapm-v0.1.md#req-pl-008) | MUST | 6.3.1 | governance | active | 1 |
 | [req-pl-009](docs/src/content/docs/specs/openapm-v0.1.md#req-pl-009) | MUST | 6.6 | governance | active | 1 |
 | [req-pl-010](docs/src/content/docs/specs/openapm-v0.1.md#req-pl-010) | MUST | 6.2 | governance | active | 1 |
-| [req-pl-011](docs/src/content/docs/specs/openapm-v0.1.md#req-pl-011) | MUST | 6.1.1 | governance | active | 1 |
+| [req-pl-011](docs/src/content/docs/specs/openapm-v0.1.md#req-pl-011) | MUST | 6.1.1 | governance | active | 2 |
 | [req-pl-012](docs/src/content/docs/specs/openapm-v0.1.md#req-pl-012) | MUST | 6.1.1 | governance | active | 1 |
 | [req-pl-013](docs/src/content/docs/specs/openapm-v0.1.md#req-pl-013) | MUST | 6.8 | governance | active | 1 |
 | [req-pl-014](docs/src/content/docs/specs/openapm-v0.1.md#req-pl-014) | MUST | 6.8 | governance | active | 1 |

--- a/docs/src/content/docs/enterprise/apm-policy.md
+++ b/docs/src/content/docs/enterprise/apm-policy.md
@@ -80,6 +80,10 @@ On GitHub and GitHub API-compatible hosts, the `.github-private` repo is preferr
 
 Set `APM_GITLAB_POLICY_REPO` to use a different project name if your org already publishes policy under another name. A project without `apm-policy` (or the configured override) is treated as a clean "no policy" outcome, matching the fallthrough behaviour on GitHub and ADO -- it does not print a warning.
 
+:::caution[Self-managed GitLab requires GITLAB_HOST or APM_GITLAB_HOSTS]
+An arbitrary FQDN is never auto-classified as GitLab -- the same domain shape could be Bitbucket, Gitea, or a plain git server. `gitlab.com` is recognised automatically, but a self-managed instance (e.g. `gitlab.example.com`) is only recognised once you set `GITLAB_HOST=gitlab.example.com` (or `APM_GITLAB_HOSTS` for more than one instance). Without it, APM falls through to the GitHub-style cascade above, which is invalid on GitLab and behaves exactly like the unfixed discovery this section describes. This mirrors `GITHUB_HOST` for GitHub Enterprise Server and `ADO_HOST` for on-prem Azure DevOps Server -- see [Environment Variables](../../reference/environment-variables/).
+:::
+
 When `apm install` or `apm audit --ci --policy org` runs in a project, APM resolves the org from the project's git remote and searches the candidate repos above (cached locally, default 1 hour TTL).
 
 Alternative sources, useful for testing or non-GitHub setups:

--- a/docs/src/content/docs/enterprise/apm-policy.md
+++ b/docs/src/content/docs/enterprise/apm-policy.md
@@ -84,6 +84,10 @@ Set `APM_GITLAB_POLICY_REPO` to use a different project name if your org already
 An arbitrary FQDN is never auto-classified as GitLab -- the same domain shape could be Bitbucket, Gitea, or a plain git server. `gitlab.com` is recognised automatically, but a self-managed instance (e.g. `gitlab.example.com`) is only recognised once you set `GITLAB_HOST=gitlab.example.com` (or `APM_GITLAB_HOSTS` for more than one instance). Without it, APM falls through to the GitHub-style cascade above, which is invalid on GitLab and behaves exactly like the unfixed discovery this section describes. This mirrors `GITHUB_HOST` for GitHub Enterprise Server and `ADO_HOST` for on-prem Azure DevOps Server -- see [Environment Variables](../../reference/environment-variables/).
 :::
 
+By default, GitLab discovery is scoped per **root group**: APM resolves the org from the first path segment of the project's git remote (e.g. a project at `team-a/subteam/project` resolves to root group `team-a`), independent of how deeply the project is nested in subgroups. A self-managed instance with many independent root groups (one per team or department) would otherwise need an `apm-policy` project under every root group.
+
+Set `APM_GITLAB_POLICY_ROOT_GROUP` on a self-managed instance to centralize policy under one designated root group instead -- every project on that instance then resolves org policy there, regardless of its own root group. Ignored on `gitlab.com`: cloud root namespaces are independent tenants, so no cross-tenant override applies there.
+
 When `apm install` or `apm audit --ci --policy org` runs in a project, APM resolves the org from the project's git remote and searches the candidate repos above (cached locally, default 1 hour TTL).
 
 Alternative sources, useful for testing or non-GitHub setups:

--- a/docs/src/content/docs/enterprise/apm-policy.md
+++ b/docs/src/content/docs/enterprise/apm-policy.md
@@ -66,6 +66,20 @@ On GitHub and GitHub API-compatible hosts, the `.github-private` repo is preferr
     apm-policy.yml         # auto-discovered by every repo in <org>
 ```
 
+**GitLab (gitlab.com and self-managed)** rejects project paths that start with `.` or `_`, so none of the candidates above are valid there. GitLab uses its own default instead:
+
+| Priority | Repo name | Valid on |
+|----------|-----------|---------|
+| 1 | `apm-policy` | GitLab (gitlab.com and self-managed) |
+
+```
+<group>/
+  apm-policy/
+    apm-policy.yml         # auto-discovered by every project in <group>
+```
+
+Set `APM_GITLAB_POLICY_REPO` to use a different project name if your org already publishes policy under another name. A project without `apm-policy` (or the configured override) is treated as a clean "no policy" outcome, matching the fallthrough behaviour on GitHub and ADO -- it does not print a warning.
+
 When `apm install` or `apm audit --ci --policy org` runs in a project, APM resolves the org from the project's git remote and searches the candidate repos above (cached locally, default 1 hour TTL).
 
 Alternative sources, useful for testing or non-GitHub setups:

--- a/docs/src/content/docs/reference/environment-variables.md
+++ b/docs/src/content/docs/reference/environment-variables.md
@@ -95,6 +95,7 @@ APM verifies HTTPS against the operating-system trust store by default. For the 
 |---|---|---|---|
 | `APM_POLICY_DISABLE` | Set to `1` to skip policy discovery and enforcement for **the entire shell session**. Loudly logged. | unset | Equivalent to the per-invocation `--no-policy` on commands that expose it. The only escape hatch for `apm deps update`. See [`apm policy`](../cli/policy/). |
 | `APM_GITLAB_POLICY_REPO` | Override the org policy project name auto-discovered on GitLab (gitlab.com and self-managed). | `apm-policy` | GitLab rejects project paths starting with `.` or `_`, so the GitHub-family candidate cascade (`.github-private`, `.github`, `.apm`, `_apm`) does not apply there. See [Policy Files](../../enterprise/apm-policy/#where-it-lives). |
+| `APM_GITLAB_POLICY_ROOT_GROUP` | Centralize GitLab org-policy discovery under one root group, overriding the project's own root group. | unset (uses the project's own root group) | Self-managed only -- ignored on `gitlab.com`, where root namespaces are independent tenants. Lets an instance with many independent root groups share one `apm-policy` project instead of needing one per group. See [Policy Files](../../enterprise/apm-policy/#where-it-lives). |
 
 ## External scanners
 

--- a/docs/src/content/docs/reference/environment-variables.md
+++ b/docs/src/content/docs/reference/environment-variables.md
@@ -94,6 +94,7 @@ APM verifies HTTPS against the operating-system trust store by default. For the 
 | Variable | Purpose | Default | Notes |
 |---|---|---|---|
 | `APM_POLICY_DISABLE` | Set to `1` to skip policy discovery and enforcement for **the entire shell session**. Loudly logged. | unset | Equivalent to the per-invocation `--no-policy` on commands that expose it. The only escape hatch for `apm deps update`. See [`apm policy`](../cli/policy/). |
+| `APM_GITLAB_POLICY_REPO` | Override the org policy project name auto-discovered on GitLab (gitlab.com and self-managed). | `apm-policy` | GitLab rejects project paths starting with `.` or `_`, so the GitHub-family candidate cascade (`.github-private`, `.github`, `.apm`, `_apm`) does not apply there. See [Policy Files](../../enterprise/apm-policy/#where-it-lives). |
 
 ## External scanners
 

--- a/src/apm_cli/policy/_gitlab.py
+++ b/src/apm_cli/policy/_gitlab.py
@@ -1,0 +1,251 @@
+"""GitLab-specific org policy discovery (split from discovery.py, see #2566).
+
+GitLab rejects project paths starting with ``.`` or ``_``, so none of the
+default candidate repo names are valid there; GitLab uses its own
+``apm-policy`` project convention, fetched via the Repository Files API.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+from urllib.parse import quote
+
+import requests
+
+from .parser import PolicyValidationError, load_policy
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from .discovery import PolicyFetchResult, _CacheEntry
+
+# GitLab rejects project paths starting with ``.`` or ``_`` (see #2566), so
+# none of the default candidates are valid there. ``apm-policy`` is the
+# default GitLab policy-repo name; override via APM_GITLAB_POLICY_REPO for
+# orgs that already use a different name.
+_GITLAB_DEFAULT_POLICY_REPO = "apm-policy"
+
+
+def _gitlab_policy_repo_candidates() -> tuple[str, ...]:
+    """Return the (single) GitLab policy repo candidate, env-overridable."""
+    return (os.environ.get("APM_GITLAB_POLICY_REPO", "").strip() or _GITLAB_DEFAULT_POLICY_REPO,)
+
+
+def _gitlab_policy_root_group(host: str, org: str) -> str:
+    """Return the effective GitLab root group for policy discovery.
+
+    Self-managed GitLab instances often host many independent root groups
+    (departments, teams) under one company-owned instance -- unlike
+    gitlab.com, where each root namespace is an independent tenant and no
+    cross-tenant override would make sense. ``APM_GITLAB_POLICY_ROOT_GROUP``
+    lets a self-managed instance centralize org policy under one designated
+    root group instead of requiring an ``apm-policy`` project per root
+    group. Distinguished from gitlab.com by exact hostname match, per
+    ``is_gitlab_hostname``'s own cloud/self-managed split: ignored on
+    gitlab.com, where *org* (the project's own root namespace, extracted
+    from its git remote) is always used unchanged.
+    """
+    if host == "gitlab.com":
+        return org
+    override = os.environ.get("APM_GITLAB_POLICY_ROOT_GROUP", "").strip()
+    return override or org
+
+
+def _fetch_from_gitlab_repo(
+    *,
+    org: str,
+    repo: str,
+    host: str,
+    port: int | None = None,
+    project_root: Path,
+    no_cache: bool = False,
+    expected_hash: str | None = None,
+    cache_only: bool = False,
+) -> PolicyFetchResult:
+    """Fetch apm-policy.yml from a GitLab project.
+
+    Mirrors ``_fetch_from_ado_repo`` but uses ``_fetch_gitlab_contents``
+    (GitLab Repository Files API) instead of ``_fetch_ado_contents``.
+    """
+    from .discovery import (
+        PolicyFetchResult,
+        _cache_entry_files_exist,
+        _cache_only_policy_result,
+        _compute_hash_normalized,
+        _detect_garbage,
+        _is_policy_empty,
+        _read_cache_entry,
+        _stale_fallback_or_error,
+        _verify_hash_pin,
+        _write_cache,
+    )
+
+    host_label = f"{host}:{port}" if port is not None else host
+    project_path = f"{org}/{repo}"
+    repo_ref = f"{host_label}/{project_path}"
+    source_label = f"org:{repo_ref}"
+    cache_entry: _CacheEntry | None = None
+    cache_entry_persisted = _cache_entry_files_exist(repo_ref, project_root)
+
+    if not no_cache:
+        cache_entry = _read_cache_entry(repo_ref, project_root, expected_hash=expected_hash)
+        if cache_entry is not None and not cache_entry.stale:
+            outcome = "empty" if _is_policy_empty(cache_entry.policy) else "found"
+            return PolicyFetchResult(
+                policy=cache_entry.policy,
+                source=cache_entry.source,
+                cached=True,
+                cache_age_seconds=cache_entry.age_seconds,
+                outcome=outcome,
+                raw_bytes_hash=cache_entry.raw_bytes_hash or None,
+                expected_hash=expected_hash,
+                warnings=cache_entry.warnings,
+            )
+
+    if cache_only:
+        return _cache_only_policy_result(
+            cache_entry,
+            source_label=source_label,
+            expected_hash=expected_hash,
+            cache_entry_persisted=cache_entry_persisted,
+        )
+
+    fetch_kwargs = {"host": host}
+    if port is not None:
+        fetch_kwargs["port"] = port
+    content, error = _fetch_gitlab_contents(
+        org,
+        repo,
+        "apm-policy.yml",
+        **fetch_kwargs,
+    )
+
+    if error:
+        # 404 = no policy, not an error. Self-managed GitLab instances have
+        # also been observed returning 410 Gone for a missing project path
+        # (see #2566); treat that the same as a clean "no policy" outcome
+        # rather than surfacing a fetch-failure warning on every invocation.
+        if "404" in error or "410" in error:
+            return PolicyFetchResult(source=source_label, outcome="absent")
+        return _stale_fallback_or_error(cache_entry, error, source_label, "cache_miss_fetch_fail")
+
+    if content is None:
+        return PolicyFetchResult(source=source_label, outcome="absent")
+
+    garbage_result = _detect_garbage(content, repo_ref, source_label, cache_entry)
+    if garbage_result is not None:
+        return garbage_result
+
+    mismatch = _verify_hash_pin(content, expected_hash, source_label)
+    if mismatch is not None:
+        return mismatch
+
+    try:
+        policy, warnings = load_policy(content)
+    except PolicyValidationError as e:
+        return PolicyFetchResult(
+            error=f"Invalid policy in {repo_ref}: {e}",
+            source=source_label,
+            outcome="malformed",
+            warnings=e.warnings,
+        )
+
+    chain_refs = [repo_ref]
+    actual_hash = _compute_hash_normalized(content, expected_hash)
+    if policy.extends is None:
+        _write_cache(
+            repo_ref,
+            policy,
+            project_root,
+            chain_refs=chain_refs,
+            raw_bytes_hash=actual_hash,
+            warnings=warnings,
+        )
+    outcome = "empty" if _is_policy_empty(policy) else "found"
+    return PolicyFetchResult(
+        policy=policy,
+        source=source_label,
+        outcome=outcome,
+        raw_bytes_hash=actual_hash,
+        expected_hash=expected_hash,
+        warnings=warnings,
+    )
+
+
+def _fetch_gitlab_contents(
+    org: str,
+    repo: str,
+    file_path: str,
+    *,
+    host: str = "gitlab.com",
+    port: int | None = None,
+) -> tuple[str | None, str | None]:
+    """Fetch file contents from a GitLab project via the Repository Files API.
+
+    Returns ``(content_string, error_string)``. One will be ``None``.
+    """
+    from ..core.auth import AuthResolver
+    from ..core.host_providers import HOST_PROVIDERS
+
+    project_path = f"{org}/{repo}"
+    host_label = f"{host}:{port}" if port is not None else host
+    repo_ref = f"{host_label}/{project_path}"
+
+    api_base = HOST_PROVIDERS["gitlab"].build_api_base(host, port)
+    encoded_project = quote(project_path, safe="")
+    encoded_file = quote(file_path, safe="")
+    # "HEAD" resolves to the project's default branch without requiring
+    # callers to know its name up front.
+    api_url = f"{api_base}/projects/{encoded_project}/repository/files/{encoded_file}/raw?ref=HEAD"
+
+    auth_resolver = AuthResolver()
+
+    def _request(token: str | None, _git_env: dict[str, str]):
+        headers = AuthResolver.gitlab_rest_headers(token)
+        response = requests.get(
+            api_url,
+            headers=headers,
+            timeout=10,
+            allow_redirects=False,
+        )
+        if response.status_code in (401, 403):
+            raise RuntimeError(f"{response.status_code}: unauthorized")
+        return response
+
+    try:
+        resp = auth_resolver.try_with_fallback(
+            host,
+            _request,
+            org=org,
+            port=port,
+            path=project_path,
+            host_type="gitlab",
+            unauth_first=False,
+        )
+        if resp.status_code in (404, 410):
+            return None, f"{resp.status_code}: Policy file not found"
+        if 300 <= resp.status_code < 400:
+            location = resp.headers.get("Location", "<no Location header>")
+            return None, (
+                f"Refusing HTTP redirect ({resp.status_code}) from {api_url} to {location}"
+            )
+        if resp.status_code != 200:
+            return None, f"HTTP {resp.status_code} fetching policy from {repo_ref}"
+        return resp.text, None
+    except requests.exceptions.Timeout:
+        return None, f"Timeout fetching policy from {repo_ref}"
+    except requests.exceptions.ConnectionError:
+        return None, f"Connection error fetching policy from {repo_ref}"
+    except RuntimeError as exc:
+        error_kwargs = {"org": org}
+        if port is not None:
+            error_kwargs["port"] = port
+        remediation = auth_resolver.build_error_context(
+            host,
+            "fetch org policy",
+            **error_kwargs,
+        )
+        return None, f"{exc}: Access denied to {repo_ref}{remediation}"
+    except Exception as e:
+        return None, f"Error fetching policy from {repo_ref}: {e}"

--- a/src/apm_cli/policy/discovery.py
+++ b/src/apm_cli/policy/discovery.py
@@ -94,6 +94,26 @@ def _gitlab_policy_repo_candidates() -> tuple[str, ...]:
     return (os.environ.get("APM_GITLAB_POLICY_REPO", "").strip() or _GITLAB_DEFAULT_POLICY_REPO,)
 
 
+def _gitlab_policy_root_group(host: str, org: str) -> str:
+    """Return the effective GitLab root group for policy discovery.
+
+    Self-managed GitLab instances often host many independent root groups
+    (departments, teams) under one company-owned instance -- unlike
+    gitlab.com, where each root namespace is an independent tenant and no
+    cross-tenant override would make sense. ``APM_GITLAB_POLICY_ROOT_GROUP``
+    lets a self-managed instance centralize org policy under one designated
+    root group instead of requiring an ``apm-policy`` project per root
+    group. Distinguished from gitlab.com by exact hostname match, per
+    ``is_gitlab_hostname``'s own cloud/self-managed split: ignored on
+    gitlab.com, where *org* (the project's own root namespace, extracted
+    from its git remote) is always used unchanged.
+    """
+    if host == "gitlab.com":
+        return org
+    override = os.environ.get("APM_GITLAB_POLICY_ROOT_GROUP", "").strip()
+    return override or org
+
+
 def _policy_repo_candidates(host: str) -> tuple[str, ...]:
     """Return candidate policy repo names for *host* in precedence order.
 
@@ -895,6 +915,8 @@ def _auto_discover(
     candidates = _policy_repo_candidates(host)
     is_ado = is_azure_devops_hostname(host)
     is_gitlab = is_gitlab_hostname(host)
+    if is_gitlab:
+        org = _gitlab_policy_root_group(host, org)
 
     for candidate_repo in candidates:
         logger.debug("Trying org policy repo candidate %s on host %s", candidate_repo, host)

--- a/src/apm_cli/policy/discovery.py
+++ b/src/apm_cli/policy/discovery.py
@@ -2,22 +2,27 @@
 
 Discovery flow:
 1. Extract org from git remote (github.com/contoso/my-project -> "contoso")
-2. Determine host profile (default or ado) to select candidate repos
-3. Try candidate repos in precedence order (.github-private > .github > .apm > _apm)
-4. Fetch apm-policy.yml via GitHub Contents API or ADO Items API
+2. Determine host profile (default, ado, or gitlab) to select candidate repos
+3. Try candidate repos in precedence order (.github-private > .github > .apm > _apm
+   on default/GitHub-family hosts; apm-policy on GitLab)
+4. Fetch apm-policy.yml via GitHub Contents API, ADO Items API, or GitLab
+   Repository Files API
 5. Resolve inheritance chain via resolve_policy_chain
 6. Cache the **merged effective policy** with chain metadata
 7. Parse and return ApmPolicy
 
 Candidate repo precedence:
-- .github-private -- private org-wide config (preferred; skipped on ADO)
-- .github  -- GitHub convention (skipped on ADO)
-- .apm     -- cross-platform convention (skipped on ADO)
-- _apm     -- universal fallback (valid on every git host)
+- .github-private -- private org-wide config (preferred; GitHub-family hosts only)
+- .github  -- GitHub convention (GitHub-family hosts only)
+- .apm     -- cross-platform convention (GitHub-family hosts only)
+- _apm     -- universal fallback (valid on GitHub-family hosts and ADO)
+- apm-policy -- GitLab-only default (GitLab rejects a leading ``.`` or ``_``
+  in project paths, so none of the above are valid there; see #2566)
 
 Supports:
 - GitHub.com and GitHub Enterprise (*.ghe.com)
 - Azure DevOps (dev.azure.com, *.visualstudio.com)
+- GitLab.com and self-managed GitLab (GITLAB_HOST / APM_GITLAB_HOSTS)
 - Manual override via --policy <path|url>
 - Cache with TTL (default 1 hour), stale fallback up to MAX_STALE_TTL
 - Atomic cache writes (temp file + os.replace)
@@ -36,7 +41,7 @@ import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from urllib.parse import urlparse, urlsplit, urlunsplit
+from urllib.parse import quote, urlparse, urlsplit, urlunsplit
 
 import requests
 import yaml
@@ -45,6 +50,7 @@ from ..cache.url_normalize import SCP_LIKE_RE
 from ..utils.github_host import (
     build_ado_api_url,
     is_azure_devops_hostname,
+    is_gitlab_hostname,
     is_visualstudio_legacy_hostname,
     parse_ado_repo_url,
 )
@@ -73,18 +79,33 @@ logger = logging.getLogger(__name__)
 _DEFAULT_POLICY_REPOS: tuple[str, ...] = (".github-private", ".github", ".apm", "_apm")
 _ADO_POLICY_REPOS: tuple[str, ...] = ("_apm",)
 
+# GitLab rejects project paths starting with ``.`` or ``_`` (see #2566), so
+# none of the default candidates are valid there. ``apm-policy`` is the
+# default GitLab policy-repo name; override via APM_GITLAB_POLICY_REPO for
+# orgs that already use a different name.
+_GITLAB_DEFAULT_POLICY_REPO = "apm-policy"
+
 # ADO project name for the policy repo (ADO requires a project container).
 ADO_POLICY_PROJECT = "_apm"
+
+
+def _gitlab_policy_repo_candidates() -> tuple[str, ...]:
+    """Return the (single) GitLab policy repo candidate, env-overridable."""
+    return (os.environ.get("APM_GITLAB_POLICY_REPO", "").strip() or _GITLAB_DEFAULT_POLICY_REPO,)
 
 
 def _policy_repo_candidates(host: str) -> tuple[str, ...]:
     """Return candidate policy repo names for *host* in precedence order.
 
     ADO hosts cannot have repo names starting/ending with ``.``, so only
-    ``_apm`` is valid.  All other hosts try the full cascade.
+    ``_apm`` is valid. GitLab additionally rejects a leading ``_``, so it
+    uses its own ``apm-policy`` default instead (#2566). All other hosts
+    try the full cascade.
     """
     if is_azure_devops_hostname(host):
         return _ADO_POLICY_REPOS
+    if is_gitlab_hostname(host):
+        return _gitlab_policy_repo_candidates()
     return _DEFAULT_POLICY_REPOS
 
 
@@ -873,6 +894,7 @@ def _auto_discover(
     org, host, port = identity
     candidates = _policy_repo_candidates(host)
     is_ado = is_azure_devops_hostname(host)
+    is_gitlab = is_gitlab_hostname(host)
 
     for candidate_repo in candidates:
         logger.debug("Trying org policy repo candidate %s on host %s", candidate_repo, host)
@@ -880,6 +902,17 @@ def _auto_discover(
             result = _fetch_from_ado_repo(
                 org=org,
                 project=ADO_POLICY_PROJECT,
+                repo=candidate_repo,
+                host=host,
+                port=port,
+                project_root=project_root,
+                no_cache=no_cache,
+                expected_hash=expected_hash,
+                cache_only=cache_only,
+            )
+        elif is_gitlab:
+            result = _fetch_from_gitlab_repo(
+                org=org,
                 repo=candidate_repo,
                 host=host,
                 port=port,
@@ -1496,6 +1529,197 @@ def _fetch_ado_contents(
         if resp.status_code != 200:
             return None, f"HTTP {resp.status_code} fetching policy from {repo_ref}"
         # ADO Items API returns raw file content by default
+        return resp.text, None
+    except requests.exceptions.Timeout:
+        return None, f"Timeout fetching policy from {repo_ref}"
+    except requests.exceptions.ConnectionError:
+        return None, f"Connection error fetching policy from {repo_ref}"
+    except RuntimeError as exc:
+        error_kwargs = {"org": org}
+        if port is not None:
+            error_kwargs["port"] = port
+        remediation = auth_resolver.build_error_context(
+            host,
+            "fetch org policy",
+            **error_kwargs,
+        )
+        return None, f"{exc}: Access denied to {repo_ref}{remediation}"
+    except Exception as e:
+        return None, f"Error fetching policy from {repo_ref}: {e}"
+
+
+# ---------------------------------------------------------------------------
+# GitLab policy fetch
+# ---------------------------------------------------------------------------
+
+
+def _fetch_from_gitlab_repo(
+    *,
+    org: str,
+    repo: str,
+    host: str,
+    port: int | None = None,
+    project_root: Path,
+    no_cache: bool = False,
+    expected_hash: str | None = None,
+    cache_only: bool = False,
+) -> PolicyFetchResult:
+    """Fetch apm-policy.yml from a GitLab project.
+
+    Mirrors ``_fetch_from_ado_repo`` but uses ``_fetch_gitlab_contents``
+    (GitLab Repository Files API) instead of ``_fetch_ado_contents``.
+    """
+    host_label = f"{host}:{port}" if port is not None else host
+    project_path = f"{org}/{repo}"
+    repo_ref = f"{host_label}/{project_path}"
+    source_label = f"org:{repo_ref}"
+    cache_entry: _CacheEntry | None = None
+    cache_entry_persisted = _cache_entry_files_exist(repo_ref, project_root)
+
+    if not no_cache:
+        cache_entry = _read_cache_entry(repo_ref, project_root, expected_hash=expected_hash)
+        if cache_entry is not None and not cache_entry.stale:
+            outcome = "empty" if _is_policy_empty(cache_entry.policy) else "found"
+            return PolicyFetchResult(
+                policy=cache_entry.policy,
+                source=cache_entry.source,
+                cached=True,
+                cache_age_seconds=cache_entry.age_seconds,
+                outcome=outcome,
+                raw_bytes_hash=cache_entry.raw_bytes_hash or None,
+                expected_hash=expected_hash,
+                warnings=cache_entry.warnings,
+            )
+
+    if cache_only:
+        return _cache_only_policy_result(
+            cache_entry,
+            source_label=source_label,
+            expected_hash=expected_hash,
+            cache_entry_persisted=cache_entry_persisted,
+        )
+
+    fetch_kwargs = {"host": host}
+    if port is not None:
+        fetch_kwargs["port"] = port
+    content, error = _fetch_gitlab_contents(
+        org,
+        repo,
+        "apm-policy.yml",
+        **fetch_kwargs,
+    )
+
+    if error:
+        # 404 = no policy, not an error. Self-managed GitLab instances have
+        # also been observed returning 410 Gone for a missing project path
+        # (see #2566); treat that the same as a clean "no policy" outcome
+        # rather than surfacing a fetch-failure warning on every invocation.
+        if "404" in error or "410" in error:
+            return PolicyFetchResult(source=source_label, outcome="absent")
+        return _stale_fallback_or_error(cache_entry, error, source_label, "cache_miss_fetch_fail")
+
+    if content is None:
+        return PolicyFetchResult(source=source_label, outcome="absent")
+
+    garbage_result = _detect_garbage(content, repo_ref, source_label, cache_entry)
+    if garbage_result is not None:
+        return garbage_result
+
+    mismatch = _verify_hash_pin(content, expected_hash, source_label)
+    if mismatch is not None:
+        return mismatch
+
+    try:
+        policy, warnings = load_policy(content)
+    except PolicyValidationError as e:
+        return PolicyFetchResult(
+            error=f"Invalid policy in {repo_ref}: {e}",
+            source=source_label,
+            outcome="malformed",
+            warnings=e.warnings,
+        )
+
+    chain_refs = [repo_ref]
+    actual_hash = _compute_hash_normalized(content, expected_hash)
+    if policy.extends is None:
+        _write_cache(
+            repo_ref,
+            policy,
+            project_root,
+            chain_refs=chain_refs,
+            raw_bytes_hash=actual_hash,
+            warnings=warnings,
+        )
+    outcome = "empty" if _is_policy_empty(policy) else "found"
+    return PolicyFetchResult(
+        policy=policy,
+        source=source_label,
+        outcome=outcome,
+        raw_bytes_hash=actual_hash,
+        expected_hash=expected_hash,
+        warnings=warnings,
+    )
+
+
+def _fetch_gitlab_contents(
+    org: str,
+    repo: str,
+    file_path: str,
+    *,
+    host: str = "gitlab.com",
+    port: int | None = None,
+) -> tuple[str | None, str | None]:
+    """Fetch file contents from a GitLab project via the Repository Files API.
+
+    Returns ``(content_string, error_string)``. One will be ``None``.
+    """
+    from ..core.auth import AuthResolver
+    from ..core.host_providers import HOST_PROVIDERS
+
+    project_path = f"{org}/{repo}"
+    host_label = f"{host}:{port}" if port is not None else host
+    repo_ref = f"{host_label}/{project_path}"
+
+    api_base = HOST_PROVIDERS["gitlab"].build_api_base(host, port)
+    encoded_project = quote(project_path, safe="")
+    encoded_file = quote(file_path, safe="")
+    # "HEAD" resolves to the project's default branch without requiring
+    # callers to know its name up front.
+    api_url = f"{api_base}/projects/{encoded_project}/repository/files/{encoded_file}/raw?ref=HEAD"
+
+    auth_resolver = AuthResolver()
+
+    def _request(token: str | None, _git_env: dict[str, str]):
+        headers = AuthResolver.gitlab_rest_headers(token)
+        response = requests.get(
+            api_url,
+            headers=headers,
+            timeout=10,
+            allow_redirects=False,
+        )
+        if response.status_code in (401, 403):
+            raise RuntimeError(f"{response.status_code}: unauthorized")
+        return response
+
+    try:
+        resp = auth_resolver.try_with_fallback(
+            host,
+            _request,
+            org=org,
+            port=port,
+            path=project_path,
+            host_type="gitlab",
+            unauth_first=True,
+        )
+        if resp.status_code in (404, 410):
+            return None, f"{resp.status_code}: Policy file not found"
+        if 300 <= resp.status_code < 400:
+            location = resp.headers.get("Location", "<no Location header>")
+            return None, (
+                f"Refusing HTTP redirect ({resp.status_code}) from {api_url} to {location}"
+            )
+        if resp.status_code != 200:
+            return None, f"HTTP {resp.status_code} fetching policy from {repo_ref}"
         return resp.text, None
     except requests.exceptions.Timeout:
         return None, f"Timeout fetching policy from {repo_ref}"

--- a/src/apm_cli/policy/discovery.py
+++ b/src/apm_cli/policy/discovery.py
@@ -1709,7 +1709,7 @@ def _fetch_gitlab_contents(
             port=port,
             path=project_path,
             host_type="gitlab",
-            unauth_first=True,
+            unauth_first=False,
         )
         if resp.status_code in (404, 410):
             return None, f"{resp.status_code}: Policy file not found"

--- a/src/apm_cli/policy/discovery.py
+++ b/src/apm_cli/policy/discovery.py
@@ -3,10 +3,8 @@
 Discovery flow:
 1. Extract org from git remote (github.com/contoso/my-project -> "contoso")
 2. Determine host profile (default, ado, or gitlab) to select candidate repos
-3. Try candidate repos in precedence order (.github-private > .github > .apm > _apm
-   on default/GitHub-family hosts; apm-policy on GitLab)
-4. Fetch apm-policy.yml via GitHub Contents API, ADO Items API, or GitLab
-   Repository Files API
+3. Try candidate repos in precedence order (per host profile; apm-policy on GitLab)
+4. Fetch apm-policy.yml via GitHub Contents API, ADO Items API, or GitLab Files API
 5. Resolve inheritance chain via resolve_policy_chain
 6. Cache the **merged effective policy** with chain metadata
 7. Parse and return ApmPolicy
@@ -16,8 +14,7 @@ Candidate repo precedence:
 - .github  -- GitHub convention (GitHub-family hosts only)
 - .apm     -- cross-platform convention (GitHub-family hosts only)
 - _apm     -- universal fallback (valid on GitHub-family hosts and ADO)
-- apm-policy -- GitLab-only default (GitLab rejects a leading ``.`` or ``_``
-  in project paths, so none of the above are valid there; see #2566)
+- apm-policy -- GitLab-only default (leading ``.``/``_`` rejected there; see #2566)
 
 Supports:
 - GitHub.com and GitHub Enterprise (*.ghe.com)
@@ -41,7 +38,7 @@ import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from urllib.parse import quote, urlparse, urlsplit, urlunsplit
+from urllib.parse import urlparse, urlsplit, urlunsplit
 
 import requests
 import yaml
@@ -56,6 +53,7 @@ from ..utils.github_host import (
 )
 from ..utils.path_security import PathTraversalError, ensure_path_within
 from ..utils.yaml_io import load_yaml_str
+from . import _gitlab
 from .parser import PolicyValidationError, load_policy
 from .project_config import (
     _DEFAULT_HASH_ALGORITHM,
@@ -79,53 +77,21 @@ logger = logging.getLogger(__name__)
 _DEFAULT_POLICY_REPOS: tuple[str, ...] = (".github-private", ".github", ".apm", "_apm")
 _ADO_POLICY_REPOS: tuple[str, ...] = ("_apm",)
 
-# GitLab rejects project paths starting with ``.`` or ``_`` (see #2566), so
-# none of the default candidates are valid there. ``apm-policy`` is the
-# default GitLab policy-repo name; override via APM_GITLAB_POLICY_REPO for
-# orgs that already use a different name.
-_GITLAB_DEFAULT_POLICY_REPO = "apm-policy"
-
 # ADO project name for the policy repo (ADO requires a project container).
 ADO_POLICY_PROJECT = "_apm"
-
-
-def _gitlab_policy_repo_candidates() -> tuple[str, ...]:
-    """Return the (single) GitLab policy repo candidate, env-overridable."""
-    return (os.environ.get("APM_GITLAB_POLICY_REPO", "").strip() or _GITLAB_DEFAULT_POLICY_REPO,)
-
-
-def _gitlab_policy_root_group(host: str, org: str) -> str:
-    """Return the effective GitLab root group for policy discovery.
-
-    Self-managed GitLab instances often host many independent root groups
-    (departments, teams) under one company-owned instance -- unlike
-    gitlab.com, where each root namespace is an independent tenant and no
-    cross-tenant override would make sense. ``APM_GITLAB_POLICY_ROOT_GROUP``
-    lets a self-managed instance centralize org policy under one designated
-    root group instead of requiring an ``apm-policy`` project per root
-    group. Distinguished from gitlab.com by exact hostname match, per
-    ``is_gitlab_hostname``'s own cloud/self-managed split: ignored on
-    gitlab.com, where *org* (the project's own root namespace, extracted
-    from its git remote) is always used unchanged.
-    """
-    if host == "gitlab.com":
-        return org
-    override = os.environ.get("APM_GITLAB_POLICY_ROOT_GROUP", "").strip()
-    return override or org
 
 
 def _policy_repo_candidates(host: str) -> tuple[str, ...]:
     """Return candidate policy repo names for *host* in precedence order.
 
     ADO hosts cannot have repo names starting/ending with ``.``, so only
-    ``_apm`` is valid. GitLab additionally rejects a leading ``_``, so it
-    uses its own ``apm-policy`` default instead (#2566). All other hosts
-    try the full cascade.
+    ``_apm`` is valid; GitLab uses its own ``apm-policy`` default (#2566).
+    All other hosts try the full cascade.
     """
     if is_azure_devops_hostname(host):
         return _ADO_POLICY_REPOS
     if is_gitlab_hostname(host):
-        return _gitlab_policy_repo_candidates()
+        return _gitlab._gitlab_policy_repo_candidates()
     return _DEFAULT_POLICY_REPOS
 
 
@@ -914,9 +880,6 @@ def _auto_discover(
     org, host, port = identity
     candidates = _policy_repo_candidates(host)
     is_ado = is_azure_devops_hostname(host)
-    is_gitlab = is_gitlab_hostname(host)
-    if is_gitlab:
-        org = _gitlab_policy_root_group(host, org)
 
     for candidate_repo in candidates:
         logger.debug("Trying org policy repo candidate %s on host %s", candidate_repo, host)
@@ -932,9 +895,9 @@ def _auto_discover(
                 expected_hash=expected_hash,
                 cache_only=cache_only,
             )
-        elif is_gitlab:
-            result = _fetch_from_gitlab_repo(
-                org=org,
+        elif is_gitlab_hostname(host):
+            result = _gitlab._fetch_from_gitlab_repo(
+                org=_gitlab._gitlab_policy_root_group(host, org),
                 repo=candidate_repo,
                 host=host,
                 port=port,
@@ -1573,192 +1536,6 @@ def _fetch_ado_contents(
 # ---------------------------------------------------------------------------
 # GitLab policy fetch
 # ---------------------------------------------------------------------------
-
-
-def _fetch_from_gitlab_repo(
-    *,
-    org: str,
-    repo: str,
-    host: str,
-    port: int | None = None,
-    project_root: Path,
-    no_cache: bool = False,
-    expected_hash: str | None = None,
-    cache_only: bool = False,
-) -> PolicyFetchResult:
-    """Fetch apm-policy.yml from a GitLab project.
-
-    Mirrors ``_fetch_from_ado_repo`` but uses ``_fetch_gitlab_contents``
-    (GitLab Repository Files API) instead of ``_fetch_ado_contents``.
-    """
-    host_label = f"{host}:{port}" if port is not None else host
-    project_path = f"{org}/{repo}"
-    repo_ref = f"{host_label}/{project_path}"
-    source_label = f"org:{repo_ref}"
-    cache_entry: _CacheEntry | None = None
-    cache_entry_persisted = _cache_entry_files_exist(repo_ref, project_root)
-
-    if not no_cache:
-        cache_entry = _read_cache_entry(repo_ref, project_root, expected_hash=expected_hash)
-        if cache_entry is not None and not cache_entry.stale:
-            outcome = "empty" if _is_policy_empty(cache_entry.policy) else "found"
-            return PolicyFetchResult(
-                policy=cache_entry.policy,
-                source=cache_entry.source,
-                cached=True,
-                cache_age_seconds=cache_entry.age_seconds,
-                outcome=outcome,
-                raw_bytes_hash=cache_entry.raw_bytes_hash or None,
-                expected_hash=expected_hash,
-                warnings=cache_entry.warnings,
-            )
-
-    if cache_only:
-        return _cache_only_policy_result(
-            cache_entry,
-            source_label=source_label,
-            expected_hash=expected_hash,
-            cache_entry_persisted=cache_entry_persisted,
-        )
-
-    fetch_kwargs = {"host": host}
-    if port is not None:
-        fetch_kwargs["port"] = port
-    content, error = _fetch_gitlab_contents(
-        org,
-        repo,
-        "apm-policy.yml",
-        **fetch_kwargs,
-    )
-
-    if error:
-        # 404 = no policy, not an error. Self-managed GitLab instances have
-        # also been observed returning 410 Gone for a missing project path
-        # (see #2566); treat that the same as a clean "no policy" outcome
-        # rather than surfacing a fetch-failure warning on every invocation.
-        if "404" in error or "410" in error:
-            return PolicyFetchResult(source=source_label, outcome="absent")
-        return _stale_fallback_or_error(cache_entry, error, source_label, "cache_miss_fetch_fail")
-
-    if content is None:
-        return PolicyFetchResult(source=source_label, outcome="absent")
-
-    garbage_result = _detect_garbage(content, repo_ref, source_label, cache_entry)
-    if garbage_result is not None:
-        return garbage_result
-
-    mismatch = _verify_hash_pin(content, expected_hash, source_label)
-    if mismatch is not None:
-        return mismatch
-
-    try:
-        policy, warnings = load_policy(content)
-    except PolicyValidationError as e:
-        return PolicyFetchResult(
-            error=f"Invalid policy in {repo_ref}: {e}",
-            source=source_label,
-            outcome="malformed",
-            warnings=e.warnings,
-        )
-
-    chain_refs = [repo_ref]
-    actual_hash = _compute_hash_normalized(content, expected_hash)
-    if policy.extends is None:
-        _write_cache(
-            repo_ref,
-            policy,
-            project_root,
-            chain_refs=chain_refs,
-            raw_bytes_hash=actual_hash,
-            warnings=warnings,
-        )
-    outcome = "empty" if _is_policy_empty(policy) else "found"
-    return PolicyFetchResult(
-        policy=policy,
-        source=source_label,
-        outcome=outcome,
-        raw_bytes_hash=actual_hash,
-        expected_hash=expected_hash,
-        warnings=warnings,
-    )
-
-
-def _fetch_gitlab_contents(
-    org: str,
-    repo: str,
-    file_path: str,
-    *,
-    host: str = "gitlab.com",
-    port: int | None = None,
-) -> tuple[str | None, str | None]:
-    """Fetch file contents from a GitLab project via the Repository Files API.
-
-    Returns ``(content_string, error_string)``. One will be ``None``.
-    """
-    from ..core.auth import AuthResolver
-    from ..core.host_providers import HOST_PROVIDERS
-
-    project_path = f"{org}/{repo}"
-    host_label = f"{host}:{port}" if port is not None else host
-    repo_ref = f"{host_label}/{project_path}"
-
-    api_base = HOST_PROVIDERS["gitlab"].build_api_base(host, port)
-    encoded_project = quote(project_path, safe="")
-    encoded_file = quote(file_path, safe="")
-    # "HEAD" resolves to the project's default branch without requiring
-    # callers to know its name up front.
-    api_url = f"{api_base}/projects/{encoded_project}/repository/files/{encoded_file}/raw?ref=HEAD"
-
-    auth_resolver = AuthResolver()
-
-    def _request(token: str | None, _git_env: dict[str, str]):
-        headers = AuthResolver.gitlab_rest_headers(token)
-        response = requests.get(
-            api_url,
-            headers=headers,
-            timeout=10,
-            allow_redirects=False,
-        )
-        if response.status_code in (401, 403):
-            raise RuntimeError(f"{response.status_code}: unauthorized")
-        return response
-
-    try:
-        resp = auth_resolver.try_with_fallback(
-            host,
-            _request,
-            org=org,
-            port=port,
-            path=project_path,
-            host_type="gitlab",
-            unauth_first=False,
-        )
-        if resp.status_code in (404, 410):
-            return None, f"{resp.status_code}: Policy file not found"
-        if 300 <= resp.status_code < 400:
-            location = resp.headers.get("Location", "<no Location header>")
-            return None, (
-                f"Refusing HTTP redirect ({resp.status_code}) from {api_url} to {location}"
-            )
-        if resp.status_code != 200:
-            return None, f"HTTP {resp.status_code} fetching policy from {repo_ref}"
-        return resp.text, None
-    except requests.exceptions.Timeout:
-        return None, f"Timeout fetching policy from {repo_ref}"
-    except requests.exceptions.ConnectionError:
-        return None, f"Connection error fetching policy from {repo_ref}"
-    except RuntimeError as exc:
-        error_kwargs = {"org": org}
-        if port is not None:
-            error_kwargs["port"] = port
-        remediation = auth_resolver.build_error_context(
-            host,
-            "fetch org policy",
-            **error_kwargs,
-        )
-        return None, f"{exc}: Access denied to {repo_ref}{remediation}"
-    except Exception as e:
-        return None, f"Error fetching policy from {repo_ref}: {e}"
 
 
 def _is_github_host(host: str) -> bool:

--- a/tests/spec_conformance/test_policy_reqs.py
+++ b/tests/spec_conformance/test_policy_reqs.py
@@ -119,6 +119,31 @@ def test_policy_provides_default_allow_list_shape():
     assert "allow" in deps and deps["allow"]["oneOf"][0]["type"] == "array"
 
 
+@pytest.mark.req("req-pl-011")
+def test_policy_gitlab_discovery_provider_is_a_distinct_convention():
+    """req-pl-011: discovery is a pluggable, per-host extension point.
+
+    The spec names `gitlab-project-yml` as an example additional provider
+    (Section 6.1.1) alongside the registered `github-owner-dotgithub`
+    default, and requires that "a consumer MUST NOT hard-code a
+    host-specific discovery convention as the sole discovery path." GitLab
+    rejects project paths starting with `.` or `_`, so it cannot reuse the
+    GitHub-default or ADO candidate conventions -- it needs (and has) its
+    own, distinct from both.
+    """
+    from apm_cli.policy.discovery import _policy_repo_candidates
+
+    github_candidates = _policy_repo_candidates("github.com")
+    ado_candidates = _policy_repo_candidates("dev.azure.com")
+    gitlab_candidates = _policy_repo_candidates("gitlab.com")
+
+    assert gitlab_candidates == ("apm-policy",)
+    assert gitlab_candidates != github_candidates
+    assert gitlab_candidates != ado_candidates
+    assert all(not name.startswith((".", "_")) for name in gitlab_candidates)
+    assert_spec_contains("gitlab-project-yml")
+
+
 @pytest.mark.req("req-pl-012")
 def test_policy_provides_default_deny_list_shape():
     schema = load_schema("policy-v0.1.schema.json")

--- a/tests/unit/policy/test_discovery.py
+++ b/tests/unit/policy/test_discovery.py
@@ -14,6 +14,11 @@ from unittest.mock import MagicMock, patch
 from urllib.parse import parse_qs, quote, urlparse, urlsplit
 
 from apm_cli.core.auth import AuthResolver as _RealAuthResolver
+from apm_cli.policy._gitlab import (
+    _fetch_from_gitlab_repo,
+    _fetch_gitlab_contents,
+    _gitlab_policy_root_group,
+)
 from apm_cli.policy.discovery import (
     CACHE_SCHEMA_VERSION,  # noqa: F401
     DEFAULT_CACHE_TTL,
@@ -25,13 +30,10 @@ from apm_cli.policy.discovery import (
     _extract_org_host_port_from_git_remote,
     _fetch_ado_contents,
     _fetch_from_ado_repo,
-    _fetch_from_gitlab_repo,
     _fetch_from_repo,
     _fetch_from_url,
     _fetch_github_contents,
-    _fetch_gitlab_contents,
     _get_cache_dir,
-    _gitlab_policy_root_group,
     _load_from_file,
     _parse_remote_url,
     _policy_repo_candidates,
@@ -1025,7 +1027,7 @@ class TestAutoDiscover(unittest.TestCase):
         mock_candidates.assert_called_once_with("ado.example.test")
         self.assertEqual(mock_ado_fetch.call_args.kwargs["port"], 8443)
 
-    @patch("apm_cli.policy.discovery._fetch_from_gitlab_repo")
+    @patch("apm_cli.policy._gitlab._fetch_from_gitlab_repo")
     @patch("apm_cli.policy.discovery._extract_org_host_port_from_git_remote")
     def test_gitlab_host_only_tries_apm_policy(self, mock_extract, mock_gitlab_fetch):
         """GitLab host profile skips the GitHub-family cascade, only tries apm-policy."""
@@ -1042,7 +1044,7 @@ class TestAutoDiscover(unittest.TestCase):
             self.assertEqual(call_kwargs["org"], "contoso")
             self.assertTrue(result.found)
 
-    @patch("apm_cli.policy.discovery._fetch_from_gitlab_repo")
+    @patch("apm_cli.policy._gitlab._fetch_from_gitlab_repo")
     @patch("apm_cli.policy.discovery._extract_org_host_port_from_git_remote")
     def test_gitlab_self_managed_preserves_remote_port(self, mock_extract, mock_gitlab_fetch):
         mock_extract.return_value = ("contoso", "gitlab.example.test", 8443)
@@ -1059,7 +1061,7 @@ class TestAutoDiscover(unittest.TestCase):
         self.assertEqual(result.outcome, "absent")
         self.assertIsNone(result.error)
 
-    @patch("apm_cli.policy.discovery._fetch_from_gitlab_repo")
+    @patch("apm_cli.policy._gitlab._fetch_from_gitlab_repo")
     @patch("apm_cli.policy.discovery._extract_org_host_port_from_git_remote")
     def test_gitlab_self_managed_root_group_override_reaches_fetch(
         self, mock_extract, mock_gitlab_fetch
@@ -1086,7 +1088,7 @@ class TestAutoDiscover(unittest.TestCase):
 
         self.assertEqual(mock_gitlab_fetch.call_args.kwargs["org"], "platform-governance")
 
-    @patch("apm_cli.policy.discovery._fetch_from_gitlab_repo")
+    @patch("apm_cli.policy._gitlab._fetch_from_gitlab_repo")
     @patch("apm_cli.policy.discovery._extract_org_host_port_from_git_remote")
     def test_gitlab_cloud_ignores_root_group_override(self, mock_extract, mock_gitlab_fetch):
         """gitlab.com is multi-tenant -- the self-managed override must not
@@ -1106,7 +1108,7 @@ class TestAutoDiscover(unittest.TestCase):
 
         self.assertEqual(mock_gitlab_fetch.call_args.kwargs["org"], "team-a")
 
-    @patch("apm_cli.policy.discovery._fetch_from_gitlab_repo")
+    @patch("apm_cli.policy._gitlab._fetch_from_gitlab_repo")
     @patch("apm_cli.policy.discovery._extract_org_host_port_from_git_remote")
     def test_gitlab_absent_is_clean_no_op(self, mock_extract, mock_gitlab_fetch):
         """No apm-policy project on GitLab -> absent, not a fetch-failure warning."""
@@ -1583,7 +1585,7 @@ class TestFetchGitlabContents(unittest.TestCase):
         return resolver
 
     @patch("apm_cli.core.auth.AuthResolver")
-    @patch("apm_cli.policy.discovery.requests.get")
+    @patch("apm_cli.policy._gitlab.requests.get")
     def test_success(self, mock_get, mock_resolver_cls):
         self._resolver(mock_resolver_cls, "my-gitlab-token")
         mock_resp = MagicMock()
@@ -1636,7 +1638,7 @@ class TestFetchGitlabContents(unittest.TestCase):
         with (
             patch.dict(os.environ, env, clear=True),
             patch.object(GitHubTokenManager, "resolve_credential_from_git", return_value=None),
-            patch("apm_cli.policy.discovery.requests.get", side_effect=fake_get) as mock_get,
+            patch("apm_cli.policy._gitlab.requests.get", side_effect=fake_get) as mock_get,
         ):
             content, error = _fetch_gitlab_contents("contoso", "apm-policy", "apm-policy.yml")
 
@@ -1648,7 +1650,7 @@ class TestFetchGitlabContents(unittest.TestCase):
         self.assertEqual(mock_get.call_args.kwargs["headers"].get("PRIVATE-TOKEN"), "glpat_secret")
 
     @patch("apm_cli.core.auth.AuthResolver")
-    @patch("apm_cli.policy.discovery.requests.get")
+    @patch("apm_cli.policy._gitlab.requests.get")
     def test_404_returns_error(self, mock_get, mock_resolver_cls):
         self._resolver(mock_resolver_cls, "my-gitlab-token")
         mock_resp = MagicMock()
@@ -1660,7 +1662,7 @@ class TestFetchGitlabContents(unittest.TestCase):
         self.assertIn("404", error)
 
     @patch("apm_cli.core.auth.AuthResolver")
-    @patch("apm_cli.policy.discovery.requests.get")
+    @patch("apm_cli.policy._gitlab.requests.get")
     def test_410_returns_not_found_error(self, mock_get, mock_resolver_cls):
         """Self-managed GitLab has been observed returning 410 for a missing project (#2566)."""
         self._resolver(mock_resolver_cls, "my-gitlab-token")
@@ -1673,7 +1675,7 @@ class TestFetchGitlabContents(unittest.TestCase):
         self.assertIn("410", error)
 
     @patch("apm_cli.core.auth.AuthResolver")
-    @patch("apm_cli.policy.discovery.requests.get")
+    @patch("apm_cli.policy._gitlab.requests.get")
     def test_401_returns_error(self, mock_get, mock_resolver_cls):
         resolver = self._resolver(mock_resolver_cls, "my-gitlab-token")
         mock_resp = MagicMock()
@@ -1689,7 +1691,7 @@ class TestFetchGitlabContents(unittest.TestCase):
         )
 
     @patch("apm_cli.core.auth.AuthResolver")
-    @patch("apm_cli.policy.discovery.requests.get")
+    @patch("apm_cli.policy._gitlab.requests.get")
     def test_redirect_rejected(self, mock_get, mock_resolver_cls):
         self._resolver(mock_resolver_cls, "my-gitlab-token")
         mock_resp = MagicMock()
@@ -1702,7 +1704,7 @@ class TestFetchGitlabContents(unittest.TestCase):
         self.assertIn("redirect", error.lower())
 
     @patch("apm_cli.core.auth.AuthResolver")
-    @patch("apm_cli.policy.discovery.requests.get")
+    @patch("apm_cli.policy._gitlab.requests.get")
     def test_no_auth_token_still_sends_request(self, mock_get, mock_resolver_cls):
         """Unauthenticated requests are allowed (public GitLab projects)."""
         self._resolver(mock_resolver_cls, None)
@@ -1719,7 +1721,7 @@ class TestFetchGitlabContents(unittest.TestCase):
         self.assertNotIn("Authorization", headers)
 
     @patch("apm_cli.core.auth.AuthResolver")
-    @patch("apm_cli.policy.discovery.requests.get")
+    @patch("apm_cli.policy._gitlab.requests.get")
     def test_custom_self_managed_host_and_port(self, mock_get, mock_resolver_cls):
         resolver = self._resolver(mock_resolver_cls, "my-gitlab-token")
         mock_get.return_value = MagicMock(status_code=200, text=VALID_POLICY_YAML)
@@ -1748,7 +1750,7 @@ class TestFetchGitlabContents(unittest.TestCase):
 class TestFetchFromGitlabRepo(unittest.TestCase):
     """Test _fetch_from_gitlab_repo orchestration around the GitLab transport."""
 
-    @patch("apm_cli.policy.discovery._fetch_gitlab_contents")
+    @patch("apm_cli.policy._gitlab._fetch_gitlab_contents")
     def test_200_caches_result(self, mock_fetch):
         mock_fetch.return_value = (VALID_POLICY_YAML, None)
 
@@ -1765,7 +1767,7 @@ class TestFetchFromGitlabRepo(unittest.TestCase):
             self.assertEqual(result.source, "org:gitlab.com/contoso/apm-policy")
             self.assertFalse(result.cached)
 
-    @patch("apm_cli.policy.discovery._fetch_gitlab_contents")
+    @patch("apm_cli.policy._gitlab._fetch_gitlab_contents")
     def test_404_no_error(self, mock_fetch):
         mock_fetch.return_value = (None, "404: Policy file not found")
 
@@ -1781,7 +1783,7 @@ class TestFetchFromGitlabRepo(unittest.TestCase):
             self.assertEqual(result.outcome, "absent")
             self.assertIsNone(result.error)
 
-    @patch("apm_cli.policy.discovery._fetch_gitlab_contents")
+    @patch("apm_cli.policy._gitlab._fetch_gitlab_contents")
     def test_410_is_treated_as_absent_no_op(self, mock_fetch):
         """410 on self-managed GitLab must be a clean no-op, not a warning (#2566)."""
         mock_fetch.return_value = (None, "410: Policy file not found")
@@ -1798,7 +1800,7 @@ class TestFetchFromGitlabRepo(unittest.TestCase):
             self.assertEqual(result.outcome, "absent")
             self.assertIsNone(result.error)
 
-    @patch("apm_cli.policy.discovery._fetch_gitlab_contents")
+    @patch("apm_cli.policy._gitlab._fetch_gitlab_contents")
     def test_api_error_uses_stale_cache(self, mock_fetch):
         mock_fetch.return_value = (None, "Connection error fetching policy")
 
@@ -1823,7 +1825,7 @@ class TestFetchFromGitlabRepo(unittest.TestCase):
             self.assertTrue(result.cached)
             self.assertEqual(result.outcome, "cached_stale")
 
-    @patch("apm_cli.policy.discovery._fetch_gitlab_contents")
+    @patch("apm_cli.policy._gitlab._fetch_gitlab_contents")
     def test_invalid_policy_yaml(self, mock_fetch):
         mock_fetch.return_value = ("enforcement: bogus\n", None)
 

--- a/tests/unit/policy/test_discovery.py
+++ b/tests/unit/policy/test_discovery.py
@@ -31,6 +31,7 @@ from apm_cli.policy.discovery import (
     _fetch_github_contents,
     _fetch_gitlab_contents,
     _get_cache_dir,
+    _gitlab_policy_root_group,
     _load_from_file,
     _parse_remote_url,
     _policy_repo_candidates,
@@ -1060,6 +1061,53 @@ class TestAutoDiscover(unittest.TestCase):
 
     @patch("apm_cli.policy.discovery._fetch_from_gitlab_repo")
     @patch("apm_cli.policy.discovery._extract_org_host_port_from_git_remote")
+    def test_gitlab_self_managed_root_group_override_reaches_fetch(
+        self, mock_extract, mock_gitlab_fetch
+    ):
+        """A project under team-a's own remote still resolves to the
+        instance-wide policy root group when APM_GITLAB_POLICY_ROOT_GROUP is
+        set, so many independent root groups can share one apm-policy
+        project instead of needing one apiece."""
+        mock_extract.return_value = ("team-a", "gitlab.example.test", None)
+        mock_gitlab_fetch.return_value = PolicyFetchResult(outcome="absent")
+
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "GITLAB_HOST": "gitlab.example.test",
+                    "APM_GITLAB_POLICY_ROOT_GROUP": "platform-governance",
+                },
+                clear=False,
+            ),
+            tempfile.TemporaryDirectory() as tmpdir,
+        ):
+            _auto_discover(Path(tmpdir), no_cache=True)
+
+        self.assertEqual(mock_gitlab_fetch.call_args.kwargs["org"], "platform-governance")
+
+    @patch("apm_cli.policy.discovery._fetch_from_gitlab_repo")
+    @patch("apm_cli.policy.discovery._extract_org_host_port_from_git_remote")
+    def test_gitlab_cloud_ignores_root_group_override(self, mock_extract, mock_gitlab_fetch):
+        """gitlab.com is multi-tenant -- the self-managed override must not
+        leak into cloud discovery even if the env var happens to be set."""
+        mock_extract.return_value = ("team-a", "gitlab.com", None)
+        mock_gitlab_fetch.return_value = PolicyFetchResult(outcome="absent")
+
+        with (
+            patch.dict(
+                os.environ,
+                {"APM_GITLAB_POLICY_ROOT_GROUP": "platform-governance"},
+                clear=False,
+            ),
+            tempfile.TemporaryDirectory() as tmpdir,
+        ):
+            _auto_discover(Path(tmpdir), no_cache=True)
+
+        self.assertEqual(mock_gitlab_fetch.call_args.kwargs["org"], "team-a")
+
+    @patch("apm_cli.policy.discovery._fetch_from_gitlab_repo")
+    @patch("apm_cli.policy.discovery._extract_org_host_port_from_git_remote")
     def test_gitlab_absent_is_clean_no_op(self, mock_extract, mock_gitlab_fetch):
         """No apm-policy project on GitLab -> absent, not a fetch-failure warning."""
         mock_extract.return_value = ("contoso", "gitlab.com", None)
@@ -1113,6 +1161,41 @@ class TestPolicyRepoCandidates(unittest.TestCase):
         with patch.dict(os.environ, {"APM_GITLAB_POLICY_REPO": "org-policy"}, clear=False):
             result = _policy_repo_candidates("gitlab.com")
         self.assertEqual(result, ("org-policy",))
+
+
+class TestGitlabPolicyRootGroup(unittest.TestCase):
+    """Test _gitlab_policy_root_group: cloud vs self-managed root-group override."""
+
+    def test_gitlab_com_ignores_override(self):
+        """Cloud gitlab.com is a multi-tenant host -- no cross-tenant override."""
+        with patch.dict(os.environ, {"APM_GITLAB_POLICY_ROOT_GROUP": "central"}, clear=False):
+            result = _gitlab_policy_root_group("gitlab.com", "team-a")
+        self.assertEqual(result, "team-a")
+
+    def test_gitlab_com_without_override_returns_org_unchanged(self):
+        result = _gitlab_policy_root_group("gitlab.com", "team-a")
+        self.assertEqual(result, "team-a")
+
+    def test_self_managed_without_override_returns_org_unchanged(self):
+        env = {}
+        with patch.dict(os.environ, env, clear=True):
+            result = _gitlab_policy_root_group("gitlab.example.com", "team-a")
+        self.assertEqual(result, "team-a")
+
+    def test_self_managed_with_override_centralizes_on_configured_group(self):
+        """Self-managed instances often host many independent root groups
+        (departments/teams); the override lets them all share one policy
+        root group instead of requiring an apm-policy project per group."""
+        env = {"APM_GITLAB_POLICY_ROOT_GROUP": "platform-governance"}
+        with patch.dict(os.environ, env, clear=False):
+            result = _gitlab_policy_root_group("gitlab.example.com", "team-a")
+        self.assertEqual(result, "platform-governance")
+
+    def test_self_managed_blank_override_returns_org_unchanged(self):
+        env = {"APM_GITLAB_POLICY_ROOT_GROUP": "   "}
+        with patch.dict(os.environ, env, clear=False):
+            result = _gitlab_policy_root_group("gitlab.example.com", "team-a")
+        self.assertEqual(result, "team-a")
 
 
 class TestFetchAdoContents(unittest.TestCase):

--- a/tests/unit/policy/test_discovery.py
+++ b/tests/unit/policy/test_discovery.py
@@ -11,7 +11,7 @@ import time
 import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, quote, urlparse, urlsplit
 
 from apm_cli.core.auth import AuthResolver as _RealAuthResolver
 from apm_cli.policy.discovery import (
@@ -1515,8 +1515,54 @@ class TestFetchGitlabContents(unittest.TestCase):
         headers = call_kwargs[1].get("headers", {})
         self.assertEqual(headers.get("PRIVATE-TOKEN"), "my-gitlab-token")
         api_url = mock_get.call_args.args[0]
-        self.assertIn("/projects/contoso%2Fapm-policy/repository/files/", api_url)
-        self.assertIn("ref=HEAD", api_url)
+        parsed = urlsplit(api_url)
+        self.assertEqual(
+            parsed.path,
+            "/api/v4/projects/"
+            + quote("contoso/apm-policy", safe="")
+            + "/repository/files/apm-policy.yml/raw",
+        )
+        self.assertEqual(parse_qs(parsed.query).get("ref"), ["HEAD"])
+
+    def test_private_project_authenticates_on_first_attempt(self):
+        """Regression guard (Copilot review on PR #2605): auth-first, not unauth-first.
+
+        GitLab returns 404 (not 401/403) to an unauthenticated request for a
+        private project, to avoid leaking its existence. This fetcher's
+        ``_request`` only raises on 401/403, so ``unauth_first=True`` would
+        let ``try_with_fallback`` accept that unauthenticated 404 as "the"
+        result and never retry with a configured token -- permanently
+        masking a private policy repo even with a valid GITLAB_APM_PAT set.
+        Exercises the REAL AuthResolver (not the simplified single-call stub
+        used by the other tests in this class) so the actual try_with_fallback
+        branching between an unauth-first and an auth-first attempt is
+        under test.
+        """
+        from apm_cli.core.token_manager import GitHubTokenManager
+
+        def fake_get(_url, headers=None, **_kwargs):
+            resp = MagicMock()
+            if headers and headers.get("PRIVATE-TOKEN") == "glpat_secret":
+                resp.status_code = 200
+                resp.text = VALID_POLICY_YAML
+            else:
+                resp.status_code = 404
+            return resp
+
+        env = {"GITLAB_APM_PAT": "glpat_secret"}
+        with (
+            patch.dict(os.environ, env, clear=True),
+            patch.object(GitHubTokenManager, "resolve_credential_from_git", return_value=None),
+            patch("apm_cli.policy.discovery.requests.get", side_effect=fake_get) as mock_get,
+        ):
+            content, error = _fetch_gitlab_contents("contoso", "apm-policy", "apm-policy.yml")
+
+        self.assertIsNone(error)
+        self.assertEqual(content, VALID_POLICY_YAML)
+        # The token must be on the FIRST request -- not a retry after an
+        # unauthenticated attempt was silently accepted as "not found".
+        self.assertEqual(mock_get.call_count, 1)
+        self.assertEqual(mock_get.call_args.kwargs["headers"].get("PRIVATE-TOKEN"), "glpat_secret")
 
     @patch("apm_cli.core.auth.AuthResolver")
     @patch("apm_cli.policy.discovery.requests.get")

--- a/tests/unit/policy/test_discovery.py
+++ b/tests/unit/policy/test_discovery.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 from urllib.parse import urlparse
 
+from apm_cli.core.auth import AuthResolver as _RealAuthResolver
 from apm_cli.policy.discovery import (
     CACHE_SCHEMA_VERSION,  # noqa: F401
     DEFAULT_CACHE_TTL,
@@ -24,9 +25,11 @@ from apm_cli.policy.discovery import (
     _extract_org_host_port_from_git_remote,
     _fetch_ado_contents,
     _fetch_from_ado_repo,
+    _fetch_from_gitlab_repo,
     _fetch_from_repo,
     _fetch_from_url,
     _fetch_github_contents,
+    _fetch_gitlab_contents,
     _get_cache_dir,
     _load_from_file,
     _parse_remote_url,
@@ -67,6 +70,14 @@ class TestParseRemoteUrl(unittest.TestCase):
     def test_ado(self):
         result = _parse_remote_url("https://dev.azure.com/contoso/project/_git/repo")
         self.assertEqual(result, ("contoso", "dev.azure.com"))
+
+    def test_https_gitlab(self):
+        result = _parse_remote_url("https://gitlab.com/contoso/my-project.git")
+        self.assertEqual(result, ("contoso", "gitlab.com"))
+
+    def test_ssh_gitlab_self_managed(self):
+        result = _parse_remote_url("git@gitlab.example.com:contoso/my-project.git")
+        self.assertEqual(result, ("contoso", "gitlab.example.com"))
 
     def test_ssh_no_git_suffix(self):
         result = _parse_remote_url("git@github.com:contoso/my-project")
@@ -1013,6 +1024,53 @@ class TestAutoDiscover(unittest.TestCase):
         mock_candidates.assert_called_once_with("ado.example.test")
         self.assertEqual(mock_ado_fetch.call_args.kwargs["port"], 8443)
 
+    @patch("apm_cli.policy.discovery._fetch_from_gitlab_repo")
+    @patch("apm_cli.policy.discovery._extract_org_host_port_from_git_remote")
+    def test_gitlab_host_only_tries_apm_policy(self, mock_extract, mock_gitlab_fetch):
+        """GitLab host profile skips the GitHub-family cascade, only tries apm-policy."""
+        mock_extract.return_value = ("contoso", "gitlab.com", None)
+        mock_gitlab_fetch.return_value = PolicyFetchResult(
+            policy=ApmPolicy(), source="org:gitlab.com/contoso/apm-policy", outcome="found"
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = _auto_discover(Path(tmpdir), no_cache=True)
+            mock_gitlab_fetch.assert_called_once()
+            call_kwargs = mock_gitlab_fetch.call_args.kwargs
+            self.assertEqual(call_kwargs["repo"], "apm-policy")
+            self.assertEqual(call_kwargs["org"], "contoso")
+            self.assertTrue(result.found)
+
+    @patch("apm_cli.policy.discovery._fetch_from_gitlab_repo")
+    @patch("apm_cli.policy.discovery._extract_org_host_port_from_git_remote")
+    def test_gitlab_self_managed_preserves_remote_port(self, mock_extract, mock_gitlab_fetch):
+        mock_extract.return_value = ("contoso", "gitlab.example.test", 8443)
+        mock_gitlab_fetch.return_value = PolicyFetchResult(outcome="absent")
+
+        with (
+            patch.dict(os.environ, {"GITLAB_HOST": "gitlab.example.test"}, clear=False),
+            tempfile.TemporaryDirectory() as tmpdir,
+        ):
+            result = _auto_discover(Path(tmpdir), no_cache=True)
+
+        self.assertEqual(mock_gitlab_fetch.call_args.kwargs["port"], 8443)
+        # Absent (no policy published) must be a clean no-op, not an error.
+        self.assertEqual(result.outcome, "absent")
+        self.assertIsNone(result.error)
+
+    @patch("apm_cli.policy.discovery._fetch_from_gitlab_repo")
+    @patch("apm_cli.policy.discovery._extract_org_host_port_from_git_remote")
+    def test_gitlab_absent_is_clean_no_op(self, mock_extract, mock_gitlab_fetch):
+        """No apm-policy project on GitLab -> absent, not a fetch-failure warning."""
+        mock_extract.return_value = ("contoso", "gitlab.com", None)
+        mock_gitlab_fetch.return_value = PolicyFetchResult(outcome="absent")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = _auto_discover(Path(tmpdir), no_cache=True)
+            self.assertFalse(result.found)
+            self.assertEqual(result.outcome, "absent")
+            self.assertIsNone(result.error)
+
 
 class TestPolicyRepoCandidates(unittest.TestCase):
     """Test _policy_repo_candidates host profile selection."""
@@ -1040,6 +1098,21 @@ class TestPolicyRepoCandidates(unittest.TestCase):
     def test_unknown_host_returns_all(self):
         result = _policy_repo_candidates("gitlab.example.com")
         self.assertEqual(result, (".github-private", ".github", ".apm", "_apm"))
+
+    def test_gitlab_com_only_tries_apm_policy(self):
+        """GitLab rejects a leading '.' or '_' in project paths (#2566)."""
+        result = _policy_repo_candidates("gitlab.com")
+        self.assertEqual(result, ("apm-policy",))
+
+    def test_gitlab_self_managed_via_env_only_tries_apm_policy(self):
+        with patch.dict(os.environ, {"GITLAB_HOST": "gitlab.example.com"}, clear=False):
+            result = _policy_repo_candidates("gitlab.example.com")
+        self.assertEqual(result, ("apm-policy",))
+
+    def test_gitlab_policy_repo_env_override(self):
+        with patch.dict(os.environ, {"APM_GITLAB_POLICY_REPO": "org-policy"}, clear=False):
+            result = _policy_repo_candidates("gitlab.com")
+        self.assertEqual(result, ("org-policy",))
 
 
 class TestFetchAdoContents(unittest.TestCase):
@@ -1392,6 +1465,249 @@ class TestGetTokenForHost(unittest.TestCase):
         token = _get_token_for_host("github.com")
         # All env vars are empty strings, which are falsy
         self.assertFalse(token)
+
+
+class TestFetchGitlabContents(unittest.TestCase):
+    """Test _fetch_gitlab_contents for the GitLab Repository Files API."""
+
+    def _auth_context(self, token: str | None):
+        ctx = MagicMock()
+        ctx.token = token
+        ctx.git_env = {}
+        return ctx
+
+    def _resolver(self, mock_resolver_cls, token: str | None):
+        # gitlab_rest_headers is a plain @staticmethod (no instance state), so
+        # delegate the mocked class's attribute to the real implementation --
+        # otherwise ``AuthResolver.gitlab_rest_headers(token)`` in production
+        # code would return a MagicMock instead of real headers. _RealAuthResolver
+        # was imported at module load time, before @patch replaced the name in
+        # apm_cli.core.auth, so it still points at the genuine class.
+        mock_resolver_cls.gitlab_rest_headers = _RealAuthResolver.gitlab_rest_headers
+
+        resolver = mock_resolver_cls.return_value
+        resolver.resolve.return_value = self._auth_context(token)
+        resolver.build_error_context.return_value = "\n    auth remediation"
+
+        def try_with_fallback(host, operation, **kwargs):
+            resolve_kwargs = {"org": kwargs.get("org")}
+            if kwargs.get("port") is not None:
+                resolve_kwargs["port"] = kwargs["port"]
+            ctx = resolver.resolve(host, **resolve_kwargs)
+            return operation(ctx.token, ctx.git_env)
+
+        resolver.try_with_fallback.side_effect = try_with_fallback
+        return resolver
+
+    @patch("apm_cli.core.auth.AuthResolver")
+    @patch("apm_cli.policy.discovery.requests.get")
+    def test_success(self, mock_get, mock_resolver_cls):
+        self._resolver(mock_resolver_cls, "my-gitlab-token")
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.text = VALID_POLICY_YAML
+        mock_get.return_value = mock_resp
+
+        content, error = _fetch_gitlab_contents("contoso", "apm-policy", "apm-policy.yml")
+        self.assertIsNone(error)
+        self.assertEqual(content, VALID_POLICY_YAML)
+        call_kwargs = mock_get.call_args
+        headers = call_kwargs[1].get("headers", {})
+        self.assertEqual(headers.get("PRIVATE-TOKEN"), "my-gitlab-token")
+        api_url = mock_get.call_args.args[0]
+        self.assertIn("/projects/contoso%2Fapm-policy/repository/files/", api_url)
+        self.assertIn("ref=HEAD", api_url)
+
+    @patch("apm_cli.core.auth.AuthResolver")
+    @patch("apm_cli.policy.discovery.requests.get")
+    def test_404_returns_error(self, mock_get, mock_resolver_cls):
+        self._resolver(mock_resolver_cls, "my-gitlab-token")
+        mock_resp = MagicMock()
+        mock_resp.status_code = 404
+        mock_get.return_value = mock_resp
+
+        content, error = _fetch_gitlab_contents("contoso", "apm-policy", "apm-policy.yml")
+        self.assertIsNone(content)
+        self.assertIn("404", error)
+
+    @patch("apm_cli.core.auth.AuthResolver")
+    @patch("apm_cli.policy.discovery.requests.get")
+    def test_410_returns_not_found_error(self, mock_get, mock_resolver_cls):
+        """Self-managed GitLab has been observed returning 410 for a missing project (#2566)."""
+        self._resolver(mock_resolver_cls, "my-gitlab-token")
+        mock_resp = MagicMock()
+        mock_resp.status_code = 410
+        mock_get.return_value = mock_resp
+
+        content, error = _fetch_gitlab_contents("contoso", "apm-policy", "apm-policy.yml")
+        self.assertIsNone(content)
+        self.assertIn("410", error)
+
+    @patch("apm_cli.core.auth.AuthResolver")
+    @patch("apm_cli.policy.discovery.requests.get")
+    def test_401_returns_error(self, mock_get, mock_resolver_cls):
+        resolver = self._resolver(mock_resolver_cls, "my-gitlab-token")
+        mock_resp = MagicMock()
+        mock_resp.status_code = 401
+        mock_get.return_value = mock_resp
+
+        content, error = _fetch_gitlab_contents("contoso", "apm-policy", "apm-policy.yml")
+        self.assertIsNone(content)
+        self.assertIn("401", error)
+        self.assertIn("auth remediation", error)
+        resolver.build_error_context.assert_called_once_with(
+            "gitlab.com", "fetch org policy", org="contoso"
+        )
+
+    @patch("apm_cli.core.auth.AuthResolver")
+    @patch("apm_cli.policy.discovery.requests.get")
+    def test_redirect_rejected(self, mock_get, mock_resolver_cls):
+        self._resolver(mock_resolver_cls, "my-gitlab-token")
+        mock_resp = MagicMock()
+        mock_resp.status_code = 302
+        mock_resp.headers = {"Location": "https://evil.example.com"}
+        mock_get.return_value = mock_resp
+
+        content, error = _fetch_gitlab_contents("contoso", "apm-policy", "apm-policy.yml")
+        self.assertIsNone(content)
+        self.assertIn("redirect", error.lower())
+
+    @patch("apm_cli.core.auth.AuthResolver")
+    @patch("apm_cli.policy.discovery.requests.get")
+    def test_no_auth_token_still_sends_request(self, mock_get, mock_resolver_cls):
+        """Unauthenticated requests are allowed (public GitLab projects)."""
+        self._resolver(mock_resolver_cls, None)
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.text = VALID_POLICY_YAML
+        mock_get.return_value = mock_resp
+
+        _content, error = _fetch_gitlab_contents("contoso", "apm-policy", "apm-policy.yml")
+        self.assertIsNone(error)
+        call_kwargs = mock_get.call_args
+        headers = call_kwargs[1].get("headers", {})
+        self.assertNotIn("PRIVATE-TOKEN", headers)
+        self.assertNotIn("Authorization", headers)
+
+    @patch("apm_cli.core.auth.AuthResolver")
+    @patch("apm_cli.policy.discovery.requests.get")
+    def test_custom_self_managed_host_and_port(self, mock_get, mock_resolver_cls):
+        resolver = self._resolver(mock_resolver_cls, "my-gitlab-token")
+        mock_get.return_value = MagicMock(status_code=200, text=VALID_POLICY_YAML)
+
+        with patch.dict(os.environ, {"GITLAB_HOST": "gitlab.example.test"}, clear=False):
+            content, error = _fetch_gitlab_contents(
+                "contoso",
+                "apm-policy",
+                "apm-policy.yml",
+                host="gitlab.example.test",
+                port=8443,
+            )
+
+        self.assertIsNone(error)
+        self.assertEqual(content, VALID_POLICY_YAML)
+        parsed = urlparse(mock_get.call_args.args[0])
+        self.assertEqual(parsed.hostname, "gitlab.example.test")
+        self.assertEqual(parsed.port, 8443)
+        resolver.resolve.assert_called_once_with(
+            "gitlab.example.test",
+            org="contoso",
+            port=8443,
+        )
+
+
+class TestFetchFromGitlabRepo(unittest.TestCase):
+    """Test _fetch_from_gitlab_repo orchestration around the GitLab transport."""
+
+    @patch("apm_cli.policy.discovery._fetch_gitlab_contents")
+    def test_200_caches_result(self, mock_fetch):
+        mock_fetch.return_value = (VALID_POLICY_YAML, None)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            result = _fetch_from_gitlab_repo(
+                org="contoso",
+                repo="apm-policy",
+                host="gitlab.com",
+                project_root=root,
+                no_cache=True,
+            )
+            self.assertTrue(result.found)
+            self.assertEqual(result.source, "org:gitlab.com/contoso/apm-policy")
+            self.assertFalse(result.cached)
+
+    @patch("apm_cli.policy.discovery._fetch_gitlab_contents")
+    def test_404_no_error(self, mock_fetch):
+        mock_fetch.return_value = (None, "404: Policy file not found")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = _fetch_from_gitlab_repo(
+                org="contoso",
+                repo="apm-policy",
+                host="gitlab.com",
+                project_root=Path(tmpdir),
+                no_cache=True,
+            )
+            self.assertFalse(result.found)
+            self.assertEqual(result.outcome, "absent")
+            self.assertIsNone(result.error)
+
+    @patch("apm_cli.policy.discovery._fetch_gitlab_contents")
+    def test_410_is_treated_as_absent_no_op(self, mock_fetch):
+        """410 on self-managed GitLab must be a clean no-op, not a warning (#2566)."""
+        mock_fetch.return_value = (None, "410: Policy file not found")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = _fetch_from_gitlab_repo(
+                org="contoso",
+                repo="apm-policy",
+                host="gitlab.example.test",
+                project_root=Path(tmpdir),
+                no_cache=True,
+            )
+            self.assertFalse(result.found)
+            self.assertEqual(result.outcome, "absent")
+            self.assertIsNone(result.error)
+
+    @patch("apm_cli.policy.discovery._fetch_gitlab_contents")
+    def test_api_error_uses_stale_cache(self, mock_fetch):
+        mock_fetch.return_value = (None, "Connection error fetching policy")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            repo_ref = "gitlab.com/contoso/apm-policy"
+            _write_cache(repo_ref, _make_test_policy(), root)
+            cache_dir = _get_cache_dir(root)
+            key = _cache_key(repo_ref)
+            meta_file = cache_dir / f"{key}.meta.json"
+            meta = json.loads(meta_file.read_text(encoding="utf-8"))
+            meta["cached_at"] = time.time() - DEFAULT_CACHE_TTL - 100
+            meta_file.write_text(json.dumps(meta), encoding="utf-8")
+
+            result = _fetch_from_gitlab_repo(
+                org="contoso",
+                repo="apm-policy",
+                host="gitlab.com",
+                project_root=root,
+            )
+            self.assertTrue(result.found)
+            self.assertTrue(result.cached)
+            self.assertEqual(result.outcome, "cached_stale")
+
+    @patch("apm_cli.policy.discovery._fetch_gitlab_contents")
+    def test_invalid_policy_yaml(self, mock_fetch):
+        mock_fetch.return_value = ("enforcement: bogus\n", None)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = _fetch_from_gitlab_repo(
+                org="contoso",
+                repo="apm-policy",
+                host="gitlab.com",
+                project_root=Path(tmpdir),
+                no_cache=True,
+            )
+            self.assertFalse(result.found)
+            self.assertIn("Invalid policy", result.error)
 
 
 class TestPolicyFetchResult(unittest.TestCase):


### PR DESCRIPTION
## Summary

- GitLab rejects project paths starting with `.` or `_`, so every candidate in the existing discovery cascade (`.github-private`, `.github`, `.apm`, `_apm`) is an invalid GitLab project path -- org-policy auto-discovery was impossible on GitLab (self-hosted or gitlab.com).
- Adds a GitLab host branch to `_policy_repo_candidates()` using `apm-policy` as the default project name (override via `APM_GITLAB_POLICY_REPO`), mirroring the existing ADO project-coordinate fix (#2450).
- Adds `_fetch_from_gitlab_repo` / `_fetch_gitlab_contents`, mirroring the existing ADO fetch path but using GitLab's REST v4 Repository Files API (`/projects/:id/repository/files/:file_path/raw`).
- Both 404 and 410 (self-managed GitLab has been observed returning 410 for a missing project) now resolve to a clean `absent` outcome instead of a fetch-failure warning on every `apm install` / `apm audit`.
- `extends: org` in an inherited policy chain works for GitLab for free, since it re-enters the now-fixed auto-discovery path.
- Cites the existing pluggable-discovery requirement `req-pl-011` (Section 6.1.1, which already names `gitlab-project-yml` as an example provider) with a new conformance test, satisfying the Mode B silent-extension gate for this critical-path change. `CONFORMANCE.{md,json}` regenerated accordingly.
- **New:** `APM_GITLAB_POLICY_ROOT_GROUP` -- self-managed GitLab discovery is scoped per root group by default (first path segment of the project's git remote), same as GitHub's `owner/apm-policy` model. A company running a self-managed instance with many independent root groups (one per team/department) would otherwise need an `apm-policy` project under every one of them. This env var lets every project on that instance resolve org policy at one designated root group instead. Ignored on `gitlab.com` (exact hostname match) -- verified against real gitlab.com traffic that the override has no effect there even when set.

**Known trade-off (not addressed here):** this fetch path is REST-only, like the existing GitHub/ADO fetchers. Elsewhere in this codebase (`download_strategies.py::download_gitlab_file`), GitLab file fetches go git-transport-first specifically because some self-hosted GitLab instances disable/block the REST API entirely (documented there as "the 410-killer"). If that's also true for an org's *policy* repo, this fix still produces the correct user-facing outcome (a clean "absent", not an error) but for the "wrong" reason (API blocked vs. genuinely no policy). Adding git-transport-first to policy discovery would be a larger change to a currently REST-only-for-every-host code path; flagging as a scoped-out follow-up rather than silently doing it.

**Also observed during live testing (not a bug in this PR):** a GitLab project that was recently renamed or deleted keeps redirecting its old path for a grace period; the existing redirect-refusal guard (inherited unchanged from the GitHub/ADO fetchers, a deliberate SSRF protection) surfaces that as a fetch-failure notice rather than a clean absent. A genuinely never-created policy project resolves to a clean `absent` as expected. Worth a separate follow-up issue if it matters in practice.

Deliberately out of scope (tracked in the umbrella issue #1925 the report links to): routing an explicit `apm audit --policy <owner/repo>` override or an explicit (non-`org`) `extends:` ref through GitLab's API. Those go through the GitHub-Contents-API-shaped path today regardless of host, which is a pre-existing gap this issue doesn't ask to close.

Closes #2566.