### PR TITLE
fix: support catalog-only marketplace plugins

### DIFF
--- a/.apm/instructions/architecture.instructions.md
+++ b/.apm/instructions/architecture.instructions.md
@@ -77,6 +77,7 @@ semicolon-delimited, and specific to the file(s) that own the fact.
 | Effective marketplace output path | marketplace/output_profiles.py (resolve_effective_output_path) | `src/apm_cli/marketplace/output_profiles.py` |
 | Bootstrap project-name validation and fallback | core/project_name.py (resolve_bootstrap_project_name) | `src/apm_cli/core/project_name.py` |
 | Marketplace raw-structure diagnostics | marketplace/models.py parser; validator.py consumes them | `src/apm_cli/marketplace/models.py`; `src/apm_cli/marketplace/validator.py` |
+| Catalog-only marketplace manifest materialization | deps/_shared.py (materialize_marketplace_manifest) | `src/apm_cli/deps/_shared.py` |
 | Agent Plugins v1 contract interpretation, component discovery, and portable manifest authority | agent_plugins/loader.py (load_agent_plugin, _load_apm_configuration) | `src/apm_cli/agent_plugins/loader.py`; `src/apm_cli/agent_plugins/ir.py` |
 | Agent Plugin producer portable-surface admission | bundle/agent_plugin_exporter.py (_require_portable_agent_plugin) | `src/apm_cli/bundle/agent_plugin_exporter.py` |
 | APMPackage interpreted-manifest construction | models/apm_package.py (APMPackage.from_mapping) | `src/apm_cli/models/apm_package.py` |

--- a/.apm/instructions/architecture.instructions.md
+++ b/.apm/instructions/architecture.instructions.md
@@ -83,7 +83,7 @@ semicolon-delimited, and specific to the file(s) that own the fact.
 | APMPackage interpreted-manifest construction | models/apm_package.py (APMPackage.from_mapping) | `src/apm_cli/models/apm_package.py` |
 | Agent Plugin compatibility package projection | agent_plugins/projection.py (project_agent_plugin_package) | `src/apm_cli/agent_plugins/projection.py`; `src/apm_cli/models/validation.py` |
 | Network host literal parsing and loopback classification | utils/net.py (parse_host_address, is_loopback_host) | `src/apm_cli/utils/net.py` |
-| Legacy plugin declared-skill membership | deps/plugin_parser.py (_map_plugin_artifacts, normalized_plugin_skill_sources) | `src/apm_cli/deps/plugin_parser.py`; `src/apm_cli/integration/skill_integrator.py` |
+| Legacy plugin declared-skill membership and plugin-root placeholder expansion | deps/plugin_parser.py (_map_plugin_artifacts, normalized_plugin_skill_sources, resolve_plugin_root_placeholders) | `src/apm_cli/deps/plugin_parser.py`; `src/apm_cli/integration/skill_integrator.py` |
 | User-root scoped instruction eligibility | integration/targets.py (TargetProfile.include_scoped_in_user_root_context) | `src/apm_cli/integration/targets.py` |
 | Native Agent Plugin registration admission (Copilot target + client capability) | copilot_plugins/capability.py (resolve_native_registration_capability, admits_native_plugin) | `src/apm_cli/copilot_plugins/capability.py` |
 | APM-owned Copilot marketplace catalog, settings entries, and ownership ledger | copilot_plugins/registrar.py (synchronize_copilot_plugins, resync_native_plugins) | `src/apm_cli/copilot_plugins/registrar.py`; `src/apm_cli/copilot_plugins/settings.py`; `src/apm_cli/copilot_plugins/catalog.py` |

--- a/.github/instructions/architecture.instructions.md
+++ b/.github/instructions/architecture.instructions.md
@@ -77,6 +77,7 @@ semicolon-delimited, and specific to the file(s) that own the fact.
 | Effective marketplace output path | marketplace/output_profiles.py (resolve_effective_output_path) | `src/apm_cli/marketplace/output_profiles.py` |
 | Bootstrap project-name validation and fallback | core/project_name.py (resolve_bootstrap_project_name) | `src/apm_cli/core/project_name.py` |
 | Marketplace raw-structure diagnostics | marketplace/models.py parser; validator.py consumes them | `src/apm_cli/marketplace/models.py`; `src/apm_cli/marketplace/validator.py` |
+| Catalog-only marketplace manifest materialization | deps/_shared.py (materialize_marketplace_manifest) | `src/apm_cli/deps/_shared.py` |
 | Agent Plugins v1 contract interpretation, component discovery, and portable manifest authority | agent_plugins/loader.py (load_agent_plugin, _load_apm_configuration) | `src/apm_cli/agent_plugins/loader.py`; `src/apm_cli/agent_plugins/ir.py` |
 | Agent Plugin producer portable-surface admission | bundle/agent_plugin_exporter.py (_require_portable_agent_plugin) | `src/apm_cli/bundle/agent_plugin_exporter.py` |
 | APMPackage interpreted-manifest construction | models/apm_package.py (APMPackage.from_mapping) | `src/apm_cli/models/apm_package.py` |

--- a/.github/instructions/architecture.instructions.md
+++ b/.github/instructions/architecture.instructions.md
@@ -83,7 +83,7 @@ semicolon-delimited, and specific to the file(s) that own the fact.
 | APMPackage interpreted-manifest construction | models/apm_package.py (APMPackage.from_mapping) | `src/apm_cli/models/apm_package.py` |
 | Agent Plugin compatibility package projection | agent_plugins/projection.py (project_agent_plugin_package) | `src/apm_cli/agent_plugins/projection.py`; `src/apm_cli/models/validation.py` |
 | Network host literal parsing and loopback classification | utils/net.py (parse_host_address, is_loopback_host) | `src/apm_cli/utils/net.py` |
