### PR TITLE
fix: preserve deployments when integration is skipped (closes #2744)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `apm install` now preserves previously deployed skills when package
+  integration is skipped instead of treating them as stale cleanup candidates.
+  (#2758)
 - `apm install` no longer silently drops instruction Markdown whose
   unfenced bodies contain `---` horizontal rules. It now stops the whole package
   before deploying any primitive when instruction frontmatter is invalid YAML or

--- a/src/apm_cli/install/context.py
+++ b/src/apm_cli/install/context.py
@@ -140,6 +140,7 @@ class InstallContext:
     # Integrate phase outputs (written by integrate, read by cleanup/lockfile/summary)
     # ------------------------------------------------------------------
     intended_dep_keys: set[str] = field(default_factory=set)
+    # Absent means integration skipped; empty means it completed with no files.
     package_deployed_files: dict[str, list[str]] = field(default_factory=dict)
     # Cleanup refusals retain the original lockfile hash, not a hash of
     # user-edited bytes. Lockfile assembly consumes this after cleanup.

--- a/src/apm_cli/install/sources.py
+++ b/src/apm_cli/install/sources.py
@@ -491,10 +491,9 @@ class CachedDependencySource(DependencySource):
                 details = "; ".join(native_validation.errors) or "validator returned no package"
                 raise DirectDependencyError(f"Cached Agent Plugin is invalid: {details}")
 
-        # Skip integration entirely if no targets.  The template will
-        # write the empty deployed_files entry on its own (single source
-        # of truth), so we just signal "skip integration" via
-        # package_info=None.
+        # Skip integration entirely if no targets. The template leaves this
+        # dependency absent from the integration outcome so cleanup and
+        # lockfile reconciliation preserve its prior deployment claims.
         # In lockfile_only mode, skip this early return so installed_packages
         # is populated before we return without deploying any files.
         if not ctx.targets and not ctx.lockfile_only and native_validation is None:

--- a/src/apm_cli/install/template.py
+++ b/src/apm_cli/install/template.py
@@ -321,10 +321,9 @@ def _integrate_materialization(
             return deltas
 
     # No-op when targets are empty or acquire decided to skip integration
-    # (signalled by package_info=None).  Still record an empty deployed
-    # list so cleanup phase has a deterministic state.
+    # (signalled by package_info=None). Leave this dependency absent from the
+    # integration outcome so cleanup does not treat every prior file as stale.
     if m.package_info is None or not ctx.targets:
-        ctx.package_deployed_files[dep_key] = []
         return deltas
 
     try:

--- a/tests/integration/test_skipped_integration_preserves_deployments.py
+++ b/tests/integration/test_skipped_integration_preserves_deployments.py
@@ -1,0 +1,80 @@
+"""Skipped-integration deployment preservation contract."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from apm_cli.core.scope import InstallScope
+from apm_cli.deps.lockfile import LockedDependency, LockFile
+from apm_cli.install.phases import cleanup
+from apm_cli.install.phases.lockfile import LockfileBuilder
+from apm_cli.install.sources import Materialization
+from apm_cli.install.template import run_integration_template
+from apm_cli.utils.content_hash import compute_file_hash
+from apm_cli.utils.diagnostics import DiagnosticCollector
+
+pytestmark = [pytest.mark.integration, pytest.mark.component]
+
+
+def test_skipped_integration_preserves_prior_files_and_lock_claims(
+    tmp_path: Path,
+) -> None:
+    """Keep real deployed skills and their lock claims when integration skips."""
+    dep_key = "owner/package"
+    deployed_files = [f".agents/skills/skill-{index:02d}/SKILL.md" for index in range(24)]
+    deployed_hashes = {}
+    for relative in deployed_files:
+        deployed_path = tmp_path / relative
+        deployed_path.parent.mkdir(parents=True)
+        deployed_path.write_text(f"# {relative}\n", encoding="ascii")
+        deployed_hashes[relative] = compute_file_hash(deployed_path)
+
+    previous = LockFile()
+    previous.add_dependency(
+        LockedDependency(
+            repo_url=dep_key,
+            deployed_files=deployed_files,
+            deployed_file_hashes=deployed_hashes,
+        )
+    )
+    current = LockFile()
+    current.add_dependency(LockedDependency(repo_url=dep_key))
+    diagnostics = DiagnosticCollector()
+    ctx = SimpleNamespace(
+        existing_lockfile=previous,
+        only_packages=False,
+        intended_dep_keys={dep_key},
+        package_deployed_files={},
+        orphan_cleanup_retained={},
+        package_cleanup_retained={},
+        project_root=tmp_path,
+        targets=[],
+        diagnostics=diagnostics,
+        logger=None,
+        scope=InstallScope.PROJECT,
+        skill_subset_from_cli=False,
+        skill_subset=None,
+    )
+    source = SimpleNamespace(
+        ctx=ctx,
+        dep_ref=SimpleNamespace(is_local=False, local_path=None),
+        INTEGRATE_ERROR_PREFIX="Failed to integrate primitives",
+    )
+
+    run_integration_template(
+        source,
+        materialization=Materialization(
+            package_info=None,
+            install_path=tmp_path / "unused",
+            dep_key=dep_key,
+            deltas={"installed": 0},
+        ),
+    )
+    cleanup.run(ctx)
+    LockfileBuilder(ctx)._attach_deployed_files(current)
+
+    assert ctx.package_deployed_files == {}
+    assert all((tmp_path / relative).is_file() for relative in deployed_files)
+    assert current.get_dependency(dep_key).deployed_files == deployed_files
+    assert current.get_dependency(dep_key).deployed_file_hashes == deployed_hashes

--- a/tests/integration/test_skipped_integration_preserves_deployments.py
+++ b/tests/integration/test_skipped_integration_preserves_deployments.py
@@ -22,6 +22,9 @@ def test_skipped_integration_preserves_prior_files_and_lock_claims(
 ) -> None:
     """Keep real deployed skills and their lock claims when integration skips."""
     dep_key = "owner/package"
+    prior_commit = "a" * 40
+    current_commit = "b" * 40
+    current_content_hash = "sha256:new-package"
     deployed_files = [f".agents/skills/skill-{index:02d}/SKILL.md" for index in range(24)]
     deployed_hashes = {}
     for relative in deployed_files:
@@ -34,12 +37,14 @@ def test_skipped_integration_preserves_prior_files_and_lock_claims(
     previous.add_dependency(
         LockedDependency(
             repo_url=dep_key,
+            resolved_commit=prior_commit,
+            content_hash="sha256:prior-package",
             deployed_files=deployed_files,
             deployed_file_hashes=deployed_hashes,
         )
     )
     current = LockFile()
-    current.add_dependency(LockedDependency(repo_url=dep_key))
+    current.add_dependency(LockedDependency(repo_url=dep_key, resolved_commit=current_commit))
     diagnostics = DiagnosticCollector()
     ctx = SimpleNamespace(
         existing_lockfile=previous,
@@ -48,6 +53,7 @@ def test_skipped_integration_preserves_prior_files_and_lock_claims(
         package_deployed_files={},
         orphan_cleanup_retained={},
         package_cleanup_retained={},
+        package_hashes={dep_key: current_content_hash},
         project_root=tmp_path,
         targets=[],
         diagnostics=diagnostics,
@@ -55,6 +61,7 @@ def test_skipped_integration_preserves_prior_files_and_lock_claims(
         scope=InstallScope.PROJECT,
         skill_subset_from_cli=False,
         skill_subset=None,
+        update_refs=True,
     )
     source = SimpleNamespace(
         ctx=ctx,
@@ -72,9 +79,14 @@ def test_skipped_integration_preserves_prior_files_and_lock_claims(
         ),
     )
     cleanup.run(ctx)
-    LockfileBuilder(ctx)._attach_deployed_files(current)
+    builder = LockfileBuilder(ctx)
+    builder._attach_deployed_files(current)
+    builder._attach_content_hashes(current)
 
     assert ctx.package_deployed_files == {}
     assert all((tmp_path / relative).is_file() for relative in deployed_files)
-    assert current.get_dependency(dep_key).deployed_files == deployed_files
-    assert current.get_dependency(dep_key).deployed_file_hashes == deployed_hashes
+    locked = current.get_dependency(dep_key)
+    assert locked.resolved_commit == current_commit
+    assert locked.content_hash == current_content_hash
+    assert locked.deployed_files == deployed_files
+    assert locked.deployed_file_hashes == deployed_hashes

--- a/tests/spec_conformance/mode_b_detector.sh
+++ b/tests/spec_conformance/mode_b_detector.sh
@@ -95,14 +95,17 @@ if [ -z "$RAW_DIFF" ]; then
   exit 0
 fi
 
-ADDED="$(printf '%s\n' "$RAW_DIFF" \
-  | grep -E '^\+[^+]' \
-  | grep -vE '^\+\s*$' \
-  | grep -vE '^\+\s*(#|"""|'\'')' \
-  | grep -vE '^\+\s*(from |import )' \
-  | grep -vE '^\+\s*@' \
-  | grep -vE '^\+\s*[a-zA-Z_][a-zA-Z0-9_]*\s*:\s*[A-Za-z_][A-Za-z0-9_\[\], |\.]*\s*(=.*)?$' \
-  | wc -l | tr -d ' ' || true)"
+ADDED="$(printf '%s\n' "$RAW_DIFF" | awk '
+  /^\+[^+]/ &&
+  !/^\+[[:space:]]*$/ &&
+  !/^\+[[:space:]]*(#|"""|'\'')/ &&
+  !/^\+[[:space:]]*(from |import )/ &&
+  !/^\+[[:space:]]*@/ &&
+  !/^\+[[:space:]]*[a-zA-Z_][a-zA-Z0-9_]*[[:space:]]*:[[:space:]]*[A-Za-z_][A-Za-z0-9_\[\], |.]*[[:space:]]*(=.*)?$/ {
+    count++
+  }
+  END { print count + 0 }
+')"
 
 if [ "$ADDED" -lt "$THRESHOLD" ]; then
   echo "[+] mode_b: ${ADDED} substantive added lines (< ${THRESHOLD}); OK"

--- a/tests/spec_conformance/mode_b_detector.sh
+++ b/tests/spec_conformance/mode_b_detector.sh
@@ -102,7 +102,7 @@ ADDED="$(printf '%s\n' "$RAW_DIFF" \
   | grep -vE '^\+\s*(from |import )' \
   | grep -vE '^\+\s*@' \
   | grep -vE '^\+\s*[a-zA-Z_][a-zA-Z0-9_]*\s*:\s*[A-Za-z_][A-Za-z0-9_\[\], |\.]*\s*(=.*)?$' \
-  | wc -l | tr -d ' ')"
+  | wc -l | tr -d ' ' || true)"
 
 if [ "$ADDED" -lt "$THRESHOLD" ]; then
   echo "[+] mode_b: ${ADDED} substantive added lines (< ${THRESHOLD}); OK"

--- a/tests/spec_conformance/test_mode_b_detector.py
+++ b/tests/spec_conformance/test_mode_b_detector.py
@@ -130,6 +130,23 @@ def test_detector_passes_on_out_of_scope_only(tmp_path):
     assert "no critical-path diff" in out.stdout, out.stdout
 
 
+def test_detector_passes_when_critical_diff_has_no_substantive_additions(tmp_path):
+    """A comment-only critical-path diff MUST report zero and exit 0."""
+    repo = _make_repo(tmp_path)
+    target = repo / "src" / "apm_cli" / "install" / ".keep"
+    target.write_text("# Clarify existing behavior.\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "clarify install comment")
+
+    out = _run_detector(repo)
+
+    assert out.returncode == 0, (
+        f"comment-only diff MUST pass; got exit {out.returncode}\n"
+        f"stdout: {out.stdout}\nstderr: {out.stderr}"
+    )
+    assert "0 substantive added lines" in out.stdout, out.stdout
+
+
 def test_detector_fires_on_substantive_critical_path_add(tmp_path):
     """Substantive critical-path add with NO spec edit MUST fire."""
     repo = _make_repo(tmp_path)

--- a/tests/unit/install/phases/test_cleanup_phase.py
+++ b/tests/unit/install/phases/test_cleanup_phase.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from apm_cli.install.phases import cleanup
+from apm_cli.install.sources import Materialization
+from apm_cli.install.template import run_integration_template
 from apm_cli.integration.cleanup import CleanupResult
 
 
@@ -325,6 +328,55 @@ class TestStaleCleanupNoPackageDeployedFiles:
         ctx = _make_ctx(existing_lockfile=lf, package_deployed_files={})
         cleanup.run(ctx)
         ctx.logger.stale_cleanup.assert_not_called()
+
+    def test_skipped_integration_does_not_mark_prior_skills_stale(self):
+        prior_skills = [f".agents/skills/skill-{index:02d}/SKILL.md" for index in range(24)]
+        previous = _make_orphan_dep(prior_skills)
+        ctx = _make_ctx(
+            existing_lockfile=_make_lockfile({"pkg": previous}),
+            intended_dep_keys={"pkg"},
+            package_deployed_files={},
+        )
+        source = SimpleNamespace(
+            ctx=ctx,
+            dep_ref=SimpleNamespace(is_local=False, local_path=None),
+            INTEGRATE_ERROR_PREFIX="Failed to integrate primitives",
+        )
+        ctx.skill_subset_from_cli = False
+        ctx.skill_subset = None
+
+        run_integration_template(
+            source,
+            materialization=Materialization(
+                package_info=None,
+                install_path=Path("/unused"),
+                dep_key="pkg",
+                deltas={"installed": 0},
+            ),
+        )
+
+        with patch(
+            "apm_cli.install.phases.cleanup.remove_stale_deployed_files",
+            return_value=CleanupResult(),
+        ) as remove_stale:
+            cleanup.run(ctx)
+
+        assert ctx.package_deployed_files == {}
+        remove_stale.assert_not_called()
+
+    def test_completed_integration_with_same_prior_skills_has_no_stale_cleanup(self):
+        deployed_skills = [f".agents/skills/skill-{index:02d}/SKILL.md" for index in range(24)]
+        previous = _make_orphan_dep(deployed_skills)
+        ctx = _make_ctx(
+            existing_lockfile=_make_lockfile({"pkg": previous}),
+            intended_dep_keys={"pkg"},
+            package_deployed_files={"pkg": list(deployed_skills)},
+        )
+
+        with patch("apm_cli.install.phases.cleanup.remove_stale_deployed_files") as remove_stale:
+            cleanup.run(ctx)
+
+        remove_stale.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/install/test_agent_plugin_deployment_boundary.py
+++ b/tests/unit/install/test_agent_plugin_deployment_boundary.py
@@ -262,7 +262,7 @@ def test_materialization_without_package_metadata_preserves_no_target_noop(tmp_p
     deltas = run_integration_template(source)
 
     assert deltas == {"installed": 0}
-    assert ctx.package_deployed_files == {"owner/package": []}
+    assert ctx.package_deployed_files == {}
     assert diagnostics.error_count == 0
 
 


### PR DESCRIPTION
## Problem

A skipped package integration was recorded as a completed empty deployment. Stale cleanup then interpreted every file from the prior lockfile as removed and deleted deployed skills.

## Approach

Leave skipped packages absent from the run integration outcome. Cleanup therefore ignores them, and lockfile reconciliation preserves their prior deployment claims.

## Validation

- `uv run --frozen --extra dev pytest -q tests/unit/install` - 2091 passed
- `uv run --extra dev pytest -q tests/integration/test_skipped_integration_preserves_deployments.py tests/unit/install/phases/test_cleanup_phase.py::TestStaleCleanupNoPackageDeployedFiles::test_skipped_integration_does_not_mark_prior_skills_stale tests/unit/install/phases/test_cleanup_phase.py::TestStaleCleanupNoPackageDeployedFiles::test_completed_integration_with_same_prior_skills_has_no_stale_cleanup tests/unit/install/test_agent_plugin_deployment_boundary.py::test_materialization_without_package_metadata_preserves_no_target_noop tests/spec_conformance/test_mode_b_detector.py` - 17 passed
- Canonical ruff check and format, pylint duplication, auth signal, and architecture boundary lint passed at `25684034d8b364ef8444611f87b01d1270263d64`
- Test architecture ratchets passed: 54 quality tests, assertion-quality clean, and exact-duplicate checks clean

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|-------------------------|--------------|--------------------|------|
| 1 | Re-running `apm install` when package integration is skipped preserves all previously deployed skills and their lockfile claims while a newly resolved package identity remains explicit. | Portability by manifest, Governed by policy, DevX (pragmatic as npm) | `tests/integration/test_skipped_integration_preserves_deployments.py::test_skipped_integration_preserves_prior_files_and_lock_claims` (regression-trap for #2744) | integration |
| 2 | A completed integration with an unchanged deployed-skill set does not remove those skills as stale. | Governed by policy, DevX (pragmatic as npm) | `tests/unit/install/phases/test_cleanup_phase.py::TestStaleCleanupNoPackageDeployedFiles::test_completed_integration_with_same_prior_skills_has_no_stale_cleanup` | unit |

## Mutation break

- Restoring the empty deployment assignment made the integration, cleanup, and deployment-boundary regressions fail; removing it restored the green suite.
- Removing the Mode B zero-count guard made its comment-only critical-path regression fail; restoring it returned the spec-conformance suite to green.

## Architecture

Classification: ordinary-fix. This corrects the existing integration-outcome sentinel behavior without adding, extending, or splitting a durable authority, so no static owner guard is required. The deterministic owner-touch detector reported no canonical owner touches.

Closes #2744
