### PR TITLE
fix: classify dot-prefixed marketplace paths as local

### DIFF
--- a/src/apm_cli/marketplace/source_identity.py
+++ b/src/apm_cli/marketplace/source_identity.py
@@ -250,7 +250,11 @@ def _looks_like_local_marketplace_source(raw: str) -> bool:
     """Return whether *raw* is a local filesystem source."""
     if raw.lower().startswith("file://"):
         return True
-    if raw.startswith(("/", "./", "../", "~/", ".\\", "..\\", "~\\")) or raw == "~":
+    if (
+        raw.startswith(("/", "./", "../", "~/", ".\\", "..\\", "~\\"))
+        or raw == "~"
+        or (raw.startswith(".") and ("/" in raw or "\\" in raw))
+    ):
         return True
     return len(raw) >= 3 and raw[0].isalpha() and raw[1] == ":" and raw[2] in ("\\", "/")
 

--- a/tests/unit/marketplace/test_parser.py
+++ b/tests/unit/marketplace/test_parser.py
@@ -24,6 +24,7 @@ from apm_cli.marketplace.source_identity import parse_marketplace_source
     [
         "/srv/marketplaces/agent-forge",
         "./relative/path",
+        ".github/plugin/marketplace.json",
         "../up/path",
         "~/code/marketplace",
         "~",

--- a/tests/unit/marketplace/test_parser.py
+++ b/tests/unit/marketplace/test_parser.py
@@ -44,6 +44,7 @@ def test_local_paths_classified_as_local(raw: str) -> None:
         r"C:\repos\mkt",
         r"C:/repos/mkt",
         r".\local",
+        r".github\plugin\marketplace.json",
     ],
 )
 def test_windows_paths_classified_as_local(raw: str) -> None:


### PR DESCRIPTION
## Summary

- Classify dot-prefixed local marketplace paths such as `.github/plugin/marketplace.json` before shorthand parsing.
- Preserve existing GitHub `OWNER/REPO` shorthand behavior.
- Add parser regression tests for POSIX and Windows path separators.

Fixes #2728

## Scenario Evidence

| User promise | APM principle | Regression trap |
|---|---|---|
| Dot-prefixed marketplace paths using slash or backslash separators are treated as local sources. | DevX | `tests/unit/marketplace/test_parser.py::test_local_paths_classified_as_local` and `tests/unit/marketplace/test_parser.py::test_windows_paths_classified_as_local` |

## Validation

- `uv run pytest tests/unit/marketplace/test_parser.py -q` (52 passed)
- `uv run ruff check src tests/unit/marketplace/test_parser.py` is blocked by pre-existing repository-wide lint findings outside this diff.
- `uv run ruff format --check src tests/unit/marketplace/test_parser.py` passed.
- `uv run mypy src/apm_cli` is blocked by existing cross-repository errors.
- `uv run pytest tests/unit -q -x` is blocked by an existing Windows POSIX-mode test failure after 20 passed.
