### PR TITLE
docs: align monorepo release layout

### DIFF
--- a/docs/src/content/docs/producer/repo-shapes.md
+++ b/docs/src/content/docs/producer/repo-shapes.md
@@ -104,7 +104,7 @@ writes `marketplace.json` only. No bundle is produced because
 
 > **Advanced.** Most first-time authors should start with single-plugin or aggregator. Reach for hybrid when you're shipping your own plugin *and* curating others. [`DevExpGbb/zava-agent-config`](https://github.com/DevExpGbb/zava-agent-config) is the live reference: 7 plugins under `plugins/`, one root `apm.yml`, releases via [microsoft/apm-action@v1](https://github.com/microsoft/apm-action) `mode: release`.
 
-One repo, many plugins under `packages/`, one marketplace at the root
+One repo, many plugins under `plugins/`, one marketplace at the root
 that lists them as local-path entries. Each plugin gets its own
 `apm.yml` so it can be compiled and tested in isolation.
 
@@ -113,7 +113,7 @@ Layout:
 ```text
 my-monorepo/
   apm.yml                          # marketplace + local-path packages
-  packages/
+  plugins/
     plugin-a/
       apm.yml                      # plugin-a's manifest
       .apm/
@@ -139,21 +139,26 @@ my-monorepo/
 > including after `apm init` writes `includes: auto`. Mixed layouts pack from
 > `.apm/` and warn about each skipped root source. `apm install` only discovers
 > instructions, commands, and prompts under `.apm/<type>/`, so authoring
-> `packages/plugin-a/instructions/style.instructions.md` instead of
-> `packages/plugin-a/.apm/instructions/style.instructions.md` can install
+> `plugins/plugin-a/instructions/style.instructions.md` instead of
+> `plugins/plugin-a/.apm/instructions/style.instructions.md` can install
 > incomplete. See [Pack a bundle -- source layout and install-time
 > discovery](../pack-a-bundle/#source-layout-and-install-time-discovery)
 > for the full per-primitive scan-path reference.
 
+`plugins/` is not an APM CLI repository requirement: a package `source:` can
+point to another directory. This walkthrough uses `plugins/` because
+`microsoft/apm-action` with `mode: release` autodetects aggregator members
+only at `plugins/<name>/apm.yml`.
+
 Scaffold:
 
 ```bash
-apm plugin init plugin-a --yes              # cd packages/plugin-a first
-apm plugin init plugin-b --yes              # cd packages/plugin-b first
+apm plugin init plugin-a --yes              # cd plugins/plugin-a first
+apm plugin init plugin-b --yes              # cd plugins/plugin-b first
 cd ../..
 apm marketplace init --owner acme-org --name acme-monorepo
-apm marketplace package add ./packages/plugin-a --name plugin-a
-apm marketplace package add ./packages/plugin-b --name plugin-b
+apm marketplace package add ./plugins/plugin-a --name plugin-a
+apm marketplace package add ./plugins/plugin-b --name plugin-b
 ```
 
 Resulting root `apm.yml`:
@@ -173,10 +178,10 @@ marketplace:
     strategy: lockstep              # see versioning-strategies
   packages:
     - name: plugin-a
-      source: ./packages/plugin-a
+      source: ./plugins/plugin-a
       version: 1.0.0
     - name: plugin-b
-      source: ./packages/plugin-b
+      source: ./plugins/plugin-b
       version: 1.0.0
 ```
 

--- a/docs/src/content/docs/producer/repo-shapes.md
+++ b/docs/src/content/docs/producer/repo-shapes.md
@@ -153,9 +153,11 @@ only at `plugins/<name>/apm.yml`.
 Scaffold:
 
 ```bash
-apm plugin init plugin-a --yes              # cd plugins/plugin-a first
-apm plugin init plugin-b --yes              # cd plugins/plugin-b first
-cd ../..
+mkdir -p plugins
+cd plugins
+apm plugin init plugin-a --yes
+apm plugin init plugin-b --yes
+cd ..
 apm marketplace init --owner acme-org --name acme-monorepo
 apm marketplace package add ./plugins/plugin-a --name plugin-a
 apm marketplace package add ./plugins/plugin-b --name plugin-b

--- a/docs/src/content/docs/producer/repo-shapes.md
+++ b/docs/src/content/docs/producer/repo-shapes.md
@@ -35,7 +35,7 @@ Scaffold:
 ```bash
 apm plugin init my-plugin --yes
 apm marketplace init --owner acme-org --name my-marketplace
-apm marketplace package add ./ --name my-plugin --version 0.1.0
+apm marketplace package add ./ --name my-plugin --version 0.1.0 --no-verify
 ```
 
 Resulting `apm.yml`:
@@ -153,12 +153,14 @@ only at `plugins/<name>/apm.yml`.
 Scaffold:
 
 ```bash
