### PR TITLE
Suggest close marketplace plugin names when install cannot find a plugin

### DIFF
--- a/src/apm_cli/marketplace/errors.py
+++ b/src/apm_cli/marketplace/errors.py
@@ -28,13 +28,24 @@ class MarketplaceNotFoundError(MarketplaceError):
 class PluginNotFoundError(MarketplaceError):
     """Raised when a plugin is not found in a marketplace."""
 
-    def __init__(self, plugin_name: str, marketplace_name: str):
+    def __init__(
+        self,
+        plugin_name: str,
+        marketplace_name: str,
+        *,
+        suggestions: list[str] | None = None,
+    ):
         self.plugin_name = plugin_name
         self.marketplace_name = marketplace_name
-        super().__init__(
+        message = (
             f"Plugin '{plugin_name}' not found in marketplace '{marketplace_name}'. "
             f"Run 'apm marketplace browse {marketplace_name}' to see available plugins."
         )
+        if suggestions:
+            from ..utils.suggestions import format_close_match_hint
+
+            message += format_close_match_hint(suggestions, similar_label="Similar plugins")
+        super().__init__(message)
 
 
 class MarketplaceYmlError(MarketplaceError):

--- a/src/apm_cli/marketplace/resolver.py
+++ b/src/apm_cli/marketplace/resolver.py
@@ -857,7 +857,22 @@ def resolve_marketplace_plugin(
 
     plugin = manifest.find_plugin(plugin_name)
     if plugin is None:
-        raise PluginNotFoundError(plugin_name, marketplace_name)
+        from ..utils.suggestions import close_name_matches
+
+        plugin_names: list[str] = []
+        try:
+            plugin_names = [p.name for p in manifest.plugins]
+        except Exception:
+            logger.debug(
+                "Could not enumerate marketplace plugins for suggestions",
+                exc_info=True,
+            )
+        suggestions = close_name_matches(plugin_name, plugin_names)
+        raise PluginNotFoundError(
+            plugin_name,
+            marketplace_name,
+            suggestions=suggestions,
+        )
 
     if plugin.registry:
         selector = version_spec or plugin.version

--- a/src/apm_cli/utils/suggestions.py
+++ b/src/apm_cli/utils/suggestions.py
@@ -1,0 +1,54 @@
+"""Close-match suggestion helpers for user-facing CLI errors."""
+
+from __future__ import annotations
+
+import difflib
+from collections.abc import Iterable
+
+_CLOSE_MATCH_COUNT = 3
+_CLOSE_MATCH_CUTOFF = 0.6
+
+
+def close_name_matches(query: str, candidates: Iterable[str] | None) -> list[str]:
+    """Return up to three close matches for *query* among *candidates*.
+
+    Uses the same ``difflib.get_close_matches`` cutoff and count as
+    experimental flag-name suggestions. Returns no matches when the
+    candidate list cannot be read, rather than raising.
+    """
+    if not query:
+        return []
+    try:
+        names = [str(name) for name in (candidates or []) if name]
+    except Exception:
+        return []
+    if not names:
+        return []
+
+    by_lower: dict[str, str] = {}
+    for name in names:
+        by_lower.setdefault(name.lower(), name)
+
+    try:
+        matches = difflib.get_close_matches(
+            query.lower(),
+            list(by_lower.keys()),
+            n=_CLOSE_MATCH_COUNT,
+            cutoff=_CLOSE_MATCH_CUTOFF,
+        )
+    except Exception:
+        return []
+    return [by_lower[match] for match in matches]
+
+
+def format_close_match_hint(
+    suggestions: list[str],
+    *,
+    similar_label: str = "Similar",
+) -> str:
+    """Format close-match suggestions for appending to an error message."""
+    if not suggestions:
+        return ""
+    if len(suggestions) == 1:
+        return f" Did you mean: {suggestions[0]}?"
+    return f" {similar_label}: {', '.join(suggestions)}"

--- a/tests/unit/commands/test_install_suggestions.py
+++ b/tests/unit/commands/test_install_suggestions.py
@@ -1,0 +1,132 @@
+"""Install not-found suggestions surfaced through package resolution."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from apm_cli.commands.install import _resolve_package_references
+from apm_cli.marketplace.errors import PluginNotFoundError
+
+
+class TestInstallMarketplaceNotFoundSuggestions:
+    def test_near_miss_plugin_surfaces_suggestion_in_invalid_outcome(self):
+        with (
+            patch(
+                "apm_cli.marketplace.resolver.parse_marketplace_ref",
+                return_value=("apm-review-panl", "apm-marketplace", None),
+            ),
+            patch(
+                "apm_cli.marketplace.resolver.resolve_marketplace_plugin",
+                side_effect=PluginNotFoundError(
+                    "apm-review-panl",
+                    "apm-marketplace",
+                    suggestions=["apm-review-panel"],
+                ),
+            ),
+        ):
+            _valid, invalid, _validated, _mkt, _entries, _changed = _resolve_package_references(
+                ["apm-review-panl@apm-marketplace"],
+                [],
+                set(),
+            )
+
+        assert len(invalid) == 1
+        _package, reason = invalid[0]
+        assert _package == "apm-review-panl@apm-marketplace"
+        assert "Did you mean: apm-review-panel?" in reason
+        assert "apm marketplace browse apm-marketplace" in reason
+
+    def test_wild_plugin_name_has_no_suggestion(self):
+        with (
+            patch(
+                "apm_cli.marketplace.resolver.parse_marketplace_ref",
+                return_value=("completely-unrelated-package", "apm-marketplace", None),
+            ),
+            patch(
+                "apm_cli.marketplace.resolver.resolve_marketplace_plugin",
+                side_effect=PluginNotFoundError(
+                    "completely-unrelated-package",
+                    "apm-marketplace",
+                ),
+            ),
+        ):
+            _valid, invalid, _validated, _mkt, _entries, _changed = _resolve_package_references(
+                ["completely-unrelated-package@apm-marketplace"],
+                [],
+                set(),
+            )
+
+        _package, reason = invalid[0]
+        assert "Did you mean" not in reason
+        assert "Similar plugins" not in reason
+
+    def test_marketplace_resolution_failure_falls_back_to_plain_message(self):
+        with (
+            patch(
+                "apm_cli.marketplace.resolver.parse_marketplace_ref",
+                return_value=("missing-plugin", "apm-marketplace", None),
+            ),
+            patch(
+                "apm_cli.marketplace.resolver.resolve_marketplace_plugin",
+                side_effect=RuntimeError("catalog unavailable"),
+            ),
+        ):
+            _valid, invalid, _validated, _mkt, _entries, _changed = _resolve_package_references(
+                ["missing-plugin@apm-marketplace"],
+                [],
+                set(),
+            )
+
+        _package, reason = invalid[0]
+        assert reason == "catalog unavailable"
+        assert "Did you mean" not in reason
+
+
+class TestInstallMarketplaceNotFoundExitCode:
+    @patch("apm_cli.commands.install._validate_package_exists", return_value=True)
+    def test_marketplace_not_found_preserves_validation_failure_contract(self, _mock_validate):
+        """Marketplace not-found still lands in invalid_outcomes (exit path unchanged)."""
+        import contextlib
+        import os
+        import tempfile
+        from pathlib import Path
+
+        from click.testing import CliRunner
+
+        from apm_cli.cli import cli
+
+        runner = CliRunner()
+        try:
+            original_dir = os.getcwd()
+        except FileNotFoundError:
+            original_dir = str(Path(__file__).parent.parent.parent)
+
+        @contextlib.contextmanager
+        def _chdir_tmp():
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                try:
+                    os.chdir(tmp_dir)
+                    yield Path(tmp_dir)
+                finally:
+                    os.chdir(original_dir)
+
+        with (
+            _chdir_tmp(),
+            patch(
+                "apm_cli.marketplace.resolver.parse_marketplace_ref",
+                return_value=("apm-review-panl", "apm-marketplace", None),
+            ),
+            patch(
+                "apm_cli.marketplace.resolver.resolve_marketplace_plugin",
+                side_effect=PluginNotFoundError(
+                    "apm-review-panl",
+                    "apm-marketplace",
+                    suggestions=["apm-review-panel"],
+                ),
+            ),
+        ):
+            result = runner.invoke(cli, ["install", "apm-review-panl@apm-marketplace"])
+
+        assert result.exit_code == 1
+        assert "All packages failed validation" in result.output
+        assert "Did you mean: apm-review-panel?" in result.output

--- a/tests/unit/marketplace/test_marketplace_errors.py
+++ b/tests/unit/marketplace/test_marketplace_errors.py
@@ -47,6 +47,34 @@ class TestMarketplaceErrors:
         assert err.plugin_name == "my-plugin"
         assert err.marketplace_name == "acme"
 
+    def test_plugin_not_found_message_with_single_suggestion(self):
+        err = PluginNotFoundError(
+            "apm-review-panl",
+            "acme",
+            suggestions=["apm-review-panel"],
+        )
+        text = str(err)
+        assert text.startswith(
+            "Plugin 'apm-review-panl' not found in marketplace 'acme'. "
+            "Run 'apm marketplace browse acme' to see available plugins."
+        )
+        assert "Did you mean: apm-review-panel?" in text
+
+    def test_plugin_not_found_message_with_multiple_suggestions(self):
+        err = PluginNotFoundError(
+            "apm-review",
+            "acme",
+            suggestions=["apm-review-panel", "apm-triage-panel"],
+        )
+        assert "Similar plugins: apm-review-panel, apm-triage-panel" in str(err)
+
+    def test_plugin_not_found_message_without_suggestions_unchanged(self):
+        err = PluginNotFoundError("my-plugin", "acme", suggestions=[])
+        assert str(err) == (
+            "Plugin 'my-plugin' not found in marketplace 'acme'. "
+            "Run 'apm marketplace browse acme' to see available plugins."
+        )
+
     def test_fetch_error_message(self):
         err = MarketplaceFetchError("acme", "timeout")
         assert "acme" in str(err)

--- a/tests/unit/marketplace/test_versioned_resolver.py
+++ b/tests/unit/marketplace/test_versioned_resolver.py
@@ -154,6 +154,31 @@ class TestResolveMarketplacePlugin:
         """PluginNotFoundError when plugin is not in manifest."""
         from apm_cli.marketplace.errors import PluginNotFoundError
 
+        plugin = _make_plugin()
+        manifest = _make_manifest(plugin)
+        source = _make_source()
+
+        with (
+            patch(
+                "apm_cli.marketplace.resolver.get_marketplace_by_name",
+                return_value=source,
+            ),
+            patch(
+                "apm_cli.marketplace.resolver.fetch_or_cache",
+                return_value=manifest,
+            ),
+            pytest.raises(PluginNotFoundError) as exc_info,
+        ):
+            resolve_marketplace_plugin("my-plgin", "test-mkt")
+
+        err = exc_info.value
+        assert err.plugin_name == "my-plgin"
+        assert "Did you mean: my-plugin?" in str(err)
+        assert "apm marketplace browse test-mkt" in str(err)
+
+    def test_plugin_not_found_omits_suggestion_for_distant_name(self):
+        from apm_cli.marketplace.errors import PluginNotFoundError
+
         plugin = _make_plugin(name="existing")
         manifest = _make_manifest(plugin)
         source = _make_source()
@@ -167,9 +192,44 @@ class TestResolveMarketplacePlugin:
                 "apm_cli.marketplace.resolver.fetch_or_cache",
                 return_value=manifest,
             ),
-            pytest.raises(PluginNotFoundError),
+            pytest.raises(PluginNotFoundError) as exc_info,
         ):
-            resolve_marketplace_plugin("nonexistent", "test-mkt")
+            resolve_marketplace_plugin("zzzz-completely-unrelated-xyzqwerty", "test-mkt")
+
+        text = str(exc_info.value)
+        assert "Did you mean" not in text
+        assert "Similar plugins" not in text
+
+    def test_plugin_not_found_skips_suggestion_when_names_unreadable(self):
+        """A broken plugin list must not change the not-found error into a crash."""
+        from apm_cli.marketplace.errors import PluginNotFoundError
+
+        class BrokenManifest:
+            def find_plugin(self, _name):
+                return None
+
+            @property
+            def plugins(self):
+                raise RuntimeError("cache unreadable")
+
+        source = _make_source()
+
+        with (
+            patch(
+                "apm_cli.marketplace.resolver.get_marketplace_by_name",
+                return_value=source,
+            ),
+            patch(
+                "apm_cli.marketplace.resolver.fetch_or_cache",
+                return_value=BrokenManifest(),
+            ),
+            pytest.raises(PluginNotFoundError) as exc_info,
+        ):
+            resolve_marketplace_plugin("my-plgin", "test-mkt")
+
+        text = str(exc_info.value)
+        assert "Did you mean" not in text
+        assert "Plugin 'my-plgin' not found in marketplace 'test-mkt'" in text
 
     def test_semver_range_uses_custom_tag_pattern(self):
         """Semver range resolution passes plugin.tag_pattern to resolve_version_constraint."""

--- a/tests/unit/utils/test_suggestions.py
+++ b/tests/unit/utils/test_suggestions.py
@@ -1,0 +1,52 @@
+"""Tests for close-match suggestion helpers."""
+
+from __future__ import annotations
+
+from apm_cli.utils.suggestions import close_name_matches, format_close_match_hint
+
+
+class TestCloseNameMatches:
+    def test_near_miss_returns_suggestion(self):
+        candidates = ["apm-review-panel", "apm-triage-panel", "shepherd-driver"]
+        matches = close_name_matches("apm-review-panl", candidates)
+        assert matches[0] == "apm-review-panel"
+        assert "shepherd-driver" not in matches
+
+    def test_wildly_different_name_returns_no_suggestion(self):
+        candidates = ["apm-review-panel", "apm-triage-panel", "shepherd-driver"]
+        assert close_name_matches("completely-unrelated-package", candidates) == []
+
+    def test_empty_candidates_returns_no_suggestion(self):
+        assert close_name_matches("apm-review-panel", []) == []
+
+    def test_empty_query_returns_no_suggestion(self):
+        assert close_name_matches("", ["apm-review-panel"]) == []
+
+    def test_none_or_unreadable_candidates_return_no_suggestion(self):
+        assert close_name_matches("apm-review-panl", None) == []
+
+        class Boom:
+            def __iter__(self):
+                raise RuntimeError("marketplace cache unreadable")
+
+        assert close_name_matches("apm-review-panl", Boom()) == []
+
+    def test_match_is_case_insensitive_but_preserves_canonical_name(self):
+        assert close_name_matches("APM-REVIEW-PANL", ["apm-review-panel"]) == ["apm-review-panel"]
+
+
+class TestFormatCloseMatchHint:
+    def test_single_suggestion(self):
+        assert format_close_match_hint(["apm-review-panel"]) == " Did you mean: apm-review-panel?"
+
+    def test_multiple_suggestions(self):
+        assert (
+            format_close_match_hint(
+                ["apm-review-panel", "apm-triage-panel"],
+                similar_label="Similar plugins",
+            )
+            == " Similar plugins: apm-review-panel, apm-triage-panel"
+        )
+
+    def test_no_suggestions_returns_empty_string(self):
+        assert format_close_match_hint([]) == ""


### PR DESCRIPTION
## Description

When `apm install <plugin>@<marketplace>` cannot find the plugin, the error already tells the user to run `apm marketplace browse`. This change also appends a close-match hint from that marketplace's already-fetched plugin catalog, using the same stdlib `difflib.get_close_matches` cutoff (`0.6`) and suggestion count (`n=3`) as experimental flag-name hints.

Remote `owner/repo` misses are unchanged: there is no enumerable candidate set without inventing GitHub search. Already-installed package names are also skipped: a "not accessible" failure is often auth or existence, and suggesting a package already in `apm.yml` would send people down the wrong recovery path.

Fixes # (no linked issue)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [x] Added tests for new functionality (if applicable)

```
uv run --extra dev pytest tests/unit tests/test_console.py -x
==== 20744 passed, 3 skipped, 21 xfailed, 20 warnings in 233.93s (0:03:53) =====

uv run --extra dev ruff check src/ tests/
All checks passed!

uv run --extra dev ruff format --check src/ tests/
1698 files already formatted
```

## Spec conformance (OpenAPM v0.1)

If this PR changes behaviour that an OpenAPM v0.1 `req-XXX` covers,
confirm the three-step ritual (see CONTRIBUTING.md "Adding or
changing a normative requirement"):

- [ ] Spec edit: `docs/src/content/docs/specs/openapm-v0.1.md` updated
      (new/changed `<a id="req-XXX"></a>` anchor + prose + Appendix C
      row).
- [ ] Manifest edit: `docs/src/content/docs/specs/manifests/openapm-v0.1.requirements.yml`
      updated.
- [ ] Test edit: a `@pytest.mark.req("req-XXX")` test under
      `tests/spec_conformance/` added or extended.
- [ ] `CONFORMANCE.{md,json}` regenerated via
      `uv run --extra dev python -m tests.spec_conformance.gen_statement`
      and committed.
- [x] N/A -- this PR does not change OpenAPM-observable behaviour.

This is an APM CLI error-message improvement on the marketplace install miss path. It does not change lockfile records, resolution identity, fetch, or any consumer MUST in OpenAPM v0.1.

## Error output (before / after)

Marketplace plugin typo, catalog already in hand:

**Before**

```
[x] apm-review-panl@apm-marketplace -- Plugin 'apm-review-panl' not found in marketplace 'apm-marketplace'. Run 'apm marketplace browse apm-marketplace' to see available plugins.
```

**After** (existing text preserved; hint appended)

```
[x] apm-review-panl@apm-marketplace -- Plugin 'apm-review-panl' not found in marketplace 'apm-marketplace'. Run 'apm marketplace browse apm-marketplace' to see available plugins. Did you mean: apm-review-panel?
```

Wildly different names still get the original browse hint with no suggestion. If the plugin list cannot be read, the original message is used and install still exits `1`.
