### PR TITLE
test(auth): preserve streaming Git shim commands

### DIFF
--- a/tests/unit/test_git_credential_shim.py
+++ b/tests/unit/test_git_credential_shim.py
@@ -1,0 +1,67 @@
+"""Regression tests for the installed-binary Git credential shim."""
+
+from __future__ import annotations
+
+import os
+import queue
+import shutil
+import subprocess
+import threading
+from pathlib import Path
+
+import pytest
+
+from tests.utils.git_credential_shim import GitCredentialShimFactory
+
+
+@pytest.mark.windows_compat
+def test_git_shim_streams_bidirectional_commands(tmp_path: Path) -> None:
+    """Long-lived Git commands receive responses before their stdin closes."""
+    real_git = shutil.which("git")
+    assert real_git is not None
+
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    subprocess.run(
+        (real_git, "init", "--quiet"),
+        cwd=repository,
+        check=True,
+    )
+    shim = GitCredentialShimFactory(tmp_path / "shim").create(
+        base_env=dict(os.environ),
+        real_git=Path(real_git),
+        remote_map={},
+    )
+    shim_git = shutil.which("git", path=shim.environment["PATH"])
+    assert shim_git is not None
+
+    process = subprocess.Popen(
+        (shim_git, "cat-file", "--batch-check"),
+        cwd=repository,
+        env=shim.environment,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    assert process.stdin is not None
+    assert process.stdout is not None
+    response: queue.Queue[str] = queue.Queue()
+    reader = threading.Thread(
+        target=lambda: response.put(process.stdout.readline()),
+        daemon=True,
+    )
+    reader.start()
+
+    try:
+        process.stdin.write("HEAD\n")
+        process.stdin.flush()
+        assert response.get(timeout=5) == "HEAD missing\n"
+    finally:
+        process.stdin.close()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.terminate()
+            process.wait(timeout=5)
+        reader.join(timeout=5)

--- a/tests/utils/git_credential_shim.py
+++ b/tests/utils/git_credential_shim.py
@@ -173,8 +173,12 @@ def main():
             "language": os.environ.get("LANGUAGE"),
         }
     )
+    command = [os.environ["APM_TEST_REAL_GIT"], *rewritten_args]
+    if not remotes:
+        return subprocess.run(command, env=os.environ, check=False).returncode
+
     completed = subprocess.run(
-        [os.environ["APM_TEST_REAL_GIT"], *rewritten_args],
+        command,
         env=os.environ,
         check=False,
         capture_output=True,


### PR DESCRIPTION
# test(auth): preserve streaming Git shim commands

## TL;DR

This follows up merged PR #2534 after the review panel found that its updated
installed-CLI Git shim buffered a long-lived `git cat-file --batch-check`
process. The patch captures output only for finite remote operations and adds
a cross-platform regression test proving bidirectional Git responses remain
available before stdin closes.

> [!NOTE]
> The production locale-normalization fix is already on `main`. This PR is the
> bounded test-infrastructure follow-up discovered during post-merge review.

## Problem (WHY)

- [x] PR #2534 changed the Git test shim to `capture_output=True` for every Git
  command so it could replace remote authentication stderr.
- [x] GitPython also invokes long-lived `git cat-file --batch-check` processes.
  Capturing their stdout inside the shim withholds responses until process
  exit, while GitPython waits for a response before sending the next request.
- [x] The installed-CLI lifecycle therefore timed out before reaching its
  private-repository credential-retry assertions.
- [!] The original lifecycle test detects the stall, but its packaged-binary
  setup makes the streaming contract slower and less direct to diagnose.

The panel treated the failed E2E as load-bearing evidence rather than an
opinion: ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/)

## Approach (WHAT)

1. Build the rewritten Git command once inside the shim.
2. Route invocations without a rewritten remote directly through
   `subprocess.run` with inherited stdin, stdout, and stderr.
3. Retain captured text output only for finite remote invocations, where the
   fixture may replace localized unauthenticated stderr.
