### PR TITLE
fix(utils): write project YAML with deterministic LF so apm.yml stops flip-flopping line endings on Windows (closes #2624)

### DIFF
--- a/.apm/architecture/owners/contracts-tooling.json
+++ b/.apm/architecture/owners/contracts-tooling.json
@@ -37,6 +37,13 @@
       "guards": ["contracts-tooling-frontmatter-yaml"]
     },
     {
+      "id": "deterministic-atomic-text-writes",
+      "decision": "Deterministic UTF-8 text writes and atomic replacement",
+      "owner": "utils/atomic_io.py (write_text_lf, atomic_write_text)",
+      "selectors": ["src/apm_cli/utils/atomic_io.py"],
+      "guards": ["contracts-tooling-project-yaml-write-delegation"]
+    },
+    {
       "id": "read-only-lockfile-path",
       "decision": "Lockfile read path, timestamp emission, and reproducible fallback",
       "owner": "deps/lockfile.py (resolve_lockfile_path_for_read, LockFile.write, resolve_reproducible_timestamp)",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   outside #2707's scope. (by @MohammedAlkindi, closes #2707, #2710)
 
 ## [0.29.0] - 2026-08-30
+### Fixed
+
+- Project YAML writers now use deterministic LF line endings: rewriting
+  `apm.yml` (install, uninstall, dependency resolution) and the revision-pin
+  update path no longer flip-flops a Windows file's line endings between
+  consecutive commands, ending the resulting git diff churn. A Windows
+  `apm.yml` already in the CRLF domain has a one-time line-ending-only diff
+  on its next rewrite. (closes #2624; group 1 landed in #2638)
+
+## [0.29.0] - 2026-08-26
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Windows users no longer get line-ending-only diffs when APM rewrites
+- Windows users no longer get repeated line-ending churn when APM rewrites
   `apm.yml`: install, uninstall, dependency resolution, and revision-pin
-  updates now produce deterministic LF output. A Windows `apm.yml` already
-  in the CRLF domain has a one-time line-ending-only diff on its next rewrite.
-  (closes #2624; group 1 landed in #2638)
+  updates now produce deterministic LF output. An `apm.yml` that already uses
+  CRLF line endings normalizes to LF on its next rewrite, causing a one-time
+  whole-file line-ending change. (closes #2624)
 
 ## [0.29.0] - 2026-08-26
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Windows users no longer get line-ending-only diffs when APM rewrites
+  `apm.yml`: install, uninstall, dependency resolution, and revision-pin
+  updates now produce deterministic LF output. A Windows `apm.yml` already
+  in the CRLF domain has a one-time line-ending-only diff on its next rewrite.
+  (closes #2624; group 1 landed in #2638)
+
+## [0.29.0] - 2026-08-26
 ### Changed
 
 - Architecture ownership guards now use a sharded JSON registry and a

--- a/scripts/architecture_linter/checks/contracts_test_taxonomy.py
+++ b/scripts/architecture_linter/checks/contracts_test_taxonomy.py
@@ -66,6 +66,9 @@ _GUARD_APPLY_TO = "contracts-tooling-apply-to-placement"
 _GUARD_FRONTMATTER = "contracts-tooling-frontmatter-yaml"
 
 
+_GUARD_PROJECT_YAML_WRITES = "contracts-tooling-project-yaml-write-delegation"
+
+
 _GUARD_LOCKFILE_READ = "contracts-tooling-lockfile-read"
 
 
@@ -755,6 +758,7 @@ _FRONTMATTER_OWNER = "src/apm_cli/utils/yaml_io.py"
 _INSTRUCTION_INTEGRATOR = "src/apm_cli/integration/instruction_integrator.py"
 _CONTENT_SCANNER = "src/apm_cli/security/content_scanner.py"
 _INSTALL_SERVICES = "src/apm_cli/install/services.py"
+_REVISION_PINS = "src/apm_cli/deps/revision_pins.py"
 _FRONTMATTER_METHODS = frozenset({"load", "loads", "parse"})
 
 
@@ -1183,6 +1187,36 @@ def check_frontmatter_yaml(provider: FactsProvider) -> tuple[Violation, ...]:
     return tuple(findings)
 
 
+def check_project_yaml_write_delegation(provider: FactsProvider) -> tuple[Violation, ...]:
+    """Project YAML writers must delegate to the canonical text-write owner."""
+    rule_id = _GUARD_PROJECT_YAML_WRITES
+    contracts = (
+        (_FRONTMATTER_OWNER, "dump_yaml_roundtrip", "write_text_lf"),
+        (_FRONTMATTER_OWNER, "write_yaml_text_atomic", "atomic_write_text"),
+        (_REVISION_PINS, "apply_revision_pin_updates", "write_yaml_text_atomic"),
+    )
+    findings: list[Violation] = []
+    for path, function_name, delegate in contracts:
+        facts, failures = _facts_for(provider, path, rule_id)
+        findings.extend(failures)
+        if failures or facts.tree_index is None:
+            continue
+        function = facts.tree_index.function(function_name)
+        if function is None:
+            findings.append(_summary(rule_id, path, f"missing project YAML writer {function_name}"))
+            continue
+        calls = _named_calls(facts.tree_index.own_scope(function), delegate)
+        if len(calls) != 1:
+            findings.append(
+                _summary(
+                    rule_id,
+                    path,
+                    f"{function_name} must call {delegate} exactly once",
+                )
+            )
+    return tuple(findings)
+
+
 _LIFECYCLE_CONTRACT = "tests/quality/test_ci_topology.py"
 
 
@@ -1282,6 +1316,11 @@ RULES: tuple[Rule, ...] = (
         _GUARD_FRONTMATTER,
         "Frontmatter delimiter detection, BOM decoding, and bounded YAML parsing stay owned by utils/yaml_io.py.",
         check_frontmatter_yaml,
+    ),
+    _owner_rule(
+        _GUARD_PROJECT_YAML_WRITES,
+        "Project YAML writes route through the canonical deterministic text writers.",
+        check_project_yaml_write_delegation,
     ),
     _owner_rule(
         _GUARD_LOCKFILE_READ,

--- a/src/apm_cli/utils/atomic_io.py
+++ b/src/apm_cli/utils/atomic_io.py
@@ -53,6 +53,8 @@ def atomic_write_text(
     *,
     new_file_mode: int | None = None,
     normalize_line_endings: bool = True,
+    temp_prefix: str = "apm-atomic-",
+    temp_suffix: str = "",
 ) -> None:
     """Atomically write ``data`` (UTF-8) to ``path``.
 
@@ -72,11 +74,19 @@ def atomic_write_text(
     generated output. Callers preserving hand-authored byte ranges can
     disable normalization with ``normalize_line_endings=False``.
 
+    ``temp_prefix`` and ``temp_suffix`` let compatibility wrappers retain
+    an established sibling-file naming contract without reimplementing the
+    atomic write.
+
     On any failure, the temp file is removed and the original target
     file (if any) remains untouched.
     """
     existed = path.exists()
-    fd, tmp_name = tempfile.mkstemp(prefix="apm-atomic-", dir=str(path.parent))
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=temp_prefix,
+        suffix=temp_suffix,
+        dir=str(path.parent),
+    )
     fd_wrapped = False
     try:
         if new_file_mode is not None and not existed and hasattr(os, "fchmod"):

--- a/src/apm_cli/utils/atomic_io.py
+++ b/src/apm_cli/utils/atomic_io.py
@@ -49,8 +49,8 @@ def write_text_lf(path: Path, data: str) -> None:
 
 def _validate_temp_name_fragment(fragment: str, parameter: str) -> None:
     """Reject temp-name fragments that could escape the target directory."""
-    if "\x00" in fragment or "/" in fragment or "\\" in fragment:
-        raise ValueError(f"{parameter} must be a filename fragment without path separators")
+    if "\x00" in fragment or "/" in fragment or "\\" in fragment or ":" in fragment:
+        raise ValueError(f"{parameter} must be a portable filename fragment")
 
 
 def atomic_write_text(

--- a/src/apm_cli/utils/atomic_io.py
+++ b/src/apm_cli/utils/atomic_io.py
@@ -47,6 +47,12 @@ def write_text_lf(path: Path, data: str) -> None:
     path.write_text(normalize_crlf_to_lf(data), encoding="utf-8", newline="")
 
 
+def _validate_temp_name_fragment(fragment: str, parameter: str) -> None:
+    """Reject temp-name fragments that could escape the target directory."""
+    if "\x00" in fragment or "/" in fragment or "\\" in fragment:
+        raise ValueError(f"{parameter} must be a filename fragment without path separators")
+
+
 def atomic_write_text(
     path: Path,
     data: str,
@@ -82,6 +88,8 @@ def atomic_write_text(
     file (if any) remains untouched.
     """
     existed = path.exists()
+    _validate_temp_name_fragment(temp_prefix, "temp_prefix")
+    _validate_temp_name_fragment(temp_suffix, "temp_suffix")
     fd, tmp_name = tempfile.mkstemp(
         prefix=temp_prefix,
         suffix=temp_suffix,

--- a/src/apm_cli/utils/yaml_io.py
+++ b/src/apm_cli/utils/yaml_io.py
@@ -408,15 +408,24 @@ def load_yaml_roundtrip(path: str | Path) -> Any:
 
 
 def dump_yaml_roundtrip(data: Any, path: str | Path) -> None:
-    """Write ruamel round-trip YAML data with explicit UTF-8 encoding."""
+    """Write ruamel round-trip YAML data with explicit UTF-8 encoding.
+
+    Deterministic LF line endings (apm#2624): the project-file rewrite
+    paths that use this (install / uninstall / package-resolution
+    rewriting ``apm.yml``) previously wrote platform-native newlines, so
+    on Windows the file flip-flopped between CRLF and LF depending on
+    which command last touched it, churning git diffs. Windows files
+    already in the CRLF domain incur a one-time line-ending-only diff on
+    their next rewrite.
+    """
+    from .atomic_io import write_text_lf
+
     stream = StringIO()
     try:
         _roundtrip_yaml().dump(data, stream)
     except Exception as exc:
         _raise_as_pyyaml_error(exc)
-    text = stream.getvalue()
-    with open(path, "w", encoding="utf-8") as fh:
-        fh.write(text)
+    write_text_lf(Path(path), stream.getvalue())
 
 
 class _BoundedYAMLHandler(_FrontmatterYAMLHandler):
@@ -570,7 +579,14 @@ def write_yaml_text_atomic(
     The replacement is written to a sibling file first and then moved into
     place with ``os.replace``. If the write or replace fails, the original
     file remains untouched.
+
+    Deterministic LF line endings (apm#2624): ``newline=""`` disables the
+    platform newline translation and the content is CRLF-normalized, so
+    the on-disk bytes are identical on every OS instead of following the
+    writing platform.
     """
+    from .atomic_io import normalize_crlf_to_lf
+
     target = Path(path)
     tmp_path: Path | None = None
     try:
@@ -585,8 +601,8 @@ def write_yaml_text_atomic(
             break
         else:
             raise FileExistsError(f"Could not create a unique temp file for {target}")
-        with os.fdopen(fd, "w", encoding="utf-8") as fh:
-            fh.write(content)
+        with os.fdopen(fd, "w", encoding="utf-8", newline="") as fh:
+            fh.write(normalize_crlf_to_lf(content))
         os.replace(tmp_path, target)
         tmp_path = None
     except Exception:

--- a/src/apm_cli/utils/yaml_io.py
+++ b/src/apm_cli/utils/yaml_io.py
@@ -14,9 +14,6 @@ Public API::
     yaml_to_str(data)               -- serialize dict -> YAML string
 """
 
-import os
-import secrets
-from contextlib import suppress
 from io import StringIO
 from pathlib import Path
 from typing import Any, NoReturn
@@ -576,37 +573,17 @@ def write_yaml_text_atomic(
 ) -> None:
     """Atomically replace a YAML file with already-rendered text.
 
-    The replacement is written to a sibling file first and then moved into
-    place with ``os.replace``. If the write or replace fails, the original
-    file remains untouched.
-
-    Deterministic LF line endings (apm#2624): ``newline=""`` disables the
-    platform newline translation and the content is CRLF-normalized, so
-    the on-disk bytes are identical on every OS instead of following the
-    writing platform.
+    The canonical atomic writer creates the replacement beside the target
+    before moving it into place. If the write or replace fails, the original
+    file remains untouched. Its deterministic LF policy keeps the on-disk
+    bytes identical on every OS.
     """
-    from .atomic_io import normalize_crlf_to_lf
+    from .atomic_io import atomic_write_text
 
     target = Path(path)
-    tmp_path: Path | None = None
-    try:
-        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
-        for _attempt in range(10):
-            candidate = target.with_name(f".{target.name}.{secrets.token_hex(8)}{tmp_suffix}")
-            try:
-                fd = os.open(candidate, flags, 0o600)
-            except FileExistsError:
-                continue
-            tmp_path = candidate
-            break
-        else:
-            raise FileExistsError(f"Could not create a unique temp file for {target}")
-        with os.fdopen(fd, "w", encoding="utf-8", newline="") as fh:
-            fh.write(normalize_crlf_to_lf(content))
-        os.replace(tmp_path, target)
-        tmp_path = None
-    except Exception:
-        if tmp_path is not None:
-            with suppress(OSError):
-                tmp_path.unlink()
-        raise
+    atomic_write_text(
+        target,
+        content,
+        temp_prefix=f".{target.name}.",
+        temp_suffix=tmp_suffix,
+    )

--- a/tests/integration/test_architecture_owner_rule_mutations.py
+++ b/tests/integration/test_architecture_owner_rule_mutations.py
@@ -182,6 +182,14 @@ MUTATIONS: tuple[MutationCase, ...] = (
         intent="Single-file compilation bypasses the root overwrite eligibility owner.",
     ),
     MutationCase(
+        guard_id="contracts-tooling-project-yaml-write-delegation",
+        rule_id="contracts-tooling-project-yaml-write-delegation",
+        path="src/apm_cli/utils/yaml_io.py",
+        old="    atomic_write_text(\n",
+        new="    write_text_lf(\n",
+        intent="The atomic project YAML writer bypasses the canonical atomic writer.",
+    ),
+    MutationCase(
         guard_id="hooks-integrations-copilot-cli-mcp-paths",
         rule_id="mutation_writes.copilot_cli_mcp_paths",
         path="src/apm_cli/adapters/client/copilot.py",

--- a/tests/integration/test_manifest_comments_e2e.py
+++ b/tests/integration/test_manifest_comments_e2e.py
@@ -33,7 +33,7 @@ def test_install_preserves_manifest_comments_and_formatting(tmp_path, monkeypatc
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("APM_PROGRESS", "never")
     manifest = tmp_path / "apm.yml"
-    manifest.write_text(
+    manifest.write_bytes(
         """\
 # project intent: keep this manifest annotated
 name: comment-roundtrip
@@ -47,8 +47,7 @@ dependencies:
 targets:
   # target comment remains attached
   - copilot
-""",
-        encoding="utf-8",
+""".replace("\n", "\r\n").encode()
     )
 
     install_result = SimpleNamespace(installed_count=1, diagnostics=None)
@@ -66,6 +65,7 @@ targets:
         )
 
     assert result.exit_code == 0, result.output
+    assert b"\r" not in manifest.read_bytes()
     rendered = manifest.read_text(encoding="utf-8")
     parsed = yaml.safe_load(rendered)
 

--- a/tests/unit/deps/test_revision_pin_resolver.py
+++ b/tests/unit/deps/test_revision_pin_resolver.py
@@ -101,11 +101,14 @@ def test_revision_pin_package_name_strips_git_suffix() -> None:
     assert package_name(dependency) == "pkg"
 
 
-def test_apply_revision_pin_updates_annotates_manifest_atomically(tmp_path: Path) -> None:
+@pytest.mark.windows_compat
+def test_apply_revision_pin_updates_annotates_manifest_atomically_with_lf(tmp_path: Path) -> None:
     manifest = tmp_path / "apm.yml"
-    manifest.write_text(
-        f"name: demo\nversion: 1.0.0\ndependencies:\n  apm:\n    - org/pkg#{OLD_SHA} # v1.0.0\n",
-        encoding="utf-8",
+    manifest.write_bytes(
+        (
+            "name: demo\r\nversion: 1.0.0\r\ndependencies:\r\n"
+            f"  apm:\r\n    - org/pkg#{OLD_SHA} # v1.0.0\r\n"
+        ).encode()
     )
 
     apply_revision_pin_updates(
@@ -113,9 +116,9 @@ def test_apply_revision_pin_updates_annotates_manifest_atomically(tmp_path: Path
         [RevisionPinUpdate("org/pkg", OLD_SHA, NEW_SHA, "v2.0.0", "org/pkg")],
     )
 
-    assert manifest.read_text(encoding="utf-8").splitlines()[-1] == (
-        f"    - org/pkg#{NEW_SHA} # v2.0.0"
-    )
+    rendered = manifest.read_bytes()
+    assert b"\r" not in rendered
+    assert rendered.splitlines()[-1] == f"    - org/pkg#{NEW_SHA} # v2.0.0".encode()
 
 
 def test_apply_revision_pin_updates_keeps_old_pin_when_replace_fails(tmp_path: Path) -> None:
@@ -123,7 +126,10 @@ def test_apply_revision_pin_updates_keeps_old_pin_when_replace_fails(tmp_path: P
     original = f"name: demo\nversion: 1.0.0\ndependencies:\n  apm:\n    - org/pkg#{OLD_SHA}\n"
     manifest.write_text(original, encoding="utf-8")
 
-    with patch("apm_cli.utils.yaml_io.os.replace", side_effect=OSError("disk full")):
+    with patch(
+        "apm_cli.utils.atomic_io._replace_atomic_file",
+        side_effect=OSError("disk full"),
+    ):
         with pytest.raises(OSError, match="disk full"):
             apply_revision_pin_updates(
                 manifest,
@@ -147,7 +153,7 @@ def test_apply_revision_pin_updates_uses_project_sibling_temp_file(tmp_path: Pat
         seen_tmp_paths.append(str(src))
         real_replace(src, dst)
 
-    with patch("apm_cli.utils.yaml_io.os.replace", side_effect=capture_replace):
+    with patch("apm_cli.utils.atomic_io._replace_atomic_file", side_effect=capture_replace):
         apply_revision_pin_updates(
             manifest,
             [RevisionPinUpdate("org/pkg", OLD_SHA, NEW_SHA, "v2.0.0", "org/pkg")],
@@ -327,7 +333,7 @@ def test_apply_revision_pin_updates_uses_unique_temp_names(tmp_path: Path) -> No
         seen_tmp_paths.append(str(src))
         real_replace(src, dst)
 
-    with patch("apm_cli.utils.yaml_io.os.replace", side_effect=capture_replace):
+    with patch("apm_cli.utils.atomic_io._replace_atomic_file", side_effect=capture_replace):
         apply_revision_pin_updates(
             manifest,
             [RevisionPinUpdate("org/pkg", OLD_SHA, NEW_SHA, "v2.0.0", "org/pkg")],

--- a/tests/unit/scripts/test_architecture_runner.py
+++ b/tests/unit/scripts/test_architecture_runner.py
@@ -611,6 +611,7 @@ contracts-tooling-lockfile-read
 contracts-tooling-lockfile-timestamp
 contracts-tooling-lockfile-timestamp-constructor
 contracts-tooling-lockfile-timestamp-fallback
+contracts-tooling-project-yaml-write-delegation
 install-deployment-approval-outcome-routing
 install-deployment-audit-policy-discovery
 install-deployment-audit-replay

--- a/tests/unit/test_yaml_io.py
+++ b/tests/unit/test_yaml_io.py
@@ -421,7 +421,8 @@ class TestWriteYamlTextAtomic:
     def test_atomic_write_leaves_original_on_replace_failure(self, tmp_path, monkeypatch):
         """If os.replace fails, the original file is untouched and temp cleaned."""
 
-        from apm_cli.utils import yaml_io as _yi
+        from apm_cli.utils import atomic_io
+        from apm_cli.utils.yaml_io import write_yaml_text_atomic
 
         target = tmp_path / "out.yml"
         target.write_text("orig: 1\n", encoding="utf-8")
@@ -429,9 +430,9 @@ class TestWriteYamlTextAtomic:
         def _boom(src, dst):
             raise OSError("replace denied")
 
-        monkeypatch.setattr(_yi.os, "replace", _boom)
+        monkeypatch.setattr(atomic_io, "_replace_atomic_file", _boom)
         with pytest.raises(OSError):
-            _yi.write_yaml_text_atomic(target, "new: 2\n")
+            write_yaml_text_atomic(target, "new: 2\n")
         assert target.read_text(encoding="utf-8") == "orig: 1\n"
         leftovers = [p for p in tmp_path.iterdir() if p.name.startswith(".out.yml.")]
         assert leftovers == []

--- a/tests/unit/test_yaml_io.py
+++ b/tests/unit/test_yaml_io.py
@@ -251,6 +251,25 @@ class TestLoadYamlRoundtrip:
         assert "# deps note" in rendered
         assert "github:owner/new-skill@v1" in rendered
 
+    @pytest.mark.windows_compat
+    def test_dump_roundtrip_writes_deterministic_lf(self, tmp_path):
+        """Rewrites land as LF bytes on every OS -- no CRLF flip-flop (apm#2624).
+
+        Project-file rewrite paths (install / uninstall / package
+        resolution) previously wrote platform-native newlines here while
+        other commands wrote LF, so a Windows apm.yml alternated line
+        endings between consecutive commands and churned git diffs.
+        """
+        p = tmp_path / "apm.yml"
+        p.write_bytes(b"# note\r\nname: demo\r\ndependencies: []\r\n")
+
+        data = load_yaml_roundtrip(p)
+        dump_yaml_roundtrip(data, p)
+
+        raw = p.read_bytes()
+        assert b"\r" not in raw
+        assert b"# note\n" in raw
+
     def test_alias_expansion_bomb_fails_closed(self, tmp_path):
         """The round-trip path keeps the bounded-loader expansion guard."""
         p = tmp_path / "apm.yml"
@@ -386,6 +405,18 @@ class TestWriteYamlTextAtomic:
         target.write_text("old: 1\n", encoding="utf-8")
         write_yaml_text_atomic(target, "new: 2\n")
         assert target.read_text(encoding="utf-8") == "new: 2\n"
+
+    @pytest.mark.windows_compat
+    def test_atomic_write_is_lf_deterministic(self, tmp_path):
+        """On-disk bytes are LF regardless of platform or input domain (apm#2624)."""
+        from apm_cli.utils.yaml_io import write_yaml_text_atomic
+
+        target = tmp_path / "out.yml"
+        write_yaml_text_atomic(target, "a: 1\nb: 2\n")
+        assert target.read_bytes() == b"a: 1\nb: 2\n"
+
+        write_yaml_text_atomic(target, "a: 1\r\nb: 2\r\n")
+        assert target.read_bytes() == b"a: 1\nb: 2\n"
 
     def test_atomic_write_leaves_original_on_replace_failure(self, tmp_path, monkeypatch):
         """If os.replace fails, the original file is untouched and temp cleaned."""

--- a/tests/unit/utils/test_atomic_io.py
+++ b/tests/unit/utils/test_atomic_io.py
@@ -101,6 +101,32 @@ class TestAtomicWriteText:
 
         assert captured_kwargs[0]["prefix"] == "apm-atomic-"
 
+    @pytest.mark.parametrize(
+        ("parameter", "value"),
+        [
+            ("temp_prefix", "../escape-"),
+            ("temp_prefix", "..\\escape-"),
+            ("temp_suffix", "/../../escape"),
+            ("temp_suffix", "\\..\\..\\escape"),
+        ],
+    )
+    def test_tmp_name_fragments_cannot_escape_parent(
+        self,
+        tmp_path: Path,
+        parameter: str,
+        value: str,
+    ) -> None:
+        """Caller-provided temp naming cannot redirect creation outside the parent."""
+        target = tmp_path / "out.txt"
+
+        with (
+            patch("apm_cli.utils.atomic_io.tempfile.mkstemp") as mock_mkstemp,
+            pytest.raises(ValueError, match="without path separators"),
+        ):
+            atomic_write_text(target, "data", **{parameter: value})
+
+        mock_mkstemp.assert_not_called()
+
     # ------------------------------------------------------------------
     # fchmod / new_file_mode
     # ------------------------------------------------------------------

--- a/tests/unit/utils/test_atomic_io.py
+++ b/tests/unit/utils/test_atomic_io.py
@@ -106,8 +106,11 @@ class TestAtomicWriteText:
         [
             ("temp_prefix", "../escape-"),
             ("temp_prefix", "..\\escape-"),
+            ("temp_prefix", "C:escape-"),
+            ("temp_prefix", "invalid\x00prefix"),
             ("temp_suffix", "/../../escape"),
             ("temp_suffix", "\\..\\..\\escape"),
+            ("temp_suffix", "invalid\x00suffix"),
         ],
     )
     def test_tmp_name_fragments_cannot_escape_parent(
@@ -121,7 +124,7 @@ class TestAtomicWriteText:
 
         with (
             patch("apm_cli.utils.atomic_io.tempfile.mkstemp") as mock_mkstemp,
-            pytest.raises(ValueError, match="without path separators"),
+            pytest.raises(ValueError, match="portable filename fragment"),
         ):
             atomic_write_text(target, "data", **{parameter: value})
 


### PR DESCRIPTION
## Summary

Group 2 of #2624 fixes the remaining platform-native project YAML writers. Group 1, the bundle/plugin metadata writers, landed in #2638.

- `dump_yaml_roundtrip` now routes through `write_text_lf`.
- `write_yaml_text_atomic` now delegates to the canonical `atomic_write_text` implementation while preserving its sibling-temp naming contract.
- The architecture linter now guards both project YAML write paths against bypassing the canonical writers.

## Why

On Windows, consecutive commands could flip `apm.yml` between CRLF and LF, producing line-ending-only diffs. Deterministic LF output removes that churn and prevents future hash-visible callers from reintroducing cross-OS byte differences.

`compute_package_hash` continues to hash raw bytes.

## Scenario evidence

| Scenario | Principle(s) | Type | Test | Result |
|---|---|---|---|---|
| Round-trip rewrite converts CRLF project YAML to LF | DevX | Regression trap (unit) | `tests/unit/test_yaml_io.py::TestLoadYamlRoundtrip::test_dump_roundtrip_writes_deterministic_lf` | Pass |
| Revision-pin consumer rewrites CRLF project YAML atomically as LF | DevX; Governed by policy | Regression trap (unit) | `tests/unit/deps/test_revision_pin_resolver.py::test_apply_revision_pin_updates_annotates_manifest_atomically_with_lf` | Pass |
| `apm install` rewrites CRLF as LF while preserving comments | DevX; Governed by policy | Regression trap (integration) | `tests/integration/test_manifest_comments_e2e.py::test_install_preserves_manifest_comments_and_formatting` | Pass |
| Static owner guard rejects bypassing the canonical atomic writer | Governed by policy | Architecture mutation | `tests/integration/test_architecture_owner_rule_mutations.py` | Pass |

## Migration note

A Windows `apm.yml` already using CRLF receives a one-time line-ending-only diff on its next rewrite.

Closes #2624
