### PR TITLE
fix(deps): invalidate the manifest parse cache when apm.yml is rewritten, so re-downloads re-stamp

### DIFF
--- a/src/apm_cli/deps/github_downloader.py
+++ b/src/apm_cli/deps/github_downloader.py
@@ -1059,6 +1059,15 @@ class GitHubPackageDownloader:
         apm_yml_path = target_path / "apm.yml"
         atomic_write_text(apm_yml_path, apm_yml_content)
 
+        # Uniform invariant: every apm.yml rewrite inside a package tree
+        # drops stale from_apm_yml cache entries (virtual manifests are
+        # deterministic so a stale hit is currently harmless, but keeping
+        # the invariant unconditional prevents a silent divergence if the
+        # synthesized content ever gains run-dependent fields).
+        from ..models.apm_package import invalidate_apm_yml_cache_entry
+
+        invalidate_apm_yml_cache_entry(apm_yml_path)
+
         # Create APMPackage object
         package = APMPackage(
             name=package_name,
@@ -1822,6 +1831,9 @@ class GitHubPackageDownloader:
                     package = validation_result.package
                     package.source = dep_ref.to_github_url()
                     package.resolved_commit = resolved_ref.resolved_commit
+                    # Single stamping implementation (shared with the clone
+                    # paths): also invalidates the from_apm_yml cache entry
+                    # after rewriting apm.yml (apm#2619 migration fallout).
                     from .package_validator import stamp_plugin_version
 
                     stamp_plugin_version(

--- a/src/apm_cli/deps/package_validator.py
+++ b/src/apm_cli/deps/package_validator.py
@@ -301,3 +301,10 @@ def stamp_plugin_version(
     data = load_yaml(apm_yml_path) or {}
     data["version"] = short_sha
     dump_yaml(data, apm_yml_path)
+
+    # The file content just changed: drop stale from_apm_yml cache entries
+    # so other cache keys (different source_path anchors) cannot keep
+    # serving the pre-stamp instance (apm#2619 migration fallout).
+    from ..models.apm_package import invalidate_apm_yml_cache_entry
+
+    invalidate_apm_yml_cache_entry(apm_yml_path)

--- a/src/apm_cli/deps/plugin_parser.py
+++ b/src/apm_cli/deps/plugin_parser.py
@@ -615,6 +615,14 @@ def synthesize_apm_yml_from_plugin(plugin_path: Path, manifest: dict[str, Any]) 
     # download_virtual_file_package().
     write_text_lf(apm_yml_path, apm_yml_content)
 
+    # The file content just changed: drop stale from_apm_yml cache entries,
+    # or a same-process re-download of this package would read the OLD
+    # instance (possibly already SHA-stamped) and skip re-stamping the
+    # freshly synthesized 0.0.0 manifest (apm#2619 migration fallout).
+    from ..models.apm_package import invalidate_apm_yml_cache_entry
+
+    invalidate_apm_yml_cache_entry(apm_yml_path)
+
     return apm_yml_path
 
 

--- a/src/apm_cli/models/apm_package.py
+++ b/src/apm_cli/models/apm_package.py
@@ -7,6 +7,7 @@ compatibility.
 """
 
 import logging
+import threading
 from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -63,6 +64,7 @@ __all__ = [  # noqa: RUF022
     "PackageInfo",
     "build_installed_package_info",
     "clear_apm_yml_cache",
+    "invalidate_apm_yml_cache_entry",
     "surviving_dependency_refs_for_reintegration",
 ]
 
@@ -73,11 +75,54 @@ __all__ = [  # noqa: RUF022
 # declared them. Sharing one APMPackage instance across both would let the
 # resolver mutate ``source_path`` and poison the cache for the other consumer.
 _apm_yml_cache: dict[tuple[Path, Path | None], "APMPackage"] = {}
+# Guards every structural mutation of ``_apm_yml_cache``. The parallel
+# pre-download executor and the BFS resolver pool both insert entries from
+# worker threads while ``invalidate_apm_yml_cache_entry`` iterates the dict;
+# an unguarded concurrent insert would raise ``RuntimeError: dictionary
+# changed size during iteration`` and fail the install intermittently.
+# Lock-free ``dict.get`` reads stay safe: the lookup executes as one
+# GIL-held C-level dict operation, so it cannot observe a torn mutation.
+_apm_yml_cache_lock = threading.Lock()
+
+# Bumped under the lock by every invalidation/clear. ``from_apm_yml``
+# snapshots it BEFORE reading the file and skips its insert (still
+# returning the parsed result) when the generation moved: an in-flight
+# parse that read PRE-rewrite bytes must not re-poison the cache AFTER
+# the rewrite's invalidation ran. Global (not per-path) on purpose --
+# the cost of over-invalidation is one extra parse on the next load,
+# and a per-path map would reintroduce the iteration/mutation problem
+# the lock exists to solve.
+_apm_yml_cache_generation = 0
 
 
 def clear_apm_yml_cache() -> None:
     """Clear the from_apm_yml parse cache. Call in tests for isolation."""
-    _apm_yml_cache.clear()
+    global _apm_yml_cache_generation
+    with _apm_yml_cache_lock:
+        _apm_yml_cache_generation += 1
+        _apm_yml_cache.clear()
+
+
+def invalidate_apm_yml_cache_entry(apm_yml_path: Path) -> None:
+    """Drop every cache entry for *apm_yml_path* (all source_path variants).
+
+    MUST be called after rewriting an ``apm.yml`` on disk within a run
+    (marketplace-plugin synthesis, ``stamp_plugin_version``). The cache
+    assumes file content is stable for the process lifetime; a rewrite
+    breaks that. Concretely (apm#2619 migration surfaced this): when a
+    same-process re-download re-synthesized a marketplace plugin's
+    ``apm.yml`` at ``version: 0.0.0``, ``from_apm_yml`` returned the STALE
+    cached instance -- already stamped to the short commit SHA earlier in
+    the run -- so ``stamp_plugin_version``'s ``version == "0.0.0"`` guard
+    skipped, leaving an unstamped tree on disk whose content hash matched
+    neither the lockfile record nor a fresh install's tree.
+    """
+    global _apm_yml_cache_generation
+    resolved = apm_yml_path.resolve()
+    with _apm_yml_cache_lock:
+        _apm_yml_cache_generation += 1
+        for key in [k for k in _apm_yml_cache if k[0] == resolved]:
+            _apm_yml_cache.pop(key, None)
 
 
 def _parse_v01_registries_block(
@@ -616,6 +661,13 @@ class APMPackage:
         if cached is not None:
             return cached
 
+        # Snapshot BEFORE reading the file: if an invalidation lands while
+        # this thread parses (a concurrent rewrite of the manifest), the
+        # insert below is skipped so pre-rewrite bytes cannot re-poison
+        # the cache. Plain int read is GIL-atomic; writers bump under the
+        # lock.
+        generation_snapshot = _apm_yml_cache_generation
+
         try:
             from ..utils.yaml_io import load_yaml
 
@@ -632,7 +684,9 @@ class APMPackage:
             source_path=resolved_source,
             manifest_path=apm_yml_path,
         )
-        _apm_yml_cache[cache_key] = result
+        with _apm_yml_cache_lock:
+            if _apm_yml_cache_generation == generation_snapshot:
+                _apm_yml_cache[cache_key] = result
         return result
 
     def get_apm_dependencies(self) -> list[DependencyReference]:

--- a/tests/unit/deps/test_stamp_plugin_version.py
+++ b/tests/unit/deps/test_stamp_plugin_version.py
@@ -89,21 +89,6 @@ def test_no_op_when_apm_yml_is_missing(tmp_path):
     assert not (tmp_path / "apm.yml").exists()
 
 
-def test_no_op_when_package_is_none(tmp_path):
-    apm_yml = tmp_path / "apm.yml"
-    apm_yml.write_text("name: foo\nversion: 0.0.0\n", encoding="utf-8")
-
-    # Should not raise.
-    stamp_plugin_version(
-        None,
-        PackageType.MARKETPLACE_PLUGIN,
-        "abcdef1234567890aabbccddeeff00112233abcd",
-        tmp_path,
-    )
-
-    assert "version: 0.0.0" in apm_yml.read_text(encoding="utf-8")
-
-
 @pytest.mark.windows_compat
 def test_stamped_manifest_bytes_are_lf_only(tmp_path):
     """The stamped apm.yml lands inside a package tree hashed raw by
@@ -125,3 +110,176 @@ def test_stamped_manifest_bytes_are_lf_only(tmp_path):
     assert b"version: abcdef1" in raw
     assert b"\r" not in raw
     assert raw.endswith(b"\n")
+
+
+def test_no_op_when_package_is_none(tmp_path):
+    apm_yml = tmp_path / "apm.yml"
+    apm_yml.write_text("name: foo\nversion: 0.0.0\n", encoding="utf-8")
+
+    # Should not raise.
+    stamp_plugin_version(
+        None,
+        PackageType.MARKETPLACE_PLUGIN,
+        "abcdef1234567890aabbccddeeff00112233abcd",
+        tmp_path,
+    )
+
+    assert "version: 0.0.0" in apm_yml.read_text(encoding="utf-8")
+
+
+@pytest.mark.windows_compat
+def test_stamp_invalidates_from_apm_yml_cache(tmp_path):
+    """Stamping rewrites apm.yml, so cached from_apm_yml instances for that
+    path must be dropped -- a stale pre-stamp instance elsewhere in the run
+    would disagree with the on-disk bytes (apm#2619 migration fallout)."""
+    from apm_cli.models.apm_package import APMPackage
+
+    apm_yml = tmp_path / "apm.yml"
+    apm_yml.write_bytes(b"name: foo\nversion: 0.0.0\n")
+    first = APMPackage.from_apm_yml(apm_yml)  # populate the cache
+    assert first.version == "0.0.0"
+
+    stamp_plugin_version(
+        _pkg("0.0.0"),
+        PackageType.MARKETPLACE_PLUGIN,
+        "abcdef1234567890aabbccddeeff00112233abcd",
+        tmp_path,
+    )
+
+    reloaded = APMPackage.from_apm_yml(apm_yml)
+    assert reloaded is not first
+    assert reloaded.version == "abcdef1"
+
+
+@pytest.mark.windows_compat
+def test_restamp_after_resynthesis_is_not_skipped_by_stale_cache(tmp_path):
+    """The apm#2619 double-download interplay, distilled.
+
+    Real flow: download #1 synthesizes apm.yml (0.0.0), stamps it to the
+    short SHA; a content-hash mismatch forces a re-download in the SAME
+    process; download #2 re-synthesizes a fresh 0.0.0 manifest. Without
+    cache invalidation, from_apm_yml returned the STALE stamped instance,
+    the ``version == "0.0.0"`` stamp guard skipped, and the tree stayed
+    unstamped on disk -- hashing to a value no lockfile ever recorded.
+    """
+    from apm_cli.deps.plugin_parser import synthesize_apm_yml_from_plugin
+    from apm_cli.models.apm_package import APMPackage
+
+    sha = "2c7ec5e78b8e5d43ea02e90bb8826f6b9f147b0c"
+    plugin = tmp_path / "plug"
+    skill = plugin / "skills" / "demo"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_bytes(b"---\nname: demo\ndescription: Demo\n---\n\n# Demo\n")
+
+    # Download #1: synthesize + stamp.
+    apm_yml = synthesize_apm_yml_from_plugin(plugin, {"name": "plug"})
+    pkg = APMPackage.from_apm_yml(apm_yml)
+    stamp_plugin_version(pkg, PackageType.MARKETPLACE_PLUGIN, sha, plugin)
+    assert b"version: 2c7ec5e" in apm_yml.read_bytes()
+
+    # Re-download: pristine tree, fresh synthesis (no existing manifest).
+    apm_yml.unlink()
+    synthesize_apm_yml_from_plugin(plugin, {"name": "plug"})
+
+    fresh = APMPackage.from_apm_yml(apm_yml)
+    assert fresh.version == "0.0.0"  # stale cache would still say 2c7ec5e
+
+    # The second stamp must therefore actually run.
+    stamp_plugin_version(fresh, PackageType.MARKETPLACE_PLUGIN, sha, plugin)
+    assert fresh.version == "2c7ec5e"
+    assert b"version: 2c7ec5e" in apm_yml.read_bytes()
+
+
+def test_cache_invalidation_is_safe_under_concurrent_inserts(tmp_path):
+    """apm#2619 round-3: invalidate_apm_yml_cache_entry iterates the shared
+    manifest cache while parallel download/resolver worker threads insert
+    into it. Without the module lock this raised 'RuntimeError: dictionary
+    changed size during iteration' and failed installs intermittently."""
+    import threading
+
+    from apm_cli.models.apm_package import (
+        APMPackage,
+        invalidate_apm_yml_cache_entry,
+    )
+
+    apm_yml = tmp_path / "apm.yml"
+    apm_yml.write_bytes(b"name: foo\nversion: 0.0.0\n")
+
+    stop = threading.Event()
+    errors: list[BaseException] = []
+
+    def inserter() -> None:
+        # Distinct source_path anchors create distinct cache keys, growing
+        # the dict while the main thread iterates it.
+        i = 0
+        while not stop.is_set():
+            i += 1
+            anchor = tmp_path / f"anchor-{i}"
+            anchor.mkdir(exist_ok=True)
+            try:
+                APMPackage.from_apm_yml(apm_yml, source_path=anchor)
+            except BaseException as exc:  # pragma: no cover - failure capture
+                errors.append(exc)
+                return
+
+    thread = threading.Thread(target=inserter, daemon=True)
+    thread.start()
+    try:
+        for _ in range(300):
+            invalidate_apm_yml_cache_entry(apm_yml)
+    except BaseException as exc:  # pragma: no cover - failure capture
+        errors.append(exc)
+    finally:
+        stop.set()
+        thread.join(timeout=10)
+
+    assert not thread.is_alive(), "inserter thread wedged"
+    assert not errors, errors
+    # Drop the many unique-keyed entries this test added.
+    from apm_cli.models.apm_package import clear_apm_yml_cache
+
+    clear_apm_yml_cache()
+
+
+def test_in_flight_parse_cannot_repoison_cache_after_invalidation(tmp_path):
+    """Round-4 review: invalidation is a barrier for in-flight parses.
+
+    A thread that read PRE-rewrite bytes must not insert its stale result
+    into the cache AFTER a rewrite's invalidation ran -- otherwise the
+    exact staleness the invalidation exists to fix comes back, dependent
+    on thread interleaving. from_apm_yml snapshots a generation counter
+    before reading the file and skips the insert if it moved.
+    """
+    from unittest.mock import patch
+
+    from apm_cli.models.apm_package import (
+        APMPackage,
+        invalidate_apm_yml_cache_entry,
+    )
+
+    apm_yml = tmp_path / "apm.yml"
+    apm_yml.write_bytes(b"name: foo\nversion: 0.0.0\n")
+
+    import apm_cli.utils.yaml_io as yaml_io_mod
+
+    real_load = yaml_io_mod.load_yaml
+
+    def load_with_concurrent_rewrite(path):
+        data = real_load(path)
+        # Simulate a concurrent rewrite + invalidation landing while this
+        # "thread" is still holding the pre-rewrite parse result.
+        apm_yml.write_bytes(b"name: foo\nversion: 2c7ec5e\n")
+        invalidate_apm_yml_cache_entry(apm_yml)
+        return data
+
+    with patch(
+        "apm_cli.utils.yaml_io.load_yaml",
+        side_effect=load_with_concurrent_rewrite,
+    ):
+        stale = APMPackage.from_apm_yml(apm_yml)
+    assert stale.version == "0.0.0"  # the in-flight parse itself is fine
+
+    # The stale result must NOT have been cached: a fresh load sees the
+    # rewritten bytes.
+    fresh = APMPackage.from_apm_yml(apm_yml)
+    assert fresh.version == "2c7ec5e"


### PR DESCRIPTION
> Originally stacked on #2620; now **rebased onto `main`** (post-merge) as a single commit.

## Summary

Fixes a pre-existing bug surfaced while verifying #2620 end-to-end: `APMPackage.from_apm_yml` memoizes per path for the process lifetime, but marketplace-plugin flows rewrite `apm.yml` twice within a run (synthesis at `0.0.0`, then the short-SHA stamp). On a **same-process re-download** (e.g. integrate's content-hash mismatch pre-check rmtrees and re-acquires), re-synthesis writes a fresh `0.0.0` manifest but `from_apm_yml` returns the stale stamped instance — `stamp_plugin_version`'s `version == "0.0.0"` guard skips, and the tree is left **unstamped** on disk, hashing to a value no lockfile ever recorded.

Observable on current main (#2620 included): `apm install --update` against a stale lockfile records the unstamped-tree hash, and every subsequent fresh install hard-fails the supply-chain check with a hash matching neither domain. (Empirically reproduced with `anthropics/skills`.)

## Fix

- `invalidate_apm_yml_cache_entry(path)`, called from every `apm.yml` rewrite site inside package trees (synthesis, `stamp_plugin_version`, virtual-file manifests).
- Cache mutations hold a module lock — the invalidation iterates the dict while parallel pre-download/resolver worker threads insert into it (`RuntimeError: dictionary changed size during iteration`, reproduced; stress test included).
- A generation counter makes invalidation a barrier for in-flight parses: a parse that read pre-rewrite bytes skips its cache insert (the caching lives in `from_apm_yml`; `from_mapping` stays cache-free).
- `download_package`'s persistent-cache fast path already routes through `stamp_plugin_version` since #2654 — with the invalidation now inside `stamp_plugin_version`, that shared implementation also becomes safe on same-process re-downloads.

With this, `apm install --update` becomes a safe migration path for pre-#2620 Windows lockfiles. Full auto-migration is stacked PR #2628.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
