### PR TITLE
docs: clarify allow_insecure hardening guidance

### DIFF
--- a/docs/src/content/docs/enterprise/security.md
+++ b/docs/src/content/docs/enterprise/security.md
@@ -131,11 +131,11 @@ dependencies:
 ```
 
 For example, `http://mirror.example.com/contoso/tools` canonicalizes to
-`mirror.example.com/contoso/tools`, so it does not match this allow list. If a
-mirror's canonical host path is allowed, policy accepts that identity for both
-HTTP and HTTPS. The manifest and CLI approvals above remain the scheme-aware
-HTTP controls. `registry_source.allow_non_registry` is a separate,
-experimental registry-routing control; it does not control HTTP Git transport.
+`contoso/tools`, so it matches this allow list. Policy cannot distinguish the
+mirror hostname or HTTP from HTTPS; the manifest and CLI approvals above are
+the scheme- and host-aware HTTP controls. `registry_source.allow_non_registry`
+is a separate, experimental registry-routing control; it does not control HTTP
+Git transport.
 
 These controls make the decision visible, but they do **not** make HTTP safe:
 

--- a/docs/src/content/docs/enterprise/security.md
+++ b/docs/src/content/docs/enterprise/security.md
@@ -119,6 +119,24 @@ surfaces:
   same host as an approved direct HTTP dependency. Additional transitive hosts
   require `--allow-insecure-host HOSTNAME`.
 
+`apm-policy.yml` has no `allow_insecure` key. Dependency allow and deny lists
+match scheme-free canonical repository refs, not the manifest flag or URL
+scheme. Use them to limit which repository identities are eligible:
+
+```yaml
+enforcement: block
+dependencies:
+  allow:
+    - "contoso/**"
+```
+
+For example, `http://mirror.example.com/contoso/tools` canonicalizes to
+`mirror.example.com/contoso/tools`, so it does not match this allow list. If a
+mirror's canonical host path is allowed, policy accepts that identity for both
+HTTP and HTTPS. The manifest and CLI approvals above remain the scheme-aware
+HTTP controls. `registry_source.allow_non_registry` is a separate,
+experimental registry-routing control; it does not control HTTP Git transport.
+
 These controls make the decision visible, but they do **not** make HTTP safe:
 
 - HTTP has no transport encryption or server authentication. A machine-in-the-middle can modify repository contents or refs in transit.
@@ -521,7 +539,10 @@ For an org standardizing on APM:
 - Publish an `apm-policy.yml` from your `<org>/.github` repo with an allow list and an MCP transport restriction. See [Governance Guide](../governance-guide/).
 - Require signed commits on the source repos APM pulls from -- this is where the trust chain bottoms out.
 - Route dep traffic through an enterprise proxy with audit logging. See [Registry Proxy & Air-gapped](../registry-proxy/).
-- Forbid `allow_insecure: true` via the policy allow list, except where an air-gapped mirror demands it.
+- Reject manifest entries with `allow_insecure: true` unless an air-gapped
+  mirror requires HTTP. APM has no dedicated policy key for that field; see
+  [HTTP (insecure) dependencies](#http-insecure-dependencies) for the two
+  runtime gates and the policy boundary.
 - Scan committed `apm.yml` for literal secrets in `mcp.env` values -- APM assumes env-var indirection (`GITHUB_TOKEN: ${GITHUB_TOKEN}`) but does not enforce it. `apm install` auto-adds `apm_modules/` to `.gitignore`, keeping cached source trees out of commits.
 
 ## Frequently asked questions


### PR DESCRIPTION
## Description

Clarify the security guide's `allow_insecure` hardening advice so it matches
the implemented policy boundary.

This change:

- states that `apm-policy.yml` has no dedicated `allow_insecure` key;
- explains that dependency allow/deny rules match scheme-free canonical
  repository refs;
- adds a restrictive `dependencies.allow` example and documents its limits;
- distinguishes `registry_source.allow_non_registry` from HTTP Git transport;
- points the hardening checklist to the existing two-gate runtime controls.

Fixes #2346

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Maintenance / refactor

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [ ] Added tests for new functionality (not applicable; documentation only)

Validation performed:

- `npm run test:links` (14 tests passed)
- `npm run build` (123 pages built; 969 relative links checked)
- `git diff --check`

## Spec conformance (OpenAPM v0.1)

- [x] N/A -- this PR does not change OpenAPM-observable behaviour.
