### PR TITLE
fix(view): drop stray positional arg in resolve_marketplace_plugin call

### DIFF
--- a/src/apm_cli/commands/view.py
+++ b/src/apm_cli/commands/view.py
@@ -272,7 +272,6 @@ def _display_marketplace_plugin(
         canonical_str, _resolved = resolve_marketplace_plugin(
             plugin_name,
             marketplace_name,
-            plugin,
         )
         resolved_display = canonical_str
     except Exception:

--- a/tests/unit/test_view_command.py
+++ b/tests/unit/test_view_command.py
@@ -807,6 +807,53 @@ class TestViewMarketplaceNoField(_InfoCmdBase):
 
         assert result.exit_code == 0
 
+    def test_marketplace_ref_shows_resolved_reference(self):
+        """``apm view plugin@mkt`` renders the resolved canonical reference.
+
+        Regression: ``_display_marketplace_plugin`` used to pass the plugin row
+        as a third positional argument to ``resolve_marketplace_plugin``, which
+        only accepts two positionals.  The resulting ``TypeError`` was swallowed
+        by the surrounding ``except Exception: pass``, so the ``Resolved:`` line
+        silently disappeared instead of failing loudly.  ``autospec=True`` makes
+        the patched callable enforce the real signature, so this test fails if
+        the call site drifts from it again.
+        """
+        from apm_cli.marketplace.models import (
+            MarketplaceManifest,
+            MarketplacePlugin,
+            MarketplaceSource,
+        )
+
+        plugin = MarketplacePlugin(
+            name="my-plugin",
+            source={"type": "github", "repo": "acme/plugin", "ref": "main"},
+            version="2.0.0",
+        )
+        manifest = MarketplaceManifest(name="acme-tools", plugins=(plugin,))
+        source = MarketplaceSource(name="acme-tools", owner="acme", repo="marketplace")
+
+        with (
+            patch(
+                "apm_cli.marketplace.registry.get_marketplace_by_name",
+                return_value=source,
+            ),
+            patch(
+                "apm_cli.marketplace.client.fetch_or_cache",
+                return_value=manifest,
+            ),
+            patch(
+                "apm_cli.marketplace.resolver.resolve_marketplace_plugin",
+                autospec=True,
+                return_value=("acme/plugin@main", plugin),
+            ) as mock_resolve,
+            _force_rich_fallback(),
+        ):
+            result = self.runner.invoke(cli, ["view", "my-plugin@acme-tools"])
+
+        assert result.exit_code == 0
+        mock_resolve.assert_called_once_with("my-plugin", "acme-tools")
+        assert "acme/plugin@main" in result.output
+
     def test_non_marketplace_ref_still_uses_local_path(self):
         """``apm view org/repo`` still falls through to local metadata lookup."""
         with self._chdir_tmp() as tmp:


### PR DESCRIPTION
## Problem

`_display_marketplace_plugin` in `src/apm_cli/commands/view.py` calls the
resolver with **three** positional arguments:

```python
canonical_str, _resolved = resolve_marketplace_plugin(
    plugin_name,
    marketplace_name,
    plugin,          # <-- third positional
)
```

but `resolve_marketplace_plugin` (`src/apm_cli/marketplace/resolver.py:806`)
accepts only two — everything after the `*` is keyword-only:

```python
def resolve_marketplace_plugin(
    plugin_name: str,
    marketplace_name: str,
    *,
    version_spec: str | None = None,
    auth_resolver: object | None = None,
    warning_handler: Callable[[str], None] | None = None,
) -> MarketplacePluginResolution:
```

So the call raises `TypeError: resolve_marketplace_plugin() takes 2 positional
arguments but 3 were given`. Because the call sits inside
`try: ... except Exception: pass`, the error is swallowed and
`resolved_display` stays `None` — `apm view <plugin>@<marketplace>` silently
drops the `Resolved:` line rather than failing loudly.

## Why this is the right fix

The three other call sites in the repo all pass exactly two positionals and
route everything else through keywords:

| call site | positional args |
|---|---|
| `commands/install.py:331` | 2 (+ `version_spec`, `auth_resolver`, `warning_handler`) |
| `commands/uninstall/engine.py:531` | 2 (+ `auth_resolver`) |
| `deps/apm_resolver.py:534` | 2 (+ `version_spec`, `auth_resolver`, `warning_handler`) |
| `commands/view.py:272` | **3** ← the outlier |

The `plugin` row is already in scope in `view.py` (from
`manifest.find_plugin(plugin_name)` a few lines above) and the resolver looks
the plugin up itself, so the third argument is simply redundant. Dropping it
restores the documented two-positional contract.

## Verification

Signature replay against the real sources (`inspect.Signature.bind` on a
signature reconstructed from `resolver.py`), with the three healthy call sites
as a control group:

```
def resolve_marketplace_plugin(plugin_name, marketplace_name, *, version_spec=None,
                               auth_resolver=None, warning_handler=None)
  PASS  install.py:331   [control]  (2 pos, kw=['version_spec','auth_resolver','warning_handler'])
  PASS  engine.py:531    [control]  (2 pos, kw=['auth_resolver'])
  PASS  apm_resolver.py:534 [control] (2 pos, kw=['version_spec','auth_resolver','warning_handler'])
  FAIL  view.py:272      [SUSPECT]  (3 pos, kw=[])
          -> TypeError: too many positional arguments
```

Test suite and lint, both with the pinned toolchain:

```
$ uv run --frozen python -m pytest tests/unit/test_view_command.py
49 passed

$ ruff 0.15.12 check src/apm_cli/commands/view.py tests/unit/test_view_command.py
All checks passed!
$ ruff 0.15.12 format --check src/apm_cli/commands/view.py tests/unit/test_view_command.py
2 files already formatted
```

## Regression test

`test_marketplace_ref_shows_resolved_reference` patches the resolver with
`autospec=True`, so the mock enforces the real signature instead of silently
accepting any arity. Checked against the unpatched code — it fails there:

```
$ git checkout -- src/apm_cli/commands/view.py   # restore the bug
$ uv run --frozen python -m pytest -k test_marketplace_ref_shows_resolved_reference
E  AssertionError: Expected 'resolve_marketplace_plugin' to be called once. Called 0 times.
1 failed
```

(The autospec mock raises `TypeError` before recording the call, and the
surrounding `except Exception: pass` swallows it — which is precisely the
silent-failure mode this PR removes.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
