### PR TITLE
refactor: centralize git auth config reindexing

### DIFF
--- a/.apm/instructions/architecture.instructions.md
+++ b/.apm/instructions/architecture.instructions.md
@@ -43,6 +43,7 @@ semicolon-delimited, and specific to the file(s) that own the fact.
 | Legacy MCP runtime ownership-key migration | install/mcp/ownership.py (migrate_legacy_project_target_servers) | `src/apm_cli/install/mcp/ownership.py` |
 | Behavioral test taxonomy classification | module-level pytestmark (taxonomy inventory verifies) | `tests/quality/taxonomy_inventory_plugin.py`; `tests/quality/test_test_taxonomy.py` |
 | Host + credential resolution | core/auth.py (AuthResolver), core/host_providers.py | `src/apm_cli/core/auth.py`; `src/apm_cli/core/host_providers.py` |
+| Git auth-config retain/reindex | utils/git_env.py (retain_and_reindex_git_config) | `src/apm_cli/utils/git_env.py` |
 | Runtime descriptors | runtime/registry.py | `src/apm_cli/runtime/registry.py` |
 | User-facing output / diagnostics | CommandLogger / console owner | `src/apm_cli/core/command_logger.py`; `src/apm_cli/utils/console.py` |
 | Compiled-output writes (atomic) | CompiledOutputWriter | `src/apm_cli/compilation/output_writer.py` |

--- a/scripts/lint-architecture-boundaries.sh
+++ b/scripts/lint-architecture-boundaries.sh
@@ -976,7 +976,28 @@ if [ -n "$auth_header_dictmerge_hits" ]; then
     violations=$((violations + 1))
 fi
 
