### PR TITLE
docs: use emoji markers in target summary matrix

### DIFF
--- a/docs/src/content/docs/reference/targets-matrix.md
+++ b/docs/src/content/docs/reference/targets-matrix.md
@@ -19,18 +19,18 @@ see [Primitive types](../primitive-types/).
 
 | Target          | Deploy root            | instructions | prompts | agents | skills | commands | hooks | mcp |
 |-----------------|------------------------|:------------:|:-------:|:------:|:------:|:--------:|:-----:|:---:|
-| copilot         | `.github/`             |     [x]      |   [x]   |  [x]   |  [x]   |   [ ]    |  [x]  | [x] |
-| claude          | `.claude/`             |     [x]      |   [ ]   |  [x]   |  [x]   |   [x]    |  [x]  | [x] |
-| grok-build      | `.grok/`               |     [x]      |   [ ]   |  [x]   |  [x]   |   [x]    |  [ ]  | [ ] |
-| cursor          | `.cursor/`             |     [x]      |   [ ]   |  [x]   |  [x]   |   [x]    |  [x]  | [x] |
-| codex           | `.codex/` + `.agents/` |     [ ]      |   [ ]   |  [x]   |  [x]   |   [ ]    |  [x]  | [x] |
-| gemini          | `.gemini/`             |     [ ]      |   [ ]   |  [ ]   |  [x]   |   [x]    |  [x]  | [x] |
-| antigravity     | `.agents/`             |     [x]      |   [ ]   |  [ ]   |  [x]   |   [ ]    |  [x]  | [x] |
-| opencode        | `.opencode/`           |     [ ]      |   [ ]   |  [x]   |  [x]   |   [x]    |  [ ]  | [x] |
-| windsurf        | `.windsurf/` + `.agents/` |     [x]      |   [ ]   |  [ ]   |  [x]   |   [x]    |  [x]  | [x] |
-| kiro            | `.kiro/`               |     [x]      |   [ ]   |  [x]   |  [x]   |   [ ]    |  [x]  | [x] |
-| intellij        | user MCP config; files via Copilot |    [x] (*)   | [x] (*) | [x] (*) | [x] (*) |   [ ]    | [x] (*) | [x] |
-| agent-skills    | `.agents/`             |     [ ]      |   [ ]   |  [ ]   |  [x]   |   [ ]    |  [ ]  | [ ] |
+| copilot         | `.github/`             |     ✅      |   ✅   |  ✅   |  ✅   |   ❌    |  ✅  | ✅ |
+| claude          | `.claude/`             |     ✅      |   ❌   |  ✅   |  ✅   |   ✅    |  ✅  | ✅ |
+| grok-build      | `.grok/`               |     ✅      |   ❌   |  ✅   |  ✅   |   ✅    |  ❌  | ❌ |
+| cursor          | `.cursor/`             |     ✅      |   ❌   |  ✅   |  ✅   |   ✅    |  ✅  | ✅ |
+| codex           | `.codex/` + `.agents/` |     ❌      |   ❌   |  ✅   |  ✅   |   ❌    |  ✅  | ✅ |
+| gemini          | `.gemini/`             |     ❌      |   ❌   |  ❌   |  ✅   |   ✅    |  ✅  | ✅ |
+| antigravity     | `.agents/`             |     ✅      |   ❌   |  ❌   |  ✅   |   ❌    |  ✅  | ✅ |
+| opencode        | `.opencode/`           |     ❌      |   ❌   |  ✅   |  ✅   |   ✅    |  ❌  | ✅ |
+| windsurf        | `.windsurf/` + `.agents/` |     ✅      |   ❌   |  ❌   |  ✅   |   ✅    |  ✅  | ✅ |
+| kiro            | `.kiro/`               |     ✅      |   ❌   |  ✅   |  ✅   |   ❌    |  ✅  | ✅ |
+| intellij        | user MCP config; files via Copilot |    ✅ (*)   | ✅ (*) | ✅ (*) | ✅ (*) |   ❌    | ✅ (*) | ✅ |
+| agent-skills    | `.agents/`             |     ❌      |   ❌   |  ❌   |  ✅   |   ❌    |  ❌  | ❌ |
 
 Skills deploy to `.agents/skills/` for Copilot, Cursor, OpenCode,
 Gemini, Antigravity, Codex, and Windsurf by default (see [Skills convergence](#skills-convergence)


### PR DESCRIPTION
## Description

The targets summary matrix used text-like checkbox markers that were slower to distinguish at a glance. This change replaces supported and unsupported markers with ✅ and ❌ while preserving every support state and the IntelliJ footnotes.

**Trade-off:** This intentionally introduces Unicode into this documentation table to provide the requested visual scanability; no CLI output or source behavior changes.

N/A - no linked issue.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Maintenance / refactor

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [ ] Added tests for new functionality (if applicable)

Validation: the full CI lint mirror passed with Ruff, Ruff formatting, pylint duplicate-code detection, and the auth-signal boundary check.

## Spec conformance (OpenAPM v0.1)

If this PR changes behaviour that an OpenAPM v0.1 `req-XXX` covers,
confirm the three-step ritual (see CONTRIBUTING.md "Adding or
changing a normative requirement"):

- [ ] Spec edit: `docs/src/content/docs/specs/openapm-v0.1.md` updated
      (new/changed `<a id="req-XXX"></a>` anchor + prose + Appendix C
      row).
- [ ] Manifest edit: `docs/src/content/docs/specs/manifests/openapm-v0.1.requirements.yml`
      updated.
- [ ] Test edit: a `@pytest.mark.req("req-XXX")` test under
      `tests/spec_conformance/` added or extended.
- [ ] `CONFORMANCE.{md,json}` regenerated via
      `uv run --extra dev python -m tests.spec_conformance.gen_statement`
      and committed.
- [x] N/A -- this PR does not change OpenAPM-observable behaviour.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>