### PR TITLE
Add --category to marketplace package add/set

### DIFF
--- a/src/apm_cli/commands/marketplace/plugin/add.py
+++ b/src/apm_cli/commands/marketplace/plugin/add.py
@@ -36,6 +36,7 @@ from . import (
 @click.option("-s", "--subdir", default=None, help="Subdirectory inside source repo")
 @click.option("--tag-pattern", default=None, help="Tag pattern (e.g. 'v{version}')")
 @click.option("--tags", default=None, help="Comma-separated tags")
+@click.option("--category", default=None, help="Marketplace category")
 @click.option("--include-prerelease", is_flag=True, help="Include prerelease versions")
 @click.option("--no-verify", is_flag=True, help="Skip remote reachability check")
 @click.option("--verbose", "-v", is_flag=True, help="Show detailed output")
@@ -47,6 +48,7 @@ def add(
     subdir,
     tag_pattern,
     tags,
+    category,
     include_prerelease,
     no_verify,
     verbose,
@@ -85,6 +87,7 @@ def add(
             tag_pattern=tag_pattern,
             tags=parsed_tags,
             include_prerelease=include_prerelease,
+            category=category,
         )
     except MarketplaceYmlError as exc:
         logger.error(str(exc), symbol="error")

--- a/src/apm_cli/commands/marketplace/plugin/set.py
+++ b/src/apm_cli/commands/marketplace/plugin/set.py
@@ -28,6 +28,7 @@ from . import (
 @click.option("--subdir", default=None, help="Subdirectory inside source repo")
 @click.option("--tag-pattern", default=None, help="Tag pattern (e.g. 'v{version}')")
 @click.option("--tags", default=None, help="Comma-separated tags")
+@click.option("--category", default=None, help="Marketplace category")
 @click.option(
     "--include-prerelease",
     is_flag=True,
@@ -42,6 +43,7 @@ def set_cmd(
     subdir,
     tag_pattern,
     tags,
+    category,
     include_prerelease,
     verbose,
 ):
@@ -92,6 +94,8 @@ def set_cmd(
         fields["tag_pattern"] = tag_pattern
     if parsed_tags is not None:
         fields["tags"] = parsed_tags
+    if category is not None:
+        fields["category"] = category
     if include_prerelease is not None:
         fields["include_prerelease"] = include_prerelease
 

--- a/src/apm_cli/marketplace/yml_editor.py
+++ b/src/apm_cli/marketplace/yml_editor.py
@@ -151,6 +151,12 @@ def _validate_subdir(subdir: str) -> None:
         raise MarketplaceYmlError(str(exc)) from exc
 
 
+def _validate_category(category: str) -> None:
+    """Validate *category* is a non-empty string."""
+    if not isinstance(category, str) or not category.strip():
+        raise MarketplaceYmlError("'category' must be a non-empty string")
+
+
 # -------------------------------------------------------------------
 # Public API
 # -------------------------------------------------------------------
@@ -167,6 +173,7 @@ def add_plugin_entry(
     tag_pattern: str | None = None,
     tags: list[str] | None = None,
     include_prerelease: bool = False,
+    category: str | None = None,
 ) -> str:
     """Append a new entry to ``packages[]``.
 
@@ -187,6 +194,9 @@ def add_plugin_entry(
 
     if subdir is not None:
         _validate_subdir(subdir)
+
+    if category is not None:
+        _validate_category(category)
 
     # Derive name from source repo if not provided.
     if name is None:
@@ -225,6 +235,8 @@ def add_plugin_entry(
         new_entry["include_prerelease"] = True
     if tags is not None and len(tags) > 0:
         new_entry["tags"] = tags
+    if category is not None:
+        new_entry["category"] = category
 
     packages.append(new_entry)
 
@@ -267,11 +279,13 @@ def update_plugin_entry(yml_path: Path, name: str, **fields) -> None:
             del entry["version"]
 
     # Simple scalar fields.
-    _SIMPLE_FIELDS = ("subdir", "tag_pattern")
+    _SIMPLE_FIELDS = ("subdir", "tag_pattern", "category")
     for key in _SIMPLE_FIELDS:
         if key in fields and fields[key] is not None:
             if key == "subdir":
                 _validate_subdir(fields[key])
+            elif key == "category":
+                _validate_category(fields[key])
             entry[key] = fields[key]
 
     # Boolean field: include_prerelease.

--- a/tests/unit/marketplace/test_yml_editor.py
+++ b/tests/unit/marketplace/test_yml_editor.py
@@ -77,6 +77,7 @@ class TestAddPluginHappy:
             tag_pattern="v{version}",
             tags=["utilities", "testing"],
             include_prerelease=True,
+            category="Productivity",
         )
         assert name == "full-tool"
         data = yaml.safe_load(yml.read_text(encoding="utf-8"))
@@ -85,6 +86,7 @@ class TestAddPluginHappy:
         assert added["tag_pattern"] == "v{version}"
         assert added["tags"] == ["utilities", "testing"]
         assert added["include_prerelease"] is True
+        assert added["category"] == "Productivity"
 
     def test_name_defaults_to_repo_from_source(self, tmp_path):
         yml = _write_yml(tmp_path, _BASIC_YML)
@@ -188,6 +190,16 @@ class TestAddPluginErrors:
                 subdir="../etc",
             )
 
+    def test_blank_category_raises(self, tmp_path):
+        yml = _write_yml(tmp_path, _BASIC_YML)
+        with pytest.raises(MarketplaceYmlError, match="category"):
+            add_plugin_entry(
+                yml,
+                source="acme/tool",
+                version=">=1.0.0",
+                category="   ",
+            )
+
 
 # ---------------------------------------------------------------------------
 # add_plugin_entry - comment preservation
@@ -236,6 +248,13 @@ class TestUpdatePluginHappy:
         data = yaml.safe_load(yml.read_text(encoding="utf-8"))
         entry = data["packages"][0]
         assert entry["subdir"] == "src/plugin"
+
+    def test_update_category(self, tmp_path):
+        yml = _write_yml(tmp_path, _BASIC_YML)
+        update_plugin_entry(yml, "existing-package", category="Productivity")
+        data = yaml.safe_load(yml.read_text(encoding="utf-8"))
+        entry = data["packages"][0]
+        assert entry["category"] == "Productivity"
 
     def test_setting_ref_clears_version(self, tmp_path):
         yml = _write_yml(tmp_path, _BASIC_YML)
@@ -289,6 +308,11 @@ class TestUpdatePluginHappy:
 
 
 class TestUpdatePluginErrors:
+    def test_blank_category_raises(self, tmp_path):
+        yml = _write_yml(tmp_path, _BASIC_YML)
+        with pytest.raises(MarketplaceYmlError, match="category"):
+            update_plugin_entry(yml, "existing-package", category="   ")
+
     def test_package_not_found_raises(self, tmp_path):
         yml = _write_yml(tmp_path, _BASIC_YML)
         with pytest.raises(MarketplaceYmlError, match="not found"):


### PR DESCRIPTION
Closes #2625.

Marketplace manifest entries already support a `category` field — the schema validates it (`yml_schema.py`, "must be a non-empty string") and the output mappers already emit it (`output_mappers.py`), per the issue's own description. The CLI only exposed `--tags`, so getting a category into `marketplace.packages[]` required a manual `apm.yml` edit.

Adds `--category TEXT` to both `apm marketplace package add` and `apm marketplace package set`, mirroring the existing `--tags` plumbing through `yml_editor.py`'s `add_plugin_entry`/`update_plugin_entry`, with the same non-empty validation the schema already enforces on read (so an invalid/blank value fails immediately with an actionable message rather than persisting bad data that only fails later on `check`).

Verified end-to-end manually (`marketplace package add ... --category "Productivity"` persists correctly; `--category "   "` fails with `'category' must be a non-empty string`), plus new unit tests in `test_yml_editor.py` covering both the happy path and the validation error for `add` and `set`. Full marketplace test suite: 1511 passed. `ruff check` clean on all changed files.

Acceptance criteria from the issue:
- [x] Both commands accept `--category`
- [x] Invalid or blank categories fail with an actionable error
- [x] The field is persisted in `marketplace.packages[]`
- [x] `apm marketplace check` and `apm pack` preserve and emit category (already worked once present — pre-existing code, not touched here)
- [x] Command help and tests cover the new option