### PR TITLE
fix(marketplace): support fully qualified SSH URLs

### DIFF
--- a/.apm/architecture/owners/marketplace-plugins.json
+++ b/.apm/architecture/owners/marketplace-plugins.json
@@ -9,6 +9,13 @@
       "guards": ["marketplace-integrations-tag-pattern"]
     },
     {
+      "id": "marketplace-source-admission",
+      "decision": "Marketplace source admission and transport identity",
+      "owner": "marketplace/source_identity.py (parse_marketplace_source)",
+      "selectors": ["src/apm_cli/marketplace/source_identity.py"],
+      "guards": ["marketplace-integrations-source-admission"]
+    },
+    {
       "id": "local-marketplace-version-precedence",
       "decision": "Local marketplace package-version manifest precedence",
       "owner": "marketplace/version_check.py (_read_local_version)",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -342,6 +342,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (closes #2431, #2458)
 - `apm compile --clean` preserves APM-generated `AGENTS.md` files tracked by
   nested Git worktrees. (#2473)
+- Fully qualified `ssh://` marketplace URLs now retain their SSH username,
+  host, and custom port through registration and Git fetching. SCP-style SSH
+  sources now also fetch without forwarding HTTP credentials. (by @donglrd,
+  #2466)
 - Required MCP runtime defaults are now overrideable prompts, while secret
   defaults remain hidden and VS Code OCI launchers resolve every runtime
   placeholder without writing secret values to `mcp.json`. (#2455)

--- a/docs/src/content/docs/consumer/installing-from-marketplaces.md
+++ b/docs/src/content/docs/consumer/installing-from-marketplaces.md
@@ -21,7 +21,7 @@ or when the runtime owns the install surface (VS Code Copilot Chat).
 
 | Runtime                         | Install command                                                         | Auth                                | Cache layout                                                                 |
 |---------------------------------|-------------------------------------------------------------------------|-------------------------------------|------------------------------------------------------------------------------|
-| APM (recommended)               | `apm marketplace add <owner>/<repo>` then `apm install <pkg>@<marketplace>` | Host token (`GITHUB_APM_PAT`, etc.) via git credential helper. | `apm_modules/` in the project; `~/.apm/cache/` for fetched refs.             |
+| APM (recommended)               | `apm marketplace add <owner>/<repo>` then `apm install <pkg>@<marketplace>` | HTTPS: host token or git credential helper. SSH: local key or agent. | `apm_modules/` in the project; `~/.apm/cache/` for fetched refs.             |
 | VS Code (GitHub Copilot Chat)   | Plugin marketplace UI; or `code --install-extension` for the marketplace itself. | VS Code GitHub sign-in.             | Per-user extension store managed by VS Code. APM artifacts stream from the marketplace at activation. |
 | Cursor                          | Settings -> Plugins -> add marketplace URL.                             | Cursor account.                     | `~/.cursor/extensions/` per-user.                                            |
 | GitHub Copilot CLI              | `gh copilot marketplace add <owner>/<repo>` then `gh copilot plugin install <pkg>`. | `gh auth login`.                    | `~/.config/gh/copilot/` per-user.                                            |
@@ -90,8 +90,12 @@ browse / install / update workflow works against:
   GitHub or GitLab family flows through subprocess `git` and
   `GitCache`. Includes Azure DevOps (auth via `ADO_APM_PAT`),
   Gitea, Bitbucket Server, and self-hosted git servers.
-- **SSH URLs** -- `git@gitea.example.com:org/repo.git`. The host
-  is extracted, classified, and routed through the matching fetcher.
+- **SSH URLs** -- `git@gitea.example.com:org/repo.git`, or
+  `ssh://git@gitea.example.com:2222/org/repo.git` when the server uses a
+  non-default port. The fully qualified form retains its username and port
+  when passed to subprocess `git`. SSH uses the local key or agent
+  without forwarding HTTP credentials; passwords, query parameters, and `#ref`
+  fragments are rejected (use `--ref` instead).
   For in-repository plugins from GitLab and generic git marketplaces, APM
   keeps this consumer-selected SSH transport when it writes their concrete
   `git:` and `path:` entry to `apm.yml`. HTTPS registrations likewise remain
@@ -122,12 +126,12 @@ send custom auth headers. Use git-backed marketplaces for private
 catalogs.
 :::
 
-For generic-git marketplaces, `marketplace.json` is fetched via a
-sparse-cone clone (only the manifest path is downloaded); APM does
-not forward `GITHUB_APM_PAT` or `GITLAB_APM_PAT` to non-GitHub /
-non-GitLab hosts. Authentication falls through to the host's matching
-`*_APM_PAT` variable (such as `ADO_APM_PAT`) or local git credential
-helper when one is configured. See
+For generic HTTPS marketplaces, `marketplace.json` is fetched via Git.
+Authentication may use the host's matching `*_APM_PAT` variable (such as
+`ADO_APM_PAT`) or a local git credential helper. SSH marketplaces instead use
+the local SSH key or agent in non-interactive mode; APM does not forward HTTP
+tokens, authorization headers, askpass programs, or registry credentials to
+that subprocess. See
 [Authentication](../../getting-started/authentication/).
 
 **Lockfile note.** Relative package sources from a local marketplace record a

--- a/docs/src/content/docs/getting-started/authentication.md
+++ b/docs/src/content/docs/getting-started/authentication.md
@@ -585,13 +585,13 @@ This reproduces exactly what APM sends to the credential helper. If the returned
 When APM clones over SSH (because the dependency is an SSH URL, the user
 passed `--ssh`, `git config url.<base>.insteadOf` rewrites to SSH, or
 `--allow-protocol-fallback` is in effect), firewalls that silently drop SSH
-packets (port 22) can make `apm install` appear to hang. APM sets
-`GIT_SSH_COMMAND="ssh -o ConnectTimeout=30"` so SSH attempts fail within 30
-seconds.
+packets (port 22) can make `apm install` appear to hang. APM forces
+`BatchMode=yes`, disables askpass and HTTP credential channels, and sets a
+30-second connection timeout so SSH attempts fail without prompting.
 
 If you already set `GIT_SSH_COMMAND` (e.g., for a custom key), APM appends
-`-o ConnectTimeout=30` unless `ConnectTimeout` is already present in your
-value.
+`-o BatchMode=yes` and appends `-o ConnectTimeout=30` unless
+`ConnectTimeout` is already present in your value.
 
 If SSH is unreachable from your network, force HTTPS:
 

--- a/docs/src/content/docs/reference/cli/marketplace.md
+++ b/docs/src/content/docs/reference/cli/marketplace.md
@@ -64,7 +64,11 @@ Register a marketplace from a source reference. Accepted forms:
   `https://gitlab.com/acme/marketplace.git#v1.0.0`.
 - Hosted `marketplace.json` URL --
   `https://catalog.example.com/marketplace.json`.
-- SSH URL -- `git@host:org/repo.git` style.
+- SSH URL -- SCP-like `git@host:org/repo.git` or fully qualified
+  `ssh://git@host[:PORT]/org/repo.git`. Use the fully qualified form when the
+  server listens on a non-default SSH port; the port is optional otherwise.
+  SSH URLs cannot include passwords, queries, or fragments; use `--ref` to
+  select a branch, tag, or commit.
 - Local filesystem path -- absolute (`/srv/marketplaces/agent-forge`),
   relative (`./local-mkt`), home-based (`~/code/marketplace`), or a
   direct `marketplace.json` file.
@@ -96,6 +100,7 @@ apm marketplace add https://catalog.example.com/marketplace.json --name catalog
 
 # SSH
 apm marketplace add git@gitea.example.com:org/repo.git --name custom
+apm marketplace add ssh://git@gitea.example.com:2222/org/repo.git --name custom
 
 # Local filesystem (bare repo, working directory, or marketplace.json file)
 apm marketplace add /srv/marketplaces/agent-forge.git --name agent-forge

--- a/packages/apm-guide/.apm/skills/apm-usage/authentication.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/authentication.md
@@ -367,12 +367,10 @@ credential under a fully qualified `https://<host>:<port>/` URL.
 
 ### SSH connection hangs on corporate/VPN networks
 
-APM tries SSH as a fallback when HTTPS auth is not available. On networks
-that silently drop SSH traffic (port 22), this can appear to hang. APM sets
-`GIT_SSH_COMMAND="ssh -o ConnectTimeout=30"` so SSH attempts fail within
-30 seconds and the fallback chain continues to plain HTTPS with git
-credential helpers.
+APM tries SSH as a fallback when HTTPS auth is not available. It forces
+`BatchMode=yes`, disables askpass and HTTP credential channels, and uses a
+30-second connection timeout so SSH attempts fail without prompting.
 
 To override the SSH command (e.g., custom key path), set `GIT_SSH_COMMAND`
-in your environment. APM appends `-o ConnectTimeout=30` unless it finds
-`ConnectTimeout` already present in your value.
+in your environment. APM forces `BatchMode=yes` and appends
+`-o ConnectTimeout=30` unless it finds `ConnectTimeout` already present.

--- a/packages/apm-guide/.apm/skills/apm-usage/commands.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/commands.md
@@ -245,7 +245,7 @@ Credentials resolve via `APM_REGISTRY_TOKEN_{NAME}` env var (or `apm config set 
 
 | Command | Purpose | Key flags |
 |---------|---------|-----------|
-| `apm marketplace add SOURCE` | Register a marketplace. `SOURCE` accepts `OWNER/REPO`, `HOST/OWNER/REPO`, nested `HOST/group/sub/.../REPO`, HTTPS git URL with optional `#ref`, hosted `marketplace.json` URL, SSH URL (`git@host:org/repo.git`), local directory or file path, or `file://` URI. `--ref` applies only to git-backed sources; `--host` applies only to shorthand sources. | `-n NAME`, `-r REF`, `--host HOST` |
+| `apm marketplace add SOURCE` | Register a marketplace. `SOURCE` accepts `OWNER/REPO`, `HOST/OWNER/REPO`, nested `HOST/group/sub/.../REPO`, HTTPS git URL with optional `#ref`, hosted `marketplace.json` URL, SSH URL (`git@host:org/repo.git` or `ssh://git@host[:PORT]/org/repo.git`), local directory or file path, or `file://` URI. `--ref` applies only to git-backed sources; `--host` applies only to shorthand sources. | `-n NAME`, `-r REF`, `--host HOST` |
 | `apm marketplace list` | List registered marketplaces | -- |
 | `apm marketplace browse NAME` | Browse marketplace plugins | -- |
 | `apm marketplace update [NAME]` | Update marketplace index | -- |

--- a/scripts/architecture_linter/checks/marketplace_bundle_and_audit.py
+++ b/scripts/architecture_linter/checks/marketplace_bundle_and_audit.py
@@ -1,8 +1,8 @@
 """Bundle-format, audit, projection-boundary, and LF-writer marketplace
 analyzers.
 
-Ports the seven guard-less rules whose owner is not one of the twelve
-registry owners above: the deterministic generated-bundle LF writer guard,
+Ports the source-admission owner guard plus seven guard-less rules whose owner
+is not one of the registry owners above: the generated-bundle LF writer guard,
 the removed native Agent Plugin lifecycle tombstone, the local marketplace
 audit path resolution, the bundle-format authority
 (``check_bundle_format_authority.sh`` subchecks B1-B5, B8, B9, B17, B18), the
@@ -252,6 +252,67 @@ def _check_marketplace_source_parsing(provider: FactsProvider) -> tuple[Violatio
     return check_marketplace_source_parsing(provider, _RID_SOURCE_PARSING)
 
 
+_RID_SOURCE_ADMISSION = "marketplace-integrations-source-admission"
+_SOURCE_IDENTITY = "src/apm_cli/marketplace/source_identity.py"
+_MARKETPLACE_COMMAND = "src/apm_cli/commands/marketplace/__init__.py"
+_MARKETPLACE_MODEL = "src/apm_cli/marketplace/models.py"
+_MARKETPLACE_CLIENT = "src/apm_cli/marketplace/client.py"
+
+
+def _check_marketplace_source_admission(
+    provider: FactsProvider,
+) -> tuple[Violation, ...]:
+    """Marketplace consumers must route source identity through one parser."""
+    inventory = frozenset(provider.inventory)
+    findings: list[Violation] = []
+    required = (
+        (_SOURCE_IDENTITY, ("def parse_marketplace_source(",)),
+        (
+            _MARKETPLACE_COMMAND,
+            ("identity = parse_marketplace_source(source, host_flag)",),
+        ),
+        (
+            _MARKETPLACE_MODEL,
+            ("identity = parse_marketplace_source(self.url)",),
+        ),
+        (_MARKETPLACE_CLIENT, ("host = source.host",)),
+    )
+    for path, literals in required:
+        findings.extend(
+            _require_subs(
+                provider,
+                inventory,
+                _RID_SOURCE_ADMISSION,
+                path,
+                literals,
+                "Marketplace source admission must route through source_identity.py",
+            )
+        )
+    findings.extend(
+        _forbid_scan(
+            provider,
+            inventory,
+            _RID_SOURCE_ADMISSION,
+            (_MARKETPLACE_CLIENT,),
+            re.compile(r"\b_host_from_url\("),
+            "Marketplace client must consume the canonical source host",
+            exempt=False,
+        )
+    )
+    findings.extend(
+        _forbid_scan(
+            provider,
+            inventory,
+            _RID_SOURCE_ADMISSION,
+            (_MARKETPLACE_COMMAND,),
+            re.compile(r"SCP_LIKE_RE|AuthResolver\.classify_host|is_valid_fqdn"),
+            "Marketplace command must not reimplement source classification",
+            exempt=False,
+        )
+    )
+    return tuple(findings)
+
+
 _RID_HASH_LF = "marketplace-integrations-hash-visible-lf-writers"
 
 
@@ -302,6 +363,13 @@ RULES: tuple[Rule, ...] = (
         guard_ids=(),
         description="Marketplace source coordinates parse through DependencyReference.",
         check=_check_marketplace_source_parsing,
+    ),
+    Rule(
+        id=_RID_SOURCE_ADMISSION,
+        group=GROUP,
+        guard_ids=(_RID_SOURCE_ADMISSION,),
+        description="Marketplace source admission stays owned by marketplace/source_identity.py.",
+        check=_check_marketplace_source_admission,
     ),
     Rule(
         id=_RID_HASH_LF,

--- a/scripts/architecture_linter/checks/transport_auth_platform.py
+++ b/scripts/architecture_linter/checks/transport_auth_platform.py
@@ -136,7 +136,10 @@ def _check_host_credential_resolution(provider: FactsProvider) -> tuple[Violatio
             ("probe_env = auth_resolver.git_env_for_context(", "key = (host, dep.port, org)"),
         ),
         ("src/apm_cli/install/helpers/ref_reuse.py", ("hardened_git_env_for_context",)),
-        ("src/apm_cli/marketplace/client.py", ("hardened_git_env_for_context",)),
+        (
+            "src/apm_cli/marketplace/client.py",
+            ("resolve_for_remote", "git_env_for_remote"),
+        ),
         ("src/apm_cli/marketplace/builder.py", ("hardened_git_env_for_context",)),
         ("src/apm_cli/marketplace/auth_helpers.py", ('ctx.token or ctx.host_info.kind == "ado"',)),
         ("src/apm_cli/commands/marketplace/check.py", ("hardened_git_env_for_context",)),
@@ -495,9 +498,9 @@ def _check_url_path_security(provider: FactsProvider) -> tuple[Violation, ...]:
             provider,
             inv,
             _RID_URL_PATH,
-            "src/apm_cli/commands/marketplace/__init__.py",
-            ('decode_url_path_segments(parsed.path, context="marketplace URL path")',),
-            "marketplace command must decode URL paths through path_security",
+            "src/apm_cli/marketplace/source_identity.py",
+            ("decode_url_path_segments(path, context=context)",),
+            "marketplace source owner must decode URL paths through path_security",
         )
     )
     findings.extend(

--- a/src/apm_cli/cache/git_cache.py
+++ b/src/apm_cli/cache/git_cache.py
@@ -191,7 +191,7 @@ class GitCache:
         # Cache hit path (skip if refresh requested)
         if not self._refresh and checkout_dir.is_dir():
             if verify_checkout_sha(checkout_dir, sha):
-                _log.debug("Cache HIT: %s @ %s [%s]", url, sha[:12], variant)
+                _log.debug("Cache HIT: %s @ %s [%s]", _sanitize_url(url), sha[:12], variant)
                 with shard_lock(checkout_dir):
                     return self._finalize_sparse_checkout(
                         checkout_dir,
@@ -315,6 +315,7 @@ class GitCache:
                 text=True,
                 timeout=30,
                 env=subprocess_env,
+                stdin=subprocess.DEVNULL,
             )
         except (subprocess.TimeoutExpired, OSError) as exc:
             raise RuntimeError(
@@ -323,7 +324,8 @@ class GitCache:
 
         if result.returncode != 0:
             raise RuntimeError(
-                f"git ls-remote failed for {_sanitize_url(url)}: {result.stderr.strip()}"
+                f"git ls-remote failed for {_sanitize_url(url)}: "
+                f"{_sanitize_url(result.stderr.strip())}"
             )
 
         # Parse ls-remote output: first column is SHA
@@ -437,6 +439,7 @@ class GitCache:
                     text=True,
                     timeout=300,
                     env=subprocess_env,
+                    stdin=subprocess.DEVNULL,
                     check=True,
                 )
             except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
@@ -473,6 +476,7 @@ class GitCache:
                             text=True,
                             timeout=300,
                             env=subprocess_env,
+                            stdin=subprocess.DEVNULL,
                             check=True,
                         )
                         fallback_done = True
@@ -583,7 +587,7 @@ class GitCache:
             if final_dir.is_dir() and verify_checkout_sha(final_dir, sha):
                 _log.debug(
                     "Write-dedup HIT under lock: %s @ %s [%s]",
-                    url,
+                    _sanitize_url(url),
                     sha[:12],
                     variant,
                 )
@@ -634,6 +638,7 @@ class GitCache:
                     text=True,
                     timeout=60,
                     env=subprocess_env,
+                    stdin=subprocess.DEVNULL,
                     check=True,
                 )
                 if promisor_url:
@@ -654,6 +659,7 @@ class GitCache:
                         text=True,
                         timeout=10,
                         env=subprocess_env,
+                        stdin=subprocess.DEVNULL,
                         check=True,
                     )
                 if sparse_paths:
@@ -682,6 +688,7 @@ class GitCache:
                     text=True,
                     timeout=60,
                     env=subprocess_env,
+                    stdin=subprocess.DEVNULL,
                     check=True,
                 )
                 if sparse_paths:
@@ -735,6 +742,7 @@ class GitCache:
                 text=True,
                 timeout=10,
                 env=subprocess_env,
+                stdin=subprocess.DEVNULL,
             )
             return result.returncode == 0 and "commit" in result.stdout.strip()
         except (subprocess.TimeoutExpired, OSError):
@@ -783,6 +791,7 @@ class GitCache:
                 text=True,
                 timeout=120,
                 env=subprocess_env,
+                stdin=subprocess.DEVNULL,
                 check=True,
             )
         except subprocess.CalledProcessError:
@@ -793,6 +802,7 @@ class GitCache:
                 text=True,
                 timeout=120,
                 env=subprocess_env,
+                stdin=subprocess.DEVNULL,
                 check=True,
             )
 
@@ -900,20 +910,23 @@ def _dir_size(path: Path) -> int:
     return total
 
 
-def _sanitize_url(url: str) -> str:
-    """Strip credentials from URL for safe logging."""
+_DIAGNOSTIC_URL_RE = re.compile(r"(?i)\b(?:https?|ssh|git)://[^\s'\"<>]+")
+
+
+def _sanitize_url(value: str) -> str:
+    """Remove URL userinfo, query, and fragment data from diagnostics."""
     import urllib.parse
 
-    try:
-        parsed = urllib.parse.urlparse(url)
-        if parsed.password:
-            # Replace password with ***
-            netloc = parsed.hostname or ""
-            if parsed.username:
-                netloc = f"{parsed.username}:***@{netloc}"
-            if parsed.port:
-                netloc = f"{netloc}:{parsed.port}"
-            return urllib.parse.urlunparse(parsed._replace(netloc=netloc))
-    except Exception:
-        pass
-    return url
+    def _redact(match: re.Match[str]) -> str:
+        try:
+            parsed = urllib.parse.urlparse(match.group(0))
+            host = parsed.hostname or ""
+            if ":" in host:
+                host = f"[{host}]"
+            if parsed.port is not None:
+                host = f"{host}:{parsed.port}"
+            return urllib.parse.urlunparse(parsed._replace(netloc=host, query="", fragment=""))
+        except Exception:
+            return "<redacted git URL>"
+
+    return _DIAGNOSTIC_URL_RE.sub(_redact, value)

--- a/src/apm_cli/cache/url_normalize.py
+++ b/src/apm_cli/cache/url_normalize.py
@@ -29,8 +29,8 @@ import urllib.parse
 # counts as an SCP-shorthand SSH URL (e.g. EMU users, Azure DevOps users).
 SCP_LIKE_RE = re.compile(
     r"^(?P<user>[a-zA-Z0-9_][a-zA-Z0-9_.+-]*)@"
-    r"(?P<host>[^:/]+)"
-    r":(?P<path>.+)$"
+    r"(?P<host>[^:/\[\]]+)"
+    r":(?P<path>[^?]+)$"
 )
 
 # Default ports to strip
@@ -104,7 +104,11 @@ def normalize_repo_url(url: str) -> str:
         if port and _DEFAULT_PORTS.get(scheme) == port:
             port = None
         # Reconstruct the authority (Step 3 lowercase host, Step 4 drop password)
-        authority = f"{username}@{hostname}" if username else hostname
+        # IPv6 literals require brackets in a reconstructed URI authority.
+        rendered_host = (
+            f"[{hostname}]" if ":" in hostname and not hostname.startswith("[") else hostname
+        )
+        authority = f"{username}@{rendered_host}" if username else rendered_host
         if port:
             authority = f"{authority}:{port}"
 

--- a/src/apm_cli/commands/marketplace/__init__.py
+++ b/src/apm_cli/commands/marketplace/__init__.py
@@ -43,7 +43,6 @@ from ...marketplace.yml_schema import load_marketplace_yml
 from ...utils.console import STATUS_SYMBOLS
 from ...utils.path_security import (
     PathTraversalError,
-    decode_url_path_segments,
     validate_path_segments,
 )
 from .._helpers import _get_console, _is_interactive
@@ -250,203 +249,15 @@ def _check_gitignore_for_marketplace_json(logger):
 
 
 def _parse_marketplace_source(source: str, host_flag: str | None) -> tuple[str, str, str | None]:
-    """Parse a marketplace source argument into ``(url, kind, embedded_host)``.
+    """Compatibility adapter for the canonical marketplace source owner."""
+    from ...marketplace.source_identity import parse_marketplace_source
 
-    Accepted forms (auto-detected, in order of test):
-
-      * Local filesystem path -- absolute (``/...``), relative (``./...``,
-        ``../...``), home (``~/...``), or Windows drive letter
-        (``C:\\repos\\foo``). Returns ``kind="local"``, ``url`` is the
-        ``file://`` URI form, ``embedded_host=None``.
-      * ``file://`` URI -- same shape as a local path but explicit.
-      * SCP-like SSH (``git@host:org/repo.git``). Returns ``kind`` derived
-        from the host via ``AuthResolver.classify_host``, ``url`` rewritten
-        to the SCP form (subprocess git understands it natively),
-        ``embedded_host=<host>``.
-      * Full HTTPS URL. Returns the URL untouched, ``embedded_host``
-        extracted, ``kind`` classified by host. Hosts that ``AuthResolver``
-        does not recognise as github/gitlab fall through as ``kind="git"``
-        (subprocess git path).
-      * ``OWNER/REPO`` or ``HOST/OWNER/.../REPO`` shorthand. The HOST
-        segment is detected via ``is_valid_fqdn``. Returns a synthesised
-        ``https://`` URL plus the resolved host.
-
-    Raises ``ValueError`` on malformed input (single-segment, HTTP, empty,
-    or path-traversal sequences in any segment).
-    """
-    from urllib.parse import urlparse
-
-    from ...core.auth import AuthResolver
-    from ...utils.github_host import is_valid_fqdn
-
-    raw = (source or "").strip()
-    if not raw:
-        raise ValueError("Empty source argument")
-    if any(ord(c) < 32 for c in raw):
-        raise ValueError("Source argument contains invalid control characters")
-
-    # --- Local path detection ---------------------------------------------
-    # Catches absolute (/, ~), relative (./, ../), file:// URIs, and
-    # Windows drive letters (C:\, C:/). Done BEFORE URL parsing so a path
-    # like '/srv/foo' is not misread as a relative HTTP URL.
-    if _looks_like_local_marketplace_source(raw):
-        url = raw if raw.lower().startswith("file://") else f"file://{_expand_local_path(raw)}"
-        return url, "local", None
-
-    lowered = raw.lower()
-    if lowered.startswith("http://"):
-        raise ValueError(
-            f"Insecure HTTP URL rejected: '{raw}'. Use HTTPS for marketplace registration."
-        )
-
-    # --- SCP-like SSH (git@host:org/repo.git) -----------------------------
-    scp_match = _SCP_LIKE_RE.match(raw)
-    if scp_match:
-        host = scp_match.group("host").lower()
-        path = scp_match.group("path")
-        # Validate the path component does not carry traversal markers.
-        for seg in (s for s in path.split("/") if s):
-            validate_path_segments(seg, context="marketplace SSH path", reject_empty=True)
-        host_info = AuthResolver.classify_host(host)
-        kind = _host_kind_to_fetcher_kind(host_info.kind)
-        return raw, kind, host
-
-    # --- HTTPS URL --------------------------------------------------------
-    if lowered.startswith("https://"):
-        parsed = urlparse(raw)
-        embedded_host = (parsed.hostname or "").strip().lower()
-        if not embedded_host:
-            raise ValueError(f"HTTPS URL is missing a host: '{raw}'")
-        path_segments = decode_url_path_segments(parsed.path, context="marketplace URL path")
-        if not path_segments:
-            raise ValueError(f"HTTPS URL is missing a repo path: '{raw}'")
-        host_info = AuthResolver.classify_host(embedded_host)
-        kind = _host_kind_to_fetcher_kind(host_info.kind)
-        if kind in ("github", "gitlab") and len(path_segments) < 2:
-            # GitHub / GitLab URLs are owner/repo-shaped; a single
-            # path segment is ambiguous (no owner). Generic git URLs
-            # (kind == "git") MAY legitimately have a single segment
-            # (e.g. self-hosted ``https://gitea.example.com/repo``).
-            raise ValueError(f"Invalid format: '{raw}'. Expected 'OWNER/REPO' in the URL path.")
-        if host_flag and host_flag.strip().lower() != embedded_host:
-            import shlex as _shlex
-
-            raise ValueError(
-                f"Conflicting host: --host '{host_flag}' does not match "
-                f"'{embedded_host}' in '{raw}'.\n"
-                f"To fix: drop --host and run: apm marketplace add {_shlex.quote(raw)}"
-            )
-        return raw, kind, embedded_host
-
-    # --- Shorthand (OWNER/REPO or HOST/OWNER/.../REPO) --------------------
-    raw_segments = raw.split("/")
-    segments = list(decode_url_path_segments(raw, context="marketplace source path"))
-    if len(segments) < 2:
-        raise ValueError(
-            f"Invalid format: '{raw}'. "
-            f"Expected 'OWNER/REPO', 'HOST/OWNER/REPO', a full HTTPS URL, "
-            f"a local path, or an SSH URL."
-        )
-
-    embedded_host: str | None = None
-    if is_valid_fqdn(segments[0]):
-        if len(segments) < 3:
-            raise ValueError(
-                f"Invalid format: '{raw}'. When the first segment is a host FQDN, "
-                f"at least 'HOST/OWNER/REPO' is required."
-            )
-        embedded_host = segments[0].lower()
-        segments = segments[1:]
-        raw_segments = raw_segments[1:]
-
-    repo_name = segments[-1]
-    owner_segments = segments[:-1]
-    if not owner_segments or not repo_name:
-        raise ValueError(f"Invalid format: '{raw}'. Expected 'OWNER/REPO'.")
-
-    raw_owner_path = "/".join(raw_segments[: len(owner_segments)])
-    raw_repo_name = raw_segments[len(owner_segments)]
-
-    if embedded_host and host_flag and host_flag.strip().lower() != embedded_host:
-        import shlex as _shlex
-
-        raise ValueError(
-            f"Conflicting host: --host '{host_flag}' does not match "
-            f"'{embedded_host}' in '{raw}'.\n"
-            f"To fix: drop --host and run: apm marketplace add {_shlex.quote(raw)}"
-        )
-
-    from ...utils.github_host import default_host
-
-    resolved_host = (host_flag or "").strip().lower() or embedded_host or default_host()
-    host_info = AuthResolver.classify_host(resolved_host)
-    kind = _host_kind_to_fetcher_kind(host_info.kind)
-    url = f"https://{resolved_host}/{raw_owner_path}/{raw_repo_name}"
-    return url, kind, resolved_host
+    identity = parse_marketplace_source(source, host_flag)
+    return identity.url, identity.kind, identity.host
 
 
 # Backward-compat alias for any external callers.
 _parse_marketplace_repo = _parse_marketplace_source
-
-
-def _host_kind_to_fetcher_kind(host_kind: str) -> str:
-    """Map ``AuthResolver.classify_host`` kinds to fetcher-table kinds.
-
-    ``github`` / ``ghe_cloud`` / ``ghes`` -> ``"github"`` (Contents API)
-    ``gitlab``                            -> ``"gitlab"`` (REST v4 raw)
-    Everything else (``ado``, ``generic``) -> ``"git"`` (subprocess + GitCache)
-    """
-    if host_kind in ("github", "ghe_cloud", "ghes"):
-        return "github"
-    if host_kind == "gitlab":
-        return "gitlab"
-    return "git"
-
-
-# SCP-like SSH form: ``user@host:path``. The path component does not need
-# to start with a slash (that is what makes it SCP-like). Reuses the
-# canonical regex from ``apm_cli.cache.url_normalize`` so SCP parsing here
-# stays consistent with ``DependencyReference`` and policy discovery.
-from apm_cli.cache.url_normalize import SCP_LIKE_RE as _SCP_LIKE_RE  # noqa: E402
-
-
-def _looks_like_local_marketplace_source(raw: str) -> bool:
-    """Heuristic match for local-path marketplace sources.
-
-    Matches: absolute paths (``/...``), explicit relative (``./...``,
-    ``../...``), home (``~``, ``~/...``), ``file://`` URIs, and Windows
-    drive letters (``C:\\`` or ``C:/``). The leading-slash check is
-    POSIX-only; on Windows, absolute paths arrive as drive-letter form.
-    """
-    if not raw:
-        return False
-    if raw.lower().startswith("file://"):
-        return True
-    if raw.startswith(("/", "./", "../", "~/", ".\\", "..\\", "~\\")) or raw == "~":
-        return True
-    # Windows drive letter: C:\foo or C:/foo
-    return len(raw) >= 3 and raw[0].isalpha() and raw[1] == ":" and raw[2] in ("\\", "/")
-
-
-def _expand_local_path(raw: str) -> str:
-    """Expand ``~`` and normalise to an absolute filesystem path string.
-
-    Used when synthesising the ``file://`` URL stored in ``marketplaces.json``
-    for local-kind entries. The result is *not* resolved (no symlink follow)
-    because the fetcher does its own ``ensure_path_within`` guard against
-    the post-``resolve`` location.
-    """
-    import os.path as _osp
-
-    return _osp.abspath(_osp.expanduser(raw))
-
-
-# Host-trust classification is owned by AuthResolver.classify_host (see
-# core/auth.py). The marketplace command layer routes through it so that the
-# credential-leakage guard at registration time uses the same single source of
-# truth as the fetch-time guard in marketplace/client.py. Adding a second
-# implementation here would create silent drift on a security-critical path.
-_TRUSTED_MARKETPLACE_HOST_KINDS = ("github", "ghe_cloud", "ghes", "gitlab")
 
 
 def _marketplace_add_unsupported_host_error(
@@ -492,6 +303,7 @@ Examples:
   apm marketplace add https://gitlab.com/group/repo
   apm marketplace add https://dev.azure.com/org/proj/_git/repo --name apm-mkt
   apm marketplace add git@gitea.example.com:org/repo.git --name custom
+  apm marketplace add ssh://git@gitea.example.com:2222/org/repo.git --name custom
   apm marketplace add /srv/marketplaces/agent-forge --name agent-forge
 """
 
@@ -518,7 +330,8 @@ def add(source, name, ref, branch, host, verbose):
     SOURCE accepts: OWNER/REPO shorthand, HOST/OWNER/REPO shorthand, a full
     HTTPS git URL with optional ``#ref`` (GitHub, GitLab, Azure DevOps,
     Gitea, Bitbucket Server, or any self-hosted git server), a hosted
-    ``marketplace.json`` URL, an SSH URL (``git@host:org/repo.git``),
+    ``marketplace.json`` URL, an SSH URL (``git@host:org/repo.git`` or
+    ``ssh://git@host:2222/org/repo.git``),
     a local filesystem path, or a ``file://`` URI.
     """
     logger = CommandLogger("marketplace-add", verbose=verbose)
@@ -526,7 +339,7 @@ def add(source, name, ref, branch, host, verbose):
         from ...marketplace.client import _auto_detect_path, fetch_marketplace
         from ...marketplace.models import MarketplaceSource
         from ...marketplace.registry import add_marketplace
-        from ...utils.github_host import is_valid_fqdn
+        from ...marketplace.source_identity import parse_marketplace_source
 
         source_arg, fragment_ref = _split_source_fragment_ref(source)
 
@@ -560,13 +373,6 @@ def add(source, name, ref, branch, host, verbose):
             logger.error(str(exc))
             sys.exit(1)
 
-        if host is not None and not is_valid_fqdn(host.strip().lower()):
-            logger.error(
-                f"Invalid host: '{host}'. Expected a valid host FQDN (for example, 'github.com').",
-                symbol="error",
-            )
-            sys.exit(1)
-
         # --host is meaningful only for shorthand OWNER/REPO inputs. For URL
         # / SSH / local-path inputs the host is already embedded; warn that
         # --host is being ignored rather than silently overriding.
@@ -586,35 +392,12 @@ def add(source, name, ref, branch, host, verbose):
             host is not None
             and host.strip().lower() != (resolved_host or "").lower()
             and kind in ("git", "github", "gitlab")
-            and (source_arg.startswith(("https://", "git@", "file://")))
+            and parse_marketplace_source(url).transport in {"https", "ssh", "scp"}
         ):
             logger.warning(
                 "--host is ignored when SOURCE is a full URL.",
                 symbol="warning",
             )
-
-        # Trust gate is now scoped to kinds that would forward an APM token
-        # via header injection. The subprocess git path (kind == "git")
-        # never forwards GITHUB_APM_PAT / GITLAB_APM_PAT -- AuthResolver
-        # only emits credentials matching the classified host. Local-kind
-        # fetches use no credentials at all.
-        if kind in ("github", "gitlab"):
-            from ...core.auth import AuthResolver
-
-            host_info = AuthResolver.classify_host(resolved_host or "")
-            if host_info.kind not in _TRUSTED_MARKETPLACE_HOST_KINDS:
-                # Should not happen because _host_kind_to_fetcher_kind already
-                # mapped non-trusted kinds to "git", but defend in depth.
-                import shlex as _shlex
-
-                quoted_repo = _shlex.quote(source)
-                quoted_host = _shlex.quote(resolved_host or "")
-                logger.error(
-                    _marketplace_add_unsupported_host_error(
-                        resolved_host or "", quoted_repo, quoted_host, host_info.kind
-                    )
-                )
-                sys.exit(1)
 
         if name is not None and not _is_valid_alias(name):
             logger.error(
@@ -634,11 +417,18 @@ def add(source, name, ref, branch, host, verbose):
         if _should_warn_unpinned_git_url(
             source_arg, kind, is_direct_url, fragment_ref, explicit_ref
         ):
-            logger.warning(
-                "Pin this git marketplace with a #ref (for example, "
-                f"{source_arg}#v1.0.0) or --ref to avoid mutable branch updates.",
-                symbol="warning",
-            )
+            from ...marketplace.source_identity import parse_marketplace_source
+
+            if parse_marketplace_source(url).transport in {"ssh", "scp"}:
+                warning = (
+                    "Pin this git marketplace with --ref v1.0.0 to avoid mutable branch updates."
+                )
+            else:
+                warning = (
+                    "Pin this git marketplace with a #ref (for example, "
+                    f"{source_arg}#v1.0.0) or --ref to avoid mutable branch updates."
+                )
+            logger.warning(warning, symbol="warning")
 
         # Probe for marketplace.json location. The probe source's name is a
         # placeholder -- _auto_detect_path only consults url/ref/path/kind.
@@ -748,6 +538,8 @@ def add(source, name, ref, branch, host, verbose):
 def _split_source_fragment_ref(source: str) -> tuple[str, str]:
     """Split an HTTPS git URL #ref fragment from the URL stored in the registry."""
     raw = (source or "").strip()
+    if raw.lower().startswith("ssh://") and "#" in raw:
+        raise ValueError("SSH URL fragments are not supported; use --ref REF instead.")
     if not raw.lower().startswith("https://"):
         return raw, ""
     parsed = urlsplit(raw)
@@ -778,7 +570,11 @@ def _should_warn_unpinned_git_url(
     """Return True when a git URL source uses the implicit mutable default ref."""
     if is_direct_url or fragment_ref or explicit_ref:
         return False
-    return source.lower().startswith("https://") and kind in {"github", "gitlab", "git"}
+    if kind not in {"github", "gitlab", "git", "ado"}:
+        return False
+    from ...marketplace.source_identity import parse_marketplace_source
+
+    return parse_marketplace_source(source).transport in {"https", "ssh", "scp"}
 
 
 def _local_source_points_to_file(source: MarketplaceSource) -> bool:

--- a/src/apm_cli/core/auth.py
+++ b/src/apm_cli/core/auth.py
@@ -127,6 +127,7 @@ _PORT_CREDENTIAL_DOCS_URL = (
 _GIT_CHILD_TOKEN_ENV_NAMES = frozenset(
     {
         "ADO_APM_PAT",
+        "ARTIFACTORY_APM_TOKEN",
         "COPILOT_GITHUB_TOKEN",
         "GH_ENTERPRISE_TOKEN",
         "GH_TOKEN",
@@ -138,9 +139,15 @@ _GIT_CHILD_TOKEN_ENV_NAMES = frozenset(
         "GITHUB_TOKEN",
         "GITLAB_APM_PAT",
         "GITLAB_TOKEN",
+        "PROXY_REGISTRY_TOKEN",
     }
 )
-_GIT_CHILD_TOKEN_ENV_PREFIXES = ("GITHUB_APM_PAT_",)
+_GIT_CHILD_TOKEN_ENV_PREFIXES = (
+    "APM_REGISTRY_PASS_",
+    "APM_REGISTRY_TOKEN_",
+    "APM_REGISTRY_USER_",
+    "GITHUB_APM_PAT_",
+)
 
 # Git localises its diagnostics through gettext, but APM classifies clone
 # failures by matching English signal strings (see

--- a/src/apm_cli/marketplace/client.py
+++ b/src/apm_cli/marketplace/client.py
@@ -127,7 +127,7 @@ def _cache_key(source: MarketplaceSource) -> str:
         # Generic git / ADO: include host so a.com/o/r vs b.com/o/r never
         # collapse, and prefix by kind so the same host on the two paths keeps
         # distinct sidecar files.
-        host = _host_from_url(source.url) or source.host or "unknown"
+        host = source.host or "unknown"
         return f"{kind}__{_sanitize_cache_name(host)}__{_sanitize_cache_name(source.name)}"
     normalized_host = (source.host or "github.com").lower()
     if normalized_host == "github.com":
@@ -1106,26 +1106,10 @@ def _fetch_file(
     elif kind in ("git", "ado"):
         # For ADO and generic git, classify the host extracted from the URL so
         # each gets a correctly-typed auth context (ADO PAT/bearer routing).
-        host = _host_from_url(source.url)
+        host = source.host
         host_info = AuthResolver.classify_host(host, port=source.port) if host else None
 
     return fetcher(source, file_path, host_info=host_info, auth_resolver=auth_resolver)
-
-
-def _host_from_url(url: str) -> str:
-    """Extract host from a URL (handles SCP-like SSH URLs too)."""
-    if not url:
-        return ""
-    # SCP-like: git@host:path
-    if "@" in url and not url.startswith(("http", "git://", "ssh://", "file://")):
-        try:
-            return url.split("@", 1)[1].split(":", 1)[0]
-        except (IndexError, ValueError):
-            return ""
-    try:
-        return urlsplit(url).hostname or ""
-    except ValueError:
-        return ""
 
 
 def _auto_detect_path(

--- a/src/apm_cli/marketplace/models.py
+++ b/src/apm_cli/marketplace/models.py
@@ -11,7 +11,7 @@ import os
 from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import Any
-from urllib.parse import urlsplit
+from urllib.parse import quote, urlsplit
 
 from apm_cli.cache.url_normalize import SCP_LIKE_RE as _SCP_LIKE_RE
 from apm_cli.models.dependency.reference import DependencyReference
@@ -76,20 +76,6 @@ def _dict_source_error(source_type: str, repo: object, url: object) -> str | Non
         if not _is_valid_remote_coordinate(locator):
             return f"source: {source_type} requires a valid non-local owner/repository or url field"
     return None
-
-
-def _extract_host_from_url(url: str) -> str:
-    """Best-effort host extraction from any URL/path; empty for local paths."""
-    if not url or _looks_like_local_path(url):
-        return ""
-    scp = _SCP_LIKE_RE.match(url)
-    if scp:
-        return scp.group("host")
-    try:
-        parsed = urlsplit(url)
-    except ValueError:
-        return ""
-    return parsed.hostname or ""
 
 
 def url_names_remote_manifest(url: str) -> bool:
@@ -200,9 +186,20 @@ class MarketplaceSource:
         if not self.url:
             if self.owner and self.repo:
                 host = self.host or "github.com"
-                object.__setattr__(self, "url", f"https://{host}/{self.owner}/{self.repo}")
+                owner = quote(self.owner, safe="/")
+                repo = quote(self.repo, safe="/")
+                object.__setattr__(self, "url", f"https://{host}/{owner}/{repo}")
             # If neither URL nor legacy fields are usable, leave url empty; callers/tests
             # that pass only name=... will fail later when something tries to use it.
+
+        # Validate persisted source transport through the same admission owner
+        # used by `marketplace add`; config reload must not bypass its checks.
+        identity = None
+        if self.url:
+            from apm_cli.marketplace.source_identity import parse_marketplace_source
+
+            identity = parse_marketplace_source(self.url)
+            object.__setattr__(self, "url", identity.url)
 
         # Backfill legacy mirror fields from URL when caller used URL-only signature.
         if self.url and self.path != "" and not self.owner and not self.repo:
@@ -211,10 +208,8 @@ class MarketplaceSource:
                 object.__setattr__(self, "owner", o)
             if r:
                 object.__setattr__(self, "repo", r)
-        if self.url and self.path != "" and self.host == "github.com":
-            h = _extract_host_from_url(self.url)
-            if h:
-                object.__setattr__(self, "host", h)
+        if identity is not None and self.path != "" and self.host == "github.com" and identity.host:
+            object.__setattr__(self, "host", identity.host)
 
     # -- derived properties --------------------------------------------------
 
@@ -226,12 +221,11 @@ class MarketplaceSource:
     @property
     def port(self) -> int | None:
         """Return the explicit remote URL port, if present."""
-        if not self.url or _looks_like_local_path(self.url):
+        if not self.url:
             return None
-        try:
-            return urlsplit(self.url).port
-        except ValueError:
-            return None
+        from apm_cli.marketplace.source_identity import parse_marketplace_source
+
+        return parse_marketplace_source(self.url).port
 
     @property
     def kind(self) -> str:
@@ -240,30 +234,20 @@ class MarketplaceSource:
         Classification:
         - Local filesystem path or ``file://`` URI -> ``local``
         - Direct remote marketplace.json URL (``path == ""``) -> ``url``
+        - Explicit ``ssh://`` URL -> ``git`` (preserves the selected SSH transport)
         - Host classified by AuthResolver as github/ghe_cloud/ghes -> ``github``
         - Host classified as gitlab -> ``gitlab``
         - Host classified as Azure DevOps -> ``ado`` (REST items fast path with
           generic-git fallback; see ``marketplace.client._fetch_ado``)
-        - Anything else (generic, ssh to non-classified host) -> ``git``
+        - Anything else (generic or SCP-like SSH to a non-classified host) -> ``git``
         """
         if not self.url or _looks_like_local_path(self.url):
             return "local"
         if self.is_remote_manifest_url:
             return "url"
-        host = _extract_host_from_url(self.url)
-        if not host:
-            return "git"
-        # Lazy import to keep models.py free of heavy dependencies
-        from apm_cli.core.auth import AuthResolver
+        from apm_cli.marketplace.source_identity import parse_marketplace_source
 
-        host_kind = AuthResolver.classify_host(host).kind
-        if host_kind in ("github", "ghe_cloud", "ghes"):
-            return "github"
-        if host_kind == "gitlab":
-            return "gitlab"
-        if host_kind == "ado":
-            return "ado"
-        return "git"
+        return parse_marketplace_source(self.url).kind
 
     @property
     def local_path(self) -> str:

--- a/src/apm_cli/marketplace/registry.py
+++ b/src/apm_cli/marketplace/registry.py
@@ -75,7 +75,7 @@ def _load() -> list[MarketplaceSource]:
         for entry in data.get("marketplaces", []):
             try:
                 sources.append(MarketplaceSource.from_dict(entry))
-            except (KeyError, TypeError) as exc:
+            except (KeyError, TypeError, ValueError) as exc:
                 logger.debug("Skipping invalid marketplace entry: %s", exc)
         _registry_cache = sources
         return list(sources)

--- a/src/apm_cli/marketplace/source_identity.py
+++ b/src/apm_cli/marketplace/source_identity.py
@@ -1,0 +1,260 @@
+"""Validated transport identity for marketplace registration sources.
+
+This module is the only marketplace-layer owner of source syntax.  It keeps
+the persisted fetch transport distinct from the normalized host and port used
+for comparison and host classification.
+"""
+
+from __future__ import annotations
+
+import os.path
+import re
+from dataclasses import dataclass
+from urllib.parse import urlsplit
+
+from apm_cli.cache.url_normalize import SCP_LIKE_RE
+from apm_cli.utils.github_host import default_host, is_valid_fqdn, validate_ssh_user
+from apm_cli.utils.path_security import decode_url_path_segments, validate_path_segments
+
+_SCP_PREFIX_RE = re.compile(r"^[^/@:\s]+@(?:\[[^\]]+\]|[^/:\s]+):")
+
+
+@dataclass(frozen=True)
+class MarketplaceSourceIdentity:
+    """A validated marketplace source with fetch and comparison identities."""
+
+    url: str
+    kind: str
+    host: str | None
+    port: int | None
+    transport: str
+
+
+def parse_marketplace_source(
+    source: str, host_flag: str | None = None
+) -> MarketplaceSourceIdentity:
+    """Parse and validate a marketplace source before host classification.
+
+    The returned URL is safe to persist and pass to Git.  For explicit SSH,
+    it preserves the validated user, bracketed host, port, path case, and
+    optional ``.git`` suffix exactly as entered, except that ``ssh`` is
+    lowercased as required by URL scheme comparison.
+    """
+    raw = (source or "").strip()
+    if not raw:
+        raise ValueError("Empty source argument")
+    if any(ord(char) < 32 for char in raw):
+        raise ValueError("Source argument contains invalid control characters")
+    if host_flag is not None and not is_valid_fqdn(host_flag.strip().lower()):
+        raise ValueError(
+            f"Invalid host: '{host_flag}'. Expected a valid host FQDN (for example, 'github.com')."
+        )
+
+    if _looks_like_local_marketplace_source(raw):
+        url = raw if raw.lower().startswith("file://") else f"file://{_expand_local_path(raw)}"
+        return MarketplaceSourceIdentity(url, "local", None, None, "local")
+
+    lowered = raw.lower()
+    if lowered.startswith("http://"):
+        raise ValueError("Insecure HTTP URL rejected. Use HTTPS for marketplace registration.")
+    if lowered.startswith("ssh://"):
+        return _parse_ssh_url(raw, host_flag)
+
+    if "?" in raw and _SCP_PREFIX_RE.match(raw):
+        raise ValueError("SSH URLs cannot include queries; remove the query and use --ref REF.")
+
+    scp_match = SCP_LIKE_RE.fullmatch(raw)
+    if scp_match:
+        if "#" in raw:
+            raise ValueError("SSH URL fragments are not supported; use --ref REF instead.")
+        user = scp_match.group("user")
+        host = scp_match.group("host")
+        path = scp_match.group("path")
+        validate_ssh_user(user)
+        _validate_remote_path(path, context="marketplace SSH path")
+        normalized_host = _comparison_host(host)
+        return MarketplaceSourceIdentity(
+            raw,
+            "git",
+            normalized_host,
+            None,
+            "scp",
+        )
+
+    if lowered.startswith("https://"):
+        return _parse_https_url(raw, host_flag)
+
+    return _parse_shorthand(raw, host_flag)
+
+
+def _parse_ssh_url(raw: str, host_flag: str | None) -> MarketplaceSourceIdentity:
+    """Validate a fully qualified SSH URL without rewriting its transport."""
+    normalized_url = f"ssh://{raw[len('ssh://') :]}"
+    authority = _authority(normalized_url)
+    if authority.count("@") > 1:
+        raise ValueError("SSH URL has invalid userinfo")
+    if "@" in authority:
+        userinfo = authority.split("@", 1)[0]
+        if "%" in userinfo:
+            raise ValueError("Percent-encoded characters are not allowed in SSH userinfo")
+        if ":" in userinfo:
+            raise ValueError(
+                "SSH URL must not include a password; configure SSH authentication instead."
+            )
+    if "%" in authority.rsplit("@", 1)[-1]:
+        raise ValueError("Percent-encoded characters are not allowed in SSH hosts or ports")
+
+    try:
+        parsed = urlsplit(normalized_url)
+        host = parsed.hostname
+        port = parsed.port
+    except ValueError as exc:
+        raise ValueError("SSH URL has an invalid host or port") from exc
+
+    if not host:
+        raise ValueError("SSH URL is missing a host")
+    if parsed.query:
+        raise ValueError("SSH URL must not include a query")
+    if parsed.fragment:
+        raise ValueError("SSH URL fragments are not supported; use --ref REF instead.")
+    if parsed.password is not None:
+        raise ValueError(
+            "SSH URL must not include a password; configure SSH authentication instead."
+        )
+    if parsed.username:
+        validate_ssh_user(parsed.username)
+    if port is not None and not 1 <= port <= 65535:
+        raise ValueError("SSH URL has an invalid port")
+
+    _validate_remote_path(
+        parsed.path,
+        context="marketplace SSH URL path",
+        require_absolute=True,
+    )
+    normalized_host = _comparison_host(host)
+    return MarketplaceSourceIdentity(
+        normalized_url,
+        "git",
+        normalized_host,
+        port,
+        "ssh",
+    )
+
+
+def _parse_https_url(raw: str, host_flag: str | None) -> MarketplaceSourceIdentity:
+    """Validate an HTTPS source, then classify the already-parsed host."""
+    try:
+        parsed = urlsplit(raw)
+        host = parsed.hostname
+        port = parsed.port
+    except ValueError as exc:
+        raise ValueError("HTTPS URL has an invalid host or port") from exc
+    if not host:
+        raise ValueError("HTTPS URL is missing a host")
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError("HTTPS marketplace URLs must not include userinfo")
+
+    _validate_remote_path(parsed.path, context="marketplace URL path", require_absolute=True)
+    normalized_host = _comparison_host(host)
+    _reject_conflicting_host(host_flag, normalized_host, raw)
+    kind = _kind_for_host(normalized_host, port)
+    path_segments = [segment for segment in parsed.path.split("/") if segment]
+    if kind in {"github", "gitlab"} and len(path_segments) < 2:
+        raise ValueError("Invalid marketplace URL: expected an OWNER/REPO path")
+    return MarketplaceSourceIdentity(raw, kind, normalized_host, port, "https")
+
+
+def _parse_shorthand(raw: str, host_flag: str | None) -> MarketplaceSourceIdentity:
+    """Build a validated HTTPS identity from shorthand source syntax."""
+    segments = list(decode_url_path_segments(raw, context="marketplace shorthand"))
+    if len(segments) < 2:
+        raise ValueError(
+            "Invalid format. Expected OWNER/REPO, HOST/OWNER/REPO, a full HTTPS URL, "
+            "a local path, or an SSH URL."
+        )
+
+    embedded_host: str | None = None
+    if is_valid_fqdn(segments[0]):
+        if len(segments) < 3:
+            raise ValueError("Invalid format: HOST shorthand requires HOST/OWNER/REPO")
+        embedded_host = segments.pop(0).lower()
+
+    repo = segments[-1]
+    owner = "/".join(segments[:-1])
+    validate_path_segments(owner, context="marketplace owner path", reject_empty=True)
+    validate_path_segments(repo, context="marketplace repo name", reject_empty=True)
+    _reject_conflicting_host(host_flag, embedded_host, raw)
+
+    resolved_host = (host_flag or "").strip().lower() or embedded_host or default_host()
+    kind = _kind_for_host(resolved_host, None)
+    return MarketplaceSourceIdentity(
+        f"https://{resolved_host}/{owner}/{repo}",
+        kind,
+        resolved_host,
+        None,
+        "https",
+    )
+
+
+def _kind_for_host(host: str, port: int | None) -> str:
+    """Classify a syntactically validated host through the auth owner."""
+    from apm_cli.core.auth import AuthResolver
+
+    host_kind = AuthResolver.classify_host(host, port=port).kind
+    if host_kind in {"github", "ghe_cloud", "ghes"}:
+        return "github"
+    if host_kind == "gitlab":
+        return "gitlab"
+    if host_kind == "ado":
+        return "ado"
+    return "git"
+
+
+def _validate_remote_path(path: str, *, context: str, require_absolute: bool = False) -> None:
+    """Reject malformed encodings and path forms that alter Git's target."""
+    if not path or path == "/":
+        raise ValueError(f"{context} is missing a repo path")
+    if require_absolute:
+        if not path.startswith("/") or path.startswith("//"):
+            raise ValueError(f"{context} must begin with one repository path separator")
+    decoded_segments = decode_url_path_segments(path, context=context)
+    validate_path_segments(
+        "/".join(decoded_segments),
+        context=context,
+        reject_empty=True,
+    )
+
+
+def _authority(url: str) -> str:
+    """Return the raw authority section of a syntactically SSH-shaped URL."""
+    remainder = url[len("ssh://") :]
+    return re.split(r"[/?#]", remainder, maxsplit=1)[0]
+
+
+def _comparison_host(host: str) -> str:
+    """Normalize only the host comparison identity, not the stored transport."""
+    return host.strip().lower()
+
+
+def _reject_conflicting_host(host_flag: str | None, embedded_host: str | None, source: str) -> None:
+    if host_flag and embedded_host and host_flag.strip().lower() != embedded_host:
+        import shlex
+
+        raise ValueError(
+            "Conflicting host: --host does not match the host embedded in SOURCE.\n"
+            f"To fix: drop --host and run: apm marketplace add {shlex.quote(source)}"
+        )
+
+
+def _looks_like_local_marketplace_source(raw: str) -> bool:
+    """Return whether *raw* is a local filesystem source."""
+    if raw.lower().startswith("file://"):
+        return True
+    if raw.startswith(("/", "./", "../", "~/", ".\\", "..\\", "~\\")) or raw == "~":
+        return True
+    return len(raw) >= 3 and raw[0].isalpha() and raw[1] == ":" and raw[2] in ("\\", "/")
+
+
+def _expand_local_path(raw: str) -> str:
+    """Expand a local path without resolving symlinks."""
+    return os.path.abspath(os.path.expanduser(raw))

--- a/src/apm_cli/models/dependency/reference.py
+++ b/src/apm_cli/models/dependency/reference.py
@@ -651,10 +651,16 @@ class DependencyReference(ProviderCoordinateMixin):
             return  # bare shorthand or other form -- not in scope
 
         path_part = path_part.split("#")[0].split("?")[0]
-        decoded_path = urllib.parse.unquote(path_part)
+        # This detection pass must reveal multi-encoded primitive names so it
+        # can return the existing actionable subpath error before full parsing.
+        decoded_path = urllib.parse.unquote(  # architecture-authority-exempt: detection only
+            path_part
+        )
         while decoded_path != path_part:
             path_part = decoded_path
-            decoded_path = urllib.parse.unquote(path_part)
+            decoded_path = urllib.parse.unquote(  # architecture-authority-exempt: detection only
+                path_part
+            )
         segments = [s for s in path_part.replace("\\", "/").split("/") if s]
         if len(segments) < 3:
             return  # too few segments to contain an interior primitive name

--- a/tests/integration/test_architecture_marketplace_source_admission.py
+++ b/tests/integration/test_architecture_marketplace_source_admission.py
@@ -1,0 +1,48 @@
+"""Architecture guardrails for marketplace source admission."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.architecture_linter.runner import registered_rules, run_selected_rules
+
+_RULE_ID = "marketplace-integrations-source-admission"
+_RULES_BY_ID = {rule.id: rule for rule in registered_rules()}
+
+
+def test_marketplace_source_admission_has_single_owner() -> None:
+    """Commands, persisted models, and clients must consume one source parser."""
+    root = Path(__file__).parents[2]
+    owner = (root / "src/apm_cli/marketplace/source_identity.py").read_text(encoding="utf-8")
+    command = (root / "src/apm_cli/commands/marketplace/__init__.py").read_text(encoding="utf-8")
+    model = (root / "src/apm_cli/marketplace/models.py").read_text(encoding="utf-8")
+    client = (root / "src/apm_cli/marketplace/client.py").read_text(encoding="utf-8")
+    rule = _RULES_BY_ID[_RULE_ID]
+
+    assert owner.count("def parse_marketplace_source(") == 1
+    assert "identity = parse_marketplace_source(source, host_flag)" in command
+    assert "identity = parse_marketplace_source(self.url)" in model
+    assert "def _host_from_url(" not in client
+    assert "host = source.host" in client
+    assert "is_valid_fqdn" not in command
+    assert (
+        "Marketplace source admission stays owned by marketplace/source_identity.py"
+        in rule.description
+    )
+
+
+def test_marketplace_source_admission_guard_rejects_client_host_parser() -> None:
+    """The registered rule rejects a client-side host parser."""
+    root = Path(__file__).parents[2]
+    path = "src/apm_cli/marketplace/client.py"
+    mutated = (root / path).read_text(encoding="utf-8")
+    mutated += "\n\ndef _host_from_url(url: str) -> str:\n    return url\n"
+
+    report = run_selected_rules(
+        root,
+        (_RULE_ID,),
+        source_overrides={path: mutated},
+    )
+
+    assert report.failures == ()
+    assert any(violation.rule_id == _RULE_ID for violation in report.violations)

--- a/tests/integration/test_architecture_owner_rule_mutations.py
+++ b/tests/integration/test_architecture_owner_rule_mutations.py
@@ -446,6 +446,17 @@ MUTATIONS: tuple[MutationCase, ...] = (
         intent="Raw structural diagnostics stop originating empty in the model owner.",
     ),
     MutationCase(
+        guard_id="marketplace-integrations-source-admission",
+        rule_id="marketplace-integrations-source-admission",
+        path="src/apm_cli/marketplace/client.py",
+        old=("        host = source.host\n        host_info = AuthResolver.classify_host"),
+        new=(
+            "        host = _host_from_url(source.url)\n"
+            "        host_info = AuthResolver.classify_host"
+        ),
+        intent="Marketplace client reintroduces source-host parsing outside the owner.",
+    ),
+    MutationCase(
         guard_id="marketplace-integrations-tag-pattern",
         rule_id="marketplace-integrations-tag-pattern",
         path="src/apm_cli/marketplace/tag_pattern.py",

--- a/tests/integration/test_git_cache_hermetic.py
+++ b/tests/integration/test_git_cache_hermetic.py
@@ -855,14 +855,25 @@ class TestHelperFunctions:
         with patch("os.walk", side_effect=_raise):
             assert _dir_size(root) == 0
 
-    def test_sanitize_url_strips_password_and_preserves_port(self) -> None:
+    def test_sanitize_url_strips_userinfo_and_preserves_port(self) -> None:
         sanitized = _sanitize_url("https://alice:secret@example.com:8443/repo.git")
-        assert sanitized == "https://alice:***@example.com:8443/repo.git"
+        assert sanitized == "https://example.com:8443/repo.git"
 
-    def test_sanitize_url_leaves_username_only_url_unchanged(self) -> None:
+    def test_sanitize_url_strips_username_only_url(self) -> None:
         url = "https://alice@example.com/repo.git"
-        assert _sanitize_url(url) == url
+        assert _sanitize_url(url) == "https://example.com/repo.git"
 
-    def test_sanitize_url_returns_original_on_parser_error(self) -> None:
+    def test_sanitize_url_removes_query_fragment_and_embedded_credentials(self) -> None:
+        diagnostic = (
+            "fatal: fetch https://user:pass@example.com/repo.git?access_token=SECRET123#main failed"
+        )
+
+        sanitized = _sanitize_url(diagnostic)
+
+        assert "SECRET123" not in sanitized
+        assert "user:pass" not in sanitized
+        assert sanitized == "fatal: fetch https://example.com/repo.git failed"
+
+    def test_sanitize_url_redacts_parser_errors(self) -> None:
         with patch("urllib.parse.urlparse", side_effect=ValueError("bad url")):
-            assert _sanitize_url("https://example.com/repo.git") == "https://example.com/repo.git"
+            assert _sanitize_url("https://example.com/repo.git") == "<redacted git URL>"

--- a/tests/integration/test_marketplace_ssh_subprocess.py
+++ b/tests/integration/test_marketplace_ssh_subprocess.py
@@ -1,0 +1,105 @@
+"""Process-boundary coverage for SSH marketplace fetches."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+from urllib.parse import urlparse
+
+import pytest
+
+from apm_cli.core.auth import AuthResolver
+from apm_cli.marketplace.client import _fetch_git
+from apm_cli.marketplace.models import MarketplaceSource
+
+pytestmark = pytest.mark.component
+
+
+def test_ssh_marketplace_process_preserves_port_without_http_credentials(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The client-to-process path preserves SSH identity and strips HTTP auth."""
+    secrets = {
+        "GITHUB_APM_PAT": "platform-secret",
+        "GIT_TOKEN": "git-secret",
+        "GIT_HTTP_EXTRAHEADER": "Authorization: secret",
+        "GIT_ASKPASS": "unsafe-askpass",
+        "APM_REGISTRY_TOKEN_CORP": "registry-token",
+        "APM_REGISTRY_USER_CORP": "registry-user",
+        "APM_REGISTRY_PASS_CORP": "registry-password",
+        "PROXY_REGISTRY_TOKEN": "proxy-token",
+        "ARTIFACTORY_APM_TOKEN": "legacy-proxy-token",
+    }
+    for name, value in secrets.items():
+        monkeypatch.setenv(name, value)
+
+    source_url = "ssh://git@gitea.example.com:2222/org/repo.git"
+    source = MarketplaceSource(name="private", url=source_url)
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    (checkout / "marketplace.json").write_text(
+        json.dumps({"name": "private", "plugins": []}),
+        encoding="utf-8",
+    )
+    record_path = tmp_path / "process-record.json"
+
+    class RecordingGitCache:
+        def __init__(self, _root: Path, *, refresh: bool) -> None:
+            assert refresh is False
+
+        def get_checkout(
+            self,
+            url: str,
+            ref: str,
+            *,
+            env: dict[str, str],
+            sparse_paths: list[str] | None,
+        ) -> Path:
+            probe = (
+                "import json, os, pathlib, sys;"
+                "names=sys.argv[3:];"
+                "data={'url':sys.argv[2],"
+                "'env':{name:os.environ.get(name) for name in names}};"
+                "pathlib.Path(sys.argv[1]).write_text(json.dumps(data),encoding='utf-8')"
+            )
+            subprocess.run(
+                [sys.executable, "-c", probe, str(record_path), url, *secrets],
+                check=True,
+                env=env,
+            )
+            assert ref == "main"
+            assert sparse_paths is None
+            return checkout
+
+    resolver = AuthResolver(token_manager=MagicMock())
+    with (
+        patch.object(
+            resolver,
+            "hardened_git_base_env",
+            return_value=dict(os.environ),
+        ),
+        patch("apm_cli.cache.git_cache.GitCache", RecordingGitCache),
+        patch("apm_cli.cache.paths.get_cache_root", return_value=tmp_path / "cache"),
+    ):
+        result = _fetch_git(
+            source,
+            "marketplace.json",
+            host_info=AuthResolver.classify_host(source.host, port=source.port),
+            auth_resolver=resolver,
+        )
+
+    recorded = json.loads(record_path.read_text(encoding="utf-8"))
+    parsed = urlparse(recorded["url"])
+    assert (parsed.scheme, parsed.hostname, parsed.port, parsed.path) == (
+        "ssh",
+        "gitea.example.com",
+        2222,
+        "/org/repo.git",
+    )
+    assert all(recorded["env"][name] in (None, "") for name in secrets)
+    assert result == {"name": "private", "plugins": []}

--- a/tests/unit/cache/test_git_cache.py
+++ b/tests/unit/cache/test_git_cache.py
@@ -5,6 +5,8 @@ import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from apm_cli.cache.git_cache import GitCache
 
 
@@ -270,13 +272,15 @@ class TestCheckoutWriteDedup:
     and return immediately without doing any clone work themselves.
     """
 
-    def test_short_circuits_when_final_exists_under_lock(self, tmp_path: Path) -> None:
+    def test_short_circuits_when_final_exists_under_lock(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
         """If final_dir is already populated when the lock is acquired,
         no git subprocess is invoked."""
         from apm_cli.cache.url_normalize import cache_shard_key
 
         cache = GitCache(tmp_path)
-        url = "https://github.com/owner/repo"
+        url = "https://user:pass@github.com/owner/repo?access_token=SECRET123#main"
         sha = "1" * 40
         shard = cache_shard_key(url)
 
@@ -293,10 +297,13 @@ class TestCheckoutWriteDedup:
                 return_value=True,
             ) as mock_verify,
         ):
-            result = cache._create_checkout(url, shard, sha)
+            with caplog.at_level("DEBUG"):
+                result = cache._create_checkout(url, shard, sha)
             mock_run.assert_not_called()
             mock_verify.assert_called_with(final_dir, sha)
         assert result == final_dir
+        assert "SECRET123" not in caplog.text
+        assert "user:pass" not in caplog.text
 
     def test_proceeds_with_clone_when_final_missing(self, tmp_path: Path) -> None:
         """If final_dir does not exist on lock entry, clone happens."""

--- a/tests/unit/cache/test_git_cache_hardening.py
+++ b/tests/unit/cache/test_git_cache_hardening.py
@@ -23,8 +23,10 @@ on the next ``apm marketplace update``.
 from __future__ import annotations
 
 import contextlib
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
+from urllib.parse import urlsplit
 
 from apm_cli.cache.git_cache import GitCache, _safe_git_args
 
@@ -64,10 +66,32 @@ class TestLsRemoteHardening:
 
         argvs = _all_cmd_argvs(mock_run)
         assert argvs, "ls-remote subprocess.run was not invoked"
+        assert all(call.kwargs["stdin"] is subprocess.DEVNULL for call in mock_run.call_args_list)
         argv = argvs[0]
         assert "ls-remote" in argv
         assert "core.hooksPath=/dev/null" in argv
         assert "submodule.recurse=false" in argv
+
+
+class TestCacheHitDiagnostics:
+    def test_cache_hit_log_omits_ssh_userinfo(self, caplog, tmp_path: Path) -> None:
+        cache = GitCache(tmp_path)
+        sha = "a" * 40
+        shard = "cache-shard"
+        checkout = cache._checkouts_root / shard / sha / "full"
+        checkout.mkdir(parents=True)
+
+        with (
+            patch.object(cache, "_resolve_sha", return_value=sha),
+            patch("apm_cli.cache.git_cache.cache_shard_key", return_value=shard),
+            patch("apm_cli.cache.git_cache.verify_checkout_sha", return_value=True),
+            caplog.at_level("DEBUG", logger="apm_cli.cache.git_cache"),
+        ):
+            cache.get_checkout("ssh://sensitive-user@example.com/org/repo.git", "main")
+
+        logged_url = urlsplit(caplog.records[-1].getMessage().split()[2])
+        assert logged_url.username is None
+        assert logged_url.hostname == "example.com"
 
 
 class TestCloneHardening:

--- a/tests/unit/cache/test_git_cache_sparse.py
+++ b/tests/unit/cache/test_git_cache_sparse.py
@@ -60,8 +60,8 @@ def test_partial_clone_warning_redacts_url_credentials() -> None:
     parsed = urlparse(rendered_url)
 
     assert parsed.hostname == "github.com"
-    assert parsed.username == "alice"
-    assert parsed.password == "***"
+    assert parsed.username is None
+    assert parsed.password is None
 
 
 def test_auth_failure_is_not_classified_as_filter_rejection() -> None:

--- a/tests/unit/cache/test_url_normalize.py
+++ b/tests/unit/cache/test_url_normalize.py
@@ -30,6 +30,20 @@ class TestNormalizeRepoUrl:
         result = normalize_repo_url("ssh://git@github.com:22/owner/repo")
         assert result == "ssh://git@github.com/owner/repo"
 
+    def test_normalizes_bracketed_ipv6_default_port(self) -> None:
+        default_port = normalize_repo_url("ssh://git@[2001:DB8::1]:22/Team/Repo.git")
+        implicit_port = normalize_repo_url("ssh://git@[2001:db8::1]/Team/Repo")
+
+        assert default_port == "ssh://git@[2001:db8::1]/Team/Repo"
+        assert default_port == implicit_port
+
+    def test_preserves_bracketed_ipv6_non_default_port(self) -> None:
+        custom_port = normalize_repo_url("ssh://git@[2001:db8::1]:2222/Team/Repo.git")
+        default_port = normalize_repo_url("ssh://git@[2001:db8::1]/Team/Repo.git")
+
+        assert custom_port == "ssh://git@[2001:db8::1]:2222/Team/Repo"
+        assert cache_shard_key(custom_port) != cache_shard_key(default_port)
+
     def test_preserve_non_default_port(self) -> None:
         result = normalize_repo_url("https://github.example.com:8443/owner/repo")
         assert result == "https://github.example.com:8443/owner/repo"

--- a/tests/unit/marketplace/test_client_git.py
+++ b/tests/unit/marketplace/test_client_git.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from apm_cli.commands.marketplace import _parse_marketplace_source
 from apm_cli.marketplace.client import (
     _FETCHERS,
     _fetch_ado,
@@ -74,6 +75,109 @@ def test_fetch_git_calls_gitcache_with_sparse_path(
     call_kwargs = gitcache_mock.get_checkout.call_args.kwargs
     assert call_kwargs["env"] == {"GIT_TERMINAL_PROMPT": "0"}
     fake_auth_resolver.git_env_for_remote.assert_called_once()
+
+
+def test_fetch_git_preserves_ssh_protocol_url_with_port(tmp_path: Path, fake_auth_resolver) -> None:
+    raw = "ssh://git@github.com:2222/org/repo.git"
+    url, kind, host = _parse_marketplace_source(raw, host_flag=None)
+    source = _git_source(url)
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    (checkout / "marketplace.json").write_text(
+        json.dumps({"name": "acme", "plugins": []}), encoding="utf-8"
+    )
+
+    gitcache_mock = MagicMock()
+    gitcache_mock.get_checkout.return_value = str(checkout)
+    with (
+        patch("apm_cli.cache.git_cache.GitCache", return_value=gitcache_mock),
+        patch("apm_cli.cache.paths.get_cache_root", return_value=tmp_path / "cache"),
+    ):
+        result = _fetch_git(
+            source,
+            "marketplace.json",
+            host_info=SimpleNamespace(host=host),
+            auth_resolver=fake_auth_resolver,
+        )
+
+    assert kind == "git"
+    assert host == "github.com"
+    assert source.kind == "git"
+    assert source.to_dict()["url"] == raw
+    assert result == {"name": "acme", "plugins": []}
+    assert gitcache_mock.get_checkout.call_args.args[0] == raw
+    fake_auth_resolver.resolve.assert_not_called()
+    fake_auth_resolver.resolve_for_remote.assert_called_once()
+    fake_auth_resolver.git_env_for_remote.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "ssh://git@github.com:2222/org/repo.git",
+        "git@gitea.example.com:org/repo.git",
+    ],
+)
+def test_fetch_git_ssh_does_not_forward_http_credentials(tmp_path: Path, raw: str) -> None:
+    source = _git_source(raw)
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    (checkout / "marketplace.json").write_text("{}", encoding="utf-8")
+
+    credential_env = {
+        "GITHUB_APM_PAT": "platform-secret",
+        "GITHUB_APM_PAT_ORG": "org-secret",
+        "GIT_TOKEN": "git-secret",
+        "GIT_HTTP_EXTRAHEADER": "Authorization: Bearer header-secret",
+        "GIT_CONFIG_PARAMETERS": "'http.extraheader=Authorization: Bearer config-secret'",
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": "http.extraheader",
+        "GIT_CONFIG_VALUE_0": "Authorization: Bearer indexed-secret",
+        "GIT_ASKPASS": "echo",
+        "GIT_TERMINAL_PROMPT": "0",
+    }
+    auth_resolver = MagicMock()
+    auth_resolver.resolve_for_remote.return_value = SimpleNamespace(git_env=credential_env)
+    auth_resolver.git_env_for_remote.return_value = {
+        "GIT_TERMINAL_PROMPT": "0",
+        "GIT_SSH_COMMAND": "ssh -o BatchMode=yes -o ConnectTimeout=30",
+        "SSH_ASKPASS_REQUIRE": "never",
+        "GITHUB_APM_PAT": "",
+        "GITHUB_APM_PAT_ORG": "",
+    }
+
+    gitcache_mock = MagicMock()
+    gitcache_mock.get_checkout.return_value = str(checkout)
+    with (
+        patch("apm_cli.cache.git_cache.GitCache", return_value=gitcache_mock),
+        patch("apm_cli.cache.paths.get_cache_root", return_value=tmp_path / "cache"),
+    ):
+        result = _fetch_git(
+            source,
+            "marketplace.json",
+            host_info=SimpleNamespace(
+                host="github.com" if raw.startswith("ssh://") else "gitea.example.com"
+            ),
+            auth_resolver=auth_resolver,
+        )
+
+    assert result == {}
+    auth_resolver.resolve.assert_not_called()
+    auth_resolver.resolve_for_remote.assert_called_once()
+    auth_resolver.git_env_for_remote.assert_called_once()
+    env = gitcache_mock.get_checkout.call_args.kwargs["env"]
+    assert "GIT_TOKEN" not in env
+    assert "GIT_HTTP_EXTRAHEADER" not in env
+    assert "GIT_CONFIG_PARAMETERS" not in env
+    assert "GIT_CONFIG_COUNT" not in env
+    assert "GIT_CONFIG_KEY_0" not in env
+    assert "GIT_CONFIG_VALUE_0" not in env
+    assert "GIT_ASKPASS" not in env
+    assert env["GITHUB_APM_PAT"] == ""
+    assert env["GITHUB_APM_PAT_ORG"] == ""
+    assert env["GIT_TERMINAL_PROMPT"] == "0"
+    assert env["GIT_SSH_COMMAND"] == "ssh -o BatchMode=yes -o ConnectTimeout=30"
+    assert env["SSH_ASKPASS_REQUIRE"] == "never"
 
 
 def test_fetch_git_ado_url_routes_via_subprocess(

--- a/tests/unit/marketplace/test_marketplace_commands.py
+++ b/tests/unit/marketplace/test_marketplace_commands.py
@@ -437,6 +437,56 @@ class TestMarketplaceAdd:
         assert "--host is ignored when SOURCE is a hosted marketplace.json URL" in result.output
         assert mock_add.call_args[0][0].name == "catalog"
 
+    @patch("apm_cli.marketplace.registry.add_marketplace")
+    @patch("apm_cli.marketplace.client.fetch_marketplace")
+    @patch("apm_cli.marketplace.client._auto_detect_path")
+    def test_add_mixed_case_ssh_url_warns_host_flag_is_ignored(
+        self, mock_detect, mock_fetch, mock_add, runner
+    ):
+        from apm_cli.commands.marketplace import marketplace
+
+        mock_detect.return_value = "marketplace.json"
+        mock_fetch.return_value = MarketplaceManifest(
+            name="m",
+            plugins=(MarketplacePlugin(name="p1"),),
+        )
+        result = runner.invoke(
+            marketplace,
+            [
+                "add",
+                "SSH://git@gitea.example.com:2222/org/repo.git",
+                "--host",
+                "other.example.com",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "--host is ignored when SOURCE is a full URL" in result.output
+        registered_url = urlparse(mock_add.call_args[0][0].url)
+        assert registered_url.scheme == "ssh"
+        assert registered_url.hostname == "gitea.example.com"
+        assert registered_url.port == 2222
+
+    @patch("apm_cli.marketplace.registry.add_marketplace")
+    @patch("apm_cli.marketplace.client.fetch_marketplace")
+    @patch("apm_cli.marketplace.client._auto_detect_path")
+    def test_add_unpinned_ssh_url_warns_about_mutable_ref(
+        self, mock_detect, mock_fetch, mock_add, runner
+    ):
+        from apm_cli.commands.marketplace import marketplace
+
+        mock_detect.return_value = "marketplace.json"
+        mock_fetch.return_value = MarketplaceManifest(name="m", plugins=())
+        result = runner.invoke(
+            marketplace,
+            ["add", "ssh://git@gitea.example.com:2222/org/repo.git"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Pin this git marketplace" in result.output
+        assert "--ref v1.0.0" in result.output
+        assert "#v1.0.0" not in result.output
+
     @patch("apm_cli.marketplace.client.fetch_marketplace")
     @patch("apm_cli.marketplace.client._auto_detect_path")
     def test_add_strips_dot_git_suffix(self, mock_detect, mock_fetch, runner):

--- a/tests/unit/marketplace/test_marketplace_models.py
+++ b/tests/unit/marketplace/test_marketplace_models.py
@@ -30,6 +30,26 @@ class TestMarketplaceSource:
         assert src.host == "ado.example.test"
         assert src.port == 8443
 
+    def test_explicit_ssh_url_uses_git_fetcher_for_known_host(self):
+        src = MarketplaceSource(
+            name="private-marketplace",
+            url="ssh://git@github.com:2222/acme/private-marketplace.git",
+        )
+
+        assert src.kind == "git"
+        assert src.port == 2222
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "ssh://git:secret@github.com/acme/private-marketplace.git",
+            "ssh://git@github.com/acme/%2frepository.git",
+        ],
+    )
+    def test_url_only_source_cannot_bypass_source_admission(self, url: str):
+        with pytest.raises(ValueError):
+            MarketplaceSource(name="private-marketplace", url=url)
+
     def test_frozen(self):
         src = MarketplaceSource(name="x", owner="o", repo="r")
         with pytest.raises(AttributeError):

--- a/tests/unit/marketplace/test_marketplace_registry.py
+++ b/tests/unit/marketplace/test_marketplace_registry.py
@@ -1,6 +1,7 @@
 """Tests for marketplace registry CRUD with tmp_path isolation."""
 
-import json  # noqa: F401
+import json
+from pathlib import Path
 
 import pytest
 
@@ -51,6 +52,29 @@ class TestRegistryBasicOps:
         registry_mod.add_marketplace(src2)
         assert registry_mod.marketplace_count() == 1
 
+    def test_failed_same_alias_replacement_preserves_original_registry_bytes(self):
+        registry_mod.add_marketplace(
+            MarketplaceSource(
+                name="acme",
+                url="ssh://git@[2001:db8::1]:2222/Team/Marketplace.git",
+            )
+        )
+        path = registry_mod._marketplaces_path()
+        with open(path, "rb") as registry_file:
+            before = registry_file.read()
+
+        with pytest.raises(ValueError):
+            MarketplaceSource(
+                name="acme",
+                url="ssh://git:secret@[2001:db8::1]:2222/Team/Marketplace.git",
+            )
+
+        with open(path, "rb") as registry_file:
+            assert registry_file.read() == before
+        registry_mod._invalidate_cache()
+        restored = registry_mod.get_marketplace_by_name("acme")
+        assert restored.url == "ssh://git@[2001:db8::1]:2222/Team/Marketplace.git"
+
     def test_remove(self):
         src = MarketplaceSource(name="acme", owner="o", repo="r")
         registry_mod.add_marketplace(src)
@@ -92,6 +116,31 @@ class TestRegistryPersistence:
 
         registry_mod._invalidate_cache()
         assert registry_mod.get_registered_marketplaces() == []
+
+    def test_invalid_persisted_source_does_not_hide_valid_entries(self):
+        path = Path(registry_mod._ensure_file())
+        path.write_text(
+            json.dumps(
+                {
+                    "marketplaces": [
+                        {
+                            "name": "valid",
+                            "url": "https://github.com/acme/marketplace",
+                        },
+                        {
+                            "name": "invalid",
+                            "url": "ssh:///missing-host.git",
+                        },
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        registry_mod._invalidate_cache()
+        sources = registry_mod.get_registered_marketplaces()
+
+        assert [source.name for source in sources] == ["valid"]
 
 
 class TestRegistryUtf8RoundTrip:

--- a/tests/unit/marketplace/test_parser.py
+++ b/tests/unit/marketplace/test_parser.py
@@ -3,7 +3,7 @@
 Covers:
 - local absolute / relative / ``file://`` / ``~/`` paths
 - Windows local-path cases (drive letter, .\\, ~\\)
-- SCP-like ``git@host:org/repo.git`` SSH
+- SCP-like ``git@host:org/repo.git`` and full ``ssh://`` URLs
 - HTTPS to untrusted host classified as kind=git (was: rejected pre-PR)
 - single-segment input -> ValueError
 - existing GitHub/GitLab cases still pass
@@ -16,6 +16,7 @@ from urllib.parse import urlsplit
 import pytest
 
 from apm_cli.commands.marketplace import _parse_marketplace_source
+from apm_cli.marketplace.source_identity import parse_marketplace_source
 
 
 @pytest.mark.parametrize(
@@ -59,6 +60,127 @@ def test_scp_ssh_url_classified_as_git() -> None:
     # arbitrary-substring matches CodeQL flags as URL-sanitization weakness.
     assert url == "git@gitea.example.com:org/repo.git"
     assert host == "gitea.example.com"
+
+
+def test_scp_ssh_url_rejects_query_instead_of_falling_back_to_shorthand() -> None:
+    with pytest.raises(ValueError, match="SSH URLs cannot include queries"):
+        _parse_marketplace_source(
+            "git@gitea.example.com:org/repo.git?ref=main",
+            host_flag=None,
+        )
+
+
+def test_direct_parser_rejects_invalid_host_flag() -> None:
+    with pytest.raises(ValueError, match="Invalid host"):
+        _parse_marketplace_source("owner/repo", host_flag="not a host")
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected_port"),
+    [
+        ("ssh://git@gitea.example.com/org/repo.git", None),
+        ("ssh://git@gitea.example.com:2222/org/repo.git", 2222),
+    ],
+)
+def test_ssh_protocol_url_classified_as_git(raw: str, expected_port: int | None) -> None:
+    url, kind, host = _parse_marketplace_source(raw, host_flag=None)
+
+    parsed = urlsplit(url)
+    assert kind == "git"
+    assert url == raw
+    assert parsed.scheme == "ssh"
+    assert parsed.hostname == "gitea.example.com"
+    assert parsed.port == expected_port
+    assert parsed.path == "/org/repo.git"
+    assert host == "gitea.example.com"
+
+
+def test_ssh_protocol_url_normalizes_mixed_case_scheme() -> None:
+    url, kind, host = _parse_marketplace_source(
+        "SSH://git@gitea.example.com:2222/org/repo.git", host_flag=None
+    )
+
+    parsed = urlsplit(url)
+    assert kind == "git"
+    assert url == "ssh://git@gitea.example.com:2222/org/repo.git"
+    assert parsed.scheme == "ssh"
+    assert parsed.hostname == "gitea.example.com"
+    assert parsed.port == 2222
+    assert host == "gitea.example.com"
+
+
+def test_ssh_protocol_url_on_known_host_uses_git_fetcher() -> None:
+    url, kind, host = _parse_marketplace_source(
+        "ssh://git@github.com:2222/org/repo.git", host_flag=None
+    )
+
+    assert kind == "git"
+    assert url == "ssh://git@github.com:2222/org/repo.git"
+    assert host == "github.com"
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "ssh://git@[2001:db8::1]:2222/Team/Repo.git",
+        "ssh://git@[2001:DB8::1]/Team/Repo.git",
+    ],
+)
+def test_ssh_protocol_url_preserves_validated_transport_identity(raw: str) -> None:
+    identity = parse_marketplace_source(raw)
+
+    assert identity.url == raw
+    assert identity.kind == "git"
+    assert identity.host == "2001:db8::1"
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "ssh://git@gitea.example.com/org/repo.git?ref=main",
+        "ssh://git@gitea.example.com/org/repo.git#main",
+        "git@gitea.example.com:org/repo.git#main",
+        "ssh://git@gitea.example.com/org/%2frepo.git",
+        "ssh://git@gitea.example.com/org/%5Crepo.git",
+        "ssh://git@gitea.example.com/org/%zzrepo.git",
+        "ssh://git@gitea.example.com/org/%00repo.git",
+        "ssh://git%40user@gitea.example.com/org/repo.git",
+        "ssh://git@gitea.example.com%2fevil/org/repo.git",
+        "ssh://git@gitea.example.com%3a2222/org/repo.git",
+    ],
+)
+def test_ssh_protocol_url_rejects_ambiguous_or_unsafe_components(raw: str) -> None:
+    with pytest.raises(ValueError):
+        parse_marketplace_source(raw)
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "ssh://git@/org/repo.git",
+        "ssh://git@gitea.example.com",
+        "ssh://git@gitea.example.com:not-a-port/org/repo.git",
+        "ssh://git@gitea.example.com:0/org/repo.git",
+        "ssh://git@gitea.example.com:65536/org/repo.git",
+        "ssh://%2Doption@gitea.example.com/org/repo.git",
+        "ssh://git@gitea.example.com/org/%2e%2e/repo.git",
+        "ssh://git@gitea.example.com/org/%2e%2e%2frepo.git",
+        "ssh://git@gitea.example.com/org/%252e%252e%252frepo.git",
+    ],
+)
+def test_invalid_ssh_protocol_url_rejected(raw: str) -> None:
+    with pytest.raises(ValueError):
+        _parse_marketplace_source(raw, host_flag=None)
+
+
+def test_password_bearing_ssh_protocol_url_rejected_without_echoing_secret() -> None:
+    raw = "ssh://git:placeholder-password@gitea.example.com:2222/org/repo.git"
+
+    with pytest.raises(ValueError) as exc_info:
+        _parse_marketplace_source(raw, host_flag=None)
+
+    assert "password" in str(exc_info.value).lower()
+    assert "placeholder-password" not in str(exc_info.value)
 
 
 def test_https_untrusted_host_classified_as_git() -> None:
@@ -108,13 +230,12 @@ def test_explicit_host_flag_combined_with_owner_repo() -> None:
     assert parsed.path.rstrip("/") == "/owner/repo"
 
 
-def test_https_ado_url_classified_as_git() -> None:
-    """ADO is no longer rejected at the parser layer."""
+def test_https_ado_url_classified_as_ado() -> None:
+    """ADO stays on its HTTPS REST fetch path after source admission."""
     url, kind, host = _parse_marketplace_source(
         "https://dev.azure.com/contoso/eng/_git/agent-forge", host_flag=None
     )
-    # ADO classification routes through "git" kind so subprocess-git fetcher handles it.
-    assert kind == "git"
+    assert kind == "ado"
     # Use urlsplit().hostname for exact host match (CodeQL: avoid substring sanitization).
     assert urlsplit(url).hostname == "dev.azure.com"
     assert host == "dev.azure.com"
@@ -127,7 +248,7 @@ def test_https_ado_url_preserves_encoded_path_presentation() -> None:
     )
 
     parsed = urlsplit(url)
-    assert kind == "git"
+    assert kind == "ado"
     assert host == "dev.azure.com"
     assert parsed.path == "/contoso/My%20Projects/_git/agent-forge"
 

--- a/tests/unit/scripts/test_architecture_runner.py
+++ b/tests/unit/scripts/test_architecture_runner.py
@@ -661,6 +661,7 @@ marketplace-integrations-producer-admission
 marketplace-integrations-projection-boundary
 marketplace-integrations-raw-diagnostics
 marketplace-integrations-removed-plugin-lifecycle
+marketplace-integrations-source-admission
 marketplace-integrations-source-parsing
 marketplace-integrations-tag-pattern
 marketplace-integrations-version-precedence

--- a/tests/unit/test_git_cache_branch_coverage.py
+++ b/tests/unit/test_git_cache_branch_coverage.py
@@ -490,14 +490,14 @@ class TestSanitizeUrl:
         url = "https://github.com/org/repo.git"
         assert _sanitize_url(url) == url
 
-    def test_password_replaced(self):
+    def test_userinfo_removed(self):
         from apm_cli.cache.git_cache import _sanitize_url
 
         url = "https://user:secret@github.com/org/repo.git"
         result = _sanitize_url(url)
         assert "secret" not in result
-        assert "***" in result
-        assert "user" in result
+        assert "user" not in result
+        assert result == "https://github.com/org/repo.git"
 
     def test_bad_url_returns_original(self):
         from apm_cli.cache.git_cache import _sanitize_url

--- a/tests/unit/test_git_cache_phase3w4.py
+++ b/tests/unit/test_git_cache_phase3w4.py
@@ -490,14 +490,14 @@ class TestSanitizeUrl:
         url = "https://github.com/org/repo.git"
         assert _sanitize_url(url) == url
 
-    def test_password_replaced(self):
+    def test_userinfo_removed(self):
         from apm_cli.cache.git_cache import _sanitize_url
 
         url = "https://user:secret@github.com/org/repo.git"
         result = _sanitize_url(url)
         assert "secret" not in result
-        assert "***" in result
-        assert "user" in result
+        assert "user" not in result
+        assert result == "https://github.com/org/repo.git"
 
     def test_bad_url_returns_original(self):
         from apm_cli.cache.git_cache import _sanitize_url


### PR DESCRIPTION
# fix(marketplace): support fully qualified SSH URLs

## TL;DR

`apm marketplace add` now accepts fully qualified `ssh://` Git URLs, including custom ports, without rewriting or misclassifying them as shorthand. Marketplace source parsing has one canonical owner, and SSH fetches retain local SSH authentication while excluding APM platform and registry credentials from child Git processes. This supersedes #2466 after its contributor CLA check remained queued for a month.

> [!IMPORTANT]
> Original implementation by @donglrd, based on the report from @ryodocx in #2464. The replacement commit preserves @donglrd as co-author.

## Problem (WHY)

- [x] `apm marketplace add ssh://git@host:2222/org/repo.git` fell through to shorthand parsing, producing a mangled `ssh:/...` repository path instead of contacting the requested host.
- [x] SCP-style syntax cannot express a custom SSH port, so affected self-hosted users had no native APM syntax for their repository.
- [x] Marketplace parsing, persistence, and fetch code separately inferred source identity, creating drift risk across security-sensitive transport decisions.
- [!] Child Git processes must not inherit unrelated HTTP platform or registry credentials when the selected transport is SSH.

The fix makes the user-visible result deterministic and testable, following [“Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action.”](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) Centralizing admission in one parser follows [“Favor small, chainable primitives over monolithic frameworks.”](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/)

## Approach (WHAT)

| # | Fix | Principle |
|---:|---|---|
| 1 | Parse local, shorthand, HTTPS, SCP, and `ssh://` sources through `parse_marketplace_source`. | Vendor-neutral, DevX |
| 2 | Preserve the validated SSH username, host, port, path casing, and optional `.git` suffix in persisted marketplace state. | Portability by manifest |
| 3 | Route every remote fetch through `AuthResolver.resolve_for_remote` and `git_env_for_remote`; clear platform and registry credential variables before Git starts. | Secure by default |
| 4 | Guard the single-owner boundary through the owner registry and architecture linter. | Governed by policy |
| 5 | Keep existing HTTPS, SCP, local-path, cache, and legacy marketplace behavior covered while adding the new form. | OSS / community-driven |

## Implementation (HOW)

| Area | Files | Intent |
|---|---|---|
| Canonical source identity | `src/apm_cli/marketplace/source_identity.py` | Adds the single parser and validated `MarketplaceSourceIdentity` for transport, host, port, and fetcher kind. |
| Command and persistence adapters | `src/apm_cli/commands/marketplace/__init__.py`<br>`src/apm_cli/marketplace/models.py`<br>`src/apm_cli/marketplace/registry.py` | Replaces command-local parsing with the canonical adapter and preserves validated SSH identity across JSON round trips. |
| Fetch and auth routing | `src/apm_cli/marketplace/client.py`<br>`src/apm_cli/core/auth.py` | Uses the current remote-aware AuthResolver policy and expands child-process secret scrubbing to proxy and named-registry credentials. |
| Git cache safety | `src/apm_cli/cache/git_cache.py`<br>`src/apm_cli/cache/url_normalize.py` | Keeps SCP/SSH cache identity stable, passes hardened environments through Git operations, and redacts userinfo in cache diagnostics. |
| Existing dependency URL guard | `src/apm_cli/models/dependency/reference.py` | Documents the narrow multi-decode detection exemption retained from #2581; no dependency URL behavior changes. |
| Architecture ownership | `.apm/architecture/owners/marketplace-plugins.json`<br>`scripts/architecture_linter/checks/marketplace_bundle_and_audit.py`<br>`scripts/architecture_linter/checks/transport_auth_platform.py` | Registers source admission as a durable owner and updates URL-path/auth assertions to the current owners. |
| Architecture tests | `tests/integration/test_architecture_marketplace_source_admission.py`<br>`tests/integration/test_architecture_owner_rule_mutations.py`<br>`tests/unit/scripts/test_architecture_runner.py` | Proves the owner is registered, executable, and mutation-sensitive. |
| Runtime regression tests | `tests/integration/test_marketplace_ssh_subprocess.py`<br>`tests/integration/test_git_cache_hermetic.py`<br>`tests/unit/marketplace/test_parser.py`<br>`tests/unit/marketplace/test_client_git.py`<br>`tests/unit/marketplace/test_marketplace_commands.py`<br>`tests/unit/marketplace/test_marketplace_models.py`<br>`tests/unit/marketplace/test_marketplace_registry.py` | Covers parsing, persistence, subprocess boundaries, existing source forms, and actionable failures. |
| Cache regression tests | `tests/unit/cache/test_git_cache.py`<br>`tests/unit/cache/test_git_cache_hardening.py`<br>`tests/unit/cache/test_git_cache_sparse.py`<br>`tests/unit/cache/test_url_normalize.py`<br>`tests/unit/test_git_cache_branch_coverage.py`<br>`tests/unit/test_git_cache_phase3w4.py` | Covers cache identity, redaction, safe Git arguments, sparse behavior, and failure branches. |
| User documentation | `CHANGELOG.md`<br>`docs/src/content/docs/consumer/installing-from-marketplaces.md`<br>`docs/src/content/docs/getting-started/authentication.md`<br>`docs/src/content/docs/reference/cli/marketplace.md`<br>`packages/apm-guide/.apm/skills/apm-usage/authentication.md`<br>`packages/apm-guide/.apm/skills/apm-usage/commands.md` | Documents accepted SSH syntax, custom ports, authentication behavior, and the credential boundary. |

## Diagrams

Legend: The dashed nodes are the new source-admission path; the remaining nodes are the existing canonical remote-auth and Git-cache path retained from current `main`.

```mermaid
flowchart LR
    subgraph Admission[Marketplace source admission]
        C["apm marketplace add SOURCE"]
        P["parse_marketplace_source"]:::new
        I["MarketplaceSourceIdentity"]:::new
        M["MarketplaceSource"]
    end
    subgraph Fetch[Remote fetch]
        R["AuthResolver.resolve_for_remote"]
        E["AuthResolver.git_env_for_remote"]
        G["GitCache.get_checkout"]
        S["git subprocess"]
    end
    C --> P
    P --> I
    I --> M
    M --> R
    R --> E
    E --> G
    G --> S
    classDef new stroke-dasharray: 5 5;
    class P,I new;
```

## Trade-offs

- **Canonical parser instead of another CLI branch.** The change introduces `source_identity.py` and removes command-local parsing; retaining parallel parsers was rejected because persistence and fetch classification could drift.
- **Preserve explicit transport instead of normalizing to HTTPS.** An `ssh://` input remains SSH, including its custom port; silently rewriting it would defeat the user's authentication and routing choice.
- **Reuse current AuthResolver transport policy instead of the contributor branch's separate SSH environment builder.** This avoids a second credential authority while retaining the reviewed SSH behavior from current `main`.
- **Broader child-process secret scrub.** Proxy and named-registry credentials are removed from every Git child environment, not only marketplace SSH calls; Git has no valid use for those HTTP registry secrets.
- **One narrow architecture exemption retained.** Dependency-reference embedded-subpath detection still recursively reveals encoded primitive names to preserve its existing actionable error; that behavior is outside #2464 and remains explicitly marked.

## Benefits

1. Fully qualified SSH marketplace URLs with ports `1..65535` reach Git with scheme, user, host, port, path case, and `.git` suffix intact.
2. The #2464 reproduction advances to the Git network stage instead of failing locally with a mangled `ssh:/` path.
3. Platform PATs, proxy tokens, and named-registry credentials are absent from the real child-process environment used for an SSH fetch.
4. One registered architecture rule prevents command, model, or client code from reintroducing a second marketplace source parser.
5. Existing HTTPS, SCP, local-path, and shorthand inputs remain covered by focused regression tests.

## Validation

<details><summary>Commands executed from the cached repository environment</summary>

```bash
ruff check src/ tests/ scripts/lint_architecture_boundaries.py scripts/architecture_linter/
ruff format --check src/ tests/ scripts/lint_architecture_boundaries.py scripts/architecture_linter/
PYTHONPATH="$PWD/src:$PWD" python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/ scripts/lint_architecture_boundaries.py scripts/architecture_linter/
bash scripts/lint-auth-signals.sh
PYTHONPATH="$PWD/src:$PWD" python scripts/lint_architecture_boundaries.py --root "$PWD"
PYTHONPATH="$PWD/src:$PWD" python -m pytest -q \
  tests/unit/marketplace/test_parser.py \
  tests/unit/marketplace/test_client_git.py \
  tests/unit/marketplace/test_marketplace_models.py \
  tests/unit/marketplace/test_marketplace_registry.py \
  tests/integration/test_marketplace_ssh_subprocess.py \
  tests/integration/test_architecture_marketplace_source_admission.py \
  tests/unit/core/test_git_transport_policy.py \
  tests/integration/test_architecture_dependency_reference.py \
  tests/unit/test_generic_git_urls.py
```

</details>

Lint and architecture gates:

```text
All checks passed!
1773 files already formatted

--------------------------------------------------------------------
Your code has been rated at 10.00/10

[*] Rule A: get_bearer_provider boundary (any reference)
[*] Rule B: git ls-remote auth-delegated annotation
[+] auth-signal lint clean
```

<details><summary>Focused pytest output (366 tests)</summary>

```text
........................................................................ [ 19%]
........................................................................ [ 39%]
........................................................................ [ 59%]
........................................................................ [ 78%]
........................................................................ [ 98%]
......                                                                   [100%]
366 passed in 3.12s
```

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---:|---|---|---|---|
| 1 | Add an `ssh://` marketplace on a custom port and reach Git with the URL unchanged. | Vendor-neutral, DevX | `tests/integration/test_marketplace_ssh_subprocess.py::test_ssh_marketplace_process_preserves_port_without_http_credentials` (regression-trap for #2464)<br>`tests/unit/marketplace/test_client_git.py::test_fetch_git_preserves_ssh_protocol_url_with_port` | integration + unit |
| 2 | Fetch an SSH marketplace without exposing HTTP platform, proxy, or registry credentials to the child process. | Secure by default | `tests/integration/test_marketplace_ssh_subprocess.py::test_ssh_marketplace_process_preserves_port_without_http_credentials` | integration |
| 3 | Reject password-bearing, malformed, traversal, query, fragment, or encoded-separator SSH sources before persistence. | Secure by default, Governed by policy | `tests/unit/marketplace/test_parser.py::test_ssh_protocol_url_rejects_ambiguous_or_unsafe_components`<br>`tests/unit/marketplace/test_parser.py::test_password_bearing_ssh_protocol_url_rejected_without_echoing_secret` | unit |
| 4 | Reload a registered SSH marketplace without changing its transport identity. | Portability by manifest | `tests/unit/marketplace/test_marketplace_registry.py`<br>`tests/unit/marketplace/test_marketplace_models.py` | unit |
| 5 | Cache diagnostics do not reveal SSH userinfo. | Secure by default | `tests/unit/cache/test_git_cache_hardening.py::TestGitCacheSubprocessHardening::test_cache_hit_log_omits_ssh_userinfo` | unit |

## How to test

- [ ] Run `apm marketplace add ssh://git@HOST:2222/ORG/REPO.git --name ssh-test`; expect APM to contact `HOST:2222`, not report an `ssh:/...` local path.
- [ ] Run `apm marketplace list --verbose`; expect the stored source to retain the full `ssh://` URL and custom port.
- [ ] Set an SSH key or agent for the host and run `apm marketplace update ssh-test`; expect Git to authenticate through SSH without an interactive password prompt.
- [ ] Try `ssh://user:password@HOST/ORG/REPO.git`; expect registration to fail without echoing the password.
- [ ] Re-run the focused test command from Validation; expect `366 passed`.

Closes #2464.
Supersedes #2466.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
