### PR TITLE
Add root --quiet flag to set APM_PROGRESS=quiet

### DIFF
--- a/docs/src/content/docs/reference/environment-variables.md
+++ b/docs/src/content/docs/reference/environment-variables.md
@@ -117,7 +117,7 @@ experimental flag.
 | `APM_DEBUG` | Any non-empty value enables low-level debug logging in download, file ops, and clone-cache paths. | unset | Verbose; use for troubleshooting only. |
 | `APM_LOG_LEVEL` | Override the CLI logging level. | implementation default | Debugging escape hatch. |
 | `APM_VERBOSE` | `1` enables verbose output for the install pipeline. APM also sets this internally when `--verbose` is passed. | unset | |
-| `APM_PROGRESS` | Force the install TUI on or off: `always`/`on`/`1`/`true`/`yes` to force on; `never`/`quiet`/`off`/`0`/`false`/`no` to force off; `auto` (default) lets APM decide based on `CI`, `TERM`, and TTY. | `auto` | The CLI sets `APM_PROGRESS=quiet` when `--quiet` is passed. |
+| `APM_PROGRESS` | Force the install TUI on or off: `always`/`on`/`1`/`true`/`yes` to force on; `never`/`quiet`/`off`/`0`/`false`/`no` to force off; `auto` (default) lets APM decide based on `CI`, `TERM`, and TTY. | `auto` | The CLI sets `APM_PROGRESS=quiet` when `--quiet` / `-q` is passed (mutually exclusive with `--verbose` / `-v`). |
 | `CI` | Standard CI marker. When truthy (`1`/`true`/`yes`), APM disables the install TUI and adjusts a few interactive defaults. | unset | Read; never written. |
 | `TERM` | Standard terminal type. `""` or `dumb` disables the install TUI. | OS-provided | Read; never written. |
 

--- a/src/apm_cli/cli.py
+++ b/src/apm_cli/cli.py
@@ -145,16 +145,41 @@ def _configure_logging(verbose: bool = False) -> None:
     default=False,
     help="Enable debug-level logging (equivalent to APM_LOG_LEVEL=DEBUG).",
 )
+@click.option(
+    "--quiet",
+    "-q",
+    is_flag=True,
+    default=False,
+    help=(
+        "Suppress install progress UI (sets APM_PROGRESS=quiet). Errors and warnings still print."
+    ),
+)
 @click.pass_context
-def cli(ctx, verbose: bool) -> None:
+def cli(ctx, verbose: bool, quiet: bool) -> None:
     """Main entry point for the APM CLI."""
+    if verbose and quiet:
+        raise click.UsageError("--quiet and --verbose are mutually exclusive.")
+
     ctx.ensure_object(dict)
     ctx.obj["verbose"] = verbose
+    ctx.obj["quiet"] = quiet
     from apm_cli.core.output_mode import configure_output_mode, detect_output_mode
 
     output_mode = detect_output_mode(ctx.meta.get("apm_raw_args", sys.argv[1:]))
     configure_output_mode(output_mode)
     ctx.obj["output_mode"] = output_mode
+
+    if quiet:
+        previous_progress = os.environ.get("APM_PROGRESS")
+
+        def _restore_apm_progress() -> None:
+            if previous_progress is None:
+                os.environ.pop("APM_PROGRESS", None)
+            else:
+                os.environ["APM_PROGRESS"] = previous_progress
+
+        os.environ["APM_PROGRESS"] = "quiet"
+        ctx.call_on_close(_restore_apm_progress)
 
     if verbose:
         # Upgrade to DEBUG when the flag is set; env-var path runs in main().

--- a/src/apm_cli/cli.py
+++ b/src/apm_cli/cli.py
@@ -171,15 +171,18 @@ def cli(ctx, verbose: bool, quiet: bool) -> None:
 
     if quiet:
         previous_progress = os.environ.get("APM_PROGRESS")
+        from apm_cli.core.command_logger import configure_quiet_mode
 
-        def _restore_apm_progress() -> None:
+        def _restore_quiet_mode() -> None:
+            configure_quiet_mode(False)
             if previous_progress is None:
                 os.environ.pop("APM_PROGRESS", None)
             else:
                 os.environ["APM_PROGRESS"] = previous_progress
 
         os.environ["APM_PROGRESS"] = "quiet"
