### PR TITLE
chore: release v0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,115 +7,124 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.0] - 2026-08-26
+
 ### Added
 
-- `apm install --frozen` no longer fails on a cold cache when git-sourced
-  `apm_package` dependencies declare MCP servers; frozen hydration now
-  succeeds as expected before any packages are fetched. (closes #2456)
-- `apm install` now accepts `--trust-bin` / `--no-trust-bin` for per-invocation
-  consent over marketplace-plugin `bin/` executable deployment. `--trust-bin`
-  approves deployment silently; `--no-trust-bin` skips `bin/` even when policy
-  permits it. The `allowExecutables` policy gate still takes precedence. (closes #1620)
+- `apm install` now accepts `--trust-bin` and `--no-trust-bin` for
+  per-invocation consent over marketplace-plugin executables. Non-interactive
+  installs default to no deployment unless consent or policy permits it.
+  (closes #1620, #2508)
 - `apm pack --format agent-plugin` and
   `apm plugin init --format agent-plugin` now emit strict, portable Agent
-  Plugins 1.0 bundles. The existing no-flag default and `--format plugin` alias
-  both remain Claude-compatible; exact-schema Agent Plugins are admitted as
-  whole units and blocked before deployment until a native client lifecycle
-  qualifies, never projected as legacy primitives. (by @sergio-sisternes-epam;
-  closes #2522) (#2654)
-
-### Fixed
-
-- Fixed false-positive security blocks from source-only package files:
-  `apm install` and surviving-package reintegration now scan the same authorized
-  file set they can deploy, while deployable prompts, hooks, skills, and approved
-  plugin bins remain protected. (#2490)
-- Marketplace `sourceBase` and full HTTPS repository paths now preserve safe
-  percent-encoded segments, enabling Azure DevOps project names such as
-  `My%20Projects`. (by @aryansk; fixes #2554) (#2584)
-- `apm lock export --timestamp` now rejects malformed or timezone-naive values
-  before they enter CycloneDX or SPDX metadata. (by @manideep-malyala; fixes
-  #2659) (#2660)
-- Generated bundle and plugin metadata now uses deterministic LF line endings,
-  keeping generated metadata byte-stable across operating systems. Existing
-  generated plugin manifests on Windows may have a one-time line-ending-only
-  diff on their next forced rewrite; project YAML files are unchanged. (#2624)
-- Lockfiles generated on Windows for marketplace-plugin / skill-subset git
-  dependencies now pass `apm install --frozen` on Linux, and vice versa. APM
-  writes synthetic `apm.yml` and inline-hooks `.apm/hooks/hooks.json` files
-  with deterministic LF line endings so their `content_hash` is identical on
-  every OS. Existing Windows lockfiles may retain the old CRLF-domain hash;
-  keep the lockfile so its `resolved_commit` pins remain intact while the
-  automatic one-time repair tracked in #2628 lands. (closes #2619)
-- `apm compile` now reduces matching work for literal scoped `applyTo` patterns
-  in large repositories while preserving historical placement. It shares a
-  source inventory across discovery and placement while preserving cleanup
-  behavior, and preserves commas in character classes. (#2595)
-- Hook commands such as `"${CLAUDE_PLUGIN_ROOT}"/hooks/probe.py` now rewrite to
-  `"${CLAUDE_PLUGIN_ROOT}/hooks/probe.py"` and warn when a supported plugin-root
-  placeholder remains unresolved instead of silently deploying a dead hook.
-  OpenAPM v0.1 (`docs/src/content/docs/specs/openapm-v0.1.md#req-tg-012`) binds
-  the behavior.
-  (by @MohammedAlkindi; closes #2639) (#2645)
-- `apm install` now resolves positional virtual-subdirectory git semver ranges before literal-ref preflight, while preserving registry version validation. (by @aryansk; closes #2514) (#2590)
-- `apm uninstall --global` now cleans removed-only target files before deleting their ownership state, while preserving files owned by surviving packages. (#2658)
-
-### Fixed
-
-- GitLab (gitlab.com and self-managed) org-policy auto-discovery now uses the valid `apm-policy` project convention instead of GitHub/ADO candidate names; missing policy projects are clean no-policy outcomes, and `APM_GITLAB_POLICY_REPO` overrides the project name. (#2605)
-- Windows binary is now Authenticode-signed in the release workflow, eliminating
-  the `Trojan:Script/Wacatac.H!ml` Windows Defender false positive on unsigned
-  PyInstaller bundles. (#2435)
-- `apm install --skill <name>` now matches on plugins whose manifest declares
-  the conventional skills container (`"skills": ["./skills/"]`). The declared
-  container was normalized under its own name, burying every skill at
-  `.apm/skills/skills/<name>/` -- one level below the depth `--skill`
-  enumeration, deployment, the `bin/` security scan and primitive counting all
-  read, so selection reported `Available: (none)` even though a bare install
-  deployed those same skills. A declared entry that is itself a skill
-  (`"skills": "./skills/engineering/tdd"`) still lands under its own leaf name
-  instead of spilling a bare `SKILL.md` into the shared skills root.
-  (closes #2530)
-- Root-declared plugin components (Claude Code single-skill shape
-  `"skills": ["./"]`, and the same for agents/commands/hooks) no longer cause
-  infinite recursion or unbounded writes during `apm install`.
-  `docs/src/content/docs/specs/openapm-v0.1.md` now explicitly requires
-  containment of consumer-generated staging output. (closes #2556)
-- Multi-target `apm compile` now avoids repeating expensive project analysis
-  for each target, making multi-target runs scale like single-target runs
-  without changing generated output. (closes #2482)
-- `deployed-files-present` no longer false-positives on gitignored deploy
-  paths (e.g. `.agents/`), enabling `apm audit --ci` to pass on a fresh
-  checkout when deployed outputs are intentionally not committed. (closes
-  #2452, thanks @sergio-sisternes-epam)
-- YAML expansion guard no longer rejects large anchor-free lockfiles (150K+
-  entries) with a false-positive "billion-laughs" error. APM-generated
-  lockfiles with no anchors or aliases now load without error. (#2389)
-- `apm install` no longer skips the credential retry on non-English machines.
-  Git localises its diagnostics through gettext, so a translated stderr made an
-  authentication failure unrecognisable and private-repo installs failed with
-  misleading network guidance. Git subprocesses in the authentication retry
-  path now run with `LC_ALL=C` and `LANGUAGE=C`. (by @Naofel-eal, closes #2533)
-- Codex MCP configuration now accepts plain HTTP for loopback endpoints while
-  retaining HTTPS for every non-loopback host. (by @normandev92, #2468)
+  Plugins 1.0 bundles while preserving the existing Claude-compatible default.
+  (closes #2522, #2654)
+- The lifecycle scripts guide now documents the Windows admin-tier policy path
+  alongside the Linux and macOS path. (by @WilliamK112, closes #2621, #2640)
 
 ### Changed
 
 - **BREAKING:** A plugin `skills` declaration now exclusively controls which
-  skills deploy. Declare every intended skill (or its immediate container), or
-  remove the key to retain conventional `skills/` discovery; undeclared
-  siblings no longer deploy. An explicit `"skills": []` deploys no skills and
-  reports one actionable migration diagnostic when it shadows root skills.
-  (closes #2537)
-- `apm install` now emits a trust-posture warning (via `[!]`) when a marketplace
-  plugin deploys executables to Claude Code's PATH without an explicit `--trust-bin`
-  flag. In non-interactive (non-TTY) contexts the default is `--no-trust-bin`.
-  Pass `--trust-bin` to suppress the warning and deploy, or `apm approve` for
-  persistent per-package approval.
+  skills deploy. Declare every intended skill or remove the key to retain
+  conventional `skills/` discovery; conventional containers deploy at the
+  expected depth, while `"skills": []` deploys no skills.
+  (by @edenfunf, closes #2530, #2537, #2540)
+
 ### Fixed
 
+- Agent Plugin inventory on Windows now compares physical file bytes without
+  CRLF translation, preventing valid assets from being rejected as changed
+  during inventory. (#2694)
+- GitLab organization-policy discovery now uses the valid `apm-policy` project
+  convention and treats a missing policy project as no policy. (#2662)
+- `apm audit` now compares only APM-owned entries in shared native hook configs,
+  preserving user-authored hooks while still detecting altered APM hooks.
+  (closes #2641, #2682)
+- `apm install` and surviving-package reintegration now scan only deployable
+  package content, preventing false-positive security blocks from source-only
+  files. (by @aryansk, #2598)
+- Root-declared plugin components no longer copy a plugin into its own staging
+  tree, preventing recursive writes during `apm install`.
+  (by @YoraiLevi, closes #2556, #2557)
+- OpenCode global installs now deploy user-scope skills to its native config
+  root, and `apm compile -g` retains scoped package instructions in the user
+  `AGENTS.md`. (by @aryansk, #2596)
+- Marketplace `sourceBase` and full HTTPS repository paths now preserve safe
+  percent-encoded segments, enabling Azure DevOps project names such as
+  `My%20Projects`. (by @aryansk, fixes #2554, #2584)
+- `apm install --frozen` now hydrates git-sourced `apm_package` dependencies
+  that declare MCP servers on a cold cache. (by @sergio-sisternes-epam,
+  closes #2456, #2502)
+- `apm install` now resolves virtual-subdirectory git semver ranges before
+  literal-ref preflight while preserving registry version validation.
+  (by @aryansk, closes #2514, #2590)
+- `apm lock export --timestamp` now rejects malformed or timezone-naive values
+  before they enter CycloneDX or SPDX metadata. (by @manideep-malyala, fixes
+  #2659, #2660)
+- Generated bundle and plugin metadata now uses deterministic LF line endings,
+  keeping generated metadata byte-stable across operating systems.
+  (by @WilliamK112, #2638)
+- Lockfiles generated on Windows for marketplace-plugin / skill-subset git
+  dependencies now pass `apm install --frozen` on Linux, and vice versa, by
+  hashing synthetic manifests with deterministic LF line endings.
+  (by @McNultyyy, closes #2619, #2620)
 - Codex MCP configuration now accepts plain HTTP for loopback endpoints while
-  retaining HTTPS for every non-loopback host. (by @normandev92, #2468)
+  retaining HTTPS for every non-loopback host.
+  (by @normandev92, #2468)
+- Azure DevOps organization-policy discovery now reads repository `_apm` from
+  project `apm`, keeping direct and inherited policy coordinates consistent.
+  (closes #2429, #2450)
+- Hook commands such as `"${CLAUDE_PLUGIN_ROOT}"/hooks/probe.py` now rewrite to
+  `"${CLAUDE_PLUGIN_ROOT}/hooks/probe.py"` and warn when a supported plugin-root
+  placeholder remains unresolved instead of silently deploying a dead hook.
+  (by @MohammedAlkindi, closes #2639, #2645)
+- `apm audit --ci` now accepts valid local Claude-skill dependencies without an
+  `apm.yml` while retaining strict package-shape validation.
+  (by @lukiod, closes #2611, #2643)
+- Copilot CLI and VS Code MCP configurations now route through separate adapter
+  paths, preventing one target's configuration from being written for the
+  other. (#2669)
+- Private-repository installs no longer skip credential retry when Git emits
+  localized diagnostics. (by @Naofel-eal, closes #2533, #2534)
+- `compilation.source_attribution: false` now suppresses cosmetic annotations
+  on distributed `AGENTS.md` targets as it already did for `CLAUDE.md`.
+  (by @MohammedAlkindi, closes #2634, #2646)
+- `apm uninstall --global` now cleans removed-only target files before deleting
+  their ownership state while preserving files owned by surviving packages.
+  (#2658)
+- `apm pack --dry-run` now honors the same existing `plugin.json` overwrite
+  policy as a real non-force pack, avoiding misleading write previews.
+  (by @aryansk, #2583)
+- `apm marketplace validate` now reports malformed plugin structure by JSON path
+  and exits 1 instead of emitting misleading success output. (#2474)
+- CLI help for compile, dependency updates, and MCP install now follows the
+  target catalog and exposes the forwarded target and trust options.
+  (by @sergio-sisternes-epam, #2499)
+- `deployed-files-present` no longer false-positives on gitignored deploy
+  paths (e.g. `.agents/`), enabling `apm audit --ci` to pass on a fresh
+  checkout when deployed outputs are intentionally not committed.
+  (by @sergio-sisternes-epam, closes #2452, #2496)
+- YAML expansion guard no longer rejects large anchor-free lockfiles (150K+
+  entries) with a false-positive "billion-laughs" error.
+  (#2518)
+- SSH-based installs now fail promptly with a useful error when a key needs an
+  unavailable passphrase instead of hanging until timeout.
+  (by @sergio-sisternes-epam, fixes #1976, #2360)
+
+### Performance
+
+- `apm compile` now scopes literal `applyTo` walks to their roots, reducing
+  matching work in large repositories without changing placement.
+  (by @aryansk, #2595)
+- Multi-target `apm compile` now reuses project placement analysis across
+  targets, scaling like a single-target run without changing generated output.
+  (closes #2482, #2486)
+
+### Security
+
+- Windows release binaries are now Authenticode-signed, preventing the Windows
+  Defender false positive caused by unsigned PyInstaller bundles.
+  (by @sergio-sisternes-epam, closes #2435, #2497)
 
 ### Removed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apm-cli"
-version = "0.28.0"
+version = "0.29.0"
 description = "MCP configuration tool"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -203,7 +203,7 @@ wheels = [
 
 [[package]]
 name = "apm-cli"
-version = "0.28.0"
+version = "0.29.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
# ship(release): prepare v0.29.0

## TL;DR

Cut APM 0.29.0 as a pre-1.0 minor release. This moves the approved
`[Unreleased]` notes into a dated release section and aligns the project and
lockfile versions. The release includes new CLI and Agent Plugin contract
surface, one explicitly documented breaking plugin-skills change, and the
cycle's user-facing fixes.

> [!IMPORTANT]
> After merge, a maintainer must tag `v0.29.0`; this PR does not create or push
> the release tag.

## Problem (WHY)

- [x] The merged work since `v0.28.0` still lived under `[Unreleased]`, so the
  repository had no dated release boundary for the cycle.
- [x] `pyproject.toml` and the local `apm-cli` package entry in `uv.lock` still
  reported `0.28.0`.
- [!] The cycle contains a `**BREAKING:**` plugin-skills migration plus new
  user-visible install flags and Agent Plugins 1.0 contract surface, which
  warrants a pre-1.0 minor rather than a patch.

The release preparation follows the principle that
["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/)
and keeps the artifact concrete because
["agents pattern-match well against concrete structures"](https://agentskills.io/skill-creation/best-practices).

## Approach (WHAT)

| # | Fix | Principle |
|---:|---|---|
| 1 | Sanitize the cycle into one concise, user-facing changelog entry per merged PR. | ["Add what the agent lacks, omit what it knows"](https://agentskills.io/skill-creation/best-practices) |
| 2 | Bump the project and lockfile package versions together to `0.29.0`. | ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) |
| 3 | Stop at an open PR and retain tagging as the explicit maintainer gate. | ["Favor small, chainable primitives over monolithic frameworks."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) |

## Implementation (HOW)

| File | Change |
|---|---|
| `CHANGELOG.md` | Keeps an empty `[Unreleased]` placeholder, adds `[0.29.0] - 2026-08-26`, consolidates duplicate drafts, credits external contributors, and records the plugin-skills migration. |
| `pyproject.toml` | Changes the project version from `0.28.0` to `0.29.0`. |
| `uv.lock` | Changes only the editable `apm-cli` package version from `0.28.0` to `0.29.0`; public package URLs remain portable for OSS consumers. |

## Diagrams

Legend: the dashed nodes are the release artifacts changed by this PR; tagging
remains outside the PR as a human-controlled post-merge action.

```mermaid
flowchart LR
    subgraph Prep[Release preparation]
        C["CHANGELOG.md: 0.29.0 notes"]
        P["pyproject.toml: 0.29.0"]
        L["uv.lock: 0.29.0"]
    end
    subgraph Gate[Release gate]
        V[Lint mirror]
        R[Release PR]
    end
    subgraph Human[Post-merge human gate]
        T[Tag v0.29.0]
        W[Release workflow]
    end
    C --> V
    P --> V
    L --> V
    V --> R
    R --> T
    T --> W
    classDef new stroke-dasharray: 5 5;
    class C,P,L new;
```

## Trade-offs

- **Minor instead of patch or major.** Chose `0.29.0` because the cycle contains
  a breaking migration and new public surfaces; rejected `0.28.1` as
  under-signaling and `1.0.0` because this remains the pre-1.0 line.
- **Portable lockfile instead of internal feed URLs.** Used the approved
  Microsoft proxy for dependency access but retained canonical public source
  URLs in the committed OSS lockfile; rejected 1,562 Microsoft-internal URLs
  that external contributors could not consume.
- **Scenario Evidence omitted under the pure release-metadata/asset-bump skip.**
  This PR changes version and release-note artifacts only; it does not change
  runtime behavior or tests.

## Benefits

1. `CHANGELOG.md`, `pyproject.toml`, and `uv.lock` agree on version `0.29.0`.
2. The dated section covers 34 user-facing merged PRs and drops six
   internal/dependency-only changes.
3. `[Unreleased]` remains ready for the next development cycle.
4. The repository retains zero Microsoft-internal package-feed URLs.

## Validation

`uv lock --check --offline --default-index https://pypi.org/simple`:

```text
Resolved 107 packages in 25ms
```

<details><summary>Lint mirror output</summary>

```text
ruff check                     PASS
ruff format --check            PASS
pylint R0801 duplication       PASS
auth-signals boundary          PASS
[+] all lint-mirror checks PASSED
```

</details>

### Scenario Evidence

Skipped: this is a pure release-metadata and version-asset bump with no runtime
behavior change.

## How to test

- [ ] Run `grep '^version = ' pyproject.toml` and confirm it prints `0.29.0`.
- [ ] Inspect the `apm-cli` entry in `uv.lock` and confirm it prints `0.29.0`.
- [ ] Run `uv lock --check` and confirm the lockfile is current.
- [ ] Inspect `CHANGELOG.md` and confirm `[Unreleased]` is empty above the dated
  `[0.29.0] - 2026-08-26` section.
- [ ] After merge, tag `v0.29.0` and confirm the release workflow starts.

## Post-merge

Tag `v0.29.0` to trigger the release workflow:

```bash
git tag v0.29.0
git push origin v0.29.0
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
