### PR TITLE
fix(uninstall): clean removed-only target files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `apm uninstall --global` now cleans removed-only target files before deleting their ownership state, while preserving files owned by surviving packages. (#2658)
 - Windows binary is now Authenticode-signed in the release workflow, eliminating
   the `Trojan:Script/Wacatac.H!ml` Windows Defender false positive on unsigned
   PyInstaller bundles. (#2435)

--- a/docs/src/content/docs/reference/cli/uninstall.md
+++ b/docs/src/content/docs/reference/cli/uninstall.md
@@ -90,18 +90,23 @@ apm uninstall https://github.com/acme/my-package.git
 
 What gets removed, in order:
 
-1. The package entry in `apm.yml` under `dependencies.apm` or `devDependencies.apm`.
-2. The package folder under `apm_modules/owner/repo/`.
-3. Transitive dependencies that no remaining package depends on (npm-style pruning, computed from `apm.lock.yaml`). A transitive dependency still declared by any surviving package is preserved, even when two packages share it (a diamond-shaped install). If a surviving package's manifest can't be read, APM keeps every remaining candidate for that run rather than guessing -- re-run with `--verbose` to see which manifest failed, then fix or restore it and re-run to complete cleanup.
-4. Every file in the lockfile's `deployed_files` for the removed packages and pruned orphans, across configured target-owned folders such as `.github/`, `.claude/`, `.grok/`, and `.agents/`.
-5. Hook entries inside `.claude/settings.json`, `.cursor/hooks.json`, `.gemini/settings.json`, and `.kiro/hooks/` that the removed packages contributed. Remaining packages -- including transitive dependencies still required by another package -- have their hook entries rebuilt from the post-removal lockfile.
-6. MCP servers contributed only by the removed packages.
-7. The lockfile entries themselves. If no dependencies remain, `apm.lock.yaml` is deleted.
-8. Empty parent directories left behind by the cleanup.
+1. Target-scoped files owned only by the removed packages, while ownership state is still available for safe cleanup.
+2. The package entry in `apm.yml` under `dependencies.apm` or `devDependencies.apm`.
+3. The package folder under `apm_modules/owner/repo/`.
+4. Transitive dependencies that no remaining package depends on (npm-style pruning, computed from `apm.lock.yaml`). A transitive dependency still declared by any surviving package is preserved, even when two packages share it (a diamond-shaped install). If a surviving package's manifest can't be read, APM keeps every remaining candidate for that run rather than guessing -- re-run with `--verbose` to see which manifest failed, then fix or restore it and re-run to complete cleanup.
+5. Every remaining file in the lockfile's `deployed_files` for the removed packages and pruned orphans, across configured target-owned folders such as `.github/`, `.claude/`, `.grok/`, and `.agents/`.
+6. Hook entries inside `.claude/settings.json`, `.cursor/hooks.json`, `.gemini/settings.json`, and `.kiro/hooks/` that the removed packages contributed. Remaining packages -- including transitive dependencies still required by another package -- have their hook entries rebuilt from the post-removal lockfile.
+7. MCP servers contributed only by the removed packages.
+8. The lockfile entries themselves. If no dependencies remain, `apm.lock.yaml` is deleted.
+9. Empty parent directories left behind by the cleanup.
 
 Selection is atomic. If any requested identifier does not match a declaration,
 the command exits nonzero before lifecycle scripts or filesystem writes run. No
 matched package in the same invocation is removed. Fix the identifier and retry.
+
+If a target-scoped file owned only by a removed package was edited or cannot be
+deleted, uninstall lists the retained paths and exits before changing `apm.yml`,
+`apm.lock.yaml`, or package modules. Resolve the listed files and retry.
 
 `_local/<name>` is resolved from the manifest and lockfile metadata that produced
 the `apm deps list` row. APM does not reinterpret it as `owner/repo` or rebuild an

--- a/scripts/check_target_instruction_contraction_owner.py
+++ b/scripts/check_target_instruction_contraction_owner.py
@@ -34,6 +34,7 @@ def analyze_sources(
     manifest_source: str,
     lockfile_source: str,
     post_local_source: str,
+    uninstall_source: str | None = None,
 ) -> list[str]:
     """Return violations of target-file contraction ownership."""
     manifest_calls = _function_calls(manifest_source)
@@ -65,6 +66,12 @@ def analyze_sources(
         violations.append(
             "post-deps local must route target contraction through reconcile_deployed_block"
         )
+    if uninstall_source is not None:
+        uninstall_calls = _function_calls(uninstall_source)
+        if _MANIFEST_OWNER not in uninstall_calls.get("uninstall", set()):
+            violations.append(
+                "uninstall must route removed target files through manifest_reconcile"
+            )
     return violations
 
 
@@ -73,10 +80,12 @@ def analyze_paths(root: Path) -> list[str]:
     manifest_path = root / "src/apm_cli/install/manifest_reconcile.py"
     lockfile_path = root / "src/apm_cli/install/phases/lockfile.py"
     post_local_path = root / "src/apm_cli/install/phases/post_deps_local.py"
+    uninstall_path = root / "src/apm_cli/commands/uninstall/cli.py"
     return analyze_sources(
         manifest_path.read_text(encoding="utf-8"),
         lockfile_path.read_text(encoding="utf-8"),
         post_local_path.read_text(encoding="utf-8"),
+        uninstall_path.read_text(encoding="utf-8"),
     )
 
 

--- a/src/apm_cli/commands/uninstall/cli.py
+++ b/src/apm_cli/commands/uninstall/cli.py
@@ -258,7 +258,41 @@ def uninstall(ctx, packages, dry_run, verbose, global_):
             )
             return
 
-        # Step 3: Remove from apm.yml
+        # Step 3: Remove target-scoped files while their lockfile ownership is
+        # still recoverable. The post-removal manifest can omit a removed
+        # package's target, so its target must not be reconstructed from it.
+        if lockfile and removed_keys:
+            from ...install.manifest_reconcile import reconcile_target_deployed_files
+            from ...integration.targets import resolve_targets
+            from ...utils.diagnostics import DiagnosticCollector
+
+            cleanup_target_names = list(APMPackage.from_apm_yml(manifest_path).canonical_targets)
+            cleanup_targets = resolve_targets(
+                deploy_root,
+                user_scope=scope is InstallScope.USER,
+                explicit_target=cleanup_target_names or None,
+            )
+            reconcile_target_deployed_files(
+                project_root=deploy_root,
+                lockfile=lockfile,
+                active_targets=cleanup_targets,
+                declared_targets=cleanup_targets,
+                diagnostics=DiagnosticCollector(verbose=verbose),
+                dependency_keys=removed_keys,
+                user_scope=scope is InstallScope.USER,
+            )
+            retained_removed_files = {
+                dep_key: dep.deployed_files
+                for dep_key, dep in lockfile.dependencies.items()
+                if dep_key in removed_keys and dep.deployed_files
+            }
+            if retained_removed_files:
+                raise RuntimeError(
+                    "Uninstall could not remove all tracked target files; "
+                    "package state was preserved. Resolve the retained files and retry."
+                )
+
+        # Step 4: Remove from apm.yml
         for package in packages_to_remove:
             package_label = _dependency_public_label(package)
             if package in dev_deps:
@@ -283,12 +317,12 @@ def uninstall(ctx, packages, dry_run, verbose, global_):
             logger.error(f"Failed to write {apm_yml_path}: {e}")
             sys.exit(1)
 
-        # Step 4: Capture pre-uninstall MCP state (lockfile already read above)
+        # Step 5: Capture pre-uninstall MCP state (lockfile already read above)
         _pre_uninstall_mcp_servers = (
             builtins.set(lockfile.mcp_servers) if lockfile else builtins.set()
         )
 
-        # Step 5: Remove packages from disk
+        # Step 6: Remove packages from disk
         refreshed_survivor_keys = builtins.set()
         removed_from_modules = _remove_packages_from_disk(
             packages_to_remove,
@@ -298,13 +332,13 @@ def uninstall(ctx, packages, dry_run, verbose, global_):
             refreshed_survivor_keys=refreshed_survivor_keys,
         )
 
-        # Step 6: Cleanup transitive orphans
+        # Step 7: Cleanup transitive orphans
         orphan_removed, actual_orphans = _cleanup_transitive_orphans(
             lockfile, packages_to_remove, modules_dir, apm_yml_path, logger
         )
         removed_from_modules += orphan_removed
 
-        # Step 7: Collect deployed files for removed packages (before lockfile mutation)
+        # Step 8: Collect deployed files for removed packages (before lockfile mutation)
         from ...integration.base_integrator import BaseIntegrator
 
         removed_keys.update(actual_orphans)
@@ -317,7 +351,7 @@ def uninstall(ctx, packages, dry_run, verbose, global_):
             BaseIntegrator.normalize_managed_files(all_deployed_files) or builtins.set()
         )
 
-        # Step 8: Mutate dependency state in memory. Persistence happens once
+        # Step 9: Mutate dependency state in memory. Persistence happens once
         # after survivor ownership, hashes, ledger, and MCP state agree.
         lockfile_updated = False
         if lockfile:
@@ -335,7 +369,7 @@ def uninstall(ctx, packages, dry_run, verbose, global_):
                     del lockfile.dependencies[orphan_key]
                     lockfile_updated = True
 
-        # Step 9: Sync integrations
+        # Step 10: Sync integrations
         cleaned = {
             "prompts": 0,
             "agents": 0,
@@ -397,7 +431,7 @@ def uninstall(ctx, packages, dry_run, verbose, global_):
                 logger.progress(f"Cleaned up {count} integrated {label}", symbol="check")
                 logger.verbose_detail(f"    Removed {count} deployed {label} file(s)")
 
-        # Step 10: MCP cleanup
+        # Step 11: MCP cleanup
         from ...adapters.client.intellij import IntelliJConfigError
         from ...utils.path_security import PathTraversalError
 

--- a/src/apm_cli/commands/uninstall/cli.py
+++ b/src/apm_cli/commands/uninstall/cli.py
@@ -272,25 +272,28 @@ def uninstall(ctx, packages, dry_run, verbose, global_):
                 user_scope=scope is InstallScope.USER,
                 explicit_target=cleanup_target_names or None,
             )
+            cleanup_keys = removed_keys | builtins.set(projected_orphans)
+            retained_cleanup_paths = builtins.set()
             reconcile_target_deployed_files(
                 project_root=deploy_root,
                 lockfile=lockfile,
                 active_targets=cleanup_targets,
                 declared_targets=cleanup_targets,
                 diagnostics=DiagnosticCollector(verbose=verbose),
-                dependency_keys=removed_keys,
+                dependency_keys=cleanup_keys,
+                remove_selected_ownership=True,
+                retained_selected_paths=retained_cleanup_paths,
                 user_scope=scope is InstallScope.USER,
+                logger=logger,
             )
-            retained_removed_files = {
-                dep_key: dep.deployed_files
-                for dep_key, dep in lockfile.dependencies.items()
-                if dep_key in removed_keys and dep.deployed_files
-            }
-            if retained_removed_files:
-                raise RuntimeError(
-                    "Uninstall could not remove all tracked target files; "
-                    "package state was preserved. Resolve the retained files and retry."
+            if retained_cleanup_paths:
+                logger.error(
+                    "Uninstall could not remove tracked target files; package state was preserved."
                 )
+                for path in sorted(retained_cleanup_paths):
+                    logger.error(f"  - {path}")
+                logger.error("Resolve or remove the listed files, then retry uninstall.")
+                sys.exit(1)
 
         # Step 4: Remove from apm.yml
         for package in packages_to_remove:

--- a/src/apm_cli/core/command_logger.py
+++ b/src/apm_cli/core/command_logger.py
@@ -144,6 +144,17 @@ class CommandLogger:
         if self.verbose:
             _rich_echo(message, color="dim")
 
+    def stale_cleanup(self, dep_key: str, count: int):
+        """Log target-scoped stale-file cleanup at default verbosity."""
+        if count <= 0:
+            return
+        noun = "file" if count == 1 else "files"
+        _rich_info(f"Cleaned {count} stale {noun} from {dep_key}", symbol="info")
+
+    def cleanup_skipped_user_edit(self, rel_path: str, dep_key: str):
+        """Explain that a user-edited managed file was retained."""
+        _rich_warning(f"Retained user-edited file {rel_path} from {dep_key}; resolve it and retry.")
+
     def tree_item(self, message: str):
         """Log a tree sub-item (└─ line) under a package block.
 

--- a/src/apm_cli/core/deployment_ledger.py
+++ b/src/apm_cli/core/deployment_ledger.py
@@ -285,6 +285,30 @@ class DeploymentLedgerCodec:
         )
 
     @staticmethod
+    def replace_legacy_owners(
+        lockfile: LockFile,
+        updates: dict[str, tuple[list[str], dict[str, str]]],
+    ) -> None:
+        """Apply compatibility ownership updates through one ledger rebuild."""
+        if not updates:
+            return
+        prior_ledger = DeploymentLedgerCodec.from_lockfile(lockfile)
+        prior_bundle_paths = DeploymentLedgerCodec.local_bundle_paths(lockfile)
+        for owner, (files, hashes) in updates.items():
+            if owner == ".":
+                lockfile.local_deployed_files = list(files)
+                lockfile.local_deployed_file_hashes = dict(hashes)
+                continue
+            dependency = lockfile.dependencies[owner]
+            dependency.deployed_files = list(files)
+            dependency.deployed_file_hashes = dict(hashes)
+        DeploymentLedgerCodec._rebuild_from_legacy(
+            lockfile,
+            prior_bundle_paths,
+            prior_ledger=prior_ledger,
+        )
+
+    @staticmethod
     def record_local_bundle_files(
         lockfile: LockFile,
         files: list[str],

--- a/src/apm_cli/install/manifest_reconcile.py
+++ b/src/apm_cli/install/manifest_reconcile.py
@@ -26,6 +26,7 @@ Both import :func:`union_preserving` so the behaviour stays identical.
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import replace
 from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -162,6 +163,7 @@ def union_preserving(
     current_run_trusted: bool = True,
     owner: str = "legacy",
     include_ledger: bool = False,
+    user_scope: bool = False,
 ) -> tuple[list[str], dict[str, str]] | tuple[list[str], dict[str, str], DeploymentLedger]:
     """Union the current install's manifest with preserved other-target entries.
 
@@ -202,6 +204,11 @@ def union_preserving(
     from apm_cli.integration.targets import KNOWN_TARGETS
     from apm_cli.utils.diagnostics import DiagnosticCollector
 
+    scoped_known_targets = {
+        name: scoped_target
+        for name, target in KNOWN_TARGETS.items()
+        if (scoped_target := target.for_scope(user_scope=user_scope)) is not None
+    }
     active_by_name = {target.name: target for target in targets}
     declared_by_name = (
         {target.name: target for target in declared_targets}
@@ -215,7 +222,7 @@ def union_preserving(
         ordered = [
             *targets,
             *(declared_targets or []),
-            *KNOWN_TARGETS.values(),
+            *scoped_known_targets.values(),
         ]
         seen_names: set[str] = set()
         for profile in ordered:
@@ -237,11 +244,13 @@ def union_preserving(
         )
 
     prior_values = set(prior_files or ())
-    prior_records = {
-        key: record
-        for key, record in (prior_ledger.records.items() if prior_ledger is not None else ())
-        if record.locator.value in prior_values
-    }
+    prior_records = {}
+    for key, record in prior_ledger.records.items() if prior_ledger is not None else ():
+        if record.locator.value not in prior_values:
+            continue
+        if record.locator.target == "legacy":
+            record = replace(record, locator=_locator(record.locator.value))
+        prior_records[key] = record
     prior_record_values = {record.locator.value for record in prior_records.values()}
     for path in prior_files or ():
         if path in prior_record_values:
@@ -278,7 +287,7 @@ def union_preserving(
     )
     reconciled = DeploymentReconciler(
         Path.cwd(),
-        KNOWN_TARGETS,
+        scoped_known_targets,
         diagnostics=DiagnosticCollector(),
     ).reconcile(
         DeploymentLedger(records=prior_records),
@@ -465,6 +474,7 @@ def reconcile_deployed_block(  # noqa: PLR0913 -- deployed-state chokepoint wrap
         current_run_trusted=current_run_trusted,
         owner=owner,
         include_ledger=True,
+        user_scope=user_scope,
     )
     dropped = set(prior_files) - set(files)
     # Ledger-authoritative orphan detection. A prior value that HELD a ledger
@@ -567,6 +577,7 @@ def reconcile_target_deployed_files(
     active_targets: list[TargetProfile],
     declared_targets: list[TargetProfile] | None,
     diagnostics: DiagnosticCollector,
+    dependency_keys: set[str] | None = None,
     user_scope: bool = False,
     logger: InstallLogger | None = None,
 ) -> bool:
@@ -586,7 +597,12 @@ def reconcile_target_deployed_files(
 
     allowed_targets = [*active_targets, *(declared_targets or [])]
     allowed_prefixes, allowed_schemes = install_governance(allowed_targets)
-    known_prefixes, known_schemes = install_governance(list(KNOWN_TARGETS.values()))
+    known_targets = [
+        scoped_target
+        for target in KNOWN_TARGETS.values()
+        if (scoped_target := target.for_scope(user_scope=user_scope)) is not None
+    ]
+    known_prefixes, known_schemes = install_governance(known_targets)
 
     def _retained(files: list[str]) -> list[str]:
         if declared_targets is None:
@@ -603,7 +619,7 @@ def reconcile_target_deployed_files(
     changed = False
     prior_ledger = DeploymentLedgerCodec.from_lockfile(lockfile)
     for dep_key, dependency in lockfile.dependencies.items():
-        if dep_key == _SELF_KEY:
+        if dep_key == _SELF_KEY or (dependency_keys is not None and dep_key not in dependency_keys):
             continue
         prior_files = list(dependency.deployed_files)
         prior_hashes = dict(dependency.deployed_file_hashes)

--- a/src/apm_cli/install/manifest_reconcile.py
+++ b/src/apm_cli/install/manifest_reconcile.py
@@ -26,7 +26,6 @@ Both import :func:`union_preserving` so the behaviour stays identical.
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import replace
 from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -163,6 +162,8 @@ def union_preserving(
     current_run_trusted: bool = True,
     owner: str = "legacy",
     include_ledger: bool = False,
+    desired_owners: frozenset[str] | None = None,
+    generic_governed_values: frozenset[str] = frozenset(),
     user_scope: bool = False,
 ) -> tuple[list[str], dict[str, str]] | tuple[list[str], dict[str, str], DeploymentLedger]:
     """Union the current install's manifest with preserved other-target entries.
@@ -248,8 +249,6 @@ def union_preserving(
     for key, record in prior_ledger.records.items() if prior_ledger is not None else ():
         if record.locator.value not in prior_values:
             continue
-        if record.locator.target == "legacy":
-            record = replace(record, locator=_locator(record.locator.value))
         prior_records[key] = record
     prior_record_values = {record.locator.value for record in prior_records.values()}
     for path in prior_files or ():
@@ -297,7 +296,7 @@ def union_preserving(
             declared_targets=(
                 frozenset(declared_by_name) if declared_by_name is not None else None
             ),
-            desired_owners=None,
+            desired_owners=desired_owners,
             authoritative_targets=current_run_trusted,
             generic_governed_values=(
                 frozenset(
@@ -305,12 +304,13 @@ def union_preserving(
                     for path in prior_values
                     if is_governed_by_install(path, active_prefixes, active_schemes)
                 )
+                | generic_governed_values
                 if (
                     current_run_trusted
                     and declared_by_name is not None
                     and set(active_by_name) == set(declared_by_name)
                 )
-                else None
+                else generic_governed_values or None
             ),
         ),
     )
@@ -449,6 +449,8 @@ def reconcile_deployed_block(  # noqa: PLR0913 -- deployed-state chokepoint wrap
     owner: str = "legacy",
     include_ledger: bool = False,
     apply_disk_deletion: bool = True,
+    desired_owners: frozenset[str] | None = None,
+    generic_governed_values: frozenset[str] = frozenset(),
     user_scope: bool = False,
 ) -> tuple[list[str], dict[str, str]] | tuple[list[str], dict[str, str], DeploymentLedger]:
     """Reconcile one deployed-state block and safely remove dropped paths.
@@ -474,6 +476,8 @@ def reconcile_deployed_block(  # noqa: PLR0913 -- deployed-state chokepoint wrap
         current_run_trusted=current_run_trusted,
         owner=owner,
         include_ledger=True,
+        desired_owners=desired_owners,
+        generic_governed_values=generic_governed_values,
         user_scope=user_scope,
     )
     dropped = set(prior_files) - set(files)
@@ -578,6 +582,8 @@ def reconcile_target_deployed_files(
     declared_targets: list[TargetProfile] | None,
     diagnostics: DiagnosticCollector,
     dependency_keys: set[str] | None = None,
+    remove_selected_ownership: bool = False,
+    retained_selected_paths: set[str] | None = None,
     user_scope: bool = False,
     logger: InstallLogger | None = None,
 ) -> bool:
@@ -592,9 +598,25 @@ def reconcile_target_deployed_files(
     never silent.
     """
     from apm_cli.core.deployment_ledger import DeploymentLedgerCodec
+    from apm_cli.core.deployment_state import DeploymentLedger
     from apm_cli.deps.lockfile import _SELF_KEY
     from apm_cli.integration.targets import KNOWN_TARGETS
 
+    selected_owner_removal = remove_selected_ownership and dependency_keys is not None
+    survivor_files = {
+        path
+        for dep_key, dependency in lockfile.dependencies.items()
+        if dep_key not in (dependency_keys or set())
+        for path in dependency.deployed_files
+    }
+    desired_owners = (
+        DeploymentLedgerCodec.valid_owner_keys(
+            lockfile,
+            excluded_dependency_keys=dependency_keys or set(),
+        )
+        if selected_owner_removal
+        else None
+    )
     allowed_targets = [*active_targets, *(declared_targets or [])]
     allowed_prefixes, allowed_schemes = install_governance(allowed_targets)
     known_targets = [
@@ -605,6 +627,8 @@ def reconcile_target_deployed_files(
     known_prefixes, known_schemes = install_governance(known_targets)
 
     def _retained(files: list[str]) -> list[str]:
+        if selected_owner_removal:
+            return [path for path in files if path in survivor_files or "://" in path]
         if declared_targets is None:
             return list(files)
         return [
@@ -618,6 +642,10 @@ def reconcile_target_deployed_files(
 
     changed = False
     prior_ledger = DeploymentLedgerCodec.from_lockfile(lockfile)
+    prior_records_by_value: dict[str, dict[str, object]] = {}
+    for key, record in prior_ledger.records.items():
+        prior_records_by_value.setdefault(record.locator.value, {})[key] = record
+    dependency_updates: dict[str, tuple[list[str], dict[str, str]]] = {}
     for dep_key, dependency in lockfile.dependencies.items():
         if dep_key == _SELF_KEY or (dependency_keys is not None and dep_key not in dependency_keys):
             continue
@@ -627,6 +655,13 @@ def reconcile_target_deployed_files(
         current_hashes = {
             path: value for path, value in prior_hashes.items() if path in current_files
         }
+        dependency_ledger = DeploymentLedger(
+            records={
+                key: record
+                for path in prior_files
+                for key, record in prior_records_by_value.get(path, {}).items()
+            }
+        )
         files, hashes = reconcile_deployed_block(
             project_root=project_root,
             dep_key=dep_key,
@@ -637,37 +672,58 @@ def reconcile_target_deployed_files(
             active_targets=active_targets,
             declared_targets=declared_targets,
             diagnostics=diagnostics,
-            prior_ledger=prior_ledger,
+            prior_ledger=dependency_ledger,
             on_cleanup=partial(_surface_target_cleanup, logger, dep_key),
+            desired_owners=desired_owners,
+            generic_governed_values=(
+                frozenset(prior_files) if selected_owner_removal else frozenset()
+            ),
             user_scope=user_scope,
         )
+        if selected_owner_removal:
+            if retained_selected_paths is not None:
+                retained_selected_paths.update(
+                    path for path in files if path not in survivor_files and "://" not in path
+                )
+            continue
         if files != prior_files or hashes != prior_hashes:
-            DeploymentLedgerCodec.replace_legacy_owner(lockfile, dep_key, files, hashes)
+            dependency_updates[dep_key] = (files, hashes)
             changed = True
 
-    prior_local = list(lockfile.local_deployed_files)
-    prior_local_hashes = dict(lockfile.local_deployed_file_hashes)
-    current_local = _retained(prior_local)
-    current_local_hashes = {
-        path: value for path, value in prior_local_hashes.items() if path in current_local
-    }
-    local_files, local_hashes = reconcile_deployed_block(
-        project_root=project_root,
-        dep_key="<local .apm/>",
-        current_files=current_local,
-        current_hashes=current_local_hashes,
-        prior_files=prior_local,
-        prior_hashes=prior_local_hashes,
-        active_targets=active_targets,
-        declared_targets=declared_targets,
-        diagnostics=diagnostics,
-        prior_ledger=prior_ledger,
-        on_cleanup=partial(_surface_target_cleanup, logger, "<local .apm/>"),
-        user_scope=user_scope,
-    )
-    if local_files != prior_local or local_hashes != prior_local_hashes:
-        DeploymentLedgerCodec.replace_legacy_owner(lockfile, ".", local_files, local_hashes)
-        changed = True
+    if dependency_updates:
+        DeploymentLedgerCodec.replace_legacy_owners(lockfile, dependency_updates)
+
+    if dependency_keys is None:
+        prior_local = list(lockfile.local_deployed_files)
+        prior_local_hashes = dict(lockfile.local_deployed_file_hashes)
+        current_local = _retained(prior_local)
+        current_local_hashes = {
+            path: value for path, value in prior_local_hashes.items() if path in current_local
+        }
+        local_ledger = DeploymentLedger(
+            records={
+                key: record
+                for path in prior_local
+                for key, record in prior_records_by_value.get(path, {}).items()
+            }
+        )
+        local_files, local_hashes = reconcile_deployed_block(
+            project_root=project_root,
+            dep_key="<local .apm/>",
+            current_files=current_local,
+            current_hashes=current_local_hashes,
+            prior_files=prior_local,
+            prior_hashes=prior_local_hashes,
+            active_targets=active_targets,
+            declared_targets=declared_targets,
+            diagnostics=diagnostics,
+            prior_ledger=local_ledger,
+            on_cleanup=partial(_surface_target_cleanup, logger, "<local .apm/>"),
+            user_scope=user_scope,
+        )
+        if local_files != prior_local or local_hashes != prior_local_hashes:
+            DeploymentLedgerCodec.replace_legacy_owner(lockfile, ".", local_files, local_hashes)
+            changed = True
 
     return changed
 

--- a/tests/integration/test_global_scope_e2e.py
+++ b/tests/integration/test_global_scope_e2e.py
@@ -456,6 +456,45 @@ class TestGlobalGeminiScope:
 class TestGlobalUninstallLifecycle:
     """Test uninstall --global removes packages from user-scope metadata."""
 
+    @staticmethod
+    def _install_survivor_and_removed_target_packages(
+        apm_binary_path: Path, fake_home: Path, tmp_path: Path
+    ) -> tuple[Path, Path, Path]:
+        """Install global agent-skills survivor and OpenCode removal fixtures."""
+        survivor = _write_targeted_package(
+            tmp_path,
+            "survivor-target-cleanup",
+            ".apm/skills/survivor",
+            "SKILL.md",
+            "---\nname: survivor\ndescription: Survives removal.\n---\n# Survivor\n",
+        )
+        removed = _write_targeted_package(
+            tmp_path,
+            "removed-target-cleanup",
+            ".apm/agents",
+            "orphan.agent.md",
+            "---\nname: orphan\ndescription: Must be cleaned.\n---\n# Orphan\n",
+        )
+        survivor_install = _run_apm(
+            apm_binary_path,
+            ["install", "--global", str(survivor), "--target", "agent-skills"],
+            fake_home,
+            fake_home,
+        )
+        assert survivor_install.returncode == 0, survivor_install.stdout + survivor_install.stderr
+        removed_install = _run_apm(
+            apm_binary_path,
+            ["install", "--global", str(removed), "--target", "opencode"],
+            fake_home,
+            fake_home,
+        )
+        assert removed_install.returncode == 0, removed_install.stdout + removed_install.stderr
+        survivor_file = fake_home / ".agents" / "skills" / "survivor" / "SKILL.md"
+        removed_file = fake_home / ".config" / "opencode" / "agents" / "orphan.md"
+        assert survivor_file.exists()
+        assert removed_file.exists()
+        return removed, survivor_file, removed_file
+
     def test_uninstall_removes_package_from_user_manifest(self, apm_binary_path, fake_home):
         """Uninstall --global should remove the package entry from ~/.apm/apm.yml."""
         apm_dir = fake_home / ".apm"
@@ -524,42 +563,11 @@ class TestGlobalUninstallLifecycle:
         tmp_path,
     ):
         """A removed OpenCode agent cannot survive a manifest with agent-skills only."""
-        survivor = _write_targeted_package(
-            tmp_path,
-            "survivor-target-cleanup",
-            ".apm/skills/survivor",
-            "SKILL.md",
-            "---\nname: survivor\ndescription: Survives removal.\n---\n# Survivor\n",
+        removed, survivor_file, removed_file = self._install_survivor_and_removed_target_packages(
+            apm_binary_path, fake_home, tmp_path
         )
-        removed = _write_targeted_package(
-            tmp_path,
-            "removed-target-cleanup",
-            ".apm/agents",
-            "orphan.agent.md",
-            "---\nname: orphan\ndescription: Must be cleaned.\n---\n# Orphan\n",
-        )
-
-        survivor_install = _run_apm(
-            apm_binary_path,
-            ["install", "--global", str(survivor), "--target", "agent-skills"],
-            fake_home,
-            fake_home,
-        )
-        assert survivor_install.returncode == 0, survivor_install.stdout + survivor_install.stderr
-        removed_install = _run_apm(
-            apm_binary_path,
-            ["install", "--global", str(removed), "--target", "opencode"],
-            fake_home,
-            fake_home,
-        )
-        assert removed_install.returncode == 0, removed_install.stdout + removed_install.stderr
 
         apm_dir = fake_home / ".apm"
-        survivor_file = fake_home / ".agents" / "skills" / "survivor" / "SKILL.md"
-        removed_file = fake_home / ".config" / "opencode" / "agents" / "orphan.md"
-        assert survivor_file.exists()
-        assert removed_file.exists()
-
         uninstall_result = _run_apm(
             apm_binary_path,
             ["uninstall", "--global", str(removed)],
@@ -580,6 +588,36 @@ class TestGlobalUninstallLifecycle:
         assert "survivor-target-cleanup" in lockfile_text
         assert not (apm_dir / "apm_modules" / "_local" / "removed-target-cleanup").exists()
         assert (apm_dir / "apm_modules" / "_local" / "survivor-target-cleanup").exists()
+
+    def test_uninstall_global_preserves_state_for_user_edited_removed_target_file(
+        self,
+        apm_binary_path,
+        fake_home,
+        tmp_path,
+    ):
+        """A retained edited file leaves all removal state available for retry."""
+        removed, survivor_file, removed_file = self._install_survivor_and_removed_target_packages(
+            apm_binary_path, fake_home, tmp_path
+        )
+        removed_file.write_text("# user edit\n", encoding="utf-8")
+
+        result = _run_apm(
+            apm_binary_path,
+            ["uninstall", "--global", str(removed)],
+            fake_home,
+            fake_home,
+        )
+
+        combined = result.stdout + result.stderr
+        apm_dir = fake_home / ".apm"
+        assert result.returncode != 0, combined
+        assert ".config/opencode/agents/orphan.md" in combined
+        assert "retry uninstall" in combined
+        assert removed_file.exists()
+        assert survivor_file.exists()
+        assert "removed-target-cleanup" in (apm_dir / "apm.yml").read_text(encoding="utf-8")
+        assert "removed-target-cleanup" in (apm_dir / "apm.lock.yaml").read_text(encoding="utf-8")
+        assert (apm_dir / "apm_modules" / "_local" / "removed-target-cleanup").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_global_scope_e2e.py
+++ b/tests/integration/test_global_scope_e2e.py
@@ -67,6 +67,26 @@ def _run_apm(apm_binary_path, args, cwd, fake_home, timeout=60):
     )
 
 
+def _write_targeted_package(
+    root: Path,
+    name: str,
+    primitive_path: str,
+    filename: str,
+    content: str,
+) -> Path:
+    """Create one local package with a primitive for a selected global target."""
+    package = root / name
+    package.mkdir()
+    (package / "apm.yml").write_text(
+        yaml.dump({"name": name, "version": "1.0.0", "description": f"{name} fixture"}),
+        encoding="utf-8",
+    )
+    primitive_dir = package / primitive_path
+    primitive_dir.mkdir(parents=True)
+    (primitive_dir / filename).write_text(content, encoding="utf-8")
+    return package
+
+
 @pytest.fixture
 def local_package(tmp_path):
     """Create a minimal local APM package for testing global install.
@@ -496,6 +516,70 @@ class TestGlobalUninstallLifecycle:
         assert "not found" in combined.lower() or "not in apm.yml" in combined.lower(), (
             f"Expected 'not found' warning: {combined}"
         )
+
+    def test_uninstall_global_cleans_removed_only_target_before_state_removal(
+        self,
+        apm_binary_path,
+        fake_home,
+        tmp_path,
+    ):
+        """A removed OpenCode agent cannot survive a manifest with agent-skills only."""
+        survivor = _write_targeted_package(
+            tmp_path,
+            "survivor-target-cleanup",
+            ".apm/skills/survivor",
+            "SKILL.md",
+            "---\nname: survivor\ndescription: Survives removal.\n---\n# Survivor\n",
+        )
+        removed = _write_targeted_package(
+            tmp_path,
+            "removed-target-cleanup",
+            ".apm/agents",
+            "orphan.agent.md",
+            "---\nname: orphan\ndescription: Must be cleaned.\n---\n# Orphan\n",
+        )
+
+        survivor_install = _run_apm(
+            apm_binary_path,
+            ["install", "--global", str(survivor), "--target", "agent-skills"],
+            fake_home,
+            fake_home,
+        )
+        assert survivor_install.returncode == 0, survivor_install.stdout + survivor_install.stderr
+        removed_install = _run_apm(
+            apm_binary_path,
+            ["install", "--global", str(removed), "--target", "opencode"],
+            fake_home,
+            fake_home,
+        )
+        assert removed_install.returncode == 0, removed_install.stdout + removed_install.stderr
+
+        apm_dir = fake_home / ".apm"
+        survivor_file = fake_home / ".agents" / "skills" / "survivor" / "SKILL.md"
+        removed_file = fake_home / ".config" / "opencode" / "agents" / "orphan.md"
+        assert survivor_file.exists()
+        assert removed_file.exists()
+
+        uninstall_result = _run_apm(
+            apm_binary_path,
+            ["uninstall", "--global", str(removed)],
+            fake_home,
+            fake_home,
+        )
+        assert uninstall_result.returncode == 0, uninstall_result.stdout + uninstall_result.stderr
+
+        assert not removed_file.exists()
+        assert survivor_file.exists()
+        manifest = yaml.safe_load((apm_dir / "apm.yml").read_text(encoding="utf-8"))
+        assert isinstance(manifest, dict)
+        manifest_text = yaml.safe_dump(manifest)
+        assert "removed-target-cleanup" not in manifest_text
+        assert "survivor-target-cleanup" in manifest_text
+        lockfile_text = (apm_dir / "apm.lock.yaml").read_text(encoding="utf-8")
+        assert "removed-target-cleanup" not in lockfile_text
+        assert "survivor-target-cleanup" in lockfile_text
+        assert not (apm_dir / "apm_modules" / "_local" / "removed-target-cleanup").exists()
+        assert (apm_dir / "apm_modules" / "_local" / "survivor-target-cleanup").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/install/test_target_contraction_logging.py
+++ b/tests/unit/install/test_target_contraction_logging.py
@@ -123,5 +123,46 @@ def test_contraction_without_logger_still_deletes(tmp_path):
     assert not cursor_abs.exists()
 
 
+def test_contraction_removes_only_selected_removed_target_ownership(tmp_path):
+    """A removed target's cleanup must not depend on surviving target selection."""
+    survivor_rel = ".config/opencode/agents/survivor.md"
+    removed_rel = ".config/opencode/agents/orphan.md"
+    survivor_abs = tmp_path / survivor_rel
+    removed_abs = tmp_path / removed_rel
+    for path, body in ((survivor_abs, "# survivor\n"), (removed_abs, "# orphan\n")):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+
+    lockfile = LockFile()
+    lockfile.add_dependency(
+        LockedDependency(
+            repo_url="https://github.com/acme/survivor",
+            deployed_files=[survivor_rel],
+            deployed_file_hashes={survivor_rel: compute_file_hash(survivor_abs)},
+        )
+    )
+    removed = LockedDependency(
+        repo_url="https://github.com/acme/removed",
+        deployed_files=[removed_rel],
+        deployed_file_hashes={removed_rel: compute_file_hash(removed_abs)},
+    )
+    lockfile.add_dependency(removed)
+
+    changed = reconcile_target_deployed_files(
+        project_root=tmp_path,
+        lockfile=lockfile,
+        active_targets=[KNOWN_TARGETS["agent-skills"]],
+        declared_targets=[KNOWN_TARGETS["agent-skills"]],
+        diagnostics=DiagnosticCollector(),
+        dependency_keys={removed.get_unique_key()},
+        user_scope=True,
+    )
+
+    assert changed is True
+    assert survivor_abs.exists()
+    assert not removed_abs.exists()
+    assert lockfile.get_dependency(removed.get_unique_key()).deployed_files == []
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/install/test_target_contraction_logging.py
+++ b/tests/unit/install/test_target_contraction_logging.py
@@ -148,20 +148,58 @@ def test_contraction_removes_only_selected_removed_target_ownership(tmp_path):
     )
     lockfile.add_dependency(removed)
 
-    changed = reconcile_target_deployed_files(
+    reconcile_target_deployed_files(
         project_root=tmp_path,
         lockfile=lockfile,
         active_targets=[KNOWN_TARGETS["agent-skills"]],
         declared_targets=[KNOWN_TARGETS["agent-skills"]],
         diagnostics=DiagnosticCollector(),
         dependency_keys={removed.get_unique_key()},
+        remove_selected_ownership=True,
         user_scope=True,
     )
 
-    assert changed is True
     assert survivor_abs.exists()
     assert not removed_abs.exists()
-    assert lockfile.get_dependency(removed.get_unique_key()).deployed_files == []
+
+
+def test_selected_ownership_cleanup_removes_unique_active_target_file(tmp_path):
+    """Removing one owner deletes its file even when the target remains active."""
+    survivor_rel = ".config/opencode/agents/survivor.md"
+    removed_rel = ".config/opencode/agents/orphan.md"
+    survivor_abs = tmp_path / survivor_rel
+    removed_abs = tmp_path / removed_rel
+    for path, body in ((survivor_abs, "# survivor\n"), (removed_abs, "# orphan\n")):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+
+    lockfile = LockFile()
+    survivor = LockedDependency(
+        repo_url="https://github.com/acme/survivor",
+        deployed_files=[survivor_rel],
+        deployed_file_hashes={survivor_rel: compute_file_hash(survivor_abs)},
+    )
+    removed = LockedDependency(
+        repo_url="https://github.com/acme/removed",
+        deployed_files=[removed_rel],
+        deployed_file_hashes={removed_rel: compute_file_hash(removed_abs)},
+    )
+    lockfile.add_dependency(survivor)
+    lockfile.add_dependency(removed)
+
+    reconcile_target_deployed_files(
+        project_root=tmp_path,
+        lockfile=lockfile,
+        active_targets=[KNOWN_TARGETS["opencode"]],
+        declared_targets=[KNOWN_TARGETS["opencode"]],
+        diagnostics=DiagnosticCollector(),
+        dependency_keys={removed.get_unique_key()},
+        remove_selected_ownership=True,
+        user_scope=True,
+    )
+
+    assert survivor_abs.exists()
+    assert not removed_abs.exists()
 
 
 if __name__ == "__main__":

--- a/tests/unit/scripts/test_check_target_instruction_contraction_owner.py
+++ b/tests/unit/scripts/test_check_target_instruction_contraction_owner.py
@@ -109,3 +109,37 @@ def run():
         "post-deps local must not delete target files directly",
         "post-deps local must route target contraction through reconcile_deployed_block",
     ]
+
+
+def test_checker_rejects_uninstall_cleanup_outside_manifest_owner() -> None:
+    """Removed target files must use the same contraction owner as install."""
+    checker = _load_checker()
+    manifest_source = """
+def reconcile_deployed_block():
+    remove_stale_deployed_files()
+
+def reconcile_target_deployed_files():
+    reconcile_deployed_block()
+
+def reconcile_deployed_state():
+    reconcile_target_deployed_files()
+"""
+    lockfile_source = """
+def _reconcile_target_deployed_files():
+    reconcile_target_deployed_files()
+"""
+    post_local_source = """
+def run():
+    reconcile_deployed_block()
+"""
+    uninstall_source = """
+def uninstall():
+    remove_stale_deployed_files()
+"""
+
+    assert checker.analyze_sources(
+        manifest_source,
+        lockfile_source,
+        post_local_source,
+        uninstall_source,
+    ) == ["uninstall must route removed target files through manifest_reconcile"]


### PR DESCRIPTION
# fix(uninstall): clean removed-only target files

## TL;DR

Global uninstall now cleans files owned only by removed packages before deleting the ownership state needed to find them. The canonical manifest reconciliation owner performs the cleanup without rewriting shared ownership before the existing survivor handoff. An edited file aborts with its path and preserves manifest, lockfile, and module state for retry. Closes #2656.

> [!IMPORTANT]
> Cleanup failure preserves package state and names every retained path so users can resolve it and rerun uninstall.

## Problem (WHY)

- [x] The post-removal target set omitted an OpenCode file owned only by the removed package, leaving an orphan. [Issue #2656](https://github.com/microsoft/apm/issues/2656) records the reported outcome.
- [x] Removing manifest, module, and lockfile state first would discard the ownership evidence required for safe cleanup and retry.
- [x] A direct uninstall cleanup path would split target-scoped contraction away from its canonical owner.

## Approach (WHAT)

- Reconcile selected removed owners before package-state mutation through `reconcile_target_deployed_files()`.
- Preserve shared legacy ownership until the existing survivor handoff, while deleting only unique filesystem paths.
- Keep URI-backed runtime resources on their existing runtime-specific uninstall path.
- Batch compatibility-view updates for ordinary target contraction and reuse a per-value ledger index.
- Enforce the uninstall route with the static target-contraction ownership check.

## Implementation (HOW)

- **`src/apm_cli/commands/uninstall/cli.py`** -- invokes selected-owner cleanup before state mutation, routes visibility through `CommandLogger`, and names retained paths before exiting for retry.
- **`src/apm_cli/install/manifest_reconcile.py`** -- adds selected-owner physical cleanup that preserves shared legacy ownership, skips URI resources, scopes existing ledger records by value, and batches normal compatibility-view updates.
- **`src/apm_cli/core/deployment_ledger.py`** and **`src/apm_cli/core/command_logger.py`** -- centralize batch legacy projection and the command-level cleanup messages.
- **Tests and docs** -- add active-target and edited-file lifecycle traps, update uninstall guidance, and record the fix in Unreleased.

## Diagrams

Legend: selected-owner cleanup deletes unique filesystem paths before state mutation, while shared ownership and URI resources continue through their existing handoff paths.

```mermaid
flowchart LR
    U[uninstall] --> R[reconcile target deployed files]
    R --> F[delete unique filesystem paths]
    R --> H[preserve shared ownership and URI resources]
    F --> S[remove manifest lockfile module state]
    H --> S
    classDef new stroke-dasharray: 5 5;
    class R,F new;
```

## Trade-offs

- **Preserve shared legacy rows.** Selected-owner cleanup does not rewrite shared ownership before the established survivor reintegration path runs.
- **Leave URI resources to their runtime owner.** Copilot App and similar URI-backed entries remain on their existing uninstall cleanup path.
- **Fail before state mutation.** Edited or undeletable unique files stop uninstall with an actionable retry message.

## Benefits

1. A removed-only OpenCode agent is deleted before its ownership state disappears.
2. Same-target survivor files and URI-backed runtime resources retain their established ownership handoff.
3. Edited files preserve all package state and report the exact path to resolve.
4. Static routing and lifecycle tests trap future regressions.

## Validation

```
PYTHONPATH=src uv run --no-sync pytest <focused ownership, uninstall, and architecture nodes> -q
17 passed

Current-source global lifecycle tests
2 passed

uv run --no-sync ruff check src/ tests/
All checks passed!

uv run --no-sync ruff format --check src/ tests/
1639 files already formatted

bash scripts/lint-auth-signals.sh
[+] auth-signal lint clean

GitHub CI on e29d7139d
Lint, both Linux shards, and architecture ratchets passed
```

> [!WARNING]
> Local pylint could not run because `uv` could not fetch `setuptools`/`wheel`: `Socket is not connected (os error 57)`. GitHub CI ran pylint successfully in its passing Lint job.

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|-------------------------|--------------|--------------------|------|
| 1 | Uninstalling a global package removes a file deployed only for its removed OpenCode target. | DevX (pragmatic as npm), Multi-harness support | `tests/integration/test_global_scope_e2e.py::TestGlobalUninstallLifecycle::test_uninstall_global_cleans_removed_only_target_before_state_removal` (regression-trap for #2656) | integration |
| 2 | Removing a package does not delete another package's same-target file. | DevX (pragmatic as npm), Governed by policy | `tests/unit/test_uninstall_shared_ownership.py::test_uninstall_transfers_shared_deployed_path_ownership` | unit |
| 3 | An edited removed-only file preserves package state and identifies the retry path. | DevX (pragmatic as npm), Governed by policy | `tests/integration/test_global_scope_e2e.py::TestGlobalUninstallLifecycle::test_uninstall_global_preserves_state_for_user_edited_removed_target_file` | integration |
| 4 | Future uninstall code keeps target cleanup at the canonical reconciliation owner. | Governed by policy | `tests/integration/test_architecture_authorities.py::test_target_instruction_contraction_uses_manifest_reconciliation` | integration |

## How to test

- [ ] Run the two global uninstall lifecycle tests and confirm successful cleanup plus edited-file state preservation.
- [ ] Run `tests/unit/test_uninstall_shared_ownership.py` and confirm a shared file is retained for the survivor.
- [ ] Run `bash scripts/lint-architecture-boundaries.sh` and confirm the canonical route is accepted.

apm-spec-waiver: Restores existing target ownership cleanup; no new OpenAPM contract.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>