-        ctx.call_on_close(_restore_apm_progress)
+        configure_quiet_mode(True)
+        ctx.call_on_close(_restore_quiet_mode)
 
     if verbose:
         # Upgrade to DEBUG when the flag is set; env-var path runs in main().

--- a/src/apm_cli/core/command_logger.py
+++ b/src/apm_cli/core/command_logger.py
@@ -7,6 +7,7 @@ from apm_cli.utils.console — no new output primitives.
 
 from __future__ import annotations
 
+import os
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -22,6 +23,8 @@ from apm_cli.utils.console import (
 
 if TYPE_CHECKING:
     from apm_cli.deps.revision_pins import RevisionPinSkip
+
+_QUIET_PROGRESS_MODES = frozenset({"never", "quiet", "off", "0", "false", "no"})
 
 
 def _strip_source_prefix(source: str) -> str:
@@ -70,10 +73,21 @@ class CommandLogger:
         logger.render_summary()
     """
 
-    def __init__(self, command: str, verbose: bool = False, dry_run: bool = False):
+    def __init__(
+        self,
+        command: str,
+        verbose: bool = False,
+        dry_run: bool = False,
+        quiet: bool = False,
+    ):
         self.command = command
         self.verbose = verbose
         self.dry_run = dry_run
+        if quiet:
+            self._quiet = True
+        else:
+            mode = os.environ.get("APM_PROGRESS", "").strip().lower()
+            self._quiet = mode in _QUIET_PROGRESS_MODES
         self._diagnostics = None  # Lazy init
 
     @property
@@ -93,6 +107,8 @@ class CommandLogger:
 
     def progress(self, message: str, symbol: str = "info"):
         """Log progress during an operation."""
+        if self._quiet:
+            return
         _rich_info(message, symbol=symbol)
 
     def mcp_lookup_heartbeat(self, count: int):
@@ -106,9 +122,10 @@ class CommandLogger:
         and ``2>&1 | tee`` pipelines.
 
         Skipped silently when ``count <= 0`` to avoid noisy zero-batch
-        output on installs with no registry MCP deps.
+        output on installs with no registry MCP deps, and when ``--quiet``
+        is active (progress-only; warnings and errors still emit).
         """
-        if count <= 0:
+        if self._quiet or count <= 0:
             return
         noun = "server" if count == 1 else "servers"
         _rich_info(f"Looking up {count} MCP {noun} in registry...", symbol="running")
@@ -116,13 +133,11 @@ class CommandLogger:
     def info(self, message: str, symbol: str = "info"):
         """Log static advisory / informational context.
 
-        Distinct from :meth:`progress` only at the semantic level:
-        ``progress`` narrates an in-flight step (may be suppressed in
-        ``--quiet``/CI), while ``info`` carries persistent advisory
+        Distinct from :meth:`progress` at the quiet-mode boundary:
+        ``progress`` narrates an in-flight step and is suppressed when
+        ``--quiet`` is set, while ``info`` carries persistent advisory
         context such as recovery hints that must survive quiet-mode
-        suppression. Both currently delegate to ``_rich_info``; the
-        split exists so future quiet-mode policy can drop ``progress``
-        without dropping advisory context.
+        suppression.
         """
         _rich_info(message, symbol=symbol)
 
@@ -236,8 +251,14 @@ class InstallLogger(CommandLogger):
     full install (all deps from apm.yml). Adjusts messages accordingly.
     """
 
-    def __init__(self, verbose: bool = False, dry_run: bool = False, partial: bool = False):
-        super().__init__("install", verbose=verbose, dry_run=dry_run)
+    def __init__(
+        self,
+        verbose: bool = False,
+        dry_run: bool = False,
+        partial: bool = False,
+        quiet: bool = False,
+    ):
+        super().__init__("install", verbose=verbose, dry_run=dry_run, quiet=quiet)
         self.partial = partial  # True when specific packages are passed to `apm install`
         self._stale_cleaned_total = 0  # Accumulated by stale_cleanup / orphan_cleanup
         self._dry_run_apm_update_count = 0

--- a/src/apm_cli/core/command_logger.py
+++ b/src/apm_cli/core/command_logger.py
@@ -7,7 +7,6 @@ from apm_cli.utils.console — no new output primitives.
 
 from __future__ import annotations
 
-import os
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -24,7 +23,13 @@ from apm_cli.utils.console import (
 if TYPE_CHECKING:
     from apm_cli.deps.revision_pins import RevisionPinSkip
 
-_QUIET_PROGRESS_MODES = frozenset({"never", "quiet", "off", "0", "false", "no"})
+_process_quiet = False
+
+
+def configure_quiet_mode(enabled: bool) -> None:
+    """Record whether the current CLI process was invoked with ``--quiet``."""
+    global _process_quiet
+    _process_quiet = enabled
 
 
 def _strip_source_prefix(source: str) -> str:
@@ -78,16 +83,12 @@ class CommandLogger:
         command: str,
         verbose: bool = False,
         dry_run: bool = False,
-        quiet: bool = False,
+        quiet: bool | None = None,
     ):
         self.command = command
         self.verbose = verbose
         self.dry_run = dry_run
-        if quiet:
-            self._quiet = True
-        else:
-            mode = os.environ.get("APM_PROGRESS", "").strip().lower()
-            self._quiet = mode in _QUIET_PROGRESS_MODES
+        self._quiet = _process_quiet if quiet is None else quiet
         self._diagnostics = None  # Lazy init
 
     @property
@@ -256,7 +257,7 @@ class InstallLogger(CommandLogger):
         verbose: bool = False,
         dry_run: bool = False,
         partial: bool = False,
-        quiet: bool = False,
+        quiet: bool | None = None,
     ):
         super().__init__("install", verbose=verbose, dry_run=dry_run, quiet=quiet)
         self.partial = partial  # True when specific packages are passed to `apm install`

--- a/tests/integration/test_version_notification.py
+++ b/tests/integration/test_version_notification.py
@@ -89,7 +89,7 @@ class TestUpdateCheckSkippedOnInvalidCommand(unittest.TestCase):
         ctx.invoked_subcommand = "invalid"
 
         with ctx:
-            cli.callback(verbose=False)
+            cli.callback(verbose=False, quiet=False)
 
         mock_check.assert_not_called()
 
@@ -112,7 +112,7 @@ class TestUpdateCheckSkippedOnInvalidCommand(unittest.TestCase):
         ctx.invoked_subcommand = None
 
         with ctx:
-            cli.callback(verbose=False)
+            cli.callback(verbose=False, quiet=False)
 
         mock_check.assert_not_called()
 

--- a/tests/unit/test_cli_quiet_flag.py
+++ b/tests/unit/test_cli_quiet_flag.py
@@ -1,0 +1,86 @@
+"""Unit tests for the root-level ``--quiet`` / ``-q`` flag."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import click
+from click.testing import CliRunner
+
+from apm_cli.cli import cli
+
+
+def test_quiet_flag_sets_apm_progress_env(monkeypatch):
+    """``--quiet`` must set APM_PROGRESS=quiet as documented."""
+    monkeypatch.delenv("APM_PROGRESS", raising=False)
+
+    ctx = click.Context(cli, info_name="apm")
+    ctx.resilient_parsing = True
+    with ctx:
+        cli.callback(verbose=False, quiet=True)
+        assert os.environ.get("APM_PROGRESS") == "quiet"
+
+
+def test_default_invocation_does_not_set_apm_progress(monkeypatch):
+    """Default behaviour must not touch APM_PROGRESS."""
+    monkeypatch.delenv("APM_PROGRESS", raising=False)
+
+    ctx = click.Context(cli, info_name="apm")
+    ctx.resilient_parsing = True
+    with ctx:
+        cli.callback(verbose=False, quiet=False)
+        assert "APM_PROGRESS" not in os.environ
+
+
+def test_default_invocation_preserves_existing_apm_progress(monkeypatch):
+    monkeypatch.setenv("APM_PROGRESS", "always")
+
+    ctx = click.Context(cli, info_name="apm")
+    ctx.resilient_parsing = True
+    with ctx:
+        cli.callback(verbose=False, quiet=False)
+        assert os.environ.get("APM_PROGRESS") == "always"
+
+
+def test_quiet_and_verbose_are_mutually_exclusive():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--quiet", "--verbose", "doctor"])
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output.lower()
+
+
+def test_quiet_short_alias_sets_apm_progress(monkeypatch):
+    monkeypatch.delenv("APM_PROGRESS", raising=False)
+    seen: dict[str, str | None] = {}
+
+    def _capture_progress(*_args, **_kwargs):
+        seen["APM_PROGRESS"] = os.environ.get("APM_PROGRESS")
+
+    with (
+        patch("apm_cli.cli._check_and_notify_updates"),
+        patch("apm_cli.commands.config._show_all_user_config", side_effect=_capture_progress),
+    ):
+        result = CliRunner().invoke(cli, ["-q", "config", "list"])
+
+    assert result.exit_code == 0
+    assert seen.get("APM_PROGRESS") == "quiet"
+
+
+@patch("apm_cli.commands.install._validate_package_exists", return_value=False)
+def test_quiet_still_surfaces_validation_errors(mock_validate):
+    """Errors and warnings must remain visible under ``--quiet``."""
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli, ["--quiet", "install", "owner/nonexistent"])
+
+    assert result.exit_code != 0
+    assert mock_validate.called
+    output = result.output.lower()
+    assert "error" in output or "owner/nonexistent" in output
+
+
+def test_root_help_lists_quiet_flag():
+    result = CliRunner().invoke(cli, ["--help"])
+    assert result.exit_code == 0
+    assert "--quiet" in result.output or "-q" in result.output

