### PR TITLE
fix: allow manifestless hook packages in audit (closes #2725)

### DIFF
--- a/src/apm_cli/integration/mcp_config_view.py
+++ b/src/apm_cli/integration/mcp_config_view.py
@@ -257,6 +257,11 @@ def _allows_missing_manifest(
         )
 
     package_type, _ = detect_package_type(package_dir)
+    if package_type is PackageType.HOOK_PACKAGE:
+        return (
+            dependency_ref.is_virtual_subdirectory()
+            and dependency.package_type == PackageType.HOOK_PACKAGE.value
+        )
     return (
         package_type is PackageType.CLAUDE_SKILL
         and dependency.package_type == PackageType.CLAUDE_SKILL.value

--- a/tests/unit/integration/test_mcp_config_view.py
+++ b/tests/unit/integration/test_mcp_config_view.py
@@ -379,6 +379,116 @@ def test_manifestless_virtual_package_is_skipped(tmp_path: Path) -> None:
     assert view.problems == ()
 
 
+def test_manifestless_virtual_hook_package_is_skipped(tmp_path: Path) -> None:
+    """A matching virtual hook-package shape legitimately omits apm.yml."""
+    root = _write_manifest(tmp_path, name="root")
+    modules_root = tmp_path / "apm_modules"
+    locked = LockedDependency(
+        repo_url="owner/hooks",
+        virtual_path="packages/git-hooks",
+        is_virtual=True,
+        package_type="hook_package",
+        depth=1,
+    )
+    package_dir = locked.to_dependency_ref().get_install_path(modules_root)
+    hooks_dir = package_dir / "hooks"
+    hooks_dir.mkdir(parents=True)
+    (hooks_dir / "hooks.json").write_text('{"hooks": {}}\n', encoding="ascii")
+
+    view = _derive(root, _lock(locked), modules_root)
+
+    assert not (package_dir / "apm.yml").exists()
+    assert view.dependencies == ()
+    assert view.problems == ()
+
+
+def test_missing_virtual_hook_package_records_problem(tmp_path: Path) -> None:
+    """Lock metadata alone cannot waive an entirely absent hook package."""
+    root = _write_manifest(tmp_path, name="root")
+    modules_root = tmp_path / "apm_modules"
+    locked = LockedDependency(
+        repo_url="owner/hooks",
+        virtual_path="packages/git-hooks",
+        is_virtual=True,
+        package_type="hook_package",
+        depth=1,
+    )
+    package_dir = locked.to_dependency_ref().get_install_path(modules_root)
+
+    view = _derive(root, _lock(locked), modules_root)
+
+    assert not package_dir.exists()
+    assert len(view.problems) == 1
+    assert "manifest not found" in view.problems[0].message
+
+
+def test_manifestless_hook_package_requires_virtual_subdirectory(tmp_path: Path) -> None:
+    """A hook shape alone cannot waive the manifest for a non-virtual package."""
+    root = _write_manifest(tmp_path, name="root")
+    modules_root = tmp_path / "apm_modules"
+    locked = LockedDependency(
+        repo_url="owner/hooks",
+        package_type="hook_package",
+        depth=1,
+    )
+    package_dir = locked.to_dependency_ref().get_install_path(modules_root)
+    hooks_dir = package_dir / "hooks"
+    hooks_dir.mkdir(parents=True)
+    (hooks_dir / "hooks.json").write_text('{"hooks": {}}\n', encoding="ascii")
+
+    view = _derive(root, _lock(locked), modules_root)
+
+    assert len(view.problems) == 1
+    assert "manifest not found" in view.problems[0].message
+
+
+def test_manifestless_virtual_hook_package_requires_matching_lock_type(
+    tmp_path: Path,
+) -> None:
+    """A detected virtual hook package cannot waive mismatched lock metadata."""
+    root = _write_manifest(tmp_path, name="root")
+    modules_root = tmp_path / "apm_modules"
+    locked = LockedDependency(
+        repo_url="owner/hooks",
+        virtual_path="packages/git-hooks",
+        is_virtual=True,
+        package_type="claude_skill",
+        depth=1,
+    )
+    package_dir = locked.to_dependency_ref().get_install_path(modules_root)
+    hooks_dir = package_dir / "hooks"
+    hooks_dir.mkdir(parents=True)
+    (hooks_dir / "hooks.json").write_text('{"hooks": {}}\n', encoding="ascii")
+
+    view = _derive(root, _lock(locked), modules_root)
+
+    assert len(view.problems) == 1
+    assert "manifest not found" in view.problems[0].message
+
+
+def test_locked_virtual_hook_package_requires_matching_detected_type(
+    tmp_path: Path,
+) -> None:
+    """Hook lock metadata cannot waive a different manifestless package shape."""
+    root = _write_manifest(tmp_path, name="root")
+    modules_root = tmp_path / "apm_modules"
+    locked = LockedDependency(
+        repo_url="owner/hooks",
+        virtual_path="packages/git-hooks",
+        is_virtual=True,
+        package_type="hook_package",
+        depth=1,
+    )
+    package_dir = locked.to_dependency_ref().get_install_path(modules_root)
+    package_dir.mkdir(parents=True)
+    (package_dir / "SKILL.md").write_text("# Not a hook package\n", encoding="ascii")
+
+    view = _derive(root, _lock(locked), modules_root)
+
+    assert len(view.problems) == 1
+    assert "manifest not found" in view.problems[0].message
+
+
 def test_manifestless_virtual_skill_skipped_when_modules_not_materialized(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
# fix(audit): allow manifestless virtual hook packages

## TL;DR

`apm audit` no longer reports a missing `apm.yml` for an installed virtual
subdirectory that both detects and locks as `hook_package`. The exemption stays
fail-closed for absent, non-virtual, or type-mismatched packages.

> [!NOTE]
> This closes the permanent `config-consistency` failure reported in #2725.

## Problem (WHY)

- [x] A valid `hook_package` has `hooks/hooks.json` and no `apm.yml`, but the
  current MCP view reports the absent manifest as corruption.
- [x] Reinstalling cannot resolve the diagnostic because the package contract
  intentionally omits that manifest.
- [!] A broad lockfile-only exemption would hide missing or mislabeled package
  content.

The fix keeps audit output grounded in the installed package shape:
["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/).

## Approach (WHAT)

- Extend the existing missing-manifest decision in `CurrentMcpConfigView`.
- Require a virtual-subdirectory reference.
- Require agreement between detected and locked `hook_package` types.
- Preserve errors for absent, non-virtual, and mismatched packages.

## Implementation (HOW)

- **`src/apm_cli/integration/mcp_config_view.py`** - Extends the canonical MCP
  source view with the narrow hook-package exemption. No new decision owner or
  parallel audit path is introduced.
- **`tests/unit/integration/test_mcp_config_view.py`** - Adds the positive
  regression trap and four fail-closed controls for presence, virtual status,
  and bidirectional type agreement.

Architecture classification: `owner-extension`. The durable decision is root
versus dependency MCP declaration scope, owned by
`integration/mcp_config_view.py`; audit and install consumers continue routing
through `CurrentMcpConfigView.derive`. This extension neither centralizes nor
repairs routing, so the existing architecture boundary guard remains sufficient.

## Diagrams

Legend: The dashed node is the extended decision; both independent facts must
agree before audit suppresses the missing-manifest problem.

```mermaid
flowchart LR
    L[LockedDependency] --> V[virtual subdirectory]
    D[detected package type] --> A[missing manifest decision]
    V --> A
    A -->|"both are hook_package"| S[skip false problem]
    A -->|"absent, non-virtual, or mismatched"| P[McpSourceProblem]
    classDef new stroke-dasharray: 5 5;
    class A new;
```

## Trade-offs

- **Installed shape over lock metadata alone.** This rejects cold-cache hook
  packages rather than trusting an unverified type.
- **Narrow extension over a general manifestless-type set.** This keeps the
  existing Claude-skill behavior unchanged and makes hook-specific safeguards
  explicit.

## Benefits

1. Valid installed virtual hook packages produce zero manifest problems.
2. Four negative cases continue producing exactly one manifest problem.
3. Existing MCP view coverage remains green across all 32 tests.

## Validation

`uv run --no-sync --extra dev pytest -q tests/unit/integration/test_mcp_config_view.py`:

```text
................................                                         [100%]
32 passed in 2.24s
```

<details><summary>Lint and boundary gates</summary>

`uv run --no-sync --extra dev ruff check src/ tests/`:

```text
All checks passed!
```

`uv run --no-sync --extra dev ruff format --check src/ tests/`:

```text
1679 files already formatted
```

`uv run --no-sync --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/`:

```text
Your code has been rated at 10.00/10
```

`bash scripts/lint-auth-signals.sh` and
`bash scripts/lint-architecture-boundaries.sh`:

```text
[+] auth-signal lint clean
[+] architecture boundary lint clean
```

</details>

Mutation-break evidence: removing the new production guard makes
`test_manifestless_virtual_hook_package_is_skipped` fail because
`view.problems` contains the false `McpSourceProblem`.

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|-------------------------|--------------|--------------------|------|
| 1 | Audit a valid virtual hook-only dependency without a permanent false failure | Governed by policy, DevX | `tests/unit/integration/test_mcp_config_view.py::test_manifestless_virtual_hook_package_is_skipped` (regression-trap for #2725) | unit |
| 2 | Audit still reports genuinely missing or mislabeled hook packages | Secure by default, Governed by policy | `test_missing_virtual_hook_package_records_problem`; `test_manifestless_hook_package_requires_virtual_subdirectory`; `test_manifestless_virtual_hook_package_requires_matching_lock_type`; `test_locked_virtual_hook_package_requires_matching_detected_type` | unit |

## How to test

- [ ] Run the focused test module and observe all 32 tests pass.
- [ ] Remove the new `HOOK_PACKAGE` branch and observe the regression trap fail.
- [ ] Run the lint and architecture boundary commands and observe clean exits.

Closes #2725

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
