### PR TITLE
feat(install): auto-migrate legacy CRLF-domain lockfiles and warm trees (apm#2619)

### DIFF
--- a/.github/workflows/crlf-invariance.yml
+++ b/.github/workflows/crlf-invariance.yml
@@ -23,6 +23,7 @@ on:
       - 'src/apm_cli/deps/package_validator.py'
       - 'src/apm_cli/deps/github_downloader.py'
       - 'src/apm_cli/models/validation.py'
+      - 'src/apm_cli/install/legacy_crlf.py'
       - 'scripts/crlf_invariance_probe.py'
       - '.github/workflows/crlf-invariance.yml'
   push:
@@ -35,6 +36,7 @@ on:
       - 'src/apm_cli/deps/package_validator.py'
       - 'src/apm_cli/deps/github_downloader.py'
       - 'src/apm_cli/models/validation.py'
+      - 'src/apm_cli/install/legacy_crlf.py'
       - 'scripts/crlf_invariance_probe.py'
       - '.github/workflows/crlf-invariance.yml'
   # Merge queues do not support path filtering; run unconditionally there so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Lockfiles and warm `apm_modules` trees recorded by a pre-#2620 APM on
+  Windows are now migrated automatically: when a locked hash matches the
+  fresh tree re-hashed with only APM-authored files (synthetic `apm.yml`,
+  inline-hooks `hooks.json`) expanded to the legacy CRLF domain, the install
+  accepts it once, converges the tree to LF, warns, and re-records the
+  platform-independent hash. Any other mismatch still hard-fails the
+  supply-chain check, and `resolved_commit` pins are preserved. (#2628,
+  follow-up to #2619)
+
 ## [0.29.0] - 2026-08-26
 
 ### Added

--- a/src/apm_cli/deps/github_downloader.py
+++ b/src/apm_cli/deps/github_downloader.py
@@ -1059,6 +1059,15 @@ class GitHubPackageDownloader:
         apm_yml_path = target_path / "apm.yml"
         atomic_write_text(apm_yml_path, apm_yml_content)
 
+        # Uniform invariant: every apm.yml rewrite inside a package tree
+        # drops stale from_apm_yml cache entries (virtual manifests are
+        # deterministic so a stale hit is currently harmless, but keeping
+        # the invariant unconditional prevents a silent divergence if the
+        # synthesized content ever gains run-dependent fields).
+        from ..models.apm_package import invalidate_apm_yml_cache_entry
+
+        invalidate_apm_yml_cache_entry(apm_yml_path)
+
         # Create APMPackage object
         package = APMPackage(
             name=package_name,
@@ -1822,6 +1831,9 @@ class GitHubPackageDownloader:
                     package = validation_result.package
                     package.source = dep_ref.to_github_url()
                     package.resolved_commit = resolved_ref.resolved_commit
+                    # Single stamping implementation (shared with the clone
+                    # paths): also invalidates the from_apm_yml cache entry
+                    # after rewriting apm.yml (apm#2619 migration fallout).
                     from .package_validator import stamp_plugin_version
 
                     stamp_plugin_version(

--- a/src/apm_cli/deps/package_validator.py
+++ b/src/apm_cli/deps/package_validator.py
@@ -301,3 +301,10 @@ def stamp_plugin_version(
     data = load_yaml(apm_yml_path) or {}
     data["version"] = short_sha
     dump_yaml(data, apm_yml_path)
+
+    # The file content just changed: drop stale from_apm_yml cache entries
+    # so other cache keys (different source_path anchors) cannot keep
+    # serving the pre-stamp instance (apm#2619 migration fallout).
+    from ..models.apm_package import invalidate_apm_yml_cache_entry
+
+    invalidate_apm_yml_cache_entry(apm_yml_path)

--- a/src/apm_cli/deps/plugin_parser.py
+++ b/src/apm_cli/deps/plugin_parser.py
@@ -615,6 +615,14 @@ def synthesize_apm_yml_from_plugin(plugin_path: Path, manifest: dict[str, Any]) 
     # download_virtual_file_package().
     write_text_lf(apm_yml_path, apm_yml_content)
 
+    # The file content just changed: drop stale from_apm_yml cache entries,
+    # or a same-process re-download of this package would read the OLD
+    # instance (possibly already SHA-stamped) and skip re-stamping the
+    # freshly synthesized 0.0.0 manifest (apm#2619 migration fallout).
+    from ..models.apm_package import invalidate_apm_yml_cache_entry
+
+    invalidate_apm_yml_cache_entry(apm_yml_path)
+
     return apm_yml_path
 
 

--- a/src/apm_cli/install/legacy_crlf.py
+++ b/src/apm_cli/install/legacy_crlf.py
@@ -1,0 +1,301 @@
+"""Migration helpers for the apm#2619 / apm#2187 CRLF hash-domain bugs.
+
+APM versions before the apm#2619 fix wrote the files APM itself authors
+INSIDE installed package trees with platform-native line endings: the
+synthesized ``apm.yml`` for marketplace plugins (written by
+``synthesize_apm_yml_from_plugin`` and rewritten by
+``stamp_plugin_version``), the inline-hooks ``.apm/hooks/hooks.json``,
+and -- before 0.26.0 / apm#2187 -- the virtual-file package ``apm.yml``.
+On Windows those writes produced CRLF bytes, and because
+``compute_package_hash`` hashes raw bytes, the recorded lockfile
+``content_hash`` landed in a Windows-only "CRLF domain".
+
+The fix makes every such write LF-deterministic, which leaves two legacy
+artifacts behind:
+
+1. **Lockfiles recorded by a pre-fix Windows APM** carry the CRLF-domain
+   hash. A post-fix fresh download produces the LF-domain hash, and the
+   supply-chain check would hard-fail with a misleading
+   "supply-chain attack" message. :func:`legacy_crlf_hash` computes the
+   CRLF-domain equivalent of the freshly downloaded tree so the caller
+   can recognize this exact benign difference and accept + re-record the
+   platform-independent hash instead.
+
+2. **Warm ``apm_modules`` trees materialized by a pre-fix Windows APM**
+   still hold CRLF bytes in the APM-authored files. The cached install
+   path re-records the hash of the on-disk tree, so without intervention
+   the stale CRLF hash would be copied into every regenerated lockfile
+   forever. :func:`converge_apm_authored_files` rewrites exactly those
+   files to LF so the tree (and hence the recorded hash) converges to
+   what a fresh post-fix download produces.
+
+Only files APM itself authored are ever considered. Upstream content is
+never touched: git-materialized bytes are identical on every OS at a
+pinned commit, and normalizing them would CREATE divergence against a
+fresh download (which byte-copies them). For the same reason
+``.apm/hooks/hooks.json`` is only treated as APM-authored when the
+plugin manifest declares ``hooks`` as an INLINE object -- when ``hooks``
+names a config file, hooks.json is a byte-copy of upstream content.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from apm_cli.utils.atomic_io import atomic_write_text
+from apm_cli.utils.content_hash import compute_package_hash_with_overrides
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_MARKETPLACE_PLUGIN = "marketplace_plugin"
+
+
+def _package_type_value(package_type: Any) -> str | None:
+    """Normalize a PackageType enum / plain string / None to its string value."""
+    if package_type is None:
+        return None
+    return str(getattr(package_type, "value", package_type))
+
+
+def _is_virtual_file_dep(dep_ref: Any) -> bool:
+    """True when *dep_ref* is a virtual single-file dependency (apm#2187 class)."""
+    if dep_ref is None or not getattr(dep_ref, "is_virtual", False):
+        return False
+    is_virtual_file = getattr(dep_ref, "is_virtual_file", None)
+    if not callable(is_virtual_file):
+        return False
+    try:
+        return bool(is_virtual_file())
+    except Exception:
+        return False
+
+
+def _has_inline_hooks(install_path: Path) -> bool:
+    """True when the tree's plugin manifest declares ``hooks`` as an inline dict.
+
+    Fail-closed: any lookup or parse problem returns False, so hooks.json
+    is left alone unless we can positively establish APM authored it.
+    """
+    from apm_cli.utils.helpers import find_plugin_json
+
+    try:
+        plugin_json_path = find_plugin_json(install_path)
+    except Exception:
+        return False
+    if plugin_json_path is None:
+        return False
+
+    from apm_cli.deps.plugin_parser import parse_plugin_manifest
+
+    try:
+        manifest = parse_plugin_manifest(plugin_json_path)
+    except Exception:
+        return False
+    return isinstance(manifest.get("hooks"), dict)
+
+
+def apm_authored_files(
+    install_path: Path,
+    package_type: Any,
+    dep_ref: Any,
+) -> list[str]:
+    """POSIX relative paths of files APM itself authored inside *install_path*.
+
+    Empty for package types where APM writes nothing into the tree (plain
+    APM packages, skill bundles, hook packages): their ``apm.yml`` is
+    upstream content and must never be rewritten or hash-substituted.
+
+    When *package_type* is ``None`` (several install paths carry a
+    ``PackageInfo`` without it -- e.g. pre-download results replayed by
+    ``FreshDependencySource``), the type is detected from the tree itself.
+    Detection keys on the SAME on-disk evidence (``plugin.json`` /
+    ``.claude-plugin/``) that made validation synthesize the manifest in
+    the first place, so it cannot claim authorship of an upstream
+    ``apm.yml``: a plain APM package has no plugin evidence and detects as
+    ``APM_PACKAGE``, which owns nothing here.
+    """
+    type_value = _package_type_value(package_type)
+    if type_value is None and not _is_virtual_file_dep(dep_ref):
+        try:
+            from apm_cli.models.validation import detect_package_type
+
+            detected, _plugin_json = detect_package_type(install_path)
+            type_value = _package_type_value(detected)
+        except Exception:
+            type_value = None
+    files: list[str] = []
+    if type_value == _MARKETPLACE_PLUGIN:
+        files.append("apm.yml")
+        if _has_inline_hooks(install_path):
+            files.append(".apm/hooks/hooks.json")
+    elif _is_virtual_file_dep(dep_ref):
+        # Virtual single-file packages: apm.yml is synthesized by
+        # download_virtual_file_package (LF since 0.26.0 / PR #2223).
+        files.append("apm.yml")
+    return files
+
+
+def _safe_authored_file(install_path: Path, rel: str) -> Path | None:
+    """Resolve an authored relative path, mirroring the hash's symlink rules.
+
+    ``compute_package_hash`` never descends symlinked directories and skips
+    symlinked files, so a candidate behind a symlinked component is
+    invisible to the hash -- touching it could not converge anything and,
+    for a repo-shipped symlinked ``.apm``/``.apm/hooks`` directory, would
+    rewrite a file OUTSIDE the package tree. Returns None unless every
+    component from *install_path* down to the file is a real (non-symlink)
+    directory entry and the candidate is a regular file.
+    """
+    candidate = install_path / rel
+    parent = candidate.parent
+    while parent != install_path:
+        if parent.is_symlink():
+            return None
+        next_parent = parent.parent
+        if next_parent == parent:
+            # Walked off the top without meeting install_path -- refuse.
+            return None
+        parent = next_parent
+    if not candidate.is_file() or candidate.is_symlink():
+        return None
+    return candidate
+
+
+def _crlf_expand(data: bytes) -> bytes:
+    """Return *data* as a pre-fix Windows text-mode write would have produced it.
+
+    Normalizes to LF first so the expansion is idempotent on mixed input,
+    then expands every LF to CRLF -- exactly what Python's platform-native
+    newline translation did to the LF text the pre-fix writers emitted.
+    """
+    return data.replace(b"\r\n", b"\n").replace(b"\n", b"\r\n")
+
+
+def legacy_crlf_hash(
+    install_path: Path,
+    package_type: Any,
+    dep_ref: Any,
+) -> str | None:
+    """Hash *install_path* as if APM-authored files carried legacy CRLF bytes.
+
+    Returns None when no APM-authored file exists or none would change
+    under CRLF expansion -- callers treat None as "no legacy domain to
+    compare against" and keep their normal mismatch handling.
+    """
+    overrides: dict[str, bytes] = {}
+    for rel in apm_authored_files(install_path, package_type, dep_ref):
+        candidate = _safe_authored_file(install_path, rel)
+        if candidate is None:
+            continue
+        raw = candidate.read_bytes()
+        if b"\x00" in raw:
+            # Binary content was never produced by the text-mode writers.
+            continue
+        expanded = _crlf_expand(raw)
+        if expanded != raw:
+            overrides[rel] = expanded
+    if not overrides:
+        return None
+    return compute_package_hash_with_overrides(install_path, overrides)
+
+
+def accept_legacy_crlf_mismatch(
+    install_path: Path,
+    package_type: Any,
+    dep_ref: Any,
+    *,
+    dep_key: str,
+    locked_hash: str,
+    diagnostics: Any,
+) -> bool:
+    """True when a locked-vs-fresh hash mismatch is the benign legacy domain.
+
+    Lockfiles recorded by a pre-fix APM on Windows carry the CRLF-domain
+    hash of the files APM itself authored (synthetic ``apm.yml``, inline
+    ``hooks.json``). When the locked hash equals the fresh tree re-hashed
+    with ONLY those files CRLF-expanded, the difference is exactly that
+    benign legacy line-ending domain: warn once and let the caller
+    re-record the platform-independent hash. The equivalence is as strong
+    as the hash itself -- every other byte of the tree must match the
+    locked record. Any other mismatch returns False and the caller keeps
+    its fail-closed supply-chain behaviour.
+    """
+    legacy_hash = legacy_crlf_hash(install_path, package_type, dep_ref)
+    if legacy_hash is None or legacy_hash != locked_hash:
+        return False
+    diagnostics.warn(
+        f"Lockfile content_hash for {dep_key} was recorded by an "
+        "older APM on Windows (legacy CRLF line-ending domain, "
+        "apm#2619). Content verified equivalent; re-recording the "
+        "platform-independent hash. Run 'apm install' (or "
+        "'apm lock') once and commit the updated apm.lock.yaml "
+        "to stop this warning.",
+        package=dep_key,
+    )
+    return True
+
+
+def converge_warm_tree(
+    install_path: Path,
+    package_type: Any,
+    dep_ref: Any,
+    *,
+    dep_key: str,
+    logger: Any = None,
+) -> list[str]:
+    """Converge a warm tree's APM-authored files to LF, reporting verbosely.
+
+    A warm tree materialized by a pre-fix APM on Windows may still hold
+    CRLF bytes in the files APM itself authored. The cached install path
+    re-records the hash of the on-disk tree, so without convergence the
+    stale CRLF-domain hash would be copied into every regenerated lockfile
+    forever -- keeping installs broken for POSIX teammates even after both
+    sides upgraded.
+    """
+    changed = converge_apm_authored_files(install_path, package_type, dep_ref)
+    if changed and logger is not None:
+        logger.verbose_detail(
+            f"  Normalized legacy CRLF line endings in {', '.join(changed)} "
+            f"for {dep_key} (apm#2619 migration)"
+        )
+    return changed
+
+
+def converge_apm_authored_files(
+    install_path: Path,
+    package_type: Any,
+    dep_ref: Any,
+) -> list[str]:
+    """CRLF->LF rewrite legacy APM-authored files in a warm tree.
+
+    Returns the POSIX relative paths that were rewritten (empty when the
+    tree is already in the LF domain). Non-UTF-8 or NUL-containing files
+    are left untouched -- the pre-fix writers only ever produced UTF-8
+    (or ASCII) text, so anything else is not ours to rewrite.
+    """
+    changed: list[str] = []
+    for rel in apm_authored_files(install_path, package_type, dep_ref):
+        candidate = _safe_authored_file(install_path, rel)
+        if candidate is None:
+            continue
+        raw = candidate.read_bytes()
+        if b"\r\n" not in raw or b"\x00" in raw:
+            continue
+        try:
+            text = raw.decode("utf-8")
+        except UnicodeDecodeError:
+            continue
+        # atomic_write_text normalizes CRLF -> LF and writes LF bytes.
+        atomic_write_text(candidate, text)
+        if candidate.name == "apm.yml":
+            # Uniform invariant: every apm.yml rewrite inside a package
+            # tree drops stale from_apm_yml cache entries. The parsed
+            # content is unchanged here (CRLF -> LF only), so a stale hit
+            # is currently harmless -- but keeping the rule unconditional
+            # prevents silent divergence if that ever stops being true.
+            from apm_cli.models.apm_package import invalidate_apm_yml_cache_entry
+
+            invalidate_apm_yml_cache_entry(candidate)
+        changed.append(rel)
+    return changed

--- a/src/apm_cli/install/sources.py
+++ b/src/apm_cli/install/sources.py
@@ -33,6 +33,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from apm_cli.install.errors import DirectDependencyError
+from apm_cli.install.legacy_crlf import accept_legacy_crlf_mismatch, converge_warm_tree
 from apm_cli.install.registry_wiring import (
     get_registry_resolver,
     registry_resolution_for_cached_registry_dep,
@@ -614,6 +615,9 @@ class CachedDependencySource(DependencySource):
             )
         )
         if install_path.is_dir():
+            # apm#2619: converge legacy CRLF bytes in APM-authored files
+            # before recording, so the stale hash stops propagating.
+            converge_warm_tree(install_path, pkg_type, dep_ref, dep_key=dep_key, logger=logger)
             ctx.package_hashes[dep_key] = _compute_hash(install_path)
         if cached_package_info.package_type:
             ctx.package_types[dep_key] = cached_package_info.package_type.value
@@ -881,14 +885,24 @@ class FreshDependencySource(DependencySource):
             ):
                 _fresh_hash = ctx.package_hashes[dep_key]
                 if _fresh_hash != dep_locked_chk.content_hash:
-                    safe_rmtree(install_path, ctx.apm_modules_dir)
-                    raise DirectDependencyError(
-                        f"Content hash mismatch for {dep_key}: "
-                        f"expected {dep_locked_chk.content_hash}, got {_fresh_hash}. "
-                        "The downloaded content differs from the lockfile record. "
-                        "This may indicate a supply-chain attack. Use "
-                        "'apm install --update' to accept new content and update the lockfile."
-                    )
+                    # apm#2619: accept only the provably-benign legacy CRLF
+                    # domain (warn + re-record); else keep the hard fail.
+                    if not accept_legacy_crlf_mismatch(
+                        install_path,
+                        getattr(package_info, "package_type", None),
+                        dep_ref,
+                        dep_key=dep_key,
+                        locked_hash=dep_locked_chk.content_hash,
+                        diagnostics=diagnostics,
+                    ):
+                        safe_rmtree(install_path, ctx.apm_modules_dir)
+                        raise DirectDependencyError(
+                            f"Content hash mismatch for {dep_key}: "
+                            f"expected {dep_locked_chk.content_hash}, got {_fresh_hash}. "
+                            "The downloaded content differs from the lockfile record. "
+                            "This may indicate a supply-chain attack. Use "
+                            "'apm install --update' to accept new content and update the lockfile."
+                        )
 
             if hasattr(package_info, "package_type") and package_info.package_type:
                 ctx.package_types[dep_key] = package_info.package_type.value

--- a/src/apm_cli/models/apm_package.py
+++ b/src/apm_cli/models/apm_package.py
@@ -7,6 +7,7 @@ compatibility.
 """
 
 import logging
+import threading
 from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -63,6 +64,7 @@ __all__ = [  # noqa: RUF022
     "PackageInfo",
     "build_installed_package_info",
     "clear_apm_yml_cache",
+    "invalidate_apm_yml_cache_entry",
     "surviving_dependency_refs_for_reintegration",
 ]
 
@@ -73,11 +75,54 @@ __all__ = [  # noqa: RUF022
 # declared them. Sharing one APMPackage instance across both would let the
 # resolver mutate ``source_path`` and poison the cache for the other consumer.
 _apm_yml_cache: dict[tuple[Path, Path | None], "APMPackage"] = {}
+# Guards every structural mutation of ``_apm_yml_cache``. The parallel
+# pre-download executor and the BFS resolver pool both insert entries from
+# worker threads while ``invalidate_apm_yml_cache_entry`` iterates the dict;
+# an unguarded concurrent insert would raise ``RuntimeError: dictionary
+# changed size during iteration`` and fail the install intermittently.
+# Lock-free ``dict.get`` reads stay safe: the lookup executes as one
+# GIL-held C-level dict operation, so it cannot observe a torn mutation.
+_apm_yml_cache_lock = threading.Lock()
+
+# Bumped under the lock by every invalidation/clear. ``from_apm_yml``
+# snapshots it BEFORE reading the file and skips its insert (still
+# returning the parsed result) when the generation moved: an in-flight
+# parse that read PRE-rewrite bytes must not re-poison the cache AFTER
+# the rewrite's invalidation ran. Global (not per-path) on purpose --
+# the cost of over-invalidation is one extra parse on the next load,
+# and a per-path map would reintroduce the iteration/mutation problem
+# the lock exists to solve.
+_apm_yml_cache_generation = 0
 
 
 def clear_apm_yml_cache() -> None:
     """Clear the from_apm_yml parse cache. Call in tests for isolation."""
-    _apm_yml_cache.clear()
+    global _apm_yml_cache_generation
+    with _apm_yml_cache_lock:
+        _apm_yml_cache_generation += 1
+        _apm_yml_cache.clear()
+
+
+def invalidate_apm_yml_cache_entry(apm_yml_path: Path) -> None:
+    """Drop every cache entry for *apm_yml_path* (all source_path variants).
+
+    MUST be called after rewriting an ``apm.yml`` on disk within a run
+    (marketplace-plugin synthesis, ``stamp_plugin_version``). The cache
+    assumes file content is stable for the process lifetime; a rewrite
+    breaks that. Concretely (apm#2619 migration surfaced this): when a
+    same-process re-download re-synthesized a marketplace plugin's
+    ``apm.yml`` at ``version: 0.0.0``, ``from_apm_yml`` returned the STALE
+    cached instance -- already stamped to the short commit SHA earlier in
+    the run -- so ``stamp_plugin_version``'s ``version == "0.0.0"`` guard
+    skipped, leaving an unstamped tree on disk whose content hash matched
+    neither the lockfile record nor a fresh install's tree.
+    """
+    global _apm_yml_cache_generation
+    resolved = apm_yml_path.resolve()
+    with _apm_yml_cache_lock:
+        _apm_yml_cache_generation += 1
+        for key in [k for k in _apm_yml_cache if k[0] == resolved]:
+            _apm_yml_cache.pop(key, None)
 
 
 def _parse_v01_registries_block(
@@ -616,6 +661,13 @@ class APMPackage:
         if cached is not None:
             return cached
 
+        # Snapshot BEFORE reading the file: if an invalidation lands while
+        # this thread parses (a concurrent rewrite of the manifest), the
+        # insert below is skipped so pre-rewrite bytes cannot re-poison
+        # the cache. Plain int read is GIL-atomic; writers bump under the
+        # lock.
+        generation_snapshot = _apm_yml_cache_generation
+
         try:
             from ..utils.yaml_io import load_yaml
 
@@ -632,7 +684,9 @@ class APMPackage:
             source_path=resolved_source,
             manifest_path=apm_yml_path,
         )
-        _apm_yml_cache[cache_key] = result
+        with _apm_yml_cache_lock:
+            if _apm_yml_cache_generation == generation_snapshot:
+                _apm_yml_cache[cache_key] = result
         return result
 
     def get_apm_dependencies(self) -> list[DependencyReference]:

--- a/src/apm_cli/utils/content_hash.py
+++ b/src/apm_cli/utils/content_hash.py
@@ -1,6 +1,7 @@
 """Deterministic SHA-256 content hashing for package integrity verification."""
 
 import hashlib
+from collections.abc import Mapping
 from pathlib import Path
 
 from apm_cli.install.cache_pin import MARKER_FILENAME as _APM_PIN_MARKER
@@ -20,6 +21,33 @@ _EXCLUDED_ROOT_FILES = {_APM_PIN_MARKER}
 
 # Well-known hash for empty/missing packages
 _EMPTY_HASH = "sha256:" + hashlib.sha256(b"").hexdigest()
+
+
+def _iter_package_files(package_path: Path) -> list[Path]:
+    """Enumerate the hashable files of a package tree.
+
+    Shared by :func:`compute_package_hash` and
+    :func:`compute_package_hash_with_overrides` so both digest exactly the
+    same file set: regular files only, symlinks skipped, excluded
+    directories pruned, root-level excluded files dropped, sorted
+    lexicographically by POSIX relative path for determinism.
+    """
+    regular_files: list[Path] = []
+    for item in package_path.rglob("*"):
+        # Skip symlinks
+        if item.is_symlink():
+            continue
+        # Skip excluded directories and their contents
+        rel = item.relative_to(package_path)
+        if any(part in _EXCLUDED_DIRS for part in rel.parts):
+            continue
+        if item.is_file():
+            if len(rel.parts) == 1 and rel.name in _EXCLUDED_ROOT_FILES:
+                continue
+            regular_files.append(rel)
+
+    regular_files.sort(key=lambda p: p.as_posix())
+    return regular_files
 
 
 def compute_package_hash(package_path: Path) -> str:
@@ -56,28 +84,55 @@ def compute_package_hash(package_path: Path) -> str:
     hasher = hashlib.sha256()
     file_count = 0
 
-    # Collect all regular files, skipping excluded dirs and symlinks
-    regular_files: list[Path] = []
-    for item in package_path.rglob("*"):
-        # Skip symlinks
-        if item.is_symlink():
-            continue
-        # Skip excluded directories and their contents
-        rel = item.relative_to(package_path)
-        if any(part in _EXCLUDED_DIRS for part in rel.parts):
-            continue
-        if item.is_file():
-            if len(rel.parts) == 1 and rel.name in _EXCLUDED_ROOT_FILES:
-                continue
-            regular_files.append(rel)
-
-    # Sort lexicographically by POSIX path for determinism
-    regular_files.sort(key=lambda p: p.as_posix())
-
-    for rel_path in regular_files:
+    for rel_path in _iter_package_files(package_path):
         # Hash the relative path then the file contents
         hasher.update(rel_path.as_posix().encode("utf-8"))
         hasher.update((package_path / rel_path).read_bytes())
+        file_count += 1
+
+    if file_count == 0:
+        return _EMPTY_HASH
+
+    return f"sha256:{hasher.hexdigest()}"
+
+
+def compute_package_hash_with_overrides(
+    package_path: Path,
+    overrides: Mapping[str, bytes],
+) -> str:
+    """Compute the package hash as if selected files held different bytes.
+
+    Identical to :func:`compute_package_hash` -- same file enumeration,
+    same digest layout -- except that for every file whose POSIX relative
+    path appears in ``overrides``, the mapped bytes are hashed in place of
+    the on-disk content. Files named in ``overrides`` that do not exist in
+    the enumerated tree contribute nothing (they are not phantom-added).
+
+    Used by the apm#2619 migration path
+    (:mod:`apm_cli.install.legacy_crlf`) to answer "would this tree match
+    the locked hash if the APM-authored synthetic files still carried
+    their legacy CRLF bytes?" without mutating the tree.
+
+    Args:
+        package_path: Root directory of the installed package.
+        overrides: POSIX relative path -> replacement bytes.
+
+    Returns:
+        Hash string in format ``"sha256:<hex_digest>"``.
+    """
+    if not package_path.is_dir():
+        return _EMPTY_HASH
+
+    hasher = hashlib.sha256()
+    file_count = 0
+
+    for rel_path in _iter_package_files(package_path):
+        posix = rel_path.as_posix()
+        hasher.update(posix.encode("utf-8"))
+        if posix in overrides:
+            hasher.update(overrides[posix])
+        else:
+            hasher.update((package_path / rel_path).read_bytes())
         file_count += 1
 
     if file_count == 0:

--- a/tests/integration/test_install_content_hash_roundtrip.py
+++ b/tests/integration/test_install_content_hash_roundtrip.py
@@ -471,3 +471,238 @@ def test_marketplace_plugin_synthetic_manifest_hash_is_newline_invariant(
     # hash. This is exactly why the production writers must emit LF bytes.
     (pkg / "apm.yml").write_bytes(manifest.replace(b"\n", b"\r\n"))
     assert compute_package_hash(pkg) != lf_hash
+
+
+class _MarketplacePluginDownloader:
+    """Deterministic marketplace-plugin downloader running the REAL synthesize chain."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def download_package(
+        self, repo_ref: object, target_path: Path, *args: Any, **kwargs: Any
+    ) -> PackageInfo:
+        from apm_cli.deps.package_validator import stamp_plugin_version
+        from apm_cli.models.validation import validate_apm_package
+        from scripts.crlf_invariance_probe import PROBE_STAMP_SHA, build_synthetic_plugin_fixture
+
+        self.calls += 1
+        dep_ref = (
+            repo_ref
+            if isinstance(repo_ref, DependencyReference)
+            else DependencyReference.parse(str(repo_ref))
+        )
+        target_path = Path(target_path)
+        target_path.mkdir(parents=True, exist_ok=True)
+        build_synthetic_plugin_fixture(target_path)
+        result = validate_apm_package(target_path)
+        assert result.is_valid, result.errors
+        # Mirror the real download_package flow: marketplace plugins get
+        # their synthesized 0.0.0 version stamped with the short commit
+        # SHA. Load-bearing for the apm#2619 migration tests: a stale
+        # from_apm_yml cache entry (from a previous download in the same
+        # process) made this stamp skip on re-download, leaving an
+        # unstamped tree whose hash matched no lockfile domain.
+        stamp_plugin_version(result.package, result.package_type, PROBE_STAMP_SHA, target_path)
+        return PackageInfo(
+            package=result.package,
+            install_path=target_path,
+            installed_at=datetime.now().isoformat(),
+            dependency_ref=dep_ref,
+            resolved_reference=ResolvedReference(
+                original_ref="default",
+                ref_type=GitReferenceType.BRANCH,
+                resolved_commit=None,
+                ref_name="default",
+            ),
+            package_type=result.package_type,
+        )
+
+
+# The two files APM itself authors inside the marketplace-plugin fixture tree.
+_APM_AUTHORED_FIXTURE_FILES = ("apm.yml", ".apm/hooks/hooks.json")
+
+
+def _install_marketplace_fixture(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> tuple[Path, Path, _MarketplacePluginDownloader, CliRunner]:
+    """First install of the marketplace fixture; returns (project, install_path, dl, runner)."""
+    project = tmp_path / "project"
+    _write_project(project)
+    downloader = _MarketplacePluginDownloader()
+
+    from apm_cli.deps import github_downloader as _ghd
+
+    monkeypatch.setattr(
+        _ghd.GitHubPackageDownloader, "download_package", downloader.download_package
+    )
+    runner = CliRunner()
+    first = _run_install(runner, project, monkeypatch)
+    assert first.exit_code == 0, first.output
+    install_path = project / "apm_modules" / "acme" / "fixture-pkg"
+    assert install_path.is_dir()
+    return project, install_path, downloader, runner
+
+
+def _crlf_domain_hash(tmp_path: Path, install_path: Path) -> str:
+    """Independently construct the pre-fix Windows (CRLF-domain) tree hash.
+
+    Copies the tree and CRLF-expands the APM-authored files by hand --
+    deliberately NOT via apm_cli.install.legacy_crlf, so these tests do not
+    verify the migration helpers against themselves.
+    """
+    legacy_tree = tmp_path / "legacy-domain-copy"
+    if legacy_tree.exists():
+        shutil.rmtree(legacy_tree)
+    shutil.copytree(install_path, legacy_tree)
+    for rel in _APM_AUTHORED_FIXTURE_FILES:
+        legacy_file = legacy_tree / rel
+        legacy_file.write_bytes(legacy_file.read_bytes().replace(b"\n", b"\r\n"))
+    return compute_package_hash(legacy_tree)
+
+
+def _rewrite_locked_hash(project: Path, dep_repo_url: str, new_hash: str) -> None:
+    lock_path = project / "apm.lock.yaml"
+    lockfile = yaml.safe_load(lock_path.read_text(encoding="utf-8"))
+    for dep in lockfile.get("dependencies") or []:
+        if dep.get("repo_url") == dep_repo_url:
+            dep["content_hash"] = new_hash
+    lock_path.write_text(yaml.safe_dump(lockfile, sort_keys=False), encoding="utf-8")
+
+
+@pytest.mark.windows_compat
+def test_fresh_install_heals_legacy_crlf_domain_lockfile(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A lockfile recorded by a pre-fix Windows APM installs, warns, converges.
+
+    apm#2619 migration: the locked content_hash is the CRLF-domain hash of
+    the APM-authored synthetic files. A post-fix fresh download produces
+    the LF-domain hash; instead of hard-failing as a supply-chain event,
+    the install must recognize the exact benign legacy difference, warn,
+    and re-record the platform-independent hash.
+    """
+    project, install_path, downloader, runner = _install_marketplace_fixture(tmp_path, monkeypatch)
+    lf_hash = _locked_dep(project)["content_hash"]
+
+    crlf_hash = _crlf_domain_hash(tmp_path, install_path)
+    assert crlf_hash != lf_hash
+
+    # Simulate the pre-fix Windows lockfile, then force a fresh download.
+    _rewrite_locked_hash(project, "acme/fixture-pkg", crlf_hash)
+    shutil.rmtree(install_path)
+
+    healed = _run_install(runner, project, monkeypatch)
+    assert healed.exit_code == 0, healed.output
+    assert "apm#2619" in healed.output
+    # The healed run re-downloads (resolve-phase BFS callback, plus the
+    # integrate-phase fresh acquire once the legacy hash fails the
+    # content-match) -- a one-time migration cost. The exact count is
+    # pipeline-internal; what matters is that a download happened and the
+    # lockfile converged to the platform-independent hash.
+    assert downloader.calls > 1
+    assert _locked_dep(project)["content_hash"] == lf_hash
+
+
+@pytest.mark.windows_compat
+def test_cached_install_converges_legacy_crlf_tree(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A warm pre-fix Windows tree converges to the LF domain without re-download.
+
+    apm#2619 migration: the cached install path must rewrite the
+    APM-authored files (synthetic apm.yml, inline hooks.json) to LF before
+    re-recording the hash -- otherwise the stale CRLF-domain hash would be
+    copied into every regenerated lockfile forever.
+    """
+    project, install_path, downloader, runner = _install_marketplace_fixture(tmp_path, monkeypatch)
+    lf_hash = _locked_dep(project)["content_hash"]
+
+    # Simulate the fully-legacy state: CRLF tree AND CRLF-domain lockfile
+    # (so the cached-reuse content-hash fallback still matches).
+    for rel in _APM_AUTHORED_FIXTURE_FILES:
+        legacy_file = install_path / rel
+        legacy_file.write_bytes(legacy_file.read_bytes().replace(b"\n", b"\r\n"))
+    crlf_hash = compute_package_hash(install_path)
+    assert crlf_hash != lf_hash
+    _rewrite_locked_hash(project, "acme/fixture-pkg", crlf_hash)
+
+    second = _run_install(runner, project, monkeypatch)
+    assert second.exit_code == 0, second.output
+    assert downloader.calls == 1  # cached path, no re-download
+
+    for rel in _APM_AUTHORED_FIXTURE_FILES:
+        assert b"\r" not in (install_path / rel).read_bytes(), rel
+    assert _locked_dep(project)["content_hash"] == lf_hash
+    assert compute_package_hash(install_path) == lf_hash
+
+
+def test_fresh_install_still_blocks_genuine_hash_mismatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Negative control: the apm#2619 heal must not weaken the supply-chain gate.
+
+    A locked hash that is NOT the CRLF-domain equivalent of the fresh tree
+    (here: an unrelated digest) must still hard-fail the install.
+    """
+    project, install_path, _downloader, runner = _install_marketplace_fixture(tmp_path, monkeypatch)
+
+    bogus = "sha256:" + "0" * 64
+    _rewrite_locked_hash(project, "acme/fixture-pkg", bogus)
+    shutil.rmtree(install_path)
+
+    monkeypatch.chdir(project)
+    with patch(_PATCH_UPDATES, return_value=None):
+        blocked = runner.invoke(cli, ["install"], catch_exceptions=True)
+    output = blocked.output + str(blocked.exception or "")
+    assert blocked.exit_code != 0 or blocked.exception is not None, output
+    assert "Content hash mismatch" in output, output
+
+
+@pytest.mark.windows_compat
+def test_marketplace_plugin_lockfile_replays_under_frozen_install(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Hermetic marketplace-plugin lockfile write/read and --frozen replay.
+
+    The first install writes the lockfile; a fresh `apm install --frozen`
+    then re-downloads the plugin through the REAL synthesize+stamp chain in
+    the same process and must reproduce the recorded platform-independent
+    content_hash exactly. Deliberately does NOT clear the from_apm_yml parse
+    cache between the runs: a stale cached instance used to make the
+    re-download skip re-stamping, leaving a tree whose hash matched no
+    lockfile domain -- exactly the failure a frozen replay would trip.
+    """
+    project, install_path, downloader, runner = _install_marketplace_fixture(tmp_path, monkeypatch)
+    locked_before = _locked_dep(project)["content_hash"]
+    assert compute_package_hash(install_path) == locked_before
+
+    shutil.rmtree(install_path)
+
+    frozen = _run_command(runner, project, monkeypatch, ["install", "--frozen"])
+    assert frozen.exit_code == 0, frozen.output
+    assert downloader.calls > 1  # the replay re-downloaded, not reused
+    assert _locked_dep(project)["content_hash"] == locked_before
+    assert compute_package_hash(install_path) == locked_before
+
+
+@pytest.mark.windows_compat
+def test_frozen_replay_blocks_tampered_lockfile_hash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Negative control: --frozen replay keeps the supply-chain gate closed.
+
+    A locked content_hash that matches neither the fresh tree nor its
+    legacy CRLF domain must still hard-fail the frozen install.
+    """
+    project, install_path, _downloader, runner = _install_marketplace_fixture(tmp_path, monkeypatch)
+
+    _rewrite_locked_hash(project, "acme/fixture-pkg", "sha256:" + "0" * 64)
+    shutil.rmtree(install_path)
+
+    monkeypatch.chdir(project)
+    with patch(_PATCH_UPDATES, return_value=None):
+        blocked = runner.invoke(cli, ["install", "--frozen"], catch_exceptions=True)
+    output = blocked.output + str(blocked.exception or "")
+    assert blocked.exit_code != 0 or blocked.exception is not None, output
+    assert "Content hash mismatch" in output, output

--- a/tests/unit/deps/test_stamp_plugin_version.py
+++ b/tests/unit/deps/test_stamp_plugin_version.py
@@ -89,21 +89,6 @@ def test_no_op_when_apm_yml_is_missing(tmp_path):
     assert not (tmp_path / "apm.yml").exists()
 
 
-def test_no_op_when_package_is_none(tmp_path):
-    apm_yml = tmp_path / "apm.yml"
-    apm_yml.write_text("name: foo\nversion: 0.0.0\n", encoding="utf-8")
-
-    # Should not raise.
-    stamp_plugin_version(
-        None,
-        PackageType.MARKETPLACE_PLUGIN,
-        "abcdef1234567890aabbccddeeff00112233abcd",
-        tmp_path,
-    )
-
-    assert "version: 0.0.0" in apm_yml.read_text(encoding="utf-8")
-
-
 @pytest.mark.windows_compat
 def test_stamped_manifest_bytes_are_lf_only(tmp_path):
     """The stamped apm.yml lands inside a package tree hashed raw by
@@ -125,3 +110,176 @@ def test_stamped_manifest_bytes_are_lf_only(tmp_path):
     assert b"version: abcdef1" in raw
     assert b"\r" not in raw
     assert raw.endswith(b"\n")
+
+
+def test_no_op_when_package_is_none(tmp_path):
+    apm_yml = tmp_path / "apm.yml"
+    apm_yml.write_text("name: foo\nversion: 0.0.0\n", encoding="utf-8")
+
+    # Should not raise.
+    stamp_plugin_version(
+        None,
+        PackageType.MARKETPLACE_PLUGIN,
+        "abcdef1234567890aabbccddeeff00112233abcd",
+        tmp_path,
+    )
+
+    assert "version: 0.0.0" in apm_yml.read_text(encoding="utf-8")
+
+
+@pytest.mark.windows_compat
+def test_stamp_invalidates_from_apm_yml_cache(tmp_path):
+    """Stamping rewrites apm.yml, so cached from_apm_yml instances for that
+    path must be dropped -- a stale pre-stamp instance elsewhere in the run
+    would disagree with the on-disk bytes (apm#2619 migration fallout)."""
+    from apm_cli.models.apm_package import APMPackage
+
+    apm_yml = tmp_path / "apm.yml"
+    apm_yml.write_bytes(b"name: foo\nversion: 0.0.0\n")
+    first = APMPackage.from_apm_yml(apm_yml)  # populate the cache
+    assert first.version == "0.0.0"
+
+    stamp_plugin_version(
+        _pkg("0.0.0"),
+        PackageType.MARKETPLACE_PLUGIN,
+        "abcdef1234567890aabbccddeeff00112233abcd",
+        tmp_path,
+    )
+
+    reloaded = APMPackage.from_apm_yml(apm_yml)
+    assert reloaded is not first
+    assert reloaded.version == "abcdef1"
+
+
+@pytest.mark.windows_compat
+def test_restamp_after_resynthesis_is_not_skipped_by_stale_cache(tmp_path):
+    """The apm#2619 double-download interplay, distilled.
+
+    Real flow: download #1 synthesizes apm.yml (0.0.0), stamps it to the
+    short SHA; a content-hash mismatch forces a re-download in the SAME
+    process; download #2 re-synthesizes a fresh 0.0.0 manifest. Without
+    cache invalidation, from_apm_yml returned the STALE stamped instance,
+    the ``version == "0.0.0"`` stamp guard skipped, and the tree stayed
+    unstamped on disk -- hashing to a value no lockfile ever recorded.
+    """
+    from apm_cli.deps.plugin_parser import synthesize_apm_yml_from_plugin
+    from apm_cli.models.apm_package import APMPackage
+
+    sha = "2c7ec5e78b8e5d43ea02e90bb8826f6b9f147b0c"
+    plugin = tmp_path / "plug"
+    skill = plugin / "skills" / "demo"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_bytes(b"---\nname: demo\ndescription: Demo\n---\n\n# Demo\n")
+
+    # Download #1: synthesize + stamp.
+    apm_yml = synthesize_apm_yml_from_plugin(plugin, {"name": "plug"})
+    pkg = APMPackage.from_apm_yml(apm_yml)
+    stamp_plugin_version(pkg, PackageType.MARKETPLACE_PLUGIN, sha, plugin)
+    assert b"version: 2c7ec5e" in apm_yml.read_bytes()
+
+    # Re-download: pristine tree, fresh synthesis (no existing manifest).
+    apm_yml.unlink()
+    synthesize_apm_yml_from_plugin(plugin, {"name": "plug"})
+
+    fresh = APMPackage.from_apm_yml(apm_yml)
+    assert fresh.version == "0.0.0"  # stale cache would still say 2c7ec5e
+
+    # The second stamp must therefore actually run.
+    stamp_plugin_version(fresh, PackageType.MARKETPLACE_PLUGIN, sha, plugin)
+    assert fresh.version == "2c7ec5e"
+    assert b"version: 2c7ec5e" in apm_yml.read_bytes()
+
+
+def test_cache_invalidation_is_safe_under_concurrent_inserts(tmp_path):
+    """apm#2619 round-3: invalidate_apm_yml_cache_entry iterates the shared
+    manifest cache while parallel download/resolver worker threads insert
+    into it. Without the module lock this raised 'RuntimeError: dictionary
+    changed size during iteration' and failed installs intermittently."""
+    import threading
+
+    from apm_cli.models.apm_package import (
+        APMPackage,
+        invalidate_apm_yml_cache_entry,
+    )
+
+    apm_yml = tmp_path / "apm.yml"
+    apm_yml.write_bytes(b"name: foo\nversion: 0.0.0\n")
+
+    stop = threading.Event()
+    errors: list[BaseException] = []
+
+    def inserter() -> None:
+        # Distinct source_path anchors create distinct cache keys, growing
+        # the dict while the main thread iterates it.
+        i = 0
+        while not stop.is_set():
+            i += 1
+            anchor = tmp_path / f"anchor-{i}"
+            anchor.mkdir(exist_ok=True)
+            try:
+                APMPackage.from_apm_yml(apm_yml, source_path=anchor)
+            except BaseException as exc:  # pragma: no cover - failure capture
+                errors.append(exc)
+                return
+
+    thread = threading.Thread(target=inserter, daemon=True)
+    thread.start()
+    try:
+        for _ in range(300):
+            invalidate_apm_yml_cache_entry(apm_yml)
+    except BaseException as exc:  # pragma: no cover - failure capture
+        errors.append(exc)
+    finally:
+        stop.set()
+        thread.join(timeout=10)
+
+    assert not thread.is_alive(), "inserter thread wedged"
+    assert not errors, errors
+    # Drop the many unique-keyed entries this test added.
+    from apm_cli.models.apm_package import clear_apm_yml_cache
+
+    clear_apm_yml_cache()
+
+
+def test_in_flight_parse_cannot_repoison_cache_after_invalidation(tmp_path):
+    """Round-4 review: invalidation is a barrier for in-flight parses.
+
+    A thread that read PRE-rewrite bytes must not insert its stale result
+    into the cache AFTER a rewrite's invalidation ran -- otherwise the
+    exact staleness the invalidation exists to fix comes back, dependent
+    on thread interleaving. from_apm_yml snapshots a generation counter
+    before reading the file and skips the insert if it moved.
+    """
+    from unittest.mock import patch
+
+    from apm_cli.models.apm_package import (
+        APMPackage,
+        invalidate_apm_yml_cache_entry,
+    )
+
+    apm_yml = tmp_path / "apm.yml"
+    apm_yml.write_bytes(b"name: foo\nversion: 0.0.0\n")
+
+    import apm_cli.utils.yaml_io as yaml_io_mod
+
+    real_load = yaml_io_mod.load_yaml
+
+    def load_with_concurrent_rewrite(path):
+        data = real_load(path)
+        # Simulate a concurrent rewrite + invalidation landing while this
+        # "thread" is still holding the pre-rewrite parse result.
+        apm_yml.write_bytes(b"name: foo\nversion: 2c7ec5e\n")
+        invalidate_apm_yml_cache_entry(apm_yml)
+        return data
+
+    with patch(
+        "apm_cli.utils.yaml_io.load_yaml",
+        side_effect=load_with_concurrent_rewrite,
+    ):
+        stale = APMPackage.from_apm_yml(apm_yml)
+    assert stale.version == "0.0.0"  # the in-flight parse itself is fine
+
+    # The stale result must NOT have been cached: a fresh load sees the
+    # rewritten bytes.
+    fresh = APMPackage.from_apm_yml(apm_yml)
+    assert fresh.version == "2c7ec5e"

--- a/tests/unit/install/test_legacy_crlf.py
+++ b/tests/unit/install/test_legacy_crlf.py
@@ -1,0 +1,216 @@
+"""Tests for the apm#2619 legacy CRLF hash-domain migration helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from apm_cli.install.legacy_crlf import (
+    _crlf_expand,
+    apm_authored_files,
+    converge_apm_authored_files,
+    legacy_crlf_hash,
+)
+from apm_cli.models.validation import PackageType
+from apm_cli.utils.content_hash import (
+    compute_package_hash,
+    compute_package_hash_with_overrides,
+)
+
+# Load-bearing cross-platform regression contract (see
+# .github/instructions/tests.instructions.md): the migration must behave
+# identically on every OS.
+pytestmark = pytest.mark.windows_compat
+
+
+def _marketplace_tree(root: Path, *, inline_hooks: bool = True, crlf: bool = False) -> Path:
+    """Build a minimal marketplace-plugin install tree by hand.
+
+    ``crlf=True`` writes the APM-authored files the way a pre-fix Windows
+    APM did (CRLF); otherwise LF (post-fix / POSIX domain).
+    """
+    nl = b"\r\n" if crlf else b"\n"
+    root.mkdir(parents=True, exist_ok=True)
+    hooks_field = (
+        b'"hooks": {"PreToolUse": []}, ' if inline_hooks else b'"hooks": "my-hooks.json", '
+    )
+    (root / "plugin.json").write_bytes(
+        b'{"name": "demo-plugin", ' + hooks_field + b'"description": "Demo"}\n'
+    )
+    (root / "apm.yml").write_bytes(nl.join([b"name: demo-plugin", b"version: 2c7ec5e", b""]))
+    hooks_dir = root / ".apm" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    (hooks_dir / "hooks.json").write_bytes(nl.join([b"{", b'  "PreToolUse": []', b"}"]))
+    # Upstream content: byte-copied from git, must NEVER be rewritten.
+    skill = root / "skills" / "demo"
+    skill.mkdir(parents=True, exist_ok=True)
+    (skill / "SKILL.md").write_bytes(b"---\r\nname: demo\r\n---\r\n# upstream CRLF stays\r\n")
+    return root
+
+
+class TestApmAuthoredFiles:
+    def test_marketplace_plugin_with_inline_hooks(self, tmp_path: Path) -> None:
+        tree = _marketplace_tree(tmp_path / "pkg", inline_hooks=True)
+        files = apm_authored_files(tree, PackageType.MARKETPLACE_PLUGIN, None)
+        assert files == ["apm.yml", ".apm/hooks/hooks.json"]
+
+    def test_marketplace_plugin_with_file_path_hooks_excludes_hooks_json(
+        self, tmp_path: Path
+    ) -> None:
+        """hooks.json from a declared config FILE is a byte-copy of upstream
+        content -- normalizing it would CREATE divergence vs a fresh install."""
+        tree = _marketplace_tree(tmp_path / "pkg", inline_hooks=False)
+        files = apm_authored_files(tree, PackageType.MARKETPLACE_PLUGIN, None)
+        assert files == ["apm.yml"]
+
+    def test_string_package_type_value_accepted(self, tmp_path: Path) -> None:
+        tree = _marketplace_tree(tmp_path / "pkg", inline_hooks=False)
+        assert apm_authored_files(tree, "marketplace_plugin", None) == ["apm.yml"]
+
+    def test_virtual_file_dep_owns_its_manifest(self, tmp_path: Path) -> None:
+        dep = SimpleNamespace(is_virtual=True, is_virtual_file=lambda: True)
+        assert apm_authored_files(tmp_path, None, dep) == ["apm.yml"]
+
+    def test_plain_apm_package_owns_nothing(self, tmp_path: Path) -> None:
+        """A regular APM package's apm.yml is upstream content -- untouchable."""
+        assert apm_authored_files(tmp_path, PackageType.APM_PACKAGE, None) == []
+
+    def test_none_package_type_is_detected_from_tree(self, tmp_path: Path) -> None:
+        """Several install paths carry PackageInfo without package_type
+        (e.g. pre-download results); the type must then be detected from
+        the on-disk plugin evidence so the migration still engages."""
+        tree = _marketplace_tree(tmp_path / "pkg", inline_hooks=True)
+        assert apm_authored_files(tree, None, None) == ["apm.yml", ".apm/hooks/hooks.json"]
+
+    def test_none_package_type_without_plugin_evidence_owns_nothing(self, tmp_path: Path) -> None:
+        """No plugin evidence on disk -> detection cannot claim an upstream
+        apm.yml as APM-authored."""
+        pkg = tmp_path / "plain"
+        (pkg / ".apm" / "instructions").mkdir(parents=True)
+        (pkg / "apm.yml").write_bytes(b"name: upstream\nversion: 1.0.0\n")
+        (pkg / ".apm" / "instructions" / "a.instructions.md").write_bytes(b"# a\n")
+        assert apm_authored_files(pkg, None, None) == []
+
+
+class TestCrlfExpand:
+    def test_expands_lf_and_is_idempotent(self) -> None:
+        assert _crlf_expand(b"a\nb\n") == b"a\r\nb\r\n"
+        assert _crlf_expand(b"a\r\nb\r\n") == b"a\r\nb\r\n"
+
+    def test_mixed_domains_converge(self) -> None:
+        assert _crlf_expand(b"a\r\nb\n") == b"a\r\nb\r\n"
+
+
+class TestLegacyCrlfHash:
+    def test_matches_hash_of_hand_built_crlf_tree(self, tmp_path: Path) -> None:
+        """The computed CRLF-domain hash equals the hash of an actual tree
+        whose APM-authored files were written CRLF -- the exact bytes a
+        pre-fix Windows APM produced."""
+        lf_tree = _marketplace_tree(tmp_path / "lf", crlf=False)
+        crlf_tree = _marketplace_tree(tmp_path / "crlf", crlf=True)
+
+        computed = legacy_crlf_hash(lf_tree, PackageType.MARKETPLACE_PLUGIN, None)
+
+        assert computed == compute_package_hash(crlf_tree)
+        assert computed != compute_package_hash(lf_tree)
+
+    def test_returns_none_when_nothing_would_change(self, tmp_path: Path) -> None:
+        """A tree whose authored files have no line endings at all offers no
+        legacy domain to compare against."""
+        pkg = tmp_path / "pkg"
+        pkg.mkdir()
+        (pkg / "apm.yml").write_bytes(b"name: x")  # no newline anywhere
+        assert legacy_crlf_hash(pkg, PackageType.MARKETPLACE_PLUGIN, None) is None
+
+    def test_returns_none_for_unowned_package_types(self, tmp_path: Path) -> None:
+        tree = _marketplace_tree(tmp_path / "pkg")
+        assert legacy_crlf_hash(tree, PackageType.APM_PACKAGE, None) is None
+
+
+class TestConvergeApmAuthoredFiles:
+    def test_converges_crlf_tree_to_lf_domain(self, tmp_path: Path) -> None:
+        crlf_tree = _marketplace_tree(tmp_path / "crlf", crlf=True)
+        lf_tree = _marketplace_tree(tmp_path / "lf", crlf=False)
+
+        changed = converge_apm_authored_files(crlf_tree, PackageType.MARKETPLACE_PLUGIN, None)
+
+        assert changed == ["apm.yml", ".apm/hooks/hooks.json"]
+        assert b"\r" not in (crlf_tree / "apm.yml").read_bytes()
+        assert b"\r" not in (crlf_tree / ".apm" / "hooks" / "hooks.json").read_bytes()
+        # Upstream content is untouched -- its CRLF bytes stay hash-visible.
+        assert b"\r\n" in (crlf_tree / "skills" / "demo" / "SKILL.md").read_bytes()
+        # The converged tree now hashes identically to a post-fix tree.
+        assert compute_package_hash(crlf_tree) == compute_package_hash(lf_tree)
+
+    def test_noop_on_already_lf_tree(self, tmp_path: Path) -> None:
+        tree = _marketplace_tree(tmp_path / "pkg", crlf=False)
+        before = compute_package_hash(tree)
+        assert converge_apm_authored_files(tree, PackageType.MARKETPLACE_PLUGIN, None) == []
+        assert compute_package_hash(tree) == before
+
+    def test_noop_for_unowned_package_types(self, tmp_path: Path) -> None:
+        tree = _marketplace_tree(tmp_path / "pkg", crlf=True)
+        before = compute_package_hash(tree)
+        assert converge_apm_authored_files(tree, PackageType.APM_PACKAGE, None) == []
+        assert compute_package_hash(tree) == before
+
+    def test_missing_files_are_skipped(self, tmp_path: Path) -> None:
+        pkg = tmp_path / "pkg"
+        pkg.mkdir()
+        assert converge_apm_authored_files(pkg, PackageType.MARKETPLACE_PLUGIN, None) == []
+
+
+class TestSymlinkedParentGuard:
+    """apm#2619 round-3: authored paths behind symlinked directories are
+    invisible to compute_package_hash (rglob does not descend symlinked
+    dirs), so the migration must never read or rewrite through them --
+    for a repo-shipped symlinked .apm the write would land OUTSIDE the
+    package tree."""
+
+    def _tree_with_symlinked_apm_dir(self, tmp_path: Path) -> tuple[Path, Path]:
+        outside = tmp_path / "outside"
+        (outside / "hooks").mkdir(parents=True)
+        (outside / "hooks" / "hooks.json").write_bytes(b"{\r\n}\r\n")
+
+        pkg = tmp_path / "pkg"
+        pkg.mkdir()
+        (pkg / "plugin.json").write_bytes(
+            b'{"name": "demo-plugin", "hooks": {"PreToolUse": []}, "description": "Demo"}\n'
+        )
+        (pkg / "apm.yml").write_bytes(b"name: demo-plugin\r\nversion: 2c7ec5e\r\n")
+        try:
+            (pkg / ".apm").symlink_to(outside, target_is_directory=True)
+        except OSError:
+            pytest.skip("Symlinks not supported on this platform")
+        return pkg, outside
+
+    def test_converge_never_writes_through_symlinked_parent(self, tmp_path: Path) -> None:
+        pkg, outside = self._tree_with_symlinked_apm_dir(tmp_path)
+        before = (outside / "hooks" / "hooks.json").read_bytes()
+
+        changed = converge_apm_authored_files(pkg, PackageType.MARKETPLACE_PLUGIN, None)
+
+        # apm.yml (real file at the root) converges; the symlinked
+        # hooks.json is skipped and the out-of-tree file is untouched.
+        assert changed == ["apm.yml"]
+        assert (outside / "hooks" / "hooks.json").read_bytes() == before
+
+    def test_legacy_hash_ignores_symlinked_parent(self, tmp_path: Path) -> None:
+        pkg, outside = self._tree_with_symlinked_apm_dir(tmp_path)
+        # Fresh-download scenario: the post-fix tree is LF. The symlinked
+        # hooks.json is LF too, so an implementation without the parent
+        # guard would read through the symlink and record an override for
+        # it instead of skipping the path outright.
+        (pkg / "apm.yml").write_bytes(b"name: demo-plugin\nversion: 2c7ec5e\n")
+        (outside / "hooks" / "hooks.json").write_bytes(b"{\n}\n")
+
+        computed = legacy_crlf_hash(pkg, PackageType.MARKETPLACE_PLUGIN, None)
+
+        # apm.yml (real file at the root) contributes the only override;
+        # the symlinked hooks.json must be skipped, not read through.
+        assert computed is not None
+        assert computed == compute_package_hash_with_overrides(
+            pkg, {"apm.yml": b"name: demo-plugin\r\nversion: 2c7ec5e\r\n"}
+        )

--- a/tests/unit/test_content_hash.py
+++ b/tests/unit/test_content_hash.py
@@ -352,3 +352,56 @@ class TestLockfileContentHash:
         loaded_dep = loaded.get_dependency("owner/repo")
         assert loaded_dep is not None
         assert loaded_dep.content_hash == "sha256:deadbeef"
+
+
+@pytest.mark.windows_compat
+class TestComputePackageHashWithOverrides:
+    """apm#2619: override-hashing powers the legacy CRLF-domain equivalence check."""
+
+    def test_no_overrides_matches_plain_hash(self, tmp_path):
+        pkg = tmp_path / "pkg"
+        pkg.mkdir()
+        (pkg / "apm.yml").write_bytes(b"name: x\n")
+        (pkg / "README.md").write_bytes(b"# readme\n")
+
+        from apm_cli.utils.content_hash import compute_package_hash_with_overrides
+
+        assert compute_package_hash_with_overrides(pkg, {}) == compute_package_hash(pkg)
+
+    def test_override_matches_on_disk_replacement(self, tmp_path):
+        """Overriding bytes in memory equals actually writing those bytes."""
+        from apm_cli.utils.content_hash import compute_package_hash_with_overrides
+
+        pkg = tmp_path / "pkg"
+        sub = pkg / ".apm" / "hooks"
+        sub.mkdir(parents=True)
+        (pkg / "apm.yml").write_bytes(b"name: x\n")
+        (sub / "hooks.json").write_bytes(b"{}\n")
+
+        overridden = compute_package_hash_with_overrides(
+            pkg,
+            {"apm.yml": b"name: x\r\n", ".apm/hooks/hooks.json": b"{}\r\n"},
+        )
+
+        (pkg / "apm.yml").write_bytes(b"name: x\r\n")
+        (sub / "hooks.json").write_bytes(b"{}\r\n")
+        assert overridden == compute_package_hash(pkg)
+
+    def test_override_for_absent_file_is_ignored(self, tmp_path):
+        """Overrides never phantom-add files to the digest."""
+        from apm_cli.utils.content_hash import compute_package_hash_with_overrides
+
+        pkg = tmp_path / "pkg"
+        pkg.mkdir()
+        (pkg / "apm.yml").write_bytes(b"name: x\n")
+
+        plain = compute_package_hash(pkg)
+        assert compute_package_hash_with_overrides(pkg, {"ghost.md": b"boo"}) == plain
+
+    def test_missing_directory_returns_empty_hash(self, tmp_path):
+        from apm_cli.utils.content_hash import (
+            compute_package_hash_with_overrides,
+        )
+
+        absent = tmp_path / "nope"
+        assert compute_package_hash_with_overrides(absent, {}) == compute_package_hash(absent)


### PR DESCRIPTION
> **Stacked on the manifest-cache stamping fix #2627** — review the last commit only (`e6bc809e`). #2620 is merged; this branch is rebased on `main` past it.

## Summary

Removes the manual migration step #2620 leaves behind. Lockfiles and warm `apm_modules` trees recorded by a pre-fix APM on Windows carry the CRLF-domain `content_hash` of the APM-authored synthetic files; without this, upgrading surfaces a misleading "supply-chain attack" hard failure until the user deletes `apm_modules/` + `apm.lock.yaml` and regenerates.

## How it migrates

- **Fresh downloads**: if the locked hash equals the fresh tree re-hashed with *only* the APM-authored files (synthetic `apm.yml`, inline `hooks.json`) CRLF-expanded (`compute_package_hash_with_overrides` — no tree mutation), the difference is provably the benign legacy line-ending domain: accept, warn once, re-record the platform-independent hash. Genuine tampering still hard-fails (negative-control test included).
- **Cached installs**: legacy CRLF bytes in APM-authored files are rewritten to LF *before* the hash is re-recorded, so stale CRLF-domain hashes stop propagating into regenerated lockfiles.

Safety properties: upstream (git-materialized) content is never touched; `hooks.json` counts as APM-authored only when the plugin manifest declares hooks inline (a file-path declaration is a byte-copy of upstream content); authored paths behind symlinked directories are skipped, mirroring `compute_package_hash`'s enumeration semantics.

Verified end-to-end against the real `anthropics/skills` repro: a pre-fix Windows lockfile installs `--frozen` with a one-time warning and converges to `sha256:606a7fcb…`; a hand-CRLF-ified warm tree self-heals on the next install; reruns are silent.

Depends on the stamping-cache fix: the mismatch-triggered re-download must re-stamp for the fresh hash to be canonical.

## Panel follow-up (#2620): frozen replay coverage

Adds the requested hermetic marketplace-plugin lockfile write/read + `install --frozen` replay tests: the positive replay re-downloads through the real synthesize+stamp chain in the same process **without** clearing the manifest parse cache (a direct regression guard for #2627 — removing its invalidation makes the test fail), and a tampered-lockfile negative control keeps the frozen supply-chain gate closed.

## Spec conformance

The relaxed check is APM's internal raw-bytes package-tree `content_hash` (`docs/reference/lockfile-spec.md`); OpenAPM v0.1 reserves canonical-tree `content_hash` semantics for v0.2 (§5.6 editorial note) and anchors normative integrity on `tree_sha256` / `resolved_hash` / `deployed_file_hashes`, none of which change here. Waiver below.

apm-spec-waiver: one-time migration shim for pre-fix Windows lockfiles -- accepts the provably-benign legacy CRLF-domain content_hash of APM-authored synthetic files once and re-records the canonical hash; content_hash canonical-tree semantics are reserved for OpenAPM v0.2 (v0.1 spec section 5.6 editorial note), so no v0.1 normative contract changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