--- a/tests/unit/test_command_logger.py
+++ b/tests/unit/test_command_logger.py
@@ -125,6 +125,21 @@ class TestCommandLogger:
         )
         mock_info.assert_called_once_with("retry with --force", symbol="info")
 
+    def test_apm_progress_never_does_not_enable_logger_quiet(self, monkeypatch):
+        """APM_PROGRESS=never only disables the TUI; it is not --quiet."""
+        monkeypatch.setenv("APM_PROGRESS", "never")
+        logger = CommandLogger("test")
+        assert logger._quiet is False
+
+    def test_install_logger_inherits_process_quiet(self):
+        from apm_cli.core.command_logger import configure_quiet_mode
+
+        configure_quiet_mode(True)
+        try:
+            assert InstallLogger()._quiet is True
+        finally:
+            configure_quiet_mode(False)
+
     @patch("apm_cli.core.command_logger._rich_echo")
     def test_verbose_detail_when_verbose(self, mock_echo):
         logger = CommandLogger("test", verbose=True)

--- a/tests/unit/test_command_logger.py
+++ b/tests/unit/test_command_logger.py
@@ -93,6 +93,38 @@ class TestCommandLogger:
         logger.warning("Careful!")
         mock_warning.assert_called_once_with("Careful!", symbol="warning")
 