-| Legacy plugin declared-skill membership | deps/plugin_parser.py (_map_plugin_artifacts, normalized_plugin_skill_sources) | `src/apm_cli/deps/plugin_parser.py`; `src/apm_cli/integration/skill_integrator.py` |
+| Legacy plugin declared-skill membership and plugin-root placeholder expansion | deps/plugin_parser.py (_map_plugin_artifacts, normalized_plugin_skill_sources, resolve_plugin_root_placeholders) | `src/apm_cli/deps/plugin_parser.py`; `src/apm_cli/integration/skill_integrator.py` |
 | User-root scoped instruction eligibility | integration/targets.py (TargetProfile.include_scoped_in_user_root_context) | `src/apm_cli/integration/targets.py` |
 | Native Agent Plugin registration admission (Copilot target + client capability) | copilot_plugins/capability.py (resolve_native_registration_capability, admits_native_plugin) | `src/apm_cli/copilot_plugins/capability.py` |
 | APM-owned Copilot marketplace catalog, settings entries, and ownership ledger | copilot_plugins/registrar.py (synchronize_copilot_plugins, resync_native_plugins) | `src/apm_cli/copilot_plugins/registrar.py`; `src/apm_cli/copilot_plugins/settings.py`; `src/apm_cli/copilot_plugins/catalog.py` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (by @lkshrk, #2709).
 
 ## [0.29.0] - 2026-08-26
+## [0.29.0] - 2026-08-30
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.29.0] - 2026-08-30
+### Fixed
+
+- Marketplace installs now materialize catalog-only LSP and MCP metadata
+  without requiring a package manifest in the downloaded source
+  (by @lkshrk, #2709).
+
+## [0.29.0] - 2026-08-26
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.29.0] - 2026-08-30
 ### Fixed
 
 - Marketplace installs now materialize catalog-only LSP and MCP metadata
   without requiring a package manifest in the downloaded source
   (by @lkshrk, #2709).
 
-## [0.29.0] - 2026-08-26
 ## [0.29.0] - 2026-08-30
 
 ### Added

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -2783,7 +2783,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:94e80fb03702d02fe78db972ec8048f011befa5fa04e2761757616cf98967f5e
+  content_hash: sha256:1464599396f2dd661b98fbe153f4b08d8f0c90945e94587ad183e510dbd530ae
 - kind: project-relative
   target: copilot
   value: .github/instructions/changelog.instructions.md
@@ -3290,7 +3290,7 @@ local_deployed_file_hashes:
   .github/agents/spec-tag-architect.agent.md: sha256:82907265c5e7cf1ac61ad96866fa7c5683b69c8f09b7a4c5f3cc241acc9568ca
   .github/agents/supply-chain-security-expert.agent.md: sha256:8fb8cc426d6af17ba084a28b3f026c2b475b62e3ca63ed2f88b83bd823f877af
   .github/agents/test-coverage-expert.agent.md: sha256:48c2172d1f18a394fa83ef9dc2be0b9b921a4e51e976498165250fed66369711
-  .github/instructions/architecture.instructions.md: sha256:94e80fb03702d02fe78db972ec8048f011befa5fa04e2761757616cf98967f5e
+  .github/instructions/architecture.instructions.md: sha256:1464599396f2dd661b98fbe153f4b08d8f0c90945e94587ad183e510dbd530ae
   .github/instructions/changelog.instructions.md: sha256:1e51ec4c74e847967962bd279dc4c6e582c5d3578490b3c28d5f3acd3e05f73e
   .github/instructions/cicd.instructions.md: sha256:33201cb88ea2f34b4950a9b52f87dc8dfb682796aaf53068ba7ae406c0c5e2c2
   .github/instructions/cli.instructions.md: sha256:8e39e8d5047ce88575cb02f87c2bcede584dfef258bd86f7466c7badf136541a

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -2783,7 +2783,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:6f87b0753985449ea5648abcac24e1ecafbc2d100bcc5d9399a4f5d68b07089d
+  content_hash: sha256:94e80fb03702d02fe78db972ec8048f011befa5fa04e2761757616cf98967f5e
 - kind: project-relative
   target: copilot
   value: .github/instructions/changelog.instructions.md
@@ -3290,7 +3290,7 @@ local_deployed_file_hashes:
   .github/agents/spec-tag-architect.agent.md: sha256:82907265c5e7cf1ac61ad96866fa7c5683b69c8f09b7a4c5f3cc241acc9568ca
   .github/agents/supply-chain-security-expert.agent.md: sha256:8fb8cc426d6af17ba084a28b3f026c2b475b62e3ca63ed2f88b83bd823f877af
   .github/agents/test-coverage-expert.agent.md: sha256:48c2172d1f18a394fa83ef9dc2be0b9b921a4e51e976498165250fed66369711
-  .github/instructions/architecture.instructions.md: sha256:6f87b0753985449ea5648abcac24e1ecafbc2d100bcc5d9399a4f5d68b07089d
+  .github/instructions/architecture.instructions.md: sha256:94e80fb03702d02fe78db972ec8048f011befa5fa04e2761757616cf98967f5e
   .github/instructions/changelog.instructions.md: sha256:1e51ec4c74e847967962bd279dc4c6e582c5d3578490b3c28d5f3acd3e05f73e
   .github/instructions/cicd.instructions.md: sha256:33201cb88ea2f34b4950a9b52f87dc8dfb682796aaf53068ba7ae406c0c5e2c2
   .github/instructions/cli.instructions.md: sha256:8e39e8d5047ce88575cb02f87c2bcede584dfef258bd86f7466c7badf136541a

--- a/docs/src/content/docs/consumer/installing-from-marketplaces.md
+++ b/docs/src/content/docs/consumer/installing-from-marketplaces.md
@@ -104,6 +104,11 @@ for a self-hosted GitLab monorepo. APM preserves the package host, path, and
 ref in `apm.yml` and `apm.lock.yaml`. Invalid URLs and unsafe subdirectory
 paths fail before manifest, lockfile, or deployment writes.
 
+Marketplace entries can also provide inline LSP or MCP servers when their
+downloaded source has no package manifest. APM validates these
+[catalog-only marketplace packages](../../reference/package-types/#catalog-only-marketplace-package)
+before deployment.
+
 Marketplace publishers can route an entry through a configured APM package
 registry with the entry's `registry` and semver `version` fields. Enable the
 feature first with `apm experimental enable registries`; see

--- a/docs/src/content/docs/reference/package-types.md
+++ b/docs/src/content/docs/reference/package-types.md
@@ -4,12 +4,12 @@ sidebar:
   order: 4
 ---
 
-APM supports six package layouts, each with distinct install semantics.
-Pick the layout that matches the author's intent -- APM preserves it.
+APM supports six source layouts plus catalog-only marketplace packages.
+Pick the form that matches the author's intent -- APM preserves it.
 
 ## Layout summary
 
-| Root signal | Author intent | Install semantic |
+| Package signal | Author intent | Install semantic |
 |---|---|---|
 | `.apm/` (with or without apm.yml) | "I have N independent primitives" | Hoist each primitive into the target's runtime dirs |
 | `SKILL.md` (alone or with apm.yml -- HYBRID) | "I am one skill bundle" | Copy the whole bundle to `<target>/skills/<name>/` |
@@ -17,6 +17,7 @@ Pick the layout that matches the author's intent -- APM preserves it.
 | `hooks/*.json` only (no apm.yml or SKILL.md) | "I ship a set of harness hooks" | Deploy each hook to the target's `hooks/` directory |
 | `plugin.json` (no `$schema`) / `.claude-plugin/` | Claude plugin collection | Dissect via plugin artifact mapping |
 | `plugin.json` with an Agent Plugins `$schema` | Portable Agent Plugin | Installed whole and registered when the effective targets include Copilot |
+| Marketplace entry with inline `lspServers` or `mcpServers` | Catalog owns server metadata | Synthesize and validate `apm.yml`, then deploy servers |
 
 ## APM package (`.apm/` directory)
 
@@ -192,6 +193,20 @@ target's hooks runtime path (e.g. `.github/hooks/` for Copilot,
 primitives. If you also ship skills or instructions, prefer the `.apm/`
 layout and put your hooks under `.apm/hooks/` so they install alongside
 the rest.
+
+## Catalog-only marketplace package
+
+A marketplace entry can supply a package's only APM metadata. When its
+downloaded source has no `apm.yml`, `SKILL.md`, or plugin manifest, APM uses one
+or both inline `lspServers` and `mcpServers` fields. It admits only `name`,
+`description`, `version`, `lspServers`, and `mcpServers`; unrelated catalog
+fields, including dependency fields, cannot add APM dependencies.
+
+APM stages and validates a synthesized `apm.yml` before committing it. Every
+declared server must validate. Any failure rejects the package and removes its
+download. A symlinked package path, `apm.yml`, or `.apm` path also fails closed.
+On warm installs, APM rematerializes the manifest when the admitted catalog
+metadata variant changes.
 
 ## Plugin collection (`plugin.json`)
 

--- a/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
@@ -253,6 +253,13 @@ path. Both survive into the concrete `git:`, `path:`, and `ref:` manifest
 entry and the lockfile. Invalid URLs or unsafe paths fail before durable
 project writes.
 
+Catalog-only entries with inline `lspServers` or `mcpServers` remain valid
+marketplace dependencies when downloaded source has no package manifest. Keep
+the consumer declaration in the object form above; catalog server fields do not
+belong in `dependencies.apm`. APM ignores unrelated catalog dependency fields
+and rejects the package if any declared server is invalid. See
+[Catalog-only marketplace packages](../../../../../docs/src/content/docs/reference/package-types.md#catalog-only-marketplace-package).
+
 If the marketplace plugin entry declares `registry`, APM creates a
 registry-sourced dependency instead of Git coordinates. Enable registry support
 with `apm experimental enable registries` and configure the named registry.

--- a/scripts/lint-architecture-boundaries.sh
+++ b/scripts/lint-architecture-boundaries.sh
@@ -1777,6 +1777,8 @@ catalog_materialization_owner="src/apm_cli/deps/_shared.py"
 catalog_materialization_consumer="src/apm_cli/deps/apm_resolver.py"
 catalog_local_consumer="src/apm_cli/install/phases/local_content.py"
 catalog_local_install_consumer="src/apm_cli/install/sources.py"
+plugin_root_placeholder_owner="src/apm_cli/deps/plugin_parser.py"
+plugin_root_placeholder_consumer="src/apm_cli/models/apm_package.py"
 catalog_manifest_parallel_hits=$(
     grep -rEn --include='*.py' 'marketplace_manifest' src/apm_cli \
         | grep -v "^${catalog_materialization_owner}:" \
@@ -1802,6 +1804,10 @@ if ! grep -q '^def materialize_marketplace_manifest(' "$catalog_materialization_
         "$catalog_local_consumer" \
     || ! grep -q 'materialize_marketplace_manifest(dep_ref, install_path)' \
         "$catalog_local_install_consumer" \
+    || ! grep -q '^def resolve_plugin_root_placeholders(' \
+        "$plugin_root_placeholder_owner" \
+    || ! grep -q 'resolve_plugin_root_placeholders(' \
+        "$plugin_root_placeholder_consumer" \
     || [ -n "$catalog_manifest_parallel_hits" ] \
     || [ -n "$catalog_synthesis_parallel_hits" ]; then
     echo "[x] Catalog-only marketplace manifests must route through deps/_shared.py"

--- a/scripts/lint-architecture-boundaries.sh
+++ b/scripts/lint-architecture-boundaries.sh
@@ -1776,10 +1776,13 @@ echo "[*] AC35: catalog-only marketplace materialization authority"
 catalog_materialization_owner="src/apm_cli/deps/_shared.py"
 catalog_materialization_consumer="src/apm_cli/deps/apm_resolver.py"
 catalog_local_consumer="src/apm_cli/install/phases/local_content.py"
+catalog_local_install_consumer="src/apm_cli/install/sources.py"
 catalog_manifest_parallel_hits=$(
     grep -rEn --include='*.py' 'marketplace_manifest' src/apm_cli \
         | grep -v "^${catalog_materialization_owner}:" \
         | grep -v "^${catalog_materialization_consumer}:" \
+        | grep -v "^${catalog_local_consumer}:" \
+        | grep -v "^${catalog_local_install_consumer}:" \
         | grep -v '^src/apm_cli/marketplace/models.py:' \
         | grep -v '^src/apm_cli/models/dependency/reference.py:' \
         || true
@@ -1797,6 +1800,8 @@ if ! grep -q '^def materialize_marketplace_manifest(' "$catalog_materialization_
         "$catalog_materialization_consumer" \
     || ! grep -q 'has_marketplace_deployable_manifest(dep_ref)' \
         "$catalog_local_consumer" \
+    || ! grep -q 'materialize_marketplace_manifest(dep_ref, install_path)' \
+        "$catalog_local_install_consumer" \
     || [ -n "$catalog_manifest_parallel_hits" ] \
     || [ -n "$catalog_synthesis_parallel_hits" ]; then
     echo "[x] Catalog-only marketplace manifests must route through deps/_shared.py"

--- a/scripts/lint-architecture-boundaries.sh
+++ b/scripts/lint-architecture-boundaries.sh
@@ -1772,6 +1772,39 @@ if ! grep -q 'structural_errors: tuple\[str, \.\.\.\] = ()' "$marketplace_struct
     violations=$((violations + 1))
 fi
 
+echo "[*] AC35: catalog-only marketplace materialization authority"
+catalog_materialization_owner="src/apm_cli/deps/_shared.py"
+catalog_materialization_consumer="src/apm_cli/deps/apm_resolver.py"
+catalog_local_consumer="src/apm_cli/install/phases/local_content.py"
+catalog_manifest_parallel_hits=$(
+    grep -rEn --include='*.py' 'marketplace_manifest' src/apm_cli \
+        | grep -v "^${catalog_materialization_owner}:" \
+        | grep -v "^${catalog_materialization_consumer}:" \
+        | grep -v '^src/apm_cli/marketplace/models.py:' \
+        | grep -v '^src/apm_cli/models/dependency/reference.py:' \
+        || true
+)
+catalog_synthesis_parallel_hits=$(
+    grep -rEn --include='*.py' 'synthesize_apm_yml_from_plugin\(' src/apm_cli \
+        | grep -v "^${catalog_materialization_owner}:" \
+        | grep -v '^src/apm_cli/deps/plugin_parser.py:' \
+        || true
+)
+if ! grep -q '^def materialize_marketplace_manifest(' "$catalog_materialization_owner" \
+    || ! grep -q 'from \._shared import MarketplaceManifestMaterializationError, materialize_marketplace_manifest' \
+        "$catalog_materialization_consumer" \
+    || ! grep -q 'materialize_marketplace_manifest(dep_ref, install_path)' \
+        "$catalog_materialization_consumer" \
+    || ! grep -q 'has_marketplace_deployable_manifest(dep_ref)' \
+        "$catalog_local_consumer" \
+    || [ -n "$catalog_manifest_parallel_hits" ] \
+    || [ -n "$catalog_synthesis_parallel_hits" ]; then
+    echo "[x] Catalog-only marketplace manifests must route through deps/_shared.py"
+    [ -n "$catalog_manifest_parallel_hits" ] && echo "$catalog_manifest_parallel_hits"
+    [ -n "$catalog_synthesis_parallel_hits" ] && echo "$catalog_synthesis_parallel_hits"
+    violations=$((violations + 1))
+fi
+
 echo "[*] AC29: dependency identity and materialization path authority"
 identity_owner="src/apm_cli/models/dependency/identity.py"
 materialization_owner="src/apm_cli/models/dependency/materialization.py"

--- a/src/apm_cli/deps/_shared.py
+++ b/src/apm_cli/deps/_shared.py
@@ -11,6 +11,34 @@ if TYPE_CHECKING:
     from ..models.validation import ValidationResult
 
 
+def materialize_marketplace_manifest(dep_ref: DependencyReference, target_path: Path) -> bool:
+    """Synthesize a package when deployable components exist only in the catalog."""
+    manifest = getattr(dep_ref, "marketplace_manifest", None)
+    declared = tuple(
+        key
+        for key in ("lspServers", "mcpServers")
+        if isinstance(manifest, dict) and manifest.get(key)
+    )
+    if (target_path / "apm.yml").exists() or not declared:
+        return False
+    from apm_cli.deps.plugin_parser import synthesize_apm_yml_from_plugin
+    from apm_cli.models.apm_package import APMPackage
+    from apm_cli.utils.file_ops import robust_rmtree
+
+    try:
+        apm_yml = synthesize_apm_yml_from_plugin(target_path, dict(manifest))
+        package = APMPackage.from_apm_yml(apm_yml)
+        if "lspServers" in declared and not package.get_lsp_dependencies():
+            raise ValueError("Marketplace LSP metadata did not materialize a valid dependency")
+        if "mcpServers" in declared and not package.get_mcp_dependencies():
+            raise ValueError("Marketplace MCP metadata did not materialize a valid dependency")
+    except Exception:
+        if target_path.exists():
+            robust_rmtree(target_path, ignore_errors=True)
+        raise
+    return True
+
+
 def _validate_and_load_package(
     validation_result: ValidationResult,
     target_path: Path,
@@ -35,7 +63,11 @@ def _validate_and_load_package(
     """
     from ..agent_plugins.errors import AgentPluginError
     from ..bundle.local_bundle import route_agent_plugin_package
+    from ..models.validation import validate_apm_package
     from ..utils.file_ops import robust_rmtree
+
+    if materialize_marketplace_manifest(dep_ref, target_path):
+        validation_result = validate_apm_package(target_path)
 
     if target_path.is_dir():
         try:

--- a/src/apm_cli/deps/_shared.py
+++ b/src/apm_cli/deps/_shared.py
@@ -29,6 +29,15 @@ def has_marketplace_deployable_manifest(dep_ref: DependencyReference) -> bool:
     )
 
 
+def _marketplace_display_name(dep_ref: DependencyReference) -> str:
+    """Return a stable marketplace identity without checkout paths."""
+    plugin_name = getattr(dep_ref, "marketplace_plugin_name", None)
+    marketplace_name = getattr(dep_ref, "marketplace_name", None)
+    if plugin_name and marketplace_name:
+        return f"{plugin_name}@{marketplace_name}"
+    return dep_ref.get_display_name()
+
+
 def _manifest_digest(manifest: dict[str, object]) -> str:
     """Return a deterministic digest for consumer materialization state."""
     encoded = json.dumps(
@@ -40,19 +49,14 @@ def _manifest_digest(manifest: dict[str, object]) -> str:
     return hashlib.sha256(encoded).hexdigest()
 
 
-def _generated_manifest_digest(apm_yml_path: Path) -> str | None:
-    """Read the catalog digest marker from an APM-generated manifest."""
+def _is_generated_marketplace_manifest(apm_yml_path: Path) -> bool:
+    """Return whether a manifest carries APM's catalog-generation marker."""
     try:
         with apm_yml_path.open(encoding="utf-8") as manifest_file:
             first_line = manifest_file.readline().rstrip("\r\n")
     except OSError:
-        return None
-    if not first_line.startswith(_MARKETPLACE_MANIFEST_HEADER):
-        return None
-    digest = first_line.removeprefix(_MARKETPLACE_MANIFEST_HEADER)
-    if len(digest) == 64 and all(character in "0123456789abcdef" for character in digest):
-        return digest
-    return None
+        return False
+    return first_line.startswith(_MARKETPLACE_MANIFEST_HEADER)
 
 
 def _declared_server_names(manifest: dict[str, object], field: str) -> set[str]:
@@ -80,6 +84,7 @@ def materialize_marketplace_manifest(dep_ref: DependencyReference, target_path: 
 
     from apm_cli.deps.plugin_parser import synthesize_apm_yml_from_plugin
     from apm_cli.models.apm_package import APMPackage
+    from apm_cli.utils.atomic_io import atomic_write_text
     from apm_cli.utils.file_ops import robust_rmtree
     from apm_cli.utils.yaml_io import load_yaml
 
@@ -96,15 +101,14 @@ def materialize_marketplace_manifest(dep_ref: DependencyReference, target_path: 
                 "catalog-only package paths must not be symbolic links"
             )
         digest = _manifest_digest(manifest)
+        existing_generated = False
         if apm_yml_path.exists():
             if not apm_yml_path.is_file():
                 raise MarketplaceManifestMaterializationError(
                     "catalog-only package has a non-file apm.yml"
                 )
-            generated_digest = _generated_manifest_digest(apm_yml_path)
-            if generated_digest is None:
-                return False
-            if generated_digest == digest:
+            existing_generated = _is_generated_marketplace_manifest(apm_yml_path)
+            if not existing_generated:
                 return False
 
         if stage_path.exists() or stage_path.is_symlink():
@@ -115,7 +119,8 @@ def materialize_marketplace_manifest(dep_ref: DependencyReference, target_path: 
             output_path=stage_path,
             map_artifacts=False,
             merge_existing=False,
-            header=f"{_MARKETPLACE_MANIFEST_HEADER}{digest}",
+            substitute_plugin_root=False,
+            warn_on_invalid_servers=False,
         )
         staged_data = load_yaml(staged_apm_yml)
         if not isinstance(staged_data, dict):
@@ -144,6 +149,15 @@ def materialize_marketplace_manifest(dep_ref: DependencyReference, target_path: 
                 "catalog-only package has an unsafe .apm path"
             )
         apm_dir.mkdir(exist_ok=True)
+        staged_body = stage_path.read_text(encoding="utf-8")
+        atomic_write_text(
+            stage_path,
+            f"{_MARKETPLACE_MANIFEST_HEADER}{digest}\n{staged_body}",
+            new_file_mode=0o644,
+        )
+        if existing_generated and apm_yml_path.read_bytes() == stage_path.read_bytes():
+            stage_path.unlink()
+            return False
         os.replace(stage_path, apm_yml_path)
     except Exception as exc:
         stage_cleanup_error: OSError | None = None
@@ -160,15 +174,15 @@ def materialize_marketplace_manifest(dep_ref: DependencyReference, target_path: 
                 if stage_cleanup_error is not None:
                     cleanup_detail += f"; staging cleanup failed: {stage_cleanup_error}"
                 raise MarketplaceManifestMaterializationError(
-                    f"invalid marketplace metadata for '{dep_ref.get_display_name()}'; "
+                    f"invalid marketplace metadata for '{_marketplace_display_name(dep_ref)}'; "
                     f"rejected download cleanup also failed: {cleanup_detail}"
                 ) from exc
         if isinstance(exc, MarketplaceManifestMaterializationError):
             raise MarketplaceManifestMaterializationError(
-                f"invalid marketplace metadata for '{dep_ref.get_display_name()}': {exc}"
+                f"invalid marketplace metadata for '{_marketplace_display_name(dep_ref)}': {exc}"
             ) from exc
         raise MarketplaceManifestMaterializationError(
-            f"invalid marketplace metadata for '{dep_ref.get_display_name()}': {exc}"
+            f"invalid marketplace metadata for '{_marketplace_display_name(dep_ref)}': {exc}"
         ) from exc
     return True
 

--- a/src/apm_cli/deps/_shared.py
+++ b/src/apm_cli/deps/_shared.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -11,37 +14,162 @@ if TYPE_CHECKING:
     from ..models.validation import ValidationResult
 
 
-def materialize_marketplace_manifest(dep_ref: DependencyReference, target_path: Path) -> bool:
-    """Synthesize a package when deployable components exist only in the catalog."""
+_MARKETPLACE_MANIFEST_HEADER = "# apm-marketplace-manifest-sha256: "
+
+
+class MarketplaceManifestMaterializationError(ValueError):
+    """Catalog metadata could not be materialized as a complete package."""
+
+
+def has_marketplace_deployable_manifest(dep_ref: DependencyReference) -> bool:
+    """Return whether catalog metadata declares an inline deployable surface."""
     manifest = getattr(dep_ref, "marketplace_manifest", None)
-    declared = tuple(
-        key
-        for key in ("lspServers", "mcpServers")
-        if isinstance(manifest, dict) and manifest.get(key)
+    return isinstance(manifest, dict) and any(
+        manifest.get(field) for field in ("lspServers", "mcpServers")
     )
-    if (target_path / "apm.yml").exists() or not declared:
+
+
+def _manifest_digest(manifest: dict[str, object]) -> str:
+    """Return a deterministic digest for consumer materialization state."""
+    encoded = json.dumps(
+        manifest,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _generated_manifest_digest(apm_yml_path: Path) -> str | None:
+    """Read the catalog digest marker from an APM-generated manifest."""
+    try:
+        with apm_yml_path.open(encoding="utf-8") as manifest_file:
+            first_line = manifest_file.readline().rstrip("\r\n")
+    except OSError:
+        return None
+    if not first_line.startswith(_MARKETPLACE_MANIFEST_HEADER):
+        return None
+    digest = first_line.removeprefix(_MARKETPLACE_MANIFEST_HEADER)
+    if len(digest) == 64 and all(character in "0123456789abcdef" for character in digest):
+        return digest
+    return None
+
+
+def _declared_server_names(manifest: dict[str, object], field: str) -> set[str]:
+    """Return validated inline server names from admitted catalog metadata."""
+    raw_servers = manifest.get(field)
+    if not raw_servers:
+        return set()
+    if not isinstance(raw_servers, dict):
+        raise MarketplaceManifestMaterializationError(
+            f"catalog field '{field}' must be an inline server mapping"
+        )
+    names = set(raw_servers)
+    if any(not isinstance(name, str) or not name for name in names):
+        raise MarketplaceManifestMaterializationError(
+            f"catalog field '{field}' contains an invalid server name"
+        )
+    return names
+
+
+def materialize_marketplace_manifest(dep_ref: DependencyReference, target_path: Path) -> bool:
+    """Atomically synthesize a complete package from admitted catalog metadata."""
+    manifest = getattr(dep_ref, "marketplace_manifest", None)
+    if not has_marketplace_deployable_manifest(dep_ref) or not isinstance(manifest, dict):
         return False
+
     from apm_cli.deps.plugin_parser import synthesize_apm_yml_from_plugin
     from apm_cli.models.apm_package import APMPackage
     from apm_cli.utils.file_ops import robust_rmtree
+    from apm_cli.utils.yaml_io import load_yaml
 
+    apm_yml_path = target_path / "apm.yml"
+    apm_dir = target_path / ".apm"
+    stage_path = target_path / ".apm-marketplace-stage.yml"
     try:
-        apm_yml = synthesize_apm_yml_from_plugin(target_path, dict(manifest))
-        package = APMPackage.from_apm_yml(apm_yml)
-        if "lspServers" in declared and not package.get_lsp_dependencies():
-            raise ValueError(
-                f"Marketplace LSP metadata for {dep_ref.repo_url} at {target_path} "
-                "did not materialize a valid dependency"
+        declared_lsp = _declared_server_names(manifest, "lspServers")
+        declared_mcp = _declared_server_names(manifest, "mcpServers")
+        if not declared_lsp and not declared_mcp:
+            return False
+        if target_path.is_symlink() or apm_yml_path.is_symlink():
+            raise MarketplaceManifestMaterializationError(
+                "catalog-only package paths must not be symbolic links"
             )
-        if "mcpServers" in declared and not package.get_mcp_dependencies():
-            raise ValueError(
-                f"Marketplace MCP metadata for {dep_ref.repo_url} at {target_path} "
-                "did not materialize a valid dependency"
+        digest = _manifest_digest(manifest)
+        if apm_yml_path.exists():
+            if not apm_yml_path.is_file():
+                raise MarketplaceManifestMaterializationError(
+                    "catalog-only package has a non-file apm.yml"
+                )
+            generated_digest = _generated_manifest_digest(apm_yml_path)
+            if generated_digest is None:
+                return False
+            if generated_digest == digest:
+                return False
+
+        if stage_path.exists() or stage_path.is_symlink():
+            stage_path.unlink()
+        staged_apm_yml = synthesize_apm_yml_from_plugin(
+            target_path,
+            dict(manifest),
+            output_path=stage_path,
+            map_artifacts=False,
+            merge_existing=False,
+            header=f"{_MARKETPLACE_MANIFEST_HEADER}{digest}",
+        )
+        staged_data = load_yaml(staged_apm_yml)
+        if not isinstance(staged_data, dict):
+            raise MarketplaceManifestMaterializationError(
+                "catalog metadata produced a non-mapping manifest"
             )
-    except Exception:
+        package = APMPackage.from_mapping(
+            staged_data,
+            package_path=target_path,
+            manifest_path=staged_apm_yml,
+        )
+        actual_lsp = {dependency.name for dependency in package.get_lsp_dependencies()}
+        actual_mcp = {dependency.name for dependency in package.get_mcp_dependencies()}
+        if actual_lsp != declared_lsp:
+            missing = ", ".join(sorted(declared_lsp - actual_lsp)) or "unknown"
+            raise MarketplaceManifestMaterializationError(
+                f"catalog LSP metadata did not materialize every declared server: {missing}"
+            )
+        if actual_mcp != declared_mcp:
+            missing = ", ".join(sorted(declared_mcp - actual_mcp)) or "unknown"
+            raise MarketplaceManifestMaterializationError(
+                f"catalog MCP metadata did not materialize every declared server: {missing}"
+            )
+        if apm_dir.is_symlink() or (apm_dir.exists() and not apm_dir.is_dir()):
+            raise MarketplaceManifestMaterializationError(
+                "catalog-only package has an unsafe .apm path"
+            )
+        apm_dir.mkdir(exist_ok=True)
+        os.replace(stage_path, apm_yml_path)
+    except Exception as exc:
+        stage_cleanup_error: OSError | None = None
+        if stage_path.exists() or stage_path.is_symlink():
+            try:
+                stage_path.unlink()
+            except OSError as cleanup_exc:
+                stage_cleanup_error = cleanup_exc
         if target_path.exists():
-            robust_rmtree(target_path, ignore_errors=True)
-        raise
+            try:
+                robust_rmtree(target_path)
+            except OSError as cleanup_exc:
+                cleanup_detail = str(cleanup_exc)
+                if stage_cleanup_error is not None:
+                    cleanup_detail += f"; staging cleanup failed: {stage_cleanup_error}"
+                raise MarketplaceManifestMaterializationError(
+                    f"invalid marketplace metadata for '{dep_ref.get_display_name()}'; "
+                    f"rejected download cleanup also failed: {cleanup_detail}"
+                ) from exc
+        if isinstance(exc, MarketplaceManifestMaterializationError):
+            raise MarketplaceManifestMaterializationError(
+                f"invalid marketplace metadata for '{dep_ref.get_display_name()}': {exc}"
+            ) from exc
+        raise MarketplaceManifestMaterializationError(
+            f"invalid marketplace metadata for '{dep_ref.get_display_name()}': {exc}"
+        ) from exc
     return True
 
 

--- a/src/apm_cli/deps/_shared.py
+++ b/src/apm_cli/deps/_shared.py
@@ -29,9 +29,15 @@ def materialize_marketplace_manifest(dep_ref: DependencyReference, target_path: 
         apm_yml = synthesize_apm_yml_from_plugin(target_path, dict(manifest))
         package = APMPackage.from_apm_yml(apm_yml)
         if "lspServers" in declared and not package.get_lsp_dependencies():
-            raise ValueError("Marketplace LSP metadata did not materialize a valid dependency")
+            raise ValueError(
+                f"Marketplace LSP metadata for {dep_ref.repo_url} at {target_path} "
+                "did not materialize a valid dependency"
+            )
         if "mcpServers" in declared and not package.get_mcp_dependencies():
-            raise ValueError("Marketplace MCP metadata did not materialize a valid dependency")
+            raise ValueError(
+                f"Marketplace MCP metadata for {dep_ref.repo_url} at {target_path} "
+                "did not materialize a valid dependency"
+            )
     except Exception:
         if target_path.exists():
             robust_rmtree(target_path, ignore_errors=True)

--- a/src/apm_cli/deps/apm_resolver.py
+++ b/src/apm_cli/deps/apm_resolver.py
@@ -16,7 +16,7 @@ from ..models.apm_package import APMPackage, DependencyReference
 from ..models.validation import validate_apm_package
 from ..utils.path_security import PathTraversalError, ensure_path_within, validate_path_segments
 from ..utils.paths import portable_relpath
-from ._shared import materialize_marketplace_manifest
+from ._shared import MarketplaceManifestMaterializationError, materialize_marketplace_manifest
 from .dependency_graph import (
     CircularRef,
     DependencyGraph,
@@ -766,7 +766,11 @@ class APMDependencyResolver:
             # --- Phase C (main thread): integrate results, enqueue sub-deps ---
             for (node, dep_ref, _parent_node, is_dev), loaded_package, exc in results:
                 if exc is not None:
-                    if isinstance(exc, ValueError):
+                    if isinstance(exc, MarketplaceManifestMaterializationError):
+                        message = f"Marketplace package materialization failed: {exc}"
+                        _logger.warning(message)
+                        tree.resolution_errors.append(message)
+                    elif isinstance(exc, ValueError):
                         _logger.warning(
                             "Invalid transitive apm.yml for %s: %s",
                             dep_ref.get_display_name(),
@@ -1106,6 +1110,10 @@ class APMDependencyResolver:
                             # as already-downloaded.
                             with self._download_lock:
                                 self._downloaded_packages.discard(unique_key)
+                    except MarketplaceManifestMaterializationError:
+                        with self._download_lock:
+                            self._downloaded_packages.discard(unique_key)
+                        raise
                     except Exception as exc:
                         # Surface the failure at default verbosity AND log a
                         # traceback at debug. Previously this branch silently

--- a/src/apm_cli/deps/apm_resolver.py
+++ b/src/apm_cli/deps/apm_resolver.py
@@ -516,6 +516,8 @@ class APMDependencyResolver:
         manifest = getattr(resolution.plugin, "manifest", None)
         if isinstance(manifest, dict) and manifest:
             resolved.marketplace_manifest = dict(manifest)
+            resolved.marketplace_name = dep_ref.marketplace_name
+            resolved.marketplace_plugin_name = dep_ref.marketplace_plugin_name
         self._marketplace_provenance[resolved.get_unique_key()] = resolution.provenance(
             dep_ref.marketplace_name,
             dep_ref.marketplace_plugin_name,

--- a/src/apm_cli/deps/apm_resolver.py
+++ b/src/apm_cli/deps/apm_resolver.py
@@ -16,6 +16,7 @@ from ..models.apm_package import APMPackage, DependencyReference
 from ..models.validation import validate_apm_package
 from ..utils.path_security import PathTraversalError, ensure_path_within, validate_path_segments
 from ..utils.paths import portable_relpath
+from ._shared import materialize_marketplace_manifest
 from .dependency_graph import (
     CircularRef,
     DependencyGraph,
@@ -512,6 +513,9 @@ class APMDependencyResolver:
             if resolution.dependency_reference is not None
             else DependencyReference.parse(resolution.canonical)
         )
+        manifest = getattr(resolution.plugin, "manifest", None)
+        if isinstance(manifest, dict) and manifest:
+            resolved.marketplace_manifest = dict(manifest)
         self._marketplace_provenance[resolved.get_unique_key()] = resolution.provenance(
             dep_ref.marketplace_name,
             dep_ref.marketplace_plugin_name,
@@ -1128,6 +1132,8 @@ class APMDependencyResolver:
             # Still doesn't exist after download attempt
             if not install_path.exists():
                 return None
+
+        materialize_marketplace_manifest(dep_ref, install_path)
 
         # Native Agent Plugins must retain their projected compatibility package
         # so recursive resolution can see APM-only dependencies without requiring

--- a/src/apm_cli/deps/plugin_parser.py
+++ b/src/apm_cli/deps/plugin_parser.py
@@ -21,7 +21,7 @@ from typing import Any
 
 import yaml
 
-from ..utils.atomic_io import write_text_lf
+from ..utils.atomic_io import atomic_write_text, write_text_lf
 from ..utils.console import _rich_warning
 from ..utils.path_security import PathTraversalError, ensure_path_within
 
@@ -537,7 +537,15 @@ def _validate_declared_component_paths(plugin_path: Path, manifest: dict[str, An
             )
 
 
-def synthesize_apm_yml_from_plugin(plugin_path: Path, manifest: dict[str, Any]) -> Path:
+def synthesize_apm_yml_from_plugin(
+    plugin_path: Path,
+    manifest: dict[str, Any],
+    *,
+    output_path: Path | None = None,
+    map_artifacts: bool = True,
+    merge_existing: bool = True,
+    header: str | None = None,
+) -> Path:
     """Synthesize apm.yml from plugin metadata.
 
     Maps the plugin's agents/, skills/, commands/, hooks/ directories and
@@ -554,6 +562,10 @@ def synthesize_apm_yml_from_plugin(plugin_path: Path, manifest: dict[str, Any]) 
         plugin_path: Path to the plugin directory.
         manifest: Plugin metadata dict (only `name` is required; all other
                   fields are optional and default gracefully).
+        output_path: Optional staged manifest destination.
+        map_artifacts: Whether to copy plugin artifacts into ``.apm``.
+        merge_existing: Whether to preserve an existing package manifest.
+        header: Optional first line for generated-state metadata.
 
     Returns:
         Path: Path to the generated apm.yml.
@@ -563,12 +575,10 @@ def synthesize_apm_yml_from_plugin(plugin_path: Path, manifest: dict[str, Any]) 
 
     _validate_declared_component_paths(plugin_path, manifest)
 
-    # Create .apm directory structure
-    apm_dir = plugin_path / ".apm"
-    apm_dir.mkdir(exist_ok=True)
-
-    # Map plugin structure into .apm/ subdirectories
-    _map_plugin_artifacts(plugin_path, apm_dir, manifest)
+    if map_artifacts:
+        apm_dir = plugin_path / ".apm"
+        apm_dir.mkdir(exist_ok=True)
+        _map_plugin_artifacts(plugin_path, apm_dir, manifest)
 
     # Extract MCP servers from plugin and convert to dependency format
     mcp_servers = _extract_mcp_servers(plugin_path, manifest)
@@ -586,13 +596,14 @@ def synthesize_apm_yml_from_plugin(plugin_path: Path, manifest: dict[str, Any]) 
 
     # Load existing apm.yml as base so resolution-critical blocks are not
     # discarded when the synthesized manifest overwrites the file (#1666).
-    apm_yml_path = plugin_path / "apm.yml"
+    source_apm_yml_path = plugin_path / "apm.yml"
+    apm_yml_path = output_path or source_apm_yml_path
     existing_manifest: dict[str, Any] | None = None
-    if apm_yml_path.exists():
+    if merge_existing and source_apm_yml_path.exists():
         try:
             from ..utils.yaml_io import load_yaml
 
-            data = load_yaml(apm_yml_path)
+            data = load_yaml(source_apm_yml_path)
             if isinstance(data, dict):
                 existing_manifest = data
         except (OSError, yaml.YAMLError) as exc:
@@ -607,13 +618,18 @@ def synthesize_apm_yml_from_plugin(plugin_path: Path, manifest: dict[str, Any]) 
 
     # Generate apm.yml from plugin metadata, merging with existing manifest
     apm_yml_content = _generate_apm_yml(manifest, existing_manifest=existing_manifest)
+    if header:
+        apm_yml_content = f"{header}\n{apm_yml_content}"
 
     # LF-deterministic write (apm#2619): this synthetic manifest lands inside
     # the installed package tree that compute_package_hash() hashes raw, so a
     # platform-native text-mode write (CRLF on Windows) would make the
     # lockfile content_hash diverge across OSes. Mirrors the #2223 fix for
     # download_virtual_file_package().
-    write_text_lf(apm_yml_path, apm_yml_content)
+    if output_path is None:
+        write_text_lf(apm_yml_path, apm_yml_content)
+    else:
+        atomic_write_text(apm_yml_path, apm_yml_content, new_file_mode=0o644)
 
     return apm_yml_path
 

--- a/src/apm_cli/deps/plugin_parser.py
+++ b/src/apm_cli/deps/plugin_parser.py
@@ -544,7 +544,8 @@ def synthesize_apm_yml_from_plugin(
     output_path: Path | None = None,
     map_artifacts: bool = True,
     merge_existing: bool = True,
-    header: str | None = None,
+    substitute_plugin_root: bool = True,
+    warn_on_invalid_servers: bool = True,
 ) -> Path:
     """Synthesize apm.yml from plugin metadata.
 
@@ -565,7 +566,8 @@ def synthesize_apm_yml_from_plugin(
         output_path: Optional staged manifest destination.
         map_artifacts: Whether to copy plugin artifacts into ``.apm``.
         merge_existing: Whether to preserve an existing package manifest.
-        header: Optional first line for generated-state metadata.
+        substitute_plugin_root: Whether to resolve plugin-root placeholders.
+        warn_on_invalid_servers: Whether skipped server entries emit warnings.
 
     Returns:
         Path: Path to the generated apm.yml.
@@ -581,16 +583,32 @@ def synthesize_apm_yml_from_plugin(
         _map_plugin_artifacts(plugin_path, apm_dir, manifest)
 
     # Extract MCP servers from plugin and convert to dependency format
-    mcp_servers = _extract_mcp_servers(plugin_path, manifest)
+    mcp_servers = _extract_mcp_servers(
+        plugin_path,
+        manifest,
+        substitute_plugin_root=substitute_plugin_root,
+    )
     if mcp_servers:
-        mcp_deps = _mcp_servers_to_apm_deps(mcp_servers, plugin_path)
+        mcp_deps = _mcp_servers_to_apm_deps(
+            mcp_servers,
+            plugin_path,
+            warn_on_invalid=warn_on_invalid_servers,
+        )
         if mcp_deps:
             manifest["_mcp_deps"] = mcp_deps
 
     # Extract LSP servers from plugin and convert to dependency format
-    lsp_servers = _extract_lsp_servers(plugin_path, manifest)
+    lsp_servers = _extract_lsp_servers(
+        plugin_path,
+        manifest,
+        substitute_plugin_root=substitute_plugin_root,
+    )
     if lsp_servers:
-        lsp_deps = _lsp_servers_to_apm_deps(lsp_servers, plugin_path)
+        lsp_deps = _lsp_servers_to_apm_deps(
+            lsp_servers,
+            plugin_path,
+            warn_on_invalid=warn_on_invalid_servers,
+        )
         if lsp_deps:
             manifest["_lsp_deps"] = lsp_deps
 
@@ -618,8 +636,6 @@ def synthesize_apm_yml_from_plugin(
 
     # Generate apm.yml from plugin metadata, merging with existing manifest
     apm_yml_content = _generate_apm_yml(manifest, existing_manifest=existing_manifest)
-    if header:
-        apm_yml_content = f"{header}\n{apm_yml_content}"
 
     # LF-deterministic write (apm#2619): this synthetic manifest lands inside
     # the installed package tree that compute_package_hash() hashes raw, so a
@@ -634,7 +650,12 @@ def synthesize_apm_yml_from_plugin(
     return apm_yml_path
 
 
-def _extract_mcp_servers(plugin_path: Path, manifest: dict[str, Any]) -> dict[str, Any]:
+def _extract_mcp_servers(
+    plugin_path: Path,
+    manifest: dict[str, Any],
+    *,
+    substitute_plugin_root: bool = True,
+) -> dict[str, Any]:
     """Extract MCP server definitions from a plugin manifest.
 
     Resolves ``mcpServers`` by type (per Claude Code spec):
@@ -690,7 +711,7 @@ def _extract_mcp_servers(plugin_path: Path, manifest: dict[str, Any]) -> dict[st
                     break
 
     # Substitute ${CLAUDE_PLUGIN_ROOT} in all string values
-    if servers:
+    if servers and substitute_plugin_root:
         abs_root = str(plugin_path.resolve())
         servers = _substitute_plugin_root(servers, abs_root, logger)
 
@@ -733,27 +754,31 @@ def _substitute_plugin_root(
     servers: dict[str, Any], abs_root: str, logger: logging.Logger
 ) -> dict[str, Any]:
     """Replace ``${CLAUDE_PLUGIN_ROOT}`` in server config string values."""
-    placeholder = "${CLAUDE_PLUGIN_ROOT}"
-    substituted = False
-
-    def _walk(obj: Any) -> Any:
-        nonlocal substituted
-        if isinstance(obj, str) and placeholder in obj:
-            substituted = True
-            return obj.replace(placeholder, abs_root)
-        if isinstance(obj, dict):
-            return {k: _walk(v) for k, v in obj.items()}
-        if isinstance(obj, list):
-            return [_walk(item) for item in obj]
-        return obj
-
-    result = {name: _walk(cfg) for name, cfg in servers.items()}
-    if substituted:
+    result = resolve_plugin_root_placeholders(servers, Path(abs_root))
+    if result != servers:
         logger.info("Substituted ${CLAUDE_PLUGIN_ROOT} with %s", abs_root)
     return result
 
 
-def _mcp_servers_to_apm_deps(servers: dict[str, Any], plugin_path: Path) -> list[dict[str, Any]]:
+def resolve_plugin_root_placeholders(value: Any, plugin_path: Path) -> Any:
+    """Resolve plugin-root placeholders in an in-memory manifest value."""
+    if isinstance(value, str):
+        return value.replace("${CLAUDE_PLUGIN_ROOT}", str(plugin_path.resolve()))
+    if isinstance(value, dict):
+        return {
+            key: resolve_plugin_root_placeholders(item, plugin_path) for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [resolve_plugin_root_placeholders(item, plugin_path) for item in value]
+    return value
+
+
+def _mcp_servers_to_apm_deps(
+    servers: dict[str, Any],
+    plugin_path: Path,
+    *,
+    warn_on_invalid: bool = True,
+) -> list[dict[str, Any]]:
     """Convert raw MCP server configs to ``dependencies.mcp`` dicts.
 
     Transport inference:
@@ -785,7 +810,8 @@ def _mcp_servers_to_apm_deps(servers: dict[str, Any], plugin_path: Path) -> list
 
     for name, cfg in servers.items():
         if not isinstance(cfg, dict):
-            logger.warning("Skipping non-dict MCP server config '%s'", name)
+            if warn_on_invalid:
+                logger.warning("Skipping non-dict MCP server config '%s'", name)
             continue
 
         dep: dict[str, Any] = {"name": name, "registry": False}
@@ -803,11 +829,12 @@ def _mcp_servers_to_apm_deps(servers: dict[str, Any], plugin_path: Path) -> list
             if "headers" in cfg:
                 dep["headers"] = cfg["headers"]
         else:
-            _surface_warning(
-                f"Skipping MCP server '{name}' from plugin "
-                f"'{plugin_path.name}': no 'command' or 'url'",
-                logger,
-            )
+            if warn_on_invalid:
+                _surface_warning(
+                    f"Skipping MCP server '{name}' from plugin "
+                    f"'{plugin_path.name}': no 'command' or 'url'",
+                    logger,
+                )
             continue
 
         if "env" in cfg:
@@ -823,10 +850,11 @@ def _mcp_servers_to_apm_deps(servers: dict[str, Any], plugin_path: Path) -> list
         try:
             MCPDependency.from_dict(dep)
         except (ValueError, Exception) as exc:
-            _surface_warning(
-                f"Skipping invalid MCP server '{name}' from plugin '{plugin_path.name}': {exc}",
-                logger,
-            )
+            if warn_on_invalid:
+                _surface_warning(
+                    f"Skipping invalid MCP server '{name}' from plugin '{plugin_path.name}': {exc}",
+                    logger,
+                )
             continue
 
         deps.append(dep)
@@ -834,7 +862,12 @@ def _mcp_servers_to_apm_deps(servers: dict[str, Any], plugin_path: Path) -> list
     return deps
 
 
-def _extract_lsp_servers(plugin_path: Path, manifest: dict[str, Any]) -> dict[str, Any]:
+def _extract_lsp_servers(
+    plugin_path: Path,
+    manifest: dict[str, Any],
+    *,
+    substitute_plugin_root: bool = True,
+) -> dict[str, Any]:
     """Extract LSP server definitions from a plugin manifest.
 
     Resolves ``lspServers`` by type (per Claude Code spec):
@@ -878,7 +911,7 @@ def _extract_lsp_servers(plugin_path: Path, manifest: dict[str, Any]) -> dict[st
                     break
 
     # Substitute ${CLAUDE_PLUGIN_ROOT} in all string values
-    if servers:
+    if servers and substitute_plugin_root:
         abs_root = str(plugin_path.resolve())
         servers = _substitute_plugin_root(servers, abs_root, logger)
 
@@ -937,7 +970,12 @@ def _read_lsp_json(path: Path, logger: logging.Logger) -> dict[str, Any]:
     return dict(data)
 
 
-def _lsp_servers_to_apm_deps(servers: dict[str, Any], plugin_path: Path) -> list[dict[str, Any]]:
+def _lsp_servers_to_apm_deps(
+    servers: dict[str, Any],
+    plugin_path: Path,
+    *,
+    warn_on_invalid: bool = True,
+) -> list[dict[str, Any]]:
     """Convert raw LSP server configs to ``dependencies.lsp`` dicts.
 
     Required fields per Claude Code spec:
@@ -961,7 +999,8 @@ def _lsp_servers_to_apm_deps(servers: dict[str, Any], plugin_path: Path) -> list
 
     for name, cfg in servers.items():
         if not isinstance(cfg, dict):
-            logger.warning("Skipping non-dict LSP server config '%s'", name)
+            if warn_on_invalid:
+                logger.warning("Skipping non-dict LSP server config '%s'", name)
             continue
 
         dep: dict[str, Any] = {"name": name}
@@ -988,10 +1027,11 @@ def _lsp_servers_to_apm_deps(servers: dict[str, Any], plugin_path: Path) -> list
         try:
             LSPDependency.from_dict(dep)
         except Exception as exc:
-            _surface_warning(
-                f"Skipping invalid LSP server '{name}' from plugin '{plugin_path.name}': {exc}",
-                logger,
-            )
+            if warn_on_invalid:
+                _surface_warning(
+                    f"Skipping invalid LSP server '{name}' from plugin '{plugin_path.name}': {exc}",
+                    logger,
+                )
             continue
 
         deps.append(dep)

--- a/src/apm_cli/deps/plugin_parser.py
+++ b/src/apm_cli/deps/plugin_parser.py
@@ -1335,14 +1335,35 @@ def _union_dep_list(
 ) -> None:
     """Append *new_entries* into ``merged[key]`` without duplicates.
 
-    Both string entries and dict entries (e.g. ``{git: parent, path: ...}``)
-    are handled.  Equality is checked with ``==`` which works correctly for
-    both types.
+    Both string entries and nested mapping entries are handled. A hashable
+    structural key keeps merging linear while preserving equality semantics.
     """
     existing = merged.setdefault(key, [])
+    seen = {_dependency_entry_key(entry) for entry in existing}
     for entry in new_entries:
-        if entry not in existing:
-            existing.append(entry)
+        entry_key = _dependency_entry_key(entry)
+        if entry_key in seen:
+            continue
+        existing.append(entry)
+        seen.add(entry_key)
+
+
+def _dependency_entry_key(value: Any) -> Any:
+    """Return a hashable structural key for a manifest dependency entry."""
+    if isinstance(value, dict):
+        return (
+            "dict",
+            frozenset((key, _dependency_entry_key(item)) for key, item in value.items()),
+        )
+    if isinstance(value, list):
+        return ("list", tuple(_dependency_entry_key(item) for item in value))
+    if isinstance(value, tuple):
+        return ("tuple", tuple(_dependency_entry_key(item) for item in value))
+    try:
+        hash(value)
+    except TypeError:
+        return ("repr", repr(value))
+    return ("scalar", type(value).__qualname__, value)
 
 
 def synthesize_plugin_json_from_apm_yml(apm_yml_path: Path) -> dict:

--- a/src/apm_cli/install/phases/local_content.py
+++ b/src/apm_cli/install/phases/local_content.py
@@ -251,12 +251,14 @@ def _copy_local_package(dep_ref, install_path, base_dir, *, project_root, logger
     if not local.is_dir():
         logger.error(f"Local package path does not exist: {dep_ref.local_path}")
         return None
+    from apm_cli.deps._shared import has_marketplace_deployable_manifest
     from apm_cli.utils.helpers import find_plugin_json
 
     if (
         not (local / "apm.yml").exists()
         and not (local / "SKILL.md").exists()
         and find_plugin_json(local) is None
+        and not has_marketplace_deployable_manifest(dep_ref)
     ):
         logger.error(
             "Local package is not a valid APM package "

--- a/src/apm_cli/install/phases/resolve.py
+++ b/src/apm_cli/install/phases/resolve.py
@@ -324,7 +324,7 @@ def _fail_on_resolution_errors(ctx: InstallContext, dependency_graph) -> None:
     if not dependency_graph.resolution_errors:
         return
     for error in dependency_graph.resolution_errors:
-        if ctx.logger:
+        if ctx.logger and not error.startswith("Marketplace package materialization failed:"):
             ctx.logger.error(error)
     joined_errors = "; ".join(dependency_graph.resolution_errors)
     raise RuntimeError(f"Dependency resolution failed: {joined_errors}")

--- a/src/apm_cli/install/sources.py
+++ b/src/apm_cli/install/sources.py
@@ -180,6 +180,7 @@ class LocalDependencySource(DependencySource):
         from apm_cli.bundle.local_bundle import route_agent_plugin_package
         from apm_cli.constants import APM_YML_FILENAME
         from apm_cli.core.scope import InstallScope
+        from apm_cli.deps._shared import materialize_marketplace_manifest
         from apm_cli.deps.installed_package import InstalledPackage
         from apm_cli.install.phases.local_content import _copy_local_package
         from apm_cli.models.apm_package import (
@@ -266,6 +267,7 @@ class LocalDependencySource(DependencySource):
         if logger:
             logger.download_complete(dep_ref.local_path, ref_suffix="local")
 
+        materialize_marketplace_manifest(dep_ref, install_path)
         validation = validate_apm_package(
             install_path,
             source_path=original_src,

--- a/src/apm_cli/marketplace/models.py
+++ b/src/apm_cli/marketplace/models.py
@@ -8,7 +8,8 @@ from __future__ import annotations
 
 import logging
 import os
-from dataclasses import dataclass
+from copy import deepcopy
+from dataclasses import dataclass, field
 from typing import Any
 from urllib.parse import urlsplit
 
@@ -371,6 +372,7 @@ class MarketplacePlugin:
     # ``None`` means the field was absent (old marketplace.json); the resolver
     # falls back to its built-in default in that case.
     tag_pattern: str | None = None
+    manifest: dict[str, Any] | None = field(default=None, compare=False, hash=False, repr=False)
 
     def matches_query(self, query: str) -> bool:
         """Return True if the plugin matches a search query (case-insensitive)."""
@@ -542,6 +544,11 @@ def _parse_plugin_entry(
             source_marketplace=source_name,
             registry=registry_name,
             tag_pattern=tag_pattern,
+            manifest={
+                key: deepcopy(entry[key])
+                for key in ("name", "description", "version", "lspServers", "mcpServers")
+                if key in entry
+            },
         ),
         None,
     )

--- a/src/apm_cli/models/apm_package.py
+++ b/src/apm_cli/models/apm_package.py
@@ -438,6 +438,14 @@ class APMPackage:
             ValueError: If interpreted manifest fields are invalid.
         """
         data = dict(manifest_data)
+        from apm_cli.deps.plugin_parser import resolve_plugin_root_placeholders
+
+        for dependency_key in ("dependencies", "devDependencies"):
+            if dependency_key in data:
+                data[dependency_key] = resolve_plugin_root_placeholders(
+                    data[dependency_key],
+                    package_path,
+                )
         source_manifest = manifest_path or package_path / "apm.yml"
         resolved_source = source_path.resolve() if source_path is not None else None
 

--- a/src/apm_cli/models/dependency/reference.py
+++ b/src/apm_cli/models/dependency/reference.py
@@ -120,6 +120,7 @@ class DependencyReference(ProviderCoordinateMixin):
     marketplace_name: str | None = None
     marketplace_plugin_name: str | None = None
     marketplace_version_spec: str | None = None
+    marketplace_manifest: dict | None = None
 
     @property
     def canonical_repo_url(self) -> str:

--- a/src/apm_cli/models/dependency/reference.py
+++ b/src/apm_cli/models/dependency/reference.py
@@ -120,7 +120,7 @@ class DependencyReference(ProviderCoordinateMixin):
     marketplace_name: str | None = None
     marketplace_plugin_name: str | None = None
     marketplace_version_spec: str | None = None
-    marketplace_manifest: dict | None = None
+    marketplace_manifest: dict[str, object] | None = None
 
     @property
     def canonical_repo_url(self) -> str:

--- a/tests/integration/test_architecture_authorities.py
+++ b/tests/integration/test_architecture_authorities.py
@@ -99,6 +99,26 @@ def test_git_semver_preflight_eligibility_has_single_owner() -> None:
     assert "| Git semver preflight eligibility and resolution |" in architecture
 
 
+def test_catalog_only_marketplace_materialization_has_single_owner() -> None:
+    """Catalog metadata must reach one transactional materialization boundary."""
+    root = Path(__file__).parents[2]
+    owner = (root / "src/apm_cli/deps/_shared.py").read_text(encoding="utf-8")
+    resolver = (root / "src/apm_cli/deps/apm_resolver.py").read_text(encoding="utf-8")
+    local_content = (root / "src/apm_cli/install/phases/local_content.py").read_text(
+        encoding="utf-8"
+    )
+    guard = (root / "scripts/lint-architecture-boundaries.sh").read_text(encoding="utf-8")
+    architecture = (root / ".apm/instructions/architecture.instructions.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert owner.count("def materialize_marketplace_manifest(") == 1
+    assert "materialize_marketplace_manifest(dep_ref, install_path)" in resolver
+    assert "has_marketplace_deployable_manifest(dep_ref)" in local_content
+    assert "Catalog-only marketplace manifests must route through deps/_shared.py" in guard
+    assert "| Catalog-only marketplace manifest materialization |" in architecture
+
+
 @pytest.mark.parametrize(
     ("relative_path", "source", "expected"),
     [

--- a/tests/integration/test_architecture_authorities.py
+++ b/tests/integration/test_architecture_authorities.py
@@ -107,6 +107,7 @@ def test_catalog_only_marketplace_materialization_has_single_owner() -> None:
     local_content = (root / "src/apm_cli/install/phases/local_content.py").read_text(
         encoding="utf-8"
     )
+    install_sources = (root / "src/apm_cli/install/sources.py").read_text(encoding="utf-8")
     guard = (root / "scripts/lint-architecture-boundaries.sh").read_text(encoding="utf-8")
     architecture = (root / ".apm/instructions/architecture.instructions.md").read_text(
         encoding="utf-8"
@@ -115,6 +116,7 @@ def test_catalog_only_marketplace_materialization_has_single_owner() -> None:
     assert owner.count("def materialize_marketplace_manifest(") == 1
     assert "materialize_marketplace_manifest(dep_ref, install_path)" in resolver
     assert "has_marketplace_deployable_manifest(dep_ref)" in local_content
+    assert "materialize_marketplace_manifest(dep_ref, install_path)" in install_sources
     assert "Catalog-only marketplace manifests must route through deps/_shared.py" in guard
     assert "| Catalog-only marketplace manifest materialization |" in architecture
 

--- a/tests/integration/test_architecture_authorities.py
+++ b/tests/integration/test_architecture_authorities.py
@@ -108,6 +108,8 @@ def test_catalog_only_marketplace_materialization_has_single_owner() -> None:
         encoding="utf-8"
     )
     install_sources = (root / "src/apm_cli/install/sources.py").read_text(encoding="utf-8")
+    plugin_parser = (root / "src/apm_cli/deps/plugin_parser.py").read_text(encoding="utf-8")
+    package_model = (root / "src/apm_cli/models/apm_package.py").read_text(encoding="utf-8")
     guard = (root / "scripts/lint-architecture-boundaries.sh").read_text(encoding="utf-8")
     architecture = (root / ".apm/instructions/architecture.instructions.md").read_text(
         encoding="utf-8"
@@ -117,8 +119,13 @@ def test_catalog_only_marketplace_materialization_has_single_owner() -> None:
     assert "materialize_marketplace_manifest(dep_ref, install_path)" in resolver
     assert "has_marketplace_deployable_manifest(dep_ref)" in local_content
     assert "materialize_marketplace_manifest(dep_ref, install_path)" in install_sources
+    assert "resolve_plugin_root_placeholders(" in plugin_parser
+    assert "resolve_plugin_root_placeholders(" in package_model
     assert "Catalog-only marketplace manifests must route through deps/_shared.py" in guard
     assert "| Catalog-only marketplace manifest materialization |" in architecture
+    assert "| Legacy plugin declared-skill membership and plugin-root placeholder expansion |" in (
+        architecture
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/test_marketplace_install_local.py
+++ b/tests/integration/test_marketplace_install_local.py
@@ -26,10 +26,10 @@ from apm_cli.agent_plugins import (
 from apm_cli.bundle.local_bundle import route_agent_plugin_package
 from apm_cli.commands.install import install
 from apm_cli.commands.marketplace import marketplace as marketplace_group
-from apm_cli.deps.apm_resolver import APMDependencyResolver
 from apm_cli.marketplace import registry
 from apm_cli.marketplace.resolver import resolve_marketplace_plugin
 from apm_cli.models.dependency.reference import DependencyReference
+from apm_cli.models.validation import validate_apm_package
 
 GIT_AVAILABLE = shutil.which("git") is not None
 pytestmark = pytest.mark.skipif(not GIT_AVAILABLE, reason="git executable not available")
@@ -120,7 +120,10 @@ def test_install_resolves_local_marketplace_to_on_disk_path(tmp_path: Path) -> N
     assert Path(dep_ref.local_path).resolve() == skill_path.resolve()
 
 
-def test_catalog_only_marketplace_materializes_all_inline_servers(tmp_path: Path) -> None:
+def test_catalog_only_marketplace_installs_all_inline_servers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     repo = tmp_path / "mkt"
     manifest = {
         "name": "local-mkt",
@@ -154,47 +157,24 @@ def test_catalog_only_marketplace_materializes_all_inline_servers(tmp_path: Path
     consumer.mkdir()
     (consumer / "apm.yml").write_text(
         "name: consumer\nversion: 1.0.0\n"
+        "targets:\n  - copilot\n"
         "dependencies:\n  apm:\n"
         "    - name: catalog-only\n      marketplace: local-mkt\n"
     )
+    monkeypatch.chdir(consumer)
 
+    install_result = CliRunner().invoke(install, ["--trust-bin", "--no-policy"])
+
+    assert install_result.exit_code == 0, install_result.output
     modules = consumer / "apm_modules"
-
-    def copy_local_dependency(
-        dep_ref: DependencyReference,
-        _modules_dir: Path,
-        _parent_chain: str = "",
-    ) -> Path:
-        destination = dep_ref.get_install_path(modules)
-        shutil.copytree(Path(dep_ref.local_path), destination)
-        return destination
-
-    graph = APMDependencyResolver(
-        apm_modules_dir=modules,
-        download_callback=copy_local_dependency,
-        max_parallel=1,
-    ).resolve_dependencies(consumer)
-
-    assert not graph.has_errors(), graph.resolution_errors
-    packages = [node.package for node in graph.dependency_tree.nodes.values()]
-    assert {
-        dependency.name
-        for package in packages
-        if package is not None
-        for dependency in package.get_lsp_dependencies()
-    } == {"gopls"}
-    assert {
-        dependency.name
-        for package in packages
-        if package is not None
-        for dependency in package.get_mcp_dependencies()
-    } == {"tools"}
     generated_manifests = list(modules.rglob("apm.yml"))
     assert len(generated_manifests) == 1
-    assert all(
-        dependency.repo_url != "untrusted/injected"
-        for dependency in graph.flattened_dependencies.dependencies.values()
-    )
+    package = validate_apm_package(generated_manifests[0].parent).package
+    assert package is not None
+    assert {dependency.name for dependency in package.get_lsp_dependencies()} == {"gopls"}
+    assert {dependency.name for dependency in package.get_mcp_dependencies()} == {"tools"}
+    assert package.get_apm_dependencies() == []
+    assert (consumer / "apm.lock.yaml").is_file()
 
 
 def test_invalid_catalog_only_metadata_fails_install_resolution(

--- a/tests/integration/test_marketplace_install_local.py
+++ b/tests/integration/test_marketplace_install_local.py
@@ -24,7 +24,9 @@ from apm_cli.agent_plugins import (
     UnsupportedAgentPluginVersionError,
 )
 from apm_cli.bundle.local_bundle import route_agent_plugin_package
+from apm_cli.commands.install import install
 from apm_cli.commands.marketplace import marketplace as marketplace_group
+from apm_cli.deps.apm_resolver import APMDependencyResolver
 from apm_cli.marketplace import registry
 from apm_cli.marketplace.resolver import resolve_marketplace_plugin
 from apm_cli.models.dependency.reference import DependencyReference
@@ -116,6 +118,128 @@ def test_install_resolves_local_marketplace_to_on_disk_path(tmp_path: Path) -> N
     dep_ref = DependencyReference.parse(canonical)
     assert dep_ref.is_local
     assert Path(dep_ref.local_path).resolve() == skill_path.resolve()
+
+
+def test_catalog_only_marketplace_materializes_all_inline_servers(tmp_path: Path) -> None:
+    repo = tmp_path / "mkt"
+    manifest = {
+        "name": "local-mkt",
+        "owner": "test",
+        "plugins": [
+            {
+                "name": "catalog-only",
+                "source": "./plugins/catalog-only",
+                "version": "1.0.0",
+                "lspServers": {
+                    "gopls": {
+                        "command": "gopls",
+                        "extensionToLanguage": {".go": "go"},
+                    }
+                },
+                "mcpServers": {"tools": {"command": "echo", "args": ["tools"]}},
+                "dependencies": ["untrusted/injected"],
+            }
+        ],
+    }
+    _seed_marketplace(repo, manifest=manifest)
+    plugin_dir = repo / "plugins" / "catalog-only"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "README.md").write_text("catalog-only package")
+    result = CliRunner().invoke(
+        marketplace_group,
+        ["add", str(repo), "--name", "local-mkt"],
+    )
+    assert result.exit_code == 0, result.output
+    consumer = tmp_path / "consumer"
+    consumer.mkdir()
+    (consumer / "apm.yml").write_text(
+        "name: consumer\nversion: 1.0.0\n"
+        "dependencies:\n  apm:\n"
+        "    - name: catalog-only\n      marketplace: local-mkt\n"
+    )
+
+    modules = consumer / "apm_modules"
+
+    def copy_local_dependency(
+        dep_ref: DependencyReference,
+        _modules_dir: Path,
+        _parent_chain: str = "",
+    ) -> Path:
+        destination = dep_ref.get_install_path(modules)
+        shutil.copytree(Path(dep_ref.local_path), destination)
+        return destination
+
+    graph = APMDependencyResolver(
+        apm_modules_dir=modules,
+        download_callback=copy_local_dependency,
+        max_parallel=1,
+    ).resolve_dependencies(consumer)
+
+    assert not graph.has_errors(), graph.resolution_errors
+    packages = [node.package for node in graph.dependency_tree.nodes.values()]
+    assert {
+        dependency.name
+        for package in packages
+        if package is not None
+        for dependency in package.get_lsp_dependencies()
+    } == {"gopls"}
+    assert {
+        dependency.name
+        for package in packages
+        if package is not None
+        for dependency in package.get_mcp_dependencies()
+    } == {"tools"}
+    generated_manifests = list(modules.rglob("apm.yml"))
+    assert len(generated_manifests) == 1
+    assert all(
+        dependency.repo_url != "untrusted/injected"
+        for dependency in graph.flattened_dependencies.dependencies.values()
+    )
+
+
+def test_invalid_catalog_only_metadata_fails_install_resolution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "mkt"
+    manifest = {
+        "name": "local-mkt",
+        "owner": "test",
+        "plugins": [
+            {
+                "name": "invalid-catalog",
+                "source": "./plugins/invalid-catalog",
+                "mcpServers": {
+                    "valid": {"command": "echo"},
+                    "invalid": {"args": ["missing-command"]},
+                },
+            }
+        ],
+    }
+    _seed_marketplace(repo, manifest=manifest)
+    plugin_dir = repo / "plugins" / "invalid-catalog"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "README.md").write_text("invalid catalog package")
+    registration = CliRunner().invoke(
+        marketplace_group,
+        ["add", str(repo), "--name", "local-mkt"],
+    )
+    assert registration.exit_code == 0, registration.output
+    consumer = tmp_path / "consumer"
+    consumer.mkdir()
+    (consumer / "apm.yml").write_text(
+        "name: consumer\nversion: 1.0.0\n"
+        "targets:\n  - copilot\n"
+        "dependencies:\n  apm:\n"
+        "    - name: invalid-catalog\n      marketplace: local-mkt\n"
+    )
+    monkeypatch.chdir(consumer)
+
+    result = CliRunner().invoke(install, [])
+
+    assert result.exit_code != 0
+    assert "invalid marketplace metadata" in result.output
+    assert not (consumer / "apm.lock.yaml").exists()
 
 
 def test_install_rejects_local_marketplace_symlink_escape(tmp_path: Path) -> None:

--- a/tests/integration/test_marketplace_install_local.py
+++ b/tests/integration/test_marketplace_install_local.py
@@ -26,6 +26,7 @@ from apm_cli.agent_plugins import (
 from apm_cli.bundle.local_bundle import route_agent_plugin_package
 from apm_cli.commands.install import install
 from apm_cli.commands.marketplace import marketplace as marketplace_group
+from apm_cli.deps.apm_resolver import APMDependencyResolver
 from apm_cli.marketplace import registry
 from apm_cli.marketplace.resolver import resolve_marketplace_plugin
 from apm_cli.models.dependency.reference import DependencyReference
@@ -218,8 +219,70 @@ def test_invalid_catalog_only_metadata_fails_install_resolution(
     result = CliRunner().invoke(install, [])
 
     assert result.exit_code != 0
-    assert "invalid marketplace metadata" in result.output
+    normalized_output = " ".join(result.output.split())
+    assert "invalid marketplace metadata for 'invalid-catalog@local-mkt'" in normalized_output
+    assert normalized_output.count("invalid marketplace metadata") == 1
     assert not (consumer / "apm.lock.yaml").exists()
+
+
+def test_catalog_only_marketplace_rejects_symlinked_apm_dir(tmp_path: Path) -> None:
+    repo = tmp_path / "mkt"
+    manifest = {
+        "name": "local-mkt",
+        "owner": "test",
+        "plugins": [
+            {
+                "name": "symlinked",
+                "source": "./plugins/symlinked",
+                "mcpServers": {"server": {"command": "echo"}},
+            }
+        ],
+    }
+    _seed_marketplace(repo, manifest=manifest)
+    plugin_dir = repo / "plugins" / "symlinked"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "README.md").write_text("symlinked catalog package")
+    registration = CliRunner().invoke(
+        marketplace_group,
+        ["add", str(repo), "--name", "local-mkt"],
+    )
+    assert registration.exit_code == 0, registration.output
+    consumer = tmp_path / "consumer"
+    consumer.mkdir()
+    (consumer / "apm.yml").write_text(
+        "name: consumer\nversion: 1.0.0\n"
+        "dependencies:\n  apm:\n"
+        "    - name: symlinked\n      marketplace: local-mkt\n"
+    )
+    modules = consumer / "apm_modules"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    downloaded: list[Path] = []
+
+    def download_with_symlink(
+        dep_ref: DependencyReference,
+        _modules_dir: Path,
+        _parent_chain: str = "",
+    ) -> Path:
+        destination = dep_ref.get_install_path(modules)
+        destination.mkdir(parents=True)
+        try:
+            (destination / ".apm").symlink_to(outside, target_is_directory=True)
+        except OSError:
+            pytest.skip("symlinks are unavailable")
+        downloaded.append(destination)
+        return destination
+
+    graph = APMDependencyResolver(
+        apm_modules_dir=modules,
+        download_callback=download_with_symlink,
+        max_parallel=1,
+    ).resolve_dependencies(consumer)
+
+    assert graph.has_errors()
+    assert "unsafe .apm path" in graph.resolution_errors[0]
+    assert list(outside.iterdir()) == []
+    assert downloaded and not downloaded[0].exists()
 
 
 def test_install_rejects_local_marketplace_symlink_escape(tmp_path: Path) -> None:

--- a/tests/test_apm_resolver.py
+++ b/tests/test_apm_resolver.py
@@ -973,7 +973,7 @@ class TestMarketplaceResolution(unittest.TestCase):
             assert result.has_errors()
             assert result.resolution_errors == [
                 "Marketplace package materialization failed: invalid marketplace metadata for "
-                "'acme/mixed': catalog MCP metadata did not materialize "
+                "'mixed@catalog': catalog MCP metadata did not materialize "
                 "every declared server: invalid"
             ]
             assert not (modules / "acme" / "mixed").exists()

--- a/tests/test_apm_resolver.py
+++ b/tests/test_apm_resolver.py
@@ -928,6 +928,57 @@ class TestMarketplaceResolution(unittest.TestCase):
             assert (modules / "acme" / "gopls-lsp" / "apm.yml").is_file()
 
     @patch("apm_cli.marketplace.resolver.resolve_marketplace_plugin")
+    def test_invalid_catalog_metadata_is_a_resolution_error(self, mock_resolve):
+        plugin = parse_marketplace_json(
+            {
+                "name": "catalog",
+                "plugins": [
+                    {
+                        "name": "mixed",
+                        "source": "./plugins/mixed",
+                        "mcpServers": {
+                            "valid": {"command": "echo"},
+                            "invalid": {"args": ["missing-command"]},
+                        },
+                    }
+                ],
+            },
+            source_name="catalog",
+        ).plugins[0]
+        mock_resolve.return_value = MarketplacePluginResolution(
+            canonical="acme/mixed#main",
+            plugin=plugin,
+        )
+
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            modules = root / "apm_modules"
+            (root / "apm.yml").write_text(
+                "name: consumer\nversion: 1.0.0\n"
+                "dependencies:\n  apm:\n"
+                "    - name: mixed\n      marketplace: catalog\n"
+            )
+
+            def download(dep_ref, _modules_dir, _parent_chain=""):
+                path = dep_ref.get_install_path(modules)
+                path.mkdir(parents=True)
+                return path
+
+            result = APMDependencyResolver(
+                apm_modules_dir=modules,
+                download_callback=download,
+                max_parallel=1,
+            ).resolve_dependencies(root)
+
+            assert result.has_errors()
+            assert result.resolution_errors == [
+                "Marketplace package materialization failed: invalid marketplace metadata for "
+                "'acme/mixed': catalog MCP metadata did not materialize "
+                "every declared server: invalid"
+            ]
+            assert not (modules / "acme" / "mixed").exists()
+
+    @patch("apm_cli.marketplace.resolver.resolve_marketplace_plugin")
     def test_marketplace_dep_failure_surfaces_error(self, mock_resolve):
         mock_resolve.side_effect = PluginNotFoundError("bad-plugin", "fake-marketplace")
         with TemporaryDirectory() as temp_dir:

--- a/tests/test_apm_resolver.py
+++ b/tests/test_apm_resolver.py
@@ -6,6 +6,7 @@ from tempfile import TemporaryDirectory
 from unittest.mock import Mock, patch
 
 from apm_cli.marketplace.errors import BuildError, PluginNotFoundError
+from apm_cli.marketplace.models import parse_marketplace_json
 from apm_cli.marketplace.resolver import MarketplacePluginResolution
 from src.apm_cli.deps.apm_resolver import APMDependencyResolver
 from src.apm_cli.deps.dependency_graph import (
@@ -870,6 +871,61 @@ class TestMarketplaceResolution(unittest.TestCase):
             result = resolver.resolve_dependencies(project_root)
             assert result.flattened_dependencies.total_dependencies() == 1
             assert "acme/gopls-lsp" in result.flattened_dependencies.dependencies
+
+    @patch("apm_cli.marketplace.resolver.resolve_marketplace_plugin")
+    def test_metadata_only_marketplace_dep_uses_catalog_components(self, mock_resolve):
+        entry = {
+            "name": "gopls-lsp",
+            "source": "./plugins/gopls-lsp",
+            "lspServers": {
+                "gopls": {
+                    "command": "gopls",
+                    "extensionToLanguage": {".go": "go"},
+                }
+            },
+            "dependencies": ["untrusted/injected-dependency"],
+        }
+        plugin = parse_marketplace_json(
+            {
+                "name": "claude-plugins-official",
+                "plugins": [entry],
+            },
+            source_name="claude-plugins-official",
+        ).plugins[0]
+        entry["lspServers"]["gopls"]["command"] = "mutated"
+        assert plugin.manifest["lspServers"]["gopls"]["command"] == "gopls"
+        assert "dependencies" not in plugin.manifest
+        hash(plugin)
+        mock_resolve.return_value = MarketplacePluginResolution(
+            canonical="acme/gopls-lsp#main",
+            plugin=plugin,
+        )
+
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            modules = root / "apm_modules"
+            (root / "apm.yml").write_text(
+                "name: consumer\nversion: 1.0.0\n"
+                "dependencies:\n  apm:\n"
+                "    - name: gopls-lsp\n      marketplace: claude-plugins-official\n"
+            )
+
+            def download(dep_ref, _modules_dir, _parent_chain=""):
+                path = dep_ref.get_install_path(modules)
+                path.mkdir(parents=True)
+                (path / "README.md").write_text("metadata-only plugin")
+                return path
+
+            result = APMDependencyResolver(
+                apm_modules_dir=modules,
+                download_callback=download,
+                max_parallel=1,
+            ).resolve_dependencies(root)
+
+            packages = [node.package for node in result.dependency_tree.nodes.values()]
+            lsp = [dep for package in packages if package for dep in package.get_lsp_dependencies()]
+            assert [dep.name for dep in lsp] == ["gopls"]
+            assert (modules / "acme" / "gopls-lsp" / "apm.yml").is_file()
 
     @patch("apm_cli.marketplace.resolver.resolve_marketplace_plugin")
     def test_marketplace_dep_failure_surfaces_error(self, mock_resolve):

--- a/tests/unit/deps/test_shared.py
+++ b/tests/unit/deps/test_shared.py
@@ -7,7 +7,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from apm_cli.deps._shared import _validate_and_load_package
+from apm_cli.deps._shared import (
+    MarketplaceManifestMaterializationError,
+    _validate_and_load_package,
+    materialize_marketplace_manifest,
+)
 from apm_cli.models.apm_package import DependencyReference
 from apm_cli.models.validation import validate_apm_package
 
@@ -112,8 +116,7 @@ class TestValidateAndLoadPackage:
         with pytest.raises(ValueError) as exc_info:
             _validate_and_load_package(validate_apm_package(target), target, dep_ref)
 
-        assert dep_ref.repo_url in str(exc_info.value)
-        assert str(target) in str(exc_info.value)
+        assert "invalid marketplace metadata for 'plugins'" in str(exc_info.value)
         assert not target.exists()
 
     def test_rejects_invalid_marketplace_mcp_metadata_and_cleans_target(
@@ -132,6 +135,108 @@ class TestValidateAndLoadPackage:
             _validate_and_load_package(validate_apm_package(target), target, dep_ref)
 
         assert not target.exists()
+
+    @pytest.mark.parametrize(
+        ("field", "valid", "invalid"),
+        [
+            (
+                "lspServers",
+                {"command": "gopls", "extensionToLanguage": {".go": "go"}},
+                {"command": "gopls"},
+            ),
+            (
+                "mcpServers",
+                {"command": "echo", "args": ["ok"]},
+                {"args": ["missing-command"]},
+            ),
+        ],
+    )
+    def test_rejects_partially_invalid_marketplace_metadata(
+        self,
+        tmp_path: Path,
+        field: str,
+        valid: dict[str, object],
+        invalid: dict[str, object],
+    ) -> None:
+        target = tmp_path / "plugin"
+        target.mkdir()
+        dep_ref = DependencyReference(repo_url="owner/plugins", is_virtual=True)
+        dep_ref.marketplace_manifest = {
+            "name": "mixed-plugin",
+            field: {"valid": valid, "invalid": invalid},
+        }
+
+        with pytest.raises(
+            MarketplaceManifestMaterializationError,
+            match="did not materialize every declared server: invalid",
+        ):
+            materialize_marketplace_manifest(dep_ref, target)
+
+        assert not target.exists()
+
+    def test_rejects_dangling_apm_yml_symlink_without_writing_outside(self, tmp_path: Path) -> None:
+        target = tmp_path / "plugin"
+        target.mkdir()
+        outside = tmp_path / "outside.yml"
+        try:
+            (target / "apm.yml").symlink_to(outside)
+        except OSError:
+            pytest.skip("symlinks are unavailable")
+        dep_ref = DependencyReference(repo_url="owner/plugins", is_virtual=True)
+        dep_ref.marketplace_manifest = {
+            "name": "catalog-only",
+            "mcpServers": {"server": {"command": "echo"}},
+        }
+
+        with pytest.raises(
+            MarketplaceManifestMaterializationError,
+            match="must not be symbolic links",
+        ):
+            materialize_marketplace_manifest(dep_ref, target)
+
+        assert not outside.exists()
+        assert not target.exists()
+
+    def test_rematerializes_when_catalog_manifest_variant_changes(self, tmp_path: Path) -> None:
+        target = tmp_path / "plugin"
+        target.mkdir()
+        dep_ref = DependencyReference(repo_url="owner/plugins", is_virtual=True)
+        dep_ref.marketplace_manifest = {
+            "name": "catalog-only",
+            "mcpServers": {"first": {"command": "echo"}},
+        }
+
+        assert materialize_marketplace_manifest(dep_ref, target)
+        dep_ref.marketplace_manifest = {
+            "name": "catalog-only",
+            "mcpServers": {"second": {"command": "echo", "args": ["second"]}},
+        }
+
+        assert materialize_marketplace_manifest(dep_ref, target)
+        package = validate_apm_package(target).package
+        assert package is not None
+        assert [dependency.name for dependency in package.get_mcp_dependencies()] == ["second"]
+
+    def test_cleanup_failure_cannot_leave_generated_manifest(self, tmp_path: Path) -> None:
+        target = tmp_path / "plugin"
+        target.mkdir()
+        dep_ref = DependencyReference(repo_url="owner/plugins", is_virtual=True)
+        dep_ref.marketplace_manifest = {
+            "name": "bad-plugin",
+            "mcpServers": {"invalid": {"args": ["missing-command"]}},
+        }
+
+        with (
+            patch("apm_cli.utils.file_ops.robust_rmtree", side_effect=OSError("locked")),
+            pytest.raises(
+                MarketplaceManifestMaterializationError,
+                match="rejected download cleanup also failed",
+            ),
+        ):
+            materialize_marketplace_manifest(dep_ref, target)
+
+        assert not (target / "apm.yml").exists()
+        assert not (target / ".apm-marketplace-stage.yml").exists()
 
     def test_raises_on_invalid_result(self, tmp_path: Path) -> None:
         dep_ref = _make_dep_ref("github.com/owner/bad-pkg")

--- a/tests/unit/deps/test_shared.py
+++ b/tests/unit/deps/test_shared.py
@@ -8,6 +8,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from apm_cli.deps._shared import _validate_and_load_package
+from apm_cli.models.apm_package import DependencyReference
+from apm_cli.models.validation import validate_apm_package
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -65,6 +67,39 @@ class TestValidateAndLoadPackage:
         _validate_and_load_package(validation_result, tmp_path, dep_ref)
 
         assert package.source == "https://github.com/owner/repo"
+
+    def test_materializes_metadata_only_marketplace_plugin(self, tmp_path: Path) -> None:
+        (tmp_path / "README.md").write_text("catalog-only plugin")
+        dep_ref = DependencyReference(repo_url="owner/plugins", is_virtual=True)
+        dep_ref.marketplace_manifest = {
+            "name": "gopls-lsp",
+            "lspServers": {
+                "gopls": {
+                    "command": "gopls",
+                    "extensionToLanguage": {".go": "go"},
+                }
+            },
+        }
+
+        package = _validate_and_load_package(validate_apm_package(tmp_path), tmp_path, dep_ref)
+
+        assert [dep.name for dep in package.get_lsp_dependencies()] == ["gopls"]
+        assert (tmp_path / "apm.yml").is_file()
+
+    def test_rejects_invalid_marketplace_metadata_and_cleans_target(self, tmp_path: Path) -> None:
+        target = tmp_path / "plugin"
+        target.mkdir()
+        (target / "README.md").write_text("catalog-only plugin")
+        dep_ref = DependencyReference(repo_url="owner/plugins", is_virtual=True)
+        dep_ref.marketplace_manifest = {
+            "name": "bad-lsp",
+            "lspServers": {"gopls": {"command": "gopls"}},
+        }
+
+        with pytest.raises(ValueError, match="did not materialize"):
+            _validate_and_load_package(validate_apm_package(target), target, dep_ref)
+
+        assert not target.exists()
 
     def test_raises_on_invalid_result(self, tmp_path: Path) -> None:
         dep_ref = _make_dep_ref("github.com/owner/bad-pkg")

--- a/tests/unit/deps/test_shared.py
+++ b/tests/unit/deps/test_shared.py
@@ -12,8 +12,9 @@ from apm_cli.deps._shared import (
     _validate_and_load_package,
     materialize_marketplace_manifest,
 )
-from apm_cli.models.apm_package import DependencyReference
+from apm_cli.models.apm_package import APMPackage, DependencyReference
 from apm_cli.models.validation import validate_apm_package
+from apm_cli.utils.content_hash import compute_package_hash
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -216,6 +217,51 @@ class TestValidateAndLoadPackage:
         package = validate_apm_package(target).package
         assert package is not None
         assert [dependency.name for dependency in package.get_mcp_dependencies()] == ["second"]
+
+    def test_repairs_tampered_generated_manifest_before_reuse(self, tmp_path: Path) -> None:
+        target = tmp_path / "plugin"
+        target.mkdir()
+        dep_ref = DependencyReference(repo_url="owner/plugins", is_virtual=True)
+        dep_ref.marketplace_manifest = {
+            "name": "catalog-only",
+            "mcpServers": {"server": {"command": "echo"}},
+        }
+        assert materialize_marketplace_manifest(dep_ref, target)
+        with (target / "apm.yml").open("a", encoding="utf-8") as manifest_file:
+            manifest_file.write("\ndependencies:\n  apm:\n    - attacker/injected\n")
+
+        assert materialize_marketplace_manifest(dep_ref, target)
+        package = validate_apm_package(target).package
+        assert package is not None
+        assert package.get_apm_dependencies() == []
+
+    def test_catalog_manifest_bytes_are_independent_of_checkout_root(self, tmp_path: Path) -> None:
+        targets = [tmp_path / root / "plugin" for root in ("first", "second")]
+        manifest = {
+            "name": "portable",
+            "mcpServers": {
+                "server": {
+                    "command": "${CLAUDE_PLUGIN_ROOT}/bin/server",
+                    "args": ["--root", "${CLAUDE_PLUGIN_ROOT}"],
+                }
+            },
+        }
+        loaded_commands = []
+        for target in targets:
+            target.mkdir(parents=True)
+            (target / "README.md").write_text("portable catalog package")
+            dep_ref = DependencyReference(repo_url="owner/plugins", is_virtual=True)
+            dep_ref.marketplace_manifest = manifest
+            assert materialize_marketplace_manifest(dep_ref, target)
+            package = APMPackage.from_apm_yml(target / "apm.yml")
+            loaded_commands.append(package.get_mcp_dependencies()[0].command)
+
+        assert (targets[0] / "apm.yml").read_bytes() == (targets[1] / "apm.yml").read_bytes()
+        assert compute_package_hash(targets[0]) == compute_package_hash(targets[1])
+        assert loaded_commands == [
+            str(targets[0].resolve() / "bin" / "server"),
+            str(targets[1].resolve() / "bin" / "server"),
+        ]
 
     def test_cleanup_failure_cannot_leave_generated_manifest(self, tmp_path: Path) -> None:
         target = tmp_path / "plugin"

--- a/tests/unit/deps/test_shared.py
+++ b/tests/unit/deps/test_shared.py
@@ -86,6 +86,19 @@ class TestValidateAndLoadPackage:
         assert [dep.name for dep in package.get_lsp_dependencies()] == ["gopls"]
         assert (tmp_path / "apm.yml").is_file()
 
+    def test_materializes_metadata_only_marketplace_mcp_plugin(self, tmp_path: Path) -> None:
+        (tmp_path / "README.md").write_text("catalog-only plugin")
+        dep_ref = DependencyReference(repo_url="owner/plugins", is_virtual=True)
+        dep_ref.marketplace_manifest = {
+            "name": "test-mcp",
+            "mcpServers": {"test-server": {"command": "echo", "args": ["hello"]}},
+        }
+
+        package = _validate_and_load_package(validate_apm_package(tmp_path), tmp_path, dep_ref)
+
+        assert [dep.name for dep in package.get_mcp_dependencies()] == ["test-server"]
+        assert (tmp_path / "apm.yml").is_file()
+
     def test_rejects_invalid_marketplace_metadata_and_cleans_target(self, tmp_path: Path) -> None:
         target = tmp_path / "plugin"
         target.mkdir()
@@ -94,6 +107,25 @@ class TestValidateAndLoadPackage:
         dep_ref.marketplace_manifest = {
             "name": "bad-lsp",
             "lspServers": {"gopls": {"command": "gopls"}},
+        }
+
+        with pytest.raises(ValueError) as exc_info:
+            _validate_and_load_package(validate_apm_package(target), target, dep_ref)
+
+        assert dep_ref.repo_url in str(exc_info.value)
+        assert str(target) in str(exc_info.value)
+        assert not target.exists()
+
+    def test_rejects_invalid_marketplace_mcp_metadata_and_cleans_target(
+        self, tmp_path: Path
+    ) -> None:
+        target = tmp_path / "plugin"
+        target.mkdir()
+        (target / "README.md").write_text("catalog-only plugin")
+        dep_ref = DependencyReference(repo_url="owner/plugins", is_virtual=True)
+        dep_ref.marketplace_manifest = {
+            "name": "bad-mcp",
+            "mcpServers": {"test-server": {"args": ["hello"]}},
         }
 
         with pytest.raises(ValueError, match="did not materialize"):

--- a/tests/unit/test_plugin_parser.py
+++ b/tests/unit/test_plugin_parser.py
@@ -15,6 +15,7 @@ from apm_cli.deps.plugin_parser import (
     _holds_skill_dirs,
     _map_plugin_artifacts,
     _mcp_servers_to_apm_deps,
+    _union_dep_list,
     normalize_plugin_directory,
     normalized_plugin_skill_sources,
     parse_plugin_manifest,
@@ -22,6 +23,31 @@ from apm_cli.deps.plugin_parser import (
     validate_plugin_package,
 )
 from apm_cli.utils.helpers import find_plugin_json
+
+
+def test_union_dep_list_indexes_existing_entries_once() -> None:
+    """Large dependency merges must not scan the growing result per append."""
+
+    class NoContainsList(list):
+        def __contains__(self, _item: object) -> bool:
+            raise AssertionError("linear membership scan used")
+
+    existing = NoContainsList(
+        {"name": f"server-{index}", "command": "echo"} for index in range(100)
+    )
+    merged = {"mcp": existing}
+    new_entries = [{"name": f"server-{index}", "command": "echo"} for index in range(100, 1000)]
+    new_entries.extend(
+        [
+            {"name": "server-0", "command": "echo"},
+            {"name": "server-0", "command": "different"},
+        ]
+    )
+
+    _union_dep_list(merged, "mcp", new_entries)
+
+    assert len(existing) == 1001
+    assert existing[-1] == {"name": "server-0", "command": "different"}
 
 
 class TestFindPluginJson:


### PR DESCRIPTION
## Description

Marketplace catalog entries can contain deployable LSP/MCP metadata even when their downloaded source has no `apm.yml`, `SKILL.md`, or plugin manifest. Preserve admitted inline catalog metadata through dependency resolution and synthesize the package manifest before ordinary validation.

The fix is fail-closed:

- only `name`, `description`, `version`, `lspServers`, and `mcpServers` are retained;
- nested values are deep-copied and excluded from marketplace identity/hash;
- unrelated catalog fields cannot inject APM dependencies;
- every declared LSP/MCP component must materialize successfully;
- failed synthesis removes the rejected download.

Fixes #2708

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [x] Added tests for new functionality

Validation evidence:

- TDD regression observed failing before implementation;
- 208 focused resolver/parser tests passed;
- 20,496 Tier-1 unit/console tests passed;
- Ruff lint/format, architecture boundaries, and `git diff --check` passed;
- mandatory supply-chain review passed;
- independent contamination review confirmed only six #2708 files changed.

## How to test

```bash
uv run --python 3.12 pytest -q \
  tests/test_apm_resolver.py::TestMarketplaceResolution::test_metadata_only_marketplace_dep_uses_catalog_components \
  tests/unit/deps/test_shared.py::TestValidateAndLoadPackage::test_materializes_metadata_only_marketplace_plugin \
  tests/unit/deps/test_shared.py::TestValidateAndLoadPackage::test_rejects_invalid_marketplace_metadata_and_cleans_target
```

## Spec conformance (OpenAPM v0.1)

- [x] N/A -- this fixes marketplace package normalization and does not change the OpenAPM v0.1 manifest contract.


## Scenario Evidence

| User promise | Principle | Automated evidence | Regression trap |
|---|---|---|---|
| A catalog-only marketplace package materializes every admitted LSP and MCP server, rejects invalid metadata without durable writes, and ignores unrelated dependency fields. | Secure by default; DevX | `tests/integration/test_marketplace_install_local.py::test_catalog_only_marketplace_installs_all_inline_servers`; `tests/integration/test_marketplace_install_local.py::test_invalid_catalog_only_metadata_fails_install_resolution` | Yes - issue #2708 |

apm-spec-waiver: Marketplace catalog compatibility translates admitted metadata into the existing OpenAPM manifest contract; it adds no normative OpenAPM requirement.

