### PR TITLE
feat(uninstall): accept unambiguous short package names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `apm uninstall` now accepts an unambiguous package short name, while
+  requiring the full installed identifier when multiple owners use the same
+  name.
 - Architecture ownership guards now use a sharded JSON registry and a
   single-process Python linter while preserving exact-revision compatibility
   and reducing warm median lint time by 75%. (#2739)

--- a/docs/src/content/docs/reference/cli/uninstall.md
+++ b/docs/src/content/docs/reference/cli/uninstall.md
@@ -23,7 +23,7 @@ The command only deletes files tracked in the lockfile's `deployed_files` manife
 
 | Argument | Description |
 |---|---|
-| `PACKAGES...` | One or more packages to remove. Accepts shorthand (`owner/repo`), HTTPS URL, SSH URL, FQDN, marketplace notation (`name@marketplace`), an exact declared local path, or the portable `_local/<name>` identifier printed for a direct local dependency with matching lock metadata. Required. |
+| `PACKAGES...` | One or more packages to remove. Accepts an unambiguous short name (`repo`), shorthand (`owner/repo`), HTTPS URL, SSH URL, FQDN, marketplace notation (`name@marketplace`), an exact declared local path, or the portable `_local/<name>` identifier printed for a direct local dependency with matching lock metadata. Required. |
 
 ## Options
 
@@ -39,6 +39,12 @@ Remove one package:
 
 ```bash
 apm uninstall acme/my-package
+```
+
+Remove one package by its short name:
+
+```bash
+apm uninstall my-package
 ```
 
 Remove several at once:
@@ -103,6 +109,10 @@ What gets removed, in order:
 Selection is atomic. If any requested identifier does not match a declaration,
 the command exits nonzero before lifecycle scripts or filesystem writes run. No
 matched package in the same invocation is removed. Fix the identifier and retry.
+Short names match the final path segment of installed remote dependencies. If
+more than one owner provides that name, selection is ambiguous and the command
+exits without changes; retry with an exact `owner/repo` identifier from
+`apm deps list`.
 
 If a target-scoped file owned only by a removed package was edited or cannot be
 deleted, uninstall lists the retained paths and exits before changing `apm.yml`,

--- a/src/apm_cli/commands/uninstall/cli.py
+++ b/src/apm_cli/commands/uninstall/cli.py
@@ -43,7 +43,7 @@ def _prepare_dependency_sections(data: dict) -> tuple[bool, list, list, list]:
 
 
 @click.command(
-    help="Remove packages using manifest entries or direct locked keys from 'apm deps list'"
+    help="Remove packages by full identifier, unambiguous short name, or direct locked keys from 'apm deps list'"
 )
 @click.argument("packages", nargs=-1, required=True)
 @click.option(
@@ -69,6 +69,7 @@ def uninstall(ctx, packages, dry_run, verbose, global_):
 
     Examples:
         apm uninstall acme/my-package                # Remove one package
+        apm uninstall my-package                     # Remove by unambiguous short name
         apm uninstall org/pkg1 org/pkg2              # Remove multiple packages
         apm uninstall acme/my-package --dry-run      # Show what would be removed
         apm uninstall -g acme/my-package             # Remove from user scope

--- a/src/apm_cli/commands/uninstall/engine.py
+++ b/src/apm_cli/commands/uninstall/engine.py
@@ -625,8 +625,9 @@ def _validate_uninstall_packages(
     for package in packages:
         # A package arg is either: (a) a marketplace ref in
         # `name@marketplace[#ref]` form (no slash), (b) an `owner/repo`
-        # slug, or (c) a local filesystem path. The legacy guard below
-        # only handled (a) when there is no `/`, but Windows absolute
+        # slug or unambiguous package basename, or (c) a local filesystem
+        # path. The legacy guard below only handled (a) when there is no
+        # `/`, but Windows absolute
         # paths use backslashes (e.g. `C:\Users\...\my-pkg`) and have
         # no `/` either -- they were wrongly rejected as "Invalid
         # package format" and the DB row for any deployed copilot-app
@@ -645,13 +646,8 @@ def _validate_uninstall_packages(
                 canonical_for_match = canonical
                 display_label = package
             else:
-                logger.error(
-                    f"Invalid package format: {package}. "
-                    "Use 'owner/repo', 'plugin-name@marketplace', a local path, "
-                    "or a key copied from 'apm deps list'."
-                )
-                packages_not_found.append(package)
-                continue
+                canonical_for_match = package
+                display_label = package
         else:
             canonical_for_match = package
             display_label = package

--- a/src/apm_cli/models/dependency/selection.py
+++ b/src/apm_cli/models/dependency/selection.py
@@ -44,10 +44,15 @@ def select_manifest_dependency(
     """Select exactly one manifest entry for an uninstall identifier.
 
     Exact declared identifiers use ``DependencyReference`` identity semantics.
+    A bare package name matches the final path segment only when that name
+    identifies exactly one remote dependency.
     A portable local alias such as ``_local/pkg`` is accepted only when persisted
     lock metadata maps that alias back to one declared local dependency key.
     Ambiguous aliases fail closed instead of guessing.
     """
+    short_name = (
+        package if "/" not in package and not DependencyReference.is_local_path(package) else None
+    )
     try:
         requested_identity = DependencyReference.parse(package).get_identity()
     except (ValueError, TypeError, AttributeError, KeyError):
@@ -63,7 +68,11 @@ def select_manifest_dependency(
                 matched_entries[index] = entry
             continue
         parsed_entries.append((index, entry, dependency))
-        if dependency.get_identity() == requested_identity:
+        if dependency.get_identity() == requested_identity or (
+            short_name is not None
+            and not dependency.is_local
+            and dependency.repo_url.rstrip("/").split("/")[-1] == short_name
+        ):
             matched_entries[index] = entry
 
     locked_alias_keys: set[str] = set()

--- a/tests/unit/models/test_dependency_uninstall_selection.py
+++ b/tests/unit/models/test_dependency_uninstall_selection.py
@@ -90,6 +90,32 @@ def test_remote_dependency_named_local_owner_keeps_exact_identity_semantics() ->
     assert selection.manifest_entry == "_local/remote-package"
 
 
+def test_unique_remote_basename_selects_manifest_entry() -> None:
+    """A short package name selects one unambiguous installed dependency."""
+    selection = select_manifest_dependency(
+        "perform-code-review",
+        ["jfrog/perform-code-review#v1.15.0"],
+        lockfile=None,
+    )
+
+    assert selection.status is DependencySelectionStatus.MATCHED
+    assert selection.manifest_entry == "jfrog/perform-code-review#v1.15.0"
+    assert selection.match_count == 1
+
+
+def test_duplicate_remote_basename_is_ambiguous() -> None:
+    """A short name shared by multiple owners must fail closed."""
+    selection = select_manifest_dependency(
+        "shared-skill",
+        ["acme/shared-skill", "contoso/shared-skill"],
+        lockfile=None,
+    )
+
+    assert selection.status is DependencySelectionStatus.AMBIGUOUS
+    assert selection.manifest_entry is None
+    assert selection.match_count == 2
+
+
 @pytest.mark.windows_compat
 def test_windows_declared_path_accepts_portable_lock_alias() -> None:
     """Windows local paths match by persisted identity on every host OS."""

--- a/tests/unit/test_uninstall_engine_helpers.py
+++ b/tests/unit/test_uninstall_engine_helpers.py
@@ -101,13 +101,30 @@ class TestValidateUninstallPackages:
         assert "org/missing" in not_found
         logger.error.assert_called_once()
 
-    def test_invalid_format_no_slash_logs_error(self):
-        """Package without slash is rejected with an error message and tracked in not_found."""
+    def test_unique_short_name_matches_installed_package(self):
+        """A package basename selects its unambiguous manifest entry."""
         logger = _make_logger()
-        to_remove, not_found = _validate_uninstall_packages(["badpackage"], ["org/repo"], logger)
+        to_remove, not_found = _validate_uninstall_packages(
+            ["perform-code-review"],
+            ["jfrog/perform-code-review#v1.15.0"],
+            logger,
+        )
+        assert to_remove == ["jfrog/perform-code-review#v1.15.0"]
+        assert not_found == []
+        logger.error.assert_not_called()
+
+    def test_ambiguous_short_name_requires_exact_identifier(self):
+        """A basename shared by multiple owners is rejected without guessing."""
+        logger = _make_logger()
+        to_remove, not_found = _validate_uninstall_packages(
+            ["shared-skill"],
+            ["acme/shared-skill", "contoso/shared-skill"],
+            logger,
+        )
         assert to_remove == []
-        assert "badpackage" in not_found
+        assert not_found == ["shared-skill"]
         logger.error.assert_called_once()
+        assert "Ambiguous dependency 'shared-skill'" in logger.error.call_args.args[0]
 
     def test_multiple_packages_partial_match(self):
         """Some packages matched, others not."""
@@ -1086,20 +1103,18 @@ class TestValidateUninstallPackagesMarketplace:
         progress_msg = logger.progress.call_args[0][0]
         assert "(as " not in progress_msg
 
-    def test_invalid_format_no_slash_no_at_still_errors(self):
-        """A bare word with neither slash nor @ still triggers an error."""
+    def test_unmatched_short_name_reports_installed_inventory_hint(self):
+        """An unknown bare name follows the ordinary not-found path."""
         logger = _make_logger()
 
         to_remove, not_found = _validate_uninstall_packages(["badpackage"], ["org/repo"], logger)
 
         assert to_remove == []
-        # Invalid-format inputs MUST appear in packages_not_found (API contract).
         assert "badpackage" in not_found
         logger.error.assert_called_once()
         err_msg = logger.error.call_args[0][0]
-        assert "owner/repo" in err_msg
-        # Error must surface marketplace notation symmetrically with install.
-        assert "plugin-name@marketplace" in err_msg
+        assert "not found in apm.yml" in err_msg
+        assert "apm deps list" in err_msg
 
     def test_mixed_canonical_and_marketplace_refs(self):
         """Batch mixing canonical and marketplace refs processes both correctly."""


### PR DESCRIPTION
## Description

APM users currently need to repeat the full `owner/repo` identifier when uninstalling a package, even when the installed manifest has only one package with that name. This is particularly awkward for globally installed skills and bundles where users typically know the package's short name.

Allow `apm uninstall <name>` and `apm uninstall -g <name>` to resolve directly from installed manifest entries. Resolution fails closed when multiple owners provide the same final path segment and points users to `apm deps list` for the exact identifier. Existing canonical, marketplace, URL, and local-path selection behavior remains unchanged.

This intentionally keeps the contribution focused on uninstall UX. Current `main` already provides installed inventory through `apm deps list` and version checks through `apm outdated`; broader install-output suppression was not included because APM's default stream contains security-significant policy and cleanup warnings that should not be hidden without a separate output-policy design.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [x] Added tests for new functionality (if applicable)

Validation run:

- `uv run --extra dev pytest tests/unit tests/test_console.py -x` — 20,729 passed, 3 skipped, 21 xfailed
- `uv run --extra dev ruff check src/ tests/`
- `uv run --extra dev ruff format --check src/ tests/`

## Spec conformance (OpenAPM v0.1)

- [x] N/A -- this PR does not change an OpenAPM v0.1 normative requirement; it adds a CLI identifier convenience for selecting an already-declared dependency.

Made with [Cursor](https://cursor.com)