+    @patch("apm_cli.core.command_logger._rich_info")
+    def test_progress_is_suppressed_when_quiet(self, mock_info):
+        logger = CommandLogger("test", quiet=True)
+        logger.progress("Downloading packages...")
+        mock_info.assert_not_called()
+
+    @patch("apm_cli.core.command_logger._rich_info")
+    def test_progress_emits_when_not_quiet(self, mock_info):
+        logger = CommandLogger("test")
+        logger.progress("Downloading packages...")
+        mock_info.assert_called_once_with("Downloading packages...", symbol="info")
+
+    @patch("apm_cli.core.command_logger._rich_info")
+    def test_mcp_lookup_heartbeat_is_suppressed_when_quiet(self, mock_info):
+        logger = CommandLogger("test", quiet=True)
+        logger.mcp_lookup_heartbeat(3)
+        mock_info.assert_not_called()
+
+    @patch("apm_cli.core.command_logger._rich_warning")
+    @patch("apm_cli.core.command_logger._rich_error")
+    @patch("apm_cli.core.command_logger._rich_info")
+    def test_quiet_still_emits_errors_warnings_and_info(self, mock_info, mock_error, mock_warning):
+        logger = CommandLogger("test", quiet=True)
+        logger.error("blocked by org policy")
+        logger.warning("cleanup skipped for user-edited file")
+        logger.info("retry with --force")
+        mock_error.assert_called_once_with("blocked by org policy", symbol="error")
+        mock_warning.assert_called_once_with(
+            "cleanup skipped for user-edited file", symbol="warning"
+        )
+        mock_info.assert_called_once_with("retry with --force", symbol="info")
+
     @patch("apm_cli.core.command_logger._rich_echo")
     def test_verbose_detail_when_verbose(self, mock_echo):
         logger = CommandLogger("test", verbose=True)


