### PR TITLE
fix: avoid attributing shared .agents paths (closes #2743)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Repositories that publish plugin metadata alongside an eligible root
   `apm.yml` now install as APM packages; metadata-only manifests continue to
   select the plugin layout. (#2776)
+- Legacy lockfile synthesis now leaves shared `.agents/` deployment paths
+  unattributed instead of assigning them to Copilot's `.github/` target. (#2774)
 - `apm install` now preserves previously deployed skills when package
   integration is skipped instead of treating them as stale cleanup candidates.
   (#2758)

--- a/src/apm_cli/core/deployment_ledger.py
+++ b/src/apm_cli/core/deployment_ledger.py
@@ -35,7 +35,6 @@ _LEGACY_TARGET_PREFIXES = {
     ".gemini/": "gemini",
     ".codex/": "codex",
     ".opencode/": "opencode",
-    ".agents/": "agents",
 }
 _LEGACY_USER_TARGET_PREFIXES = {
     ".copilot/": "copilot",

--- a/tests/integration/test_lifecycle_reconciliation.py
+++ b/tests/integration/test_lifecycle_reconciliation.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+from apm_cli.core.deployment_ledger import DeploymentLedgerCodec
 from apm_cli.core.deployment_state import (
     DeploymentIntent,
     DeploymentLedger,
@@ -13,6 +14,7 @@ from apm_cli.core.deployment_state import (
     NativePayloadValidation,
 )
 from apm_cli.core.target_catalog import TARGET_CAPABILITIES
+from apm_cli.deps.lockfile import LockFile
 from apm_cli.integration.targets import TargetProfile
 from apm_cli.policy.ci_checks import _check_content_integrity
 from apm_cli.utils.diagnostics import DiagnosticCollector
@@ -81,11 +83,29 @@ def test_install_update_compile_uninstall_share_one_owner(tmp_path: Path) -> Non
     assert uninstall.removed == (locator,)
 
 
+def test_legacy_shared_agents_path_remains_unattributed(tmp_path: Path) -> None:
+    """A persisted legacy shared-root path must synthesize neutral provenance."""
+    lock_path = tmp_path / "apm.lock.yaml"
+    lock_path.write_text(
+        "lockfile_version: '1'\n"
+        "dependencies:\n"
+        "  - repo_url: owner/package\n"
+        "    deployed_files:\n"
+        "      - .agents/skills/demo/SKILL.md\n",
+        encoding="utf-8",
+    )
+
+    lockfile = LockFile.read(lock_path)
+
+    assert lockfile is not None
+    ledger = DeploymentLedgerCodec.from_lockfile(lockfile)
+    record = next(iter(ledger.records.values()))
+    assert record.locator.target == "legacy"
+
+
 def test_content_integrity_fails_when_ownership_row_is_absent(
     tmp_path: Path,
 ) -> None:
-    from apm_cli.deps.lockfile import LockFile
-
     path = tmp_path / ".github" / "agents" / "demo.agent.md"
     path.parent.mkdir(parents=True)
     path.write_text("demo", encoding="utf-8")

--- a/tests/unit/core/test_deployment_state.py
+++ b/tests/unit/core/test_deployment_state.py
@@ -555,6 +555,13 @@ def test_legacy_import_and_dual_write_are_semantically_equivalent() -> None:
     assert rebuilt.is_semantically_equivalent(lockfile)
 
 
+def test_legacy_shared_agents_path_has_unattributable_target() -> None:
+    """A shared .agents root must not be attributed to the deprecated alias."""
+    locator = DeploymentLedgerCodec._legacy_locator(".agents/skills/demo/SKILL.md")
+
+    assert locator.target == "legacy"
+
+
 def test_legacy_owner_update_preserves_canonical_shared_root_locator() -> None:
     """A compatibility projection must not demote a concrete shared-root target."""
     path = ".agents/skills/demo/SKILL.md"


### PR DESCRIPTION
Legacy deployment synthesis attributed the shared `.agents` root to the deprecated `agents` alias. No consumer branches on that value today; this is a metadata-correctness and future-proofing fix so shared-root legacy rows remain unattributable instead of looking like a real target.

The production change removes the ambiguous `.agents/` prefix mapping from legacy path synthesis so `_legacy_locator` falls back to the existing `legacy` sentinel. The property is covered at the tiers where it lives: focused unit coverage and persisted-lockfile reconciliation coverage.

Architecture classification: owner-extension; `deployment_ledger.py` remains the registered canonical owner, consumers already route through it, and the existing `install-deployment-provenance-state` static guard covers that boundary, so no new dual guard is required.

## Validation

- `uv run --frozen --extra dev pytest tests/unit/core/test_deployment_state.py -q`
- `uv run --frozen --extra dev pytest tests/integration/test_lifecycle_reconciliation.py::test_legacy_shared_agents_path_remains_unattributed -q`
- `bash scripts/lint-architecture-boundaries.sh`
- Canonical lint checks

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|---|---|---|---|
| 1 | Upgrading a legacy lockfile with a shared `.agents/` skill path records neutral legacy provenance instead of the deprecated `agents` alias. | Multi-harness support, Vendor-neutral | `tests/integration/test_lifecycle_reconciliation.py::test_legacy_shared_agents_path_remains_unattributed` (regression-trap for #2743)<br/>`tests/unit/core/test_deployment_state.py::test_legacy_shared_agents_path_has_unattributable_target` | integration, unit |

Closes #2743.