### PR TITLE
docs: add Windows lifecycle admin path

### DIFF
--- a/docs/src/content/docs/enterprise/lifecycle-scripts.md
+++ b/docs/src/content/docs/enterprise/lifecycle-scripts.md
@@ -30,7 +30,7 @@ and can delay the operation until they finish or their timeout elapses.
 Scripts are defined in three tiers. The **project tier** uses the repository `apm.yml`
 manifest under a top-level `lifecycle:` key. The **user tier** uses
 `~/.apm/apm.yml` (or `$APM_HOME/apm.yml`) under the same `lifecycle:` key.
-The **admin** tier uses `/etc/apm/policy.d/*.json` on Linux and macOS, or
+The **admin** tier uses `/etc/apm/policy.d/*.json` on POSIX systems, or
 `C:\ProgramData\APM\policy.d\*.json` on Windows. It is suited for
 machine- and fleet-managed deployment.
 
@@ -163,11 +163,12 @@ Security:
 ## Discovery locations
 
 Script files are loaded from three directories. All files are **additive** --
-every script from every file runs. Policy scripts cannot be disabled.
+every script from every file runs. Policy scripts cannot be individually
+disabled; the global kill switches below suppress all lifecycle scripts.
 
 | Priority     | Path                                                                        | Who controls     | Format |
 |--------------|-----------------------------------------------------------------------------|------------------|--------|
-| 1 (highest)  | Linux/macOS: `/etc/apm/policy.d/*.json`<br />Windows: `C:\ProgramData\APM\policy.d\*.json` | Platform/IT team | JSON   |
+| 1 (highest)  | POSIX: `/etc/apm/policy.d/*.json`<br />Windows: `C:\ProgramData\APM\policy.d\*.json` | Platform/IT team | JSON   |
 | 2            | `~/.apm/apm.yml`                                                           | Individual user  | YAML   |
 | 3            | `apm.yml` `lifecycle:`                                                     | Project          | YAML   |
 
@@ -197,10 +198,11 @@ POST body.
 
 Lifecycle scripts from different sources are subject to different trust rules:
 