+# From the empty my-monorepo repository root
 mkdir -p plugins
 cd plugins
 apm plugin init plugin-a --yes
 apm plugin init plugin-b --yes
 cd ..
 apm marketplace init --owner acme-org --name acme-monorepo
+apm marketplace package remove example-package --yes
 apm marketplace package add ./plugins/plugin-a --name plugin-a --version 0.1.0 --no-verify
 apm marketplace package add ./plugins/plugin-b --name plugin-b --version 0.1.0 --no-verify
 ```

--- a/docs/src/content/docs/producer/repo-shapes.md
+++ b/docs/src/content/docs/producer/repo-shapes.md
@@ -159,15 +159,19 @@ apm plugin init plugin-a --yes
 apm plugin init plugin-b --yes
 cd ..
 apm marketplace init --owner acme-org --name acme-monorepo
-apm marketplace package add ./plugins/plugin-a --name plugin-a
-apm marketplace package add ./plugins/plugin-b --name plugin-b
+apm marketplace package add ./plugins/plugin-a --name plugin-a --version 0.1.0 --no-verify
+apm marketplace package add ./plugins/plugin-b --name plugin-b --version 0.1.0 --no-verify
 ```
+
+`--version` avoids resolving a Git ref, while `--no-verify` skips remote
+reachability checks for the local sources. The scaffold starts every manifest
+at `0.1.0`, satisfying the lockstep strategy below.
 
 Resulting root `apm.yml`:
 
 ```yaml
 name: acme-monorepo
-version: 1.0.0
+version: 0.1.0
 description: Acme plugins shipped together
 
 marketplace:
@@ -181,10 +185,10 @@ marketplace:
   packages:
     - name: plugin-a
       source: ./plugins/plugin-a
-      version: 1.0.0
+      version: 0.1.0
     - name: plugin-b
       source: ./plugins/plugin-b
-      version: 1.0.0
+      version: 0.1.0
 ```
 
 Local-path entries skip remote resolution. Each plugin's own


### PR DESCRIPTION
# docs(producer): align monorepo release layout

## TL;DR

The Monorepo-hybrid walkthrough now consistently uses `plugins/`, matching
the release-layout signal used by `microsoft/apm-action` `mode: release`.
It also makes the constraint explicit without presenting `plugins/` as a
general APM CLI requirement.

> [!NOTE]
> Closes #2614.

## Problem (WHY)

- [x] The walkthrough documented plugin manifests beneath `packages/`.
- [x] [`detectShape()`](https://github.com/microsoft/apm-action/blob/d723bb64ed70c135bbaf87d126b721dd2dae0439/src/release.ts#L100-L122)
  recognizes an aggregator only when `plugins/<name>/apm.yml` exists.
- [!] The page already named a live reference using `plugins/`, so the
  examples and recommended release workflow contradicted one another.

## Approach (WHAT)

| # | Fix |
|---|---|
| 1 | Change all Monorepo-hybrid illustrative paths to `plugins/`. |
| 2 | Preserve the root manifest's `packages:` schema key. |
| 3 | State that this layout is load-bearing for apm-action release autodetection, not a universal CLI restriction. |

## Implementation (HOW)

- **`docs/src/content/docs/producer/repo-shapes.md`** -- aligns the layout,
  scaffold commands, local `source:` entries, and `.apm/` examples with the
  release action's aggregator convention.

## Trade-offs

- **Documentation rather than action behavior.** The existing action detection
  is unchanged; this is the smallest correction for the documented workflow.
- **`plugins/` convention.** Kept the requirement bounded to
  `microsoft/apm-action` `mode: release`; generic APM CLI `source:` paths
  remain flexible.
- **Docs-only scope.** Scenario-test evidence is not applicable.

## Benefits

1. The complete walkthrough now uses one directory convention.
2. A producer can satisfy release autodetection without inferring behavior
   from a later failure.
3. Generic APM CLI layouts remain correctly described as flexible.

## Validation

```text
$ npm --prefix docs run build
123 page(s) built
[+] Checked 975 relative link(s) across generated pages. No broken relative links found.
```

```text
$ rg 'packages/(plugin-a|plugin-b)|\./packages/(plugin-a|plugin-b)' docs/src/content/docs/producer/repo-shapes.md
No matches found.

$ git diff --check
```

## How to test

1. [ ] Open the Monorepo-hybrid walkthrough and confirm all illustrative
   plugin paths use `plugins/`.
2. [ ] Confirm the root manifest still uses the `packages:` schema key with
   `./plugins/...` sources.
3. [ ] Read the layout note and confirm it limits the path requirement to
   `microsoft/apm-action` `mode: release`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