4. Add one focused cross-platform test that sends `HEAD` to
   `cat-file --batch-check` and requires the response before closing stdin.

## Implementation (HOW)

| File | Intent |
|---|---|
| `tests/utils/git_credential_shim.py` | Separates streaming local Git commands from finite remote commands. Remote stderr synthesis remains unchanged. |
| `tests/unit/test_git_credential_shim.py` | Creates a real repository and generated shim, starts `cat-file --batch-check`, writes one request, and enforces a five-second response deadline before cleanup. |

## Diagrams

Legend: The dashed streaming path is the new branch; finite remote operations
keep the existing captured-output path needed by the locale fixture.

```mermaid
flowchart LR
    G1[Git shim invocation] --> D1{Remote URL rewritten}
    D1 -->|yes| R1[Capture finite command output]
    R1 --> R2[Substitute localized auth stderr when needed]
    D1 -->|no| S1[Inherit stdin stdout and stderr]
    S1 --> S2[Bidirectional Git response remains live]
    classDef new stroke-dasharray: 5 5;
    class S1,S2 new;
```

## Trade-offs

- **Branch on rewritten remotes, not command names.** The shim already computes
  `remotes`; reusing that fact avoids a fragile allowlist of current
  bidirectional commands.
- **Keep `subprocess.run` for both branches.** Replacing the local path with
  `exec` would be more transparent but would skip the shim's normal exit-code
  handling and complicate Windows behavior.
- **Use a real Git subprocess in the unit test.** A mocked pipe would not prove
  the buffering failure; the real `cat-file` protocol is fast and hermetic.
- **Retain the broader installed-CLI scenario.** The focused unit guard
  complements rather than replaces the full private-repository lifecycle.

## Benefits

1. Long-lived Git commands return their first response before stdin closes.
2. The localized-auth remote fixture still controls finite command stderr.
3. One five-second unit guard localizes future stream-buffering regressions.
4. The regression guard runs in the existing Windows compatibility selection.
5. The patch changes one helper branch and adds one test file.

## Validation

Exact-head targeted tests:

```text
..                                                                       [100%]
2 passed in 1.56s
```

Mutation-break proof: removing the `if not remotes` streaming branch makes
`tests/unit/test_git_credential_shim.py::test_git_shim_streams_bidirectional_commands`
fail with `_queue.Empty` after five seconds; restoring it returns the test to
green.

<details><summary>Local lint and guard evidence</summary>

`uv run --no-project --no-sync ruff check src/ tests/`:

```text
All checks passed!
```

`uv run --no-project --no-sync ruff format --check src/ tests/`:

```text
1616 files already formatted
```

`python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/`:

```text
Your code has been rated at 10.00/10
```

`bash scripts/lint-architecture-boundaries.sh` and
`bash scripts/lint-auth-signals.sh`:

```text
[+] architecture boundary lint clean
[+] auth-signal lint clean
```

</details>

The driver watches the GitHub check set for this exact head before reporting
completion.

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|-------------------------|--------------|--------------------|------|
| 1 | Git operations used during installation keep responding when they require bidirectional streaming | DevX | `tests/unit/test_git_credential_shim.py::test_git_shim_streams_bidirectional_commands` (regression-trap for #2534) | unit |
| 2 | `apm install` of a private github.com dependency under a non-English locale still reaches the authenticated retry and completes | Secure by default, DevX | `tests/integration/test_public_github_anonymous_lifecycle_e2e.py::test_private_github_fallback_normalizes_locale_and_completes_lifecycle` | e2e |

## How to test

- [ ] Run `python -m pytest -q tests/unit/test_git_credential_shim.py`; expect
  one passing cross-platform streaming test.
- [ ] Remove the `if not remotes` branch and rerun that test; expect a
  five-second `_queue.Empty` failure, then restore the branch.
- [ ] Run the private localized lifecycle test with a current packaged APM
  binary; expect install success, one credential fill, and both observed
  locale variables equal to `C`.
- [ ] Run the canonical lint chain; expect ruff, duplication, architecture, and
  auth-signal guards to complete successfully.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