-- **Policy scripts** (`/etc/apm/policy.d/*.json` on Linux/macOS or
+- **Policy scripts** (`/etc/apm/policy.d/*.json` on POSIX systems or
   `C:\ProgramData\APM\policy.d\*.json` on Windows) -- controlled by
   your platform/IT team. Run without any consent gate; they cannot be
-  disabled by the developer.
+  individually disabled by the developer. `APM_NO_SCRIPTS=1` suppresses
+  all lifecycle-script tiers for that run.
 - **User scripts** (`~/.apm/apm.yml`) -- controlled by the developer.
   Run without a gate.
 - **Project scripts** (`apm.yml` `lifecycle:`) -- committed into the repo and
@@ -231,7 +233,7 @@ policy directory to track which packages are actively used:
 
 Create `analytics.json` in the platform admin directory:
 
-- Linux/macOS: `/etc/apm/policy.d/analytics.json`
+- POSIX: `/etc/apm/policy.d/analytics.json`
 - Windows: `C:\ProgramData\APM\policy.d\analytics.json`
 
 ```json

--- a/docs/src/content/docs/enterprise/lifecycle-scripts.md
+++ b/docs/src/content/docs/enterprise/lifecycle-scripts.md
@@ -30,8 +30,9 @@ and can delay the operation until they finish or their timeout elapses.
 Scripts are defined in three tiers. The **project tier** uses the repository `apm.yml`
 manifest under a top-level `lifecycle:` key. The **user tier** uses
 `~/.apm/apm.yml` (or `$APM_HOME/apm.yml`) under the same `lifecycle:` key.
-The **admin** tier remains `/etc/apm/policy.d/*.json`, suited for machine-
-and fleet-managed deployment.
+The **admin** tier uses `/etc/apm/policy.d/*.json` on Linux and macOS, or
+`C:\ProgramData\APM\policy.d\*.json` on Windows. It is suited for
+machine- and fleet-managed deployment.
 
 ## Supported events
 
@@ -48,8 +49,9 @@ and fleet-managed deployment.
 
 Project and user manifests embed lifecycle scripts under a top-level
 `lifecycle:` key in `apm.yml`. The admin tier keeps the versioned JSON
-`{version: 1, scripts: {...}}` wrapper in `/etc/apm/policy.d/*.json`. All
-entries share the same field names and `type` discriminator.
+`{version: 1, scripts: {...}}` wrapper in the platform-specific policy
+directory shown below. All entries share the same field names and `type`
+discriminator.
 
 Each entry declares its kind via `type: command` (shell subprocess) or
 `type: http` (HTTPS webhook). An optional `description` field documents
@@ -163,11 +165,11 @@ Security:
 Script files are loaded from three directories. All files are **additive** --
 every script from every file runs. Policy scripts cannot be disabled.
 
-| Priority     | Path                        | Who controls     | Format |
-|--------------|-----------------------------|------------------|--------|
-| 1 (highest)  | `/etc/apm/policy.d/*.json`  | Platform/IT team | JSON   |
-| 2            | `~/.apm/apm.yml`            | Individual user  | YAML   |
-| 3            | `apm.yml` `lifecycle:`      | Project          | YAML   |
+| Priority     | Path                                                                        | Who controls     | Format |
+|--------------|-----------------------------------------------------------------------------|------------------|--------|
+| 1 (highest)  | Linux/macOS: `/etc/apm/policy.d/*.json`<br />Windows: `C:\ProgramData\APM\policy.d\*.json` | Platform/IT team | JSON   |
+| 2            | `~/.apm/apm.yml`                                                           | Individual user  | YAML   |
+| 3            | `apm.yml` `lifecycle:`                                                     | Project          | YAML   |
 
 Policy is a directory of JSON files. User and project sources are single
 `apm.yml` files that embed the `lifecycle:` subtree.
@@ -195,9 +197,10 @@ POST body.
 
 Lifecycle scripts from different sources are subject to different trust rules:
 
-- **Policy scripts** (`/etc/apm/policy.d/*.json`) -- controlled by your
-  platform/IT team. Run without any consent gate; they cannot be disabled
-  by the developer.
+- **Policy scripts** (`/etc/apm/policy.d/*.json` on Linux/macOS or
+  `C:\ProgramData\APM\policy.d\*.json` on Windows) -- controlled by
+  your platform/IT team. Run without any consent gate; they cannot be
+  disabled by the developer.
 - **User scripts** (`~/.apm/apm.yml`) -- controlled by the developer.
   Run without a gate.
 - **Project scripts** (`apm.yml` `lifecycle:`) -- committed into the repo and
@@ -226,7 +229,10 @@ The canonical use case for lifecycle scripts is installation analytics.
 An enterprise platform team can deploy an org-wide webhook via the
 policy directory to track which packages are actively used:
 
-Create `/etc/apm/policy.d/analytics.json`:
+Create `analytics.json` in the platform admin directory:
+
+- Linux/macOS: `/etc/apm/policy.d/analytics.json`
+- Windows: `C:\ProgramData\APM\policy.d\analytics.json`
 
 ```json
 {

--- a/packages/apm-guide/.apm/skills/apm-usage/commands.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/commands.md
@@ -170,7 +170,7 @@ If the install cache has not been warmed (e.g. a fresh checkout before the first
 | `apm lifecycle trust` | Trust `apm.yml` `lifecycle:` at its current contents so project scripts run on install | -- |
 | `apm lifecycle untrust` | Revoke trust for `apm.yml` `lifecycle:`; project scripts will stop running | -- |
 
-Lifecycle scripts fire on six events: `pre-install`, `post-install`, `pre-update`, `post-update`, `pre-uninstall`, `post-uninstall`. `post-install` fires only after success or partial success; failed and dry-run installs skip it. Script files are discovered from three sources (additive): policy (`/etc/apm/policy.d/*.json`, JSON), user (`~/.apm/apm.yml`, YAML), project (`apm.yml` `lifecycle:` at repo root, YAML). Two script types: `command` (shell via subprocess, event JSON on stdin) and `http` (HTTPS POST). Script output is appended to `~/.apm/logs/scripts.log`. See the [Lifecycle scripts](/apm/enterprise/lifecycle-scripts/) guide for full documentation.
+Lifecycle scripts fire on six events: `pre-install`, `post-install`, `pre-update`, `post-update`, `pre-uninstall`, `post-uninstall`. `post-install` fires only after success or partial success; failed and dry-run installs skip it. Script files are discovered from three sources (additive): policy (POSIX: `/etc/apm/policy.d/*.json`; Windows: `C:\ProgramData\APM\policy.d\*.json`; JSON), user (`~/.apm/apm.yml`, YAML), project (`apm.yml` `lifecycle:` at repo root, YAML). Two script types: `command` (shell via subprocess, event JSON on stdin) and `http` (HTTPS POST). Script output is appended to `~/.apm/logs/scripts.log`. See the [Lifecycle scripts](/apm/enterprise/lifecycle-scripts/) guide for full documentation.
 
 ## Distribution
 


### PR DESCRIPTION
## Description

Documents the platform-specific admin-tier lifecycle script locations throughout the lifecycle scripts guide:

- Linux/macOS: `/etc/apm/policy.d/*.json`
- Windows: `C:\ProgramData\APM\policy.d\*.json`

The discovery table, trust model, and analytics example now consistently show the Windows path from `_get_policy_scripts_dir()` instead of leaving later sections Linux-only.

Fixes #2621.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Maintenance / refactor

## Validation

- `npm run test:links` — 14 passed
- `npm run build` — 123 pages built; 969 relative links checked
- verified the rendered lifecycle page preserves the expected Windows path
- `git diff --check`

## Checklist

- [x] My changes follow the project's documentation style
- [x] I performed a self-review
- [x] The documentation builds successfully