### PR DESCRIPTION
## Description

The environment-variables docs already promised a `--quiet` flag that the CLI did not implement:

> The CLI sets `APM_PROGRESS=quiet` when `--quiet` is passed.

(`docs/src/content/docs/reference/environment-variables.md`, `APM_PROGRESS` row.) Searching `src/apm_cli/cli.py` and `src/apm_cli/commands/install.py` on `main` found no `--quiet` / `APM_QUIET` handling. This PR makes that documented contract true and nothing more.

**Semantics**

- Root `--quiet` / `-q` sets `APM_PROGRESS=quiet` for the duration of the command so the existing install TUI (`should_animate()` already honors `never|quiet|off`) stays off.
- `--quiet` and `--verbose` are mutually exclusive (`UsageError`). Combining “show me everything” with “show me almost nothing” is rejected rather than silently picking a winner.
- Default invocation does not touch `APM_PROGRESS` and does not enable logger quiet mode. `APM_PROGRESS=never` (TUI off) is **not** treated as `--quiet`.
- Errors, warnings, and `CommandLogger.info` (advisory / recovery / org-policy / cleanup meaning) still print. Only `progress` (and the MCP lookup heartbeat, which is progress) is suppressed on `CommandLogger`. Security-significant output is not gated.
- `InstallLogger` and the install pipeline `_quiet` hook pick this up via a process flag set **only** when `--quiet` is passed (not by inferring quiet from `APM_PROGRESS=never`).

**Limitation (follow-up, not this PR):** there are on the order of 201 raw `print()` calls that bypass `CommandLogger` → `console.py`. `--quiet` does not migrate or suppress those. That is expected and left for a dedicated cleanup.

Fixes # (no issue)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

Documented-but-missing CLI contract (docs already described `--quiet`; the flag was absent). Docs notes were updated only to match the mutually exclusive `--verbose` rule.

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [x] Added tests for new functionality (if applicable)

```
$ uv run --extra dev pytest tests/unit tests/test_console.py -x
==== 20739 passed, 3 skipped, 21 xfailed, 20 warnings in 219.53s (0:03:39) =====

$ uv run --extra dev ruff check src/ tests/
All checks passed!

$ uv run --extra dev ruff format --check src/ tests/
All checks passed!
1696 files already formatted
```

New coverage: `--quiet` sets `APM_PROGRESS=quiet` during the command; default does not change `APM_PROGRESS`; `-q` alias; `--quiet --verbose` errors; validation errors still surface under `--quiet`; `progress` / MCP heartbeat suppressed; errors/warnings/`info` still emit; `APM_PROGRESS=never` does not imply logger quiet; `InstallLogger` inherits process quiet.

## Spec conformance (OpenAPM v0.1)

If this PR changes behaviour that an OpenAPM v0.1 `req-XXX` covers,
confirm the three-step ritual (see CONTRIBUTING.md "Adding or
changing a normative requirement"):

- [ ] Spec edit: `docs/src/content/docs/specs/openapm-v0.1.md` updated
      (new/changed `<a id="req-XXX"></a>` anchor + prose + Appendix C
      row).
- [ ] Manifest edit: `docs/src/content/docs/specs/manifests/openapm-v0.1.requirements.yml`
      updated.
- [ ] Test edit: a `@pytest.mark.req("req-XXX")` test under
      `tests/spec_conformance/` added or extended.
- [ ] `CONFORMANCE.{md,json}` regenerated via
      `uv run --extra dev python -m tests.spec_conformance.gen_statement`
      and committed.
- [x] N/A -- this PR does not change OpenAPM-observable behaviour.

This is a CLI convenience / output-mode flag. OpenAPM v0.1 does not define a quiet-progress requirement; no spec, manifest, `@pytest.mark.req`, or `CONFORMANCE.{md,json}` regeneration.