-echo "[*] AC20: public github.com anonymous-first auth authority"
+echo "[*] AC20: Git auth-config retain/reindex authority"
+git_auth_config_owner="src/apm_cli/utils/git_env.py"
+git_auth_config_predicate_bypasses=$(
+    grep -rEn --include='*.py' \
+        '^[[:space:]]*(if|elif|return).*extraheader.*in|^[[:space:]]*(if|elif|return).*authorization:' \
+        src/apm_cli/core/auth.py \
+        src/apm_cli/utils/github_host.py \
+        | grep -v 'architecture-authority-exempt:' \
+        || true
+)
+if ! grep -q '^def is_git_auth_channel_entry(' "$git_auth_config_owner" \
+    || ! grep -q '^def retain_and_reindex_git_config(' "$git_auth_config_owner" \
+    || ! grep -q '^[[:space:]]*retain_and_reindex_git_config' src/apm_cli/core/auth.py \
+    || ! grep -q '^[[:space:]]*retain_and_reindex_git_config' src/apm_cli/utils/github_host.py \
+    || [ -n "$git_auth_config_predicate_bypasses" ]; then
+    echo "[x] Git auth-config retain/reindex must route through utils/git_env.py"
+    [ -n "$git_auth_config_predicate_bypasses" ] \
+        && echo "$git_auth_config_predicate_bypasses"
+    violations=$((violations + 1))
+fi
+
+echo "[*] AC21: public github.com anonymous-first auth authority"
 public_github_auth_owner="src/apm_cli/core/auth.py"
 public_github_auth_duplicate_defs=$(
     grep -rEn --include='*.py' \

--- a/src/apm_cli/core/auth.py
+++ b/src/apm_cli/core/auth.py
@@ -44,6 +44,7 @@ from apm_cli.core.host_providers import (
     classify_host_provider,
 )
 from apm_cli.core.token_manager import GitHubTokenManager
+from apm_cli.utils.git_env import retain_and_reindex_git_config
 from apm_cli.utils.github_host import (
     default_host,
     is_azure_devops_hostname,
@@ -1343,27 +1344,7 @@ class AuthResolver:
         env.pop("GIT_TOKEN", None)
         env.pop("GIT_HTTP_EXTRAHEADER", None)
         env.pop("GIT_CONFIG_PARAMETERS", None)
-        try:
-            count = int(env.pop("GIT_CONFIG_COUNT", "0"))
-        except ValueError:
-            count = 0
-        retained: list[tuple[str, str]] = []
-        for index in range(max(0, count)):
-            key = env.pop(f"GIT_CONFIG_KEY_{index}", "")
-            value = env.pop(f"GIT_CONFIG_VALUE_{index}", "")
-            normalized = key.lower()
-            if "extraheader" in normalized or value.strip().lower().startswith("authorization:"):
-                continue
-            if key:
-                retained.append((key, value))
-        for key in tuple(env):
-            if key.startswith(("GIT_CONFIG_KEY_", "GIT_CONFIG_VALUE_")):
-                env.pop(key, None)
-        if retained:
-            env["GIT_CONFIG_COUNT"] = str(len(retained))
-            for index, (key, value) in enumerate(retained):
-                env[f"GIT_CONFIG_KEY_{index}"] = key
-                env[f"GIT_CONFIG_VALUE_{index}"] = value
+        retain_and_reindex_git_config(env)
 
     def emit_stale_pat_diagnostic(self, host_display: str) -> None:
         """Emit a [!] warning when PAT was rejected but bearer succeeded.

--- a/src/apm_cli/utils/git_env.py
+++ b/src/apm_cli/utils/git_env.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import os
 import shutil
+from collections.abc import Iterable, Mapping, MutableMapping
 
 from apm_cli.utils.subprocess_env import external_process_env
 
@@ -48,6 +49,53 @@ _STRIP_GIT_VARS: frozenset[str] = frozenset(
         "GIT_SHALLOW_FILE",
     }
 )
+
+
+def is_git_auth_channel_entry(key: str, value: str) -> bool:
+    """Return whether an indexed Git config entry can carry authorization."""
+    return "extraheader" in key.lower() or value.strip().lower().startswith("authorization:")
+
+
+def _git_config_count(env: Mapping[str, str]) -> int:
+    """Return a safe count for the process-scoped indexed Git config."""
+    try:
+        return max(0, int(env.get("GIT_CONFIG_COUNT", "0") or "0"))
+    except ValueError:
+        return 0
+
+
+def retain_and_reindex_git_config(
+    env: MutableMapping[str, str],
+    additional_entries: Iterable[tuple[str, str]] = (),
+) -> None:
+    """Remove auth entries, preserve safe entries, and re-index the Git config.
+
+    Existing indexed entries that match :func:`is_git_auth_channel_entry` are
+    discarded. Non-auth entries are retained in order, orphaned indexed
+    variables are removed, and ``additional_entries`` are appended afterward.
+    The latter is used when a caller intentionally installs a fresh auth
+    header after inherited auth channels have been removed.
+    """
+    retained: list[tuple[str, str]] = []
+    for index in range(_git_config_count(env)):
+        key = env.get(f"GIT_CONFIG_KEY_{index}", "")
+        value = env.get(f"GIT_CONFIG_VALUE_{index}", "")
+        if key and not is_git_auth_channel_entry(key, value):
+            retained.append((key, value))
+
+    for key in tuple(env):
+        if key.startswith(("GIT_CONFIG_KEY_", "GIT_CONFIG_VALUE_")):
+            env.pop(key, None)
+    env.pop("GIT_CONFIG_COUNT", None)
+
+    retained.extend(additional_entries)
+    if not retained:
+        return
+
+    env["GIT_CONFIG_COUNT"] = str(len(retained))
+    for index, (key, value) in enumerate(retained):
+        env[f"GIT_CONFIG_KEY_{index}"] = key
+        env[f"GIT_CONFIG_VALUE_{index}"] = value
 
 
 def get_git_executable() -> str:

--- a/src/apm_cli/utils/github_host.py
+++ b/src/apm_cli/utils/github_host.py
@@ -4,6 +4,8 @@ import os
 import re
 import urllib.parse
 
+from apm_cli.utils.git_env import retain_and_reindex_git_config
+
 _ADO_SERVER_BASE_PATH_ERROR = (
     "Azure DevOps Server URLs mounted below '/tfs/' are not currently "
     "supported. Use a root-hosted collection URL such as "
@@ -624,19 +626,6 @@ def set_authorization_header_git_env(env: dict[str, str], scheme: str, credentia
     ``GIT_CONFIG_KEY_/VALUE_`` entries at or beyond the count are also
     dropped so no stale credential lingers in the child-process env table.
 
-    Note:
-        The retain/reindex predicate below intentionally mirrors
-        ``AuthResolver._clear_git_auth_env`` (``core/auth.py``) rather than
-        delegating to a shared primitive.  Extracting a single owner (e.g.
-        ``utils/git_env.py``) is the right end state -- see PR discussion on
-        #2368 and follow-up #2398 -- but doing so means editing
-        ``_clear_git_auth_env``, a security-critical function this bug does
-        not otherwise touch, which deserves its own focused security review
-        rather than riding along in this fix.
-        TODO(#2398): extract a shared ``_is_auth_channel_entry`` /
-        retain-reindex helper into ``utils/git_env.py``, and delegate both
-        this function and ``AuthResolver._clear_git_auth_env`` to it.
-
     Args:
         env: The subprocess env dict to mutate (base env already merged in).
         scheme: HTTP auth scheme, e.g. ``"Bearer"`` or ``"Basic"``.
@@ -654,26 +643,12 @@ def set_authorization_header_git_env(env: dict[str, str], scheme: str, credentia
     """
     if "\r" in scheme or "\n" in scheme or "\r" in credential or "\n" in credential:
         raise ValueError("scheme and credential must not contain CR or LF")
-    try:
-        count = max(0, int(env.get("GIT_CONFIG_COUNT", "0") or "0"))
-    except ValueError:
-        count = 0
-    retained: list[tuple[str, str]] = []
-    for index in range(count):
-        key = env.get(f"GIT_CONFIG_KEY_{index}", "")
-        value = env.get(f"GIT_CONFIG_VALUE_{index}", "")
-        if "extraheader" in key.lower() or value.strip().lower().startswith("authorization:"):
-            continue
-        if key:
-            retained.append((key, value))
-    for key in tuple(env):
-        if key.startswith(("GIT_CONFIG_KEY_", "GIT_CONFIG_VALUE_")):
-            env.pop(key, None)
-    retained.append(("http.extraheader", f"Authorization: {scheme} {credential}"))
-    env["GIT_CONFIG_COUNT"] = str(len(retained))
-    for index, (key, value) in enumerate(retained):
-        env[f"GIT_CONFIG_KEY_{index}"] = key
-        env[f"GIT_CONFIG_VALUE_{index}"] = value
+    retain_and_reindex_git_config(
+        env,
+        additional_entries=(
+            ("http.extraheader", f"Authorization: {scheme} {credential}"),
+        ),
+    )
 
 
 def set_ado_bearer_git_env(env: dict[str, str], bearer_token: str) -> None:

--- a/tests/integration/test_architecture_authorities.py
+++ b/tests/integration/test_architecture_authorities.py
@@ -26,6 +26,66 @@ def test_policy_cache_metadata_redaction_has_single_owner() -> None:
     assert "Policy cache metadata must redact URL credentials at its canonical writer" in guard
 
 
+def test_git_auth_config_retain_reindex_has_single_owner() -> None:
+    """Auth cleanup and header injection must share one Git config owner."""
+    root = Path(__file__).parents[2]
+    owner = (root / "src/apm_cli/utils/git_env.py").read_text(encoding="utf-8")
+    auth = (root / "src/apm_cli/core/auth.py").read_text(encoding="utf-8")
+    github_host = (root / "src/apm_cli/utils/github_host.py").read_text(encoding="utf-8")
+    architecture = (root / ".apm/instructions/architecture.instructions.md").read_text(
+        encoding="utf-8"
+    )
+    guard = (root / "scripts/lint-architecture-boundaries.sh").read_text(encoding="utf-8")
+
+    assert owner.count("def is_git_auth_channel_entry(") == 1
+    assert owner.count("def retain_and_reindex_git_config(") == 1
+    assert "        retain_and_reindex_git_config(env)" in auth
+    assert "    retain_and_reindex_git_config(" in github_host
+    assert "Git auth-config retain/reindex" in architecture
+    assert "Git auth-config retain/reindex must route through utils/git_env.py" in guard
+
+
+def test_git_auth_config_guard_rejects_parallel_predicate(tmp_path: Path) -> None:
+    """The boundary guard must reject a second inline auth-channel predicate."""
+    root = Path(__file__).parents[2]
+    sandbox = tmp_path / "repo"
+    shutil.copytree(
+        root,
+        sandbox,
+        ignore=shutil.ignore_patterns(
+            ".git",
+            ".venv",
+            ".pytest_cache",
+            "__pycache__",
+            "build",
+            "dist",
+            "node_modules",
+        ),
+    )
+    consumer = sandbox / "src/apm_cli/utils/github_host.py"
+    consumer.write_text(
+        consumer.read_text(encoding="utf-8")
+        + (
+            '\n\ndef _parallel_git_auth_channel_entry(key: str, value: str) -> bool:\n'
+            '    return "extraheader" in key.lower() or '
+            'value.strip().lower().startswith("authorization:")\n'
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ("bash", "scripts/lint-architecture-boundaries.sh"),
+        cwd=sandbox,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=300,
+    )
+
+    assert result.returncode == 1
+    assert "Git auth-config retain/reindex must route through utils/git_env.py" in result.stdout
+
+
 @pytest.mark.parametrize(
     ("guard", "replacement"),
     [

--- a/tests/unit/utils/test_git_env.py
+++ b/tests/unit/utils/test_git_env.py
@@ -1,0 +1,71 @@
+"""Tests for indexed Git config auth-channel handling."""
+
+from apm_cli.utils.git_env import (
+    is_git_auth_channel_entry,
+    retain_and_reindex_git_config,
+)
+
+
+def _indexed_entries(env: dict[str, str]) -> list[tuple[str, str]]:
+    """Return indexed Git config entries in declared order."""
+    return [
+        (
+            env[f"GIT_CONFIG_KEY_{index}"],
+            env[f"GIT_CONFIG_VALUE_{index}"],
+        )
+        for index in range(int(env.get("GIT_CONFIG_COUNT", "0")))
+    ]
+
+
+def test_retain_and_reindex_git_config_preserves_safe_entries_and_drops_auth() -> None:
+    """Only inherited auth channels are removed before entries are re-indexed."""
+    env = {
+        "GIT_CONFIG_COUNT": "4",
+        "GIT_CONFIG_KEY_0": "http.sslCAInfo",
+        "GIT_CONFIG_VALUE_0": "/authorization/corporate-ca.pem",
+        "GIT_CONFIG_KEY_1": "http.extraHeader",
+        "GIT_CONFIG_VALUE_1": "X-Harmless: value",
+        "GIT_CONFIG_KEY_2": "custom.policy",
+        "GIT_CONFIG_VALUE_2": "X-Custom: authorization=reviewed",
+        "GIT_CONFIG_KEY_3": "custom.header",
+        "GIT_CONFIG_VALUE_3": "Authorization: Bearer stale",
+        "GIT_CONFIG_KEY_9": "stale.orphan",
+        "GIT_CONFIG_VALUE_9": "must be removed",
+    }
+
+    retain_and_reindex_git_config(
+        env,
+        additional_entries=(("http.extraheader", "Authorization: Bearer fresh"),),
+    )
+
+    assert _indexed_entries(env) == [
+        ("http.sslCAInfo", "/authorization/corporate-ca.pem"),
+        ("custom.policy", "X-Custom: authorization=reviewed"),
+        ("http.extraheader", "Authorization: Bearer fresh"),
+    ]
+    assert "GIT_CONFIG_KEY_9" not in env
+    assert "GIT_CONFIG_VALUE_9" not in env
+
+
+def test_retain_and_reindex_git_config_tolerates_invalid_count() -> None:
+    """Blank, invalid, and negative counts do not leave indexed state behind."""
+    for count in ("", "not-a-number", "-3"):
+        env = {
+            "GIT_CONFIG_COUNT": count,
+            "GIT_CONFIG_KEY_0": "http.extraheader",
+            "GIT_CONFIG_VALUE_0": "Authorization: Bearer stale",
+        }
+
+        retain_and_reindex_git_config(env)
+
+        assert "GIT_CONFIG_COUNT" not in env
+        assert "GIT_CONFIG_KEY_0" not in env
+        assert "GIT_CONFIG_VALUE_0" not in env
+
+
+def test_is_git_auth_channel_entry_uses_exact_auth_policy() -> None:
+    """Authorization-like text in safe values must not be treated as auth."""
+    assert is_git_auth_channel_entry("http.extraHeader", "X-Harmless: value")
+    assert is_git_auth_channel_entry("custom.header", "Authorization: Bearer secret")
+    assert not is_git_auth_channel_entry("http.sslCAInfo", "/authorization/corporate-ca.pem")
+    assert not is_git_auth_channel_entry("custom.policy", "X-Custom: authorization=reviewed")


### PR DESCRIPTION
## Summary

- Centralize Git authentication environment/config reindexing in a shared utility.
- Simplify the authentication and GitHub-host resolution paths around that utility.
- Add architecture-boundary guidance plus unit and integration coverage for the shared behavior.

## Validation

- `git diff --check` — passed.
- Targeted pytest was not run locally in this submission; CI should exercise the new unit and integration coverage.
