### PR TITLE
fix: prefer APM manifests over plugins (closes #2735)

### DIFF
--- a/.apm/architecture/owners/marketplace-plugins.json
+++ b/.apm/architecture/owners/marketplace-plugins.json
@@ -64,6 +64,16 @@
       "guards": ["marketplace-integrations-agent-plugin-contract"]
     },
     {
+      "id": "package-format-precedence",
+      "decision": "Package format precedence",
+      "owner": "models/format_detection.py (NormalizationPlanner)",
+      "selectors": [
+        "src/apm_cli/bundle/local_bundle.py",
+        "src/apm_cli/models/format_detection.py"
+      ],
+      "guards": ["marketplace-integrations-package-format-precedence"]
+    },
+    {
       "id": "agent-plugin-producer-admission",
       "decision": "Agent Plugin producer portable-surface admission",
       "owner": "bundle/agent_plugin_exporter.py (_require_portable_agent_plugin)",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   project-root `.lsp.json` files remain unchanged for manual review, and target
   changes, package uninstall, and later executable denial remove only LSP
   entries that APM created. (#2733)
+- Repositories that publish plugin metadata alongside an eligible root
+  `apm.yml` now install as APM packages; metadata-only manifests continue to
+  select the plugin layout. (#2776)
 - `apm install` now preserves previously deployed skills when package
   integration is skipped instead of treating them as stale cleanup candidates.
   (#2758)

--- a/docs/src/content/docs/reference/cli/plugin.md
+++ b/docs/src/content/docs/reference/cli/plugin.md
@@ -18,6 +18,10 @@ apm plugin init my-skill --yes
 
 `apm plugin init` scaffolds a publishable plugin in the current directory: a `plugin.json` manifest plus an `apm.yml` carrying a `devDependencies` block. The result is a working tree you can commit, tag, and reference from a marketplace.
 
+The generated dependency block is empty so direct installs select the plugin
+layout. Adding an APM or MCP dependency makes `apm.yml` eligible and switches
+direct installs to the APM package layout.
+
 `apm plugin` is the noun-verb home for plugin-author workflows, mirroring `apm marketplace` for marketplace-author verbs. Today it ships a single verb -- `apm plugin init`. Sibling verbs live under the same namespace as they ship.
 
 The two common repo shapes for plugin authors -- **single-plugin** (one plugin per repo) and **aggregator** (one repo that ships a marketplace plus the plugins it indexes) -- are not gated by flags. They emerge from composing `apm plugin init` and [`apm marketplace init`](../marketplace/#apm-marketplace-init) in the same working tree.

--- a/docs/src/content/docs/reference/manifest-schema.md
+++ b/docs/src/content/docs/reference/manifest-schema.md
@@ -791,6 +791,11 @@ Created automatically by [`apm plugin init`](../cli/plugin/). Use [`apm install 
 apm install --dev owner/test-helpers
 ```
 
+Once this section contains an APM or MCP dependency, the root `apm.yml`
+becomes eligible and direct installs select the APM package layout over a
+co-located `plugin.json`. Keep the section empty when direct installs should
+select the plugin layout.
+
 Plain `apm install` (no flag) deploys both `dependencies` and
 `devDependencies`. There is no `--omit=dev` flag today; the dev/prod separation
 kicks in at `apm pack` (plugin format, the default). The local-content scanner

--- a/docs/src/content/docs/reference/package-types.md
+++ b/docs/src/content/docs/reference/package-types.md
@@ -19,6 +19,11 @@ Pick the form that matches the author's intent -- APM preserves it.
 | `plugin.json` with an Agent Plugins `$schema` | Portable Agent Plugin | Installed whole and registered when the effective targets include Copilot |
 | Marketplace entry with inline `lspServers` or `mcpServers` | Catalog owns server metadata | Synthesize and validate `apm.yml`, then deploy servers |
 
+When plugin signals coexist with an eligible `apm.yml`, the APM layout wins.
+An `apm.yml` is eligible when the root also has `.apm/` or the manifest
+declares APM or MCP dependencies. To intentionally select a plugin layout,
+omit `apm.yml` or keep it metadata-only, without `.apm/` or dependencies.
+
 ## APM package (`.apm/` directory)
 
 The classic APM layout. Primitives live under `.apm/` in typed subdirectories.

--- a/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
@@ -14,6 +14,11 @@ how to install it:
 | `plugin.json` (no `$schema`) / `.claude-plugin/` | Claude plugin collection | Dissect via plugin artifact mapping |
 | `plugin.json` with an Agent Plugins `$schema` | Portable Agent Plugin | Acquired and locked as one opaque unit; registered when effective targets include Copilot and admission gates pass. Excluded targets create no native registration or loose primitive projection. APM does not require the runtime during lifecycle operations; loading requires supported Copilot CLI 1.0.81 or newer |
 
+When plugin signals coexist with an eligible `apm.yml`, the APM layout wins.
+An `apm.yml` is eligible when the root also has `.apm/` or the manifest
+declares APM or MCP dependencies. To intentionally select a plugin layout,
+omit `apm.yml` or keep it metadata-only, without `.apm/` or dependencies.
+
 For Agent Plugins with the same declared name, a direct dependency wins over a
 transitive dependency. APM refuses same-precedence collisions and does not
 silently repoint a ledger-recorded owner to a transitive claimant.

--- a/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
@@ -109,6 +109,9 @@ debug bridges, and other author-only servers in
 `devDependencies.mcp`. The root package receives both sections in its
 authoring environment; consumers of that package receive only
 `dependencies.mcp`, including when the package is nested transitively.
+Adding either kind of MCP dependency makes the root `apm.yml` eligible, so
+direct installs select the APM package layout over a co-located plugin
+manifest. Keep `apm.yml` metadata-only to preserve plugin selection.
 See [MCP dependency formats](dependencies.md#mcp-dependency-formats).
 
 ## Hook files

--- a/scripts/architecture_linter/checks/marketplace_catalog_and_contract.py
+++ b/scripts/architecture_linter/checks/marketplace_catalog_and_contract.py
@@ -149,6 +149,7 @@ def _check_catalog_manifest(provider: FactsProvider) -> tuple[Violation, ...]:
 
 
 _RID_CONTRACT = "marketplace-integrations-agent-plugin-contract"
+_RID_FORMAT_PRECEDENCE = "marketplace-integrations-package-format-precedence"
 
 
 _LOADER = "src/apm_cli/agent_plugins/loader.py"
@@ -641,6 +642,48 @@ def _check_loader_ownership(provider: FactsProvider, inv: frozenset[str]) -> tup
     return tuple(findings)
 
 
+def _check_package_format_precedence(provider: FactsProvider) -> tuple[Violation, ...]:
+    inv = frozenset(provider.inventory)
+    findings: list[Violation] = []
+    findings.extend(
+        _require_subs(
+            provider,
+            inv,
+            _RID_FORMAT_PRECEDENCE,
+            _FORMAT_DETECTION,
+            ("class NormalizationPlanner:", "if has_eligible_apm_yml:"),
+            "NormalizationPlanner must own eligible-manifest precedence",
+        )
+    )
+    findings.extend(
+        _require_subs(
+            provider,
+            inv,
+            _RID_FORMAT_PRECEDENCE,
+            _VALIDATION,
+            (
+                "pkg_type, plugin_json_path = detect_package_type(",
+                "agent_plugin_detection=native_detection",
+            ),
+            "validation must delegate package-format precedence to the planner",
+        )
+    )
+    findings.extend(
+        _require_subs(
+            provider,
+            inv,
+            _RID_FORMAT_PRECEDENCE,
+            _LOCAL_BUNDLE,
+            (
+                "package_type, _ = detect_package_type(",
+                "if package_type != PackageType.AGENT_PLUGIN:",
+            ),
+            "Agent Plugin ingress must delegate package-format precedence to the planner",
+        )
+    )
+    return tuple(findings)
+
+
 def _calls_in_scope_match(facts: FileFacts, scope: str, terminals: frozenset[str]) -> bool:
     return any(
         call.scope == scope
@@ -698,6 +741,13 @@ RULES: tuple[Rule, ...] = (
         guard_ids=(_RID_CONTRACT,),
         description="Agent Plugins v1 contract and component IR stay owned by agent_plugins/loader.py.",
         check=_check_agent_plugin_contract,
+    ),
+    Rule(
+        id=_RID_FORMAT_PRECEDENCE,
+        group=GROUP,
+        guard_ids=(_RID_FORMAT_PRECEDENCE,),
+        description="Package ingress delegates format precedence to NormalizationPlanner.",
+        check=_check_package_format_precedence,
     ),
 )
 

--- a/scripts/architecture_linter/checks/marketplace_catalog_and_contract.py
+++ b/scripts/architecture_linter/checks/marketplace_catalog_and_contract.py
@@ -476,10 +476,12 @@ def _check_component_ir(provider: FactsProvider, inv: frozenset[str]) -> tuple[V
             _VALIDATION,
             (
                 "agent_plugin_detection: AgentPluginDetection | None = None",
+                "pkg_type, plugin_json_path = detect_package_type(",
+                "agent_plugin_detection=native_detection",
                 "result.agent_plugin = plugin",
                 "detection.manifest_path.parent.resolve() != package_root",
             ),
-            "same-root detection reuse or cross-root rejection changed",
+            "validation must reuse detection while routing precedence through the planner",
         )
     )
     findings.extend(
@@ -518,7 +520,11 @@ def _check_loader_ownership(provider: FactsProvider, inv: frozenset[str]) -> tup
             inv,
             _RID_CONTRACT,
             _LOCAL_BUNDLE,
-            ("if schema_id == PLUGIN_SCHEMA_ID:",),
+            (
+                "if schema_id == PLUGIN_SCHEMA_ID:",
+                "package_type, _ = detect_package_type(",
+                "if package_type != PackageType.AGENT_PLUGIN:",
+            ),
             "plugin schema routing must select exact schema IDs",
         )
     )

--- a/src/apm_cli/bundle/local_bundle.py
+++ b/src/apm_cli/bundle/local_bundle.py
@@ -100,9 +100,20 @@ def classify_plugin_manifest_schema(document: Mapping[str, Any]) -> PluginSchema
 def route_agent_plugin_package(package_root: Path) -> AgentPluginDetection | None:
     """Route one materialized package through canonical Agent Plugin admission."""
     from ..agent_plugins.loader import detect_agent_plugin
+    from ..models.validation import PackageType, detect_package_type
 
     detection = detect_agent_plugin(package_root)
-    if detection is not None and detection.error is not None:
+    if detection is None:
+        return None
+    package_type, _ = detect_package_type(
+        package_root,
+        agent_plugin_detection=detection,
+    )
+    if package_type != PackageType.AGENT_PLUGIN:
+        if package_type == PackageType.INVALID and detection.error is not None:
+            raise detection.error
+        return None
+    if detection.error is not None:
         raise detection.error
     return detection
 

--- a/src/apm_cli/models/format_detection.py
+++ b/src/apm_cli/models/format_detection.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
+    from ..agent_plugins import AgentPluginDetection
     from .validation import PackageType
 
 from ..constants import APM_DIR, APM_YML_FILENAME, SKILL_MD_FILENAME
@@ -301,6 +302,13 @@ class AgentPluginDetector:
         from ..agent_plugins.loader import detect_agent_plugin
 
         detection = detect_agent_plugin(package_path)
+        return self.from_detection(detection)
+
+    @staticmethod
+    def from_detection(
+        detection: AgentPluginDetection | None,
+    ) -> AgentPluginFormatEvidence | None:
+        """Convert canonical Agent Plugin detection into planner evidence."""
         if detection is None:
             return None
         return AgentPluginFormatEvidence(
@@ -357,7 +365,12 @@ class PackageFormatRegistry:
     ) -> None:
         self._detectors = detectors if detectors is not None else _DEFAULT_DETECTORS
 
-    def detect(self, package_path: Path) -> DetectionReport:
+    def detect(
+        self,
+        package_path: Path,
+        *,
+        agent_plugin_detection: AgentPluginDetection | None = None,
+    ) -> DetectionReport:
         """Run all detectors against ``package_path`` and return the report."""
         apm_yml_ev: ApmYmlFormatEvidence | None = None
         skill_md_ev: SkillMdFormatEvidence | None = None
@@ -366,7 +379,10 @@ class PackageFormatRegistry:
         claude_plugin_ev: ClaudePluginFormatEvidence | None = None
 
         for detector in self._detectors:
-            result = detector.detect(package_path)
+            if isinstance(detector, AgentPluginDetector) and agent_plugin_detection is not None:
+                result = detector.from_detection(agent_plugin_detection)
+            else:
+                result = detector.detect(package_path)
             if isinstance(result, ApmYmlFormatEvidence):
                 apm_yml_ev = result
             elif isinstance(result, SkillMdFormatEvidence):

--- a/src/apm_cli/models/format_detection.py
+++ b/src/apm_cli/models/format_detection.py
@@ -406,7 +406,8 @@ class NormalizationPlanner:
        schema family.
     3. ``MARKETPLACE_PLUGIN`` -- Claude plugin detector found a manifest
        (``plugin.json`` or ``.claude-plugin/``).
-    4. ``HYBRID`` -- root ``SKILL.md`` AND metadata-only ``apm.yml``.
+    4. ``HYBRID`` -- root ``SKILL.md`` AND ``apm.yml`` (eligible or
+       metadata-only).
     5. ``CLAUDE_SKILL`` -- root ``SKILL.md`` only (no ``apm.yml``).
     6. ``SKILL_BUNDLE`` -- nested ``skills/<name>/SKILL.md`` found.
     7. ``HOOK_PACKAGE`` -- hooks JSON found, nothing else.

--- a/src/apm_cli/models/format_detection.py
+++ b/src/apm_cli/models/format_detection.py
@@ -395,20 +395,20 @@ class PackageFormatRegistry:
 class NormalizationPlanner:
     """Maps a ``DetectionReport`` to a ``(PackageType, plugin_json_path)`` tuple.
 
-    Encodes the same cascade priority as the old if/elif chain, but the
-    logic is now explicit and the source of each branch is traceable to
+    Encodes format precedence explicitly, with each branch traceable to
     the independent detector that produced the evidence.
 
     Cascade (first match wins):
 
-    1. ``AGENT_PLUGIN`` -- root ``plugin.json`` matches the Agent Plugins
+    1. Eligible ``apm.yml`` -- preserve root or nested skill semantics,
+       otherwise select ``APM_PACKAGE``.
+    2. ``AGENT_PLUGIN`` -- root ``plugin.json`` matches the Agent Plugins
        schema family.
-    2. ``MARKETPLACE_PLUGIN`` -- Claude plugin detector found a manifest
+    3. ``MARKETPLACE_PLUGIN`` -- Claude plugin detector found a manifest
        (``plugin.json`` or ``.claude-plugin/``).
-    3. ``HYBRID`` -- root ``SKILL.md`` AND ``apm.yml`` both present.
-    4. ``CLAUDE_SKILL`` -- root ``SKILL.md`` only (no ``apm.yml``).
-    5. ``SKILL_BUNDLE`` -- nested ``skills/<name>/SKILL.md`` found.
-    6. ``APM_PACKAGE`` -- ``apm.yml`` with ``.apm/`` or declared deps.
+    4. ``HYBRID`` -- root ``SKILL.md`` AND metadata-only ``apm.yml``.
+    5. ``CLAUDE_SKILL`` -- root ``SKILL.md`` only (no ``apm.yml``).
+    6. ``SKILL_BUNDLE`` -- nested ``skills/<name>/SKILL.md`` found.
     7. ``HOOK_PACKAGE`` -- hooks JSON found, nothing else.
     8. ``INVALID`` -- no recognisable signals.
 
@@ -429,39 +429,48 @@ class NormalizationPlanner:
         sm = report.skill_md
         ay = report.apm_yml
         hj = report.hook_json
+        has_root_skill_md = sm is not None and sm.skill_md_path is not None
+        has_nested_skills = sm is not None and bool(sm.nested_skill_dirs)
+        has_eligible_apm_yml = ay is not None and (ay.has_apm_dir or ay.declares_dependencies)
 
-        # 1. Agent plugin manifest present -> AGENT_PLUGIN or INVALID.
+        # An eligible APM manifest expresses package intent more specifically
+        # than co-located plugin publishing surfaces.
+        if has_eligible_apm_yml:
+            if has_root_skill_md:
+                return PackageType.HYBRID, None
+            if has_nested_skills:
+                return PackageType.SKILL_BUNDLE, None
+            return PackageType.APM_PACKAGE, None
+
+        # Agent plugin manifest present -> AGENT_PLUGIN or INVALID.
         if ap is not None:
             if ap.supported:
                 return PackageType.AGENT_PLUGIN, ap.plugin_json_path
             return PackageType.INVALID, ap.plugin_json_path
 
-        # 2. Claude plugin manifest present -> MARKETPLACE_PLUGIN
+        # Claude plugin manifest present -> MARKETPLACE_PLUGIN
         if cp is not None:
             return PackageType.MARKETPLACE_PLUGIN, cp.plugin_json_path
 
-        # 3. Root SKILL.md + apm.yml -> HYBRID
-        has_root_skill_md = sm is not None and sm.skill_md_path is not None
+        # Root SKILL.md + apm.yml -> HYBRID
         if ay is not None and has_root_skill_md:
             return PackageType.HYBRID, None
 
-        # 4. Root SKILL.md only (no apm.yml) -> CLAUDE_SKILL
+        # Root SKILL.md only (no apm.yml) -> CLAUDE_SKILL
         if has_root_skill_md:
             return PackageType.CLAUDE_SKILL, None
 
-        # 5. Nested skills/<name>/SKILL.md -> SKILL_BUNDLE (apm.yml optional)
-        if sm is not None and sm.nested_skill_dirs:
+        # Nested skills/<name>/SKILL.md -> SKILL_BUNDLE (apm.yml optional)
+        if has_nested_skills:
             return PackageType.SKILL_BUNDLE, None
 
-        # 6. apm.yml present -> APM classification
+        # Metadata-only apm.yml without another package signal is invalid.
         if ay is not None:
-            if ay.has_apm_dir or ay.declares_dependencies:
-                return PackageType.APM_PACKAGE, None
             return PackageType.INVALID, None
 
-        # 7. hooks/*.json only -> HOOK_PACKAGE
+        # hooks/*.json only -> HOOK_PACKAGE
         if hj is not None:
             return PackageType.HOOK_PACKAGE, None
 
-        # 8. Nothing recognisable -> INVALID
+        # Nothing recognisable -> INVALID
         return PackageType.INVALID, None

--- a/src/apm_cli/models/validation.py
+++ b/src/apm_cli/models/validation.py
@@ -265,14 +265,15 @@ def detect_package_type(
 
     Cascade order (first match wins -- implemented in NormalizationPlanner):
 
-    1. ``AGENT_PLUGIN`` -- root ``plugin.json`` with the Agent Plugins schema.
-    2. ``MARKETPLACE_PLUGIN`` -- plugin manifest present: ``plugin.json``
+    1. Eligible ``apm.yml`` -- preserve root or nested skill semantics,
+       otherwise select ``APM_PACKAGE``.
+    2. ``AGENT_PLUGIN`` -- root ``plugin.json`` with the Agent Plugins schema.
+    3. ``MARKETPLACE_PLUGIN`` -- plugin manifest present: ``plugin.json``
        OR ``.claude-plugin/`` directory.
-    3. ``HYBRID`` -- root ``SKILL.md`` AND ``apm.yml`` present.
-    4. ``CLAUDE_SKILL`` -- root ``SKILL.md`` only (no ``apm.yml``).
-    5. ``SKILL_BUNDLE`` -- nested ``skills/<x>/SKILL.md`` detected;
+    4. ``HYBRID`` -- root ``SKILL.md`` AND metadata-only ``apm.yml``.
+    5. ``CLAUDE_SKILL`` -- root ``SKILL.md`` only (no ``apm.yml``).
+    6. ``SKILL_BUNDLE`` -- nested ``skills/<x>/SKILL.md`` detected;
        ``apm.yml`` optional; no ``.apm/`` required.
-    6. ``APM_PACKAGE`` -- ``apm.yml`` present with ``.apm/`` or declared deps.
     7. ``HOOK_PACKAGE`` -- ``hooks/*.json`` only, no other signals.
     8. ``INVALID`` -- nothing recognisable.
 

--- a/src/apm_cli/models/validation.py
+++ b/src/apm_cli/models/validation.py
@@ -270,7 +270,8 @@ def detect_package_type(
     2. ``AGENT_PLUGIN`` -- root ``plugin.json`` with the Agent Plugins schema.
     3. ``MARKETPLACE_PLUGIN`` -- plugin manifest present: ``plugin.json``
        OR ``.claude-plugin/`` directory.
-    4. ``HYBRID`` -- root ``SKILL.md`` AND metadata-only ``apm.yml``.
+    4. ``HYBRID`` -- root ``SKILL.md`` AND ``apm.yml`` (eligible or
+       metadata-only).
     5. ``CLAUDE_SKILL`` -- root ``SKILL.md`` only (no ``apm.yml``).
     6. ``SKILL_BUNDLE`` -- nested ``skills/<x>/SKILL.md`` detected;
        ``apm.yml`` optional; no ``.apm/`` required.

--- a/src/apm_cli/models/validation.py
+++ b/src/apm_cli/models/validation.py
@@ -255,6 +255,8 @@ def gather_detection_evidence(package_path: Path) -> DetectionEvidence:
 
 def detect_package_type(
     package_path: Path,
+    *,
+    agent_plugin_detection: AgentPluginDetection | None = None,
 ) -> tuple[PackageType, Path | None]:
     """Classify a package directory into a ``PackageType``.
 
@@ -285,7 +287,10 @@ def detect_package_type(
     """
     from .format_detection import NormalizationPlanner, PackageFormatRegistry
 
-    report = PackageFormatRegistry().detect(package_path)
+    report = PackageFormatRegistry().detect(
+        package_path,
+        agent_plugin_detection=agent_plugin_detection,
+    )
     pkg_type, plugin_json_path = NormalizationPlanner().plan(report)
     return pkg_type, plugin_json_path
 
@@ -374,13 +379,12 @@ def validate_apm_package(
     native_detection = agent_plugin_detection
     if native_detection is None:
         native_detection = detect_agent_plugin(package_path)
-    if native_detection is not None:
-        pkg_type = (
-            PackageType.AGENT_PLUGIN if native_detection.error is None else PackageType.INVALID
-        )
-        plugin_json_path = native_detection.manifest_path
-    else:
-        pkg_type, plugin_json_path = detect_package_type(package_path)
+    pkg_type, plugin_json_path = detect_package_type(
+        package_path,
+        agent_plugin_detection=native_detection,
+    )
+    if pkg_type not in {PackageType.AGENT_PLUGIN, PackageType.INVALID}:
+        native_detection = None
     result.package_type = pkg_type
 
     if pkg_type == PackageType.INVALID:

--- a/tests/integration/test_architecture_owner_rule_mutations.py
+++ b/tests/integration/test_architecture_owner_rule_mutations.py
@@ -470,6 +470,14 @@ MUTATIONS: tuple[MutationCase, ...] = (
         intent="from_apm_yml stops routing interpreted construction through from_mapping.",
     ),
     MutationCase(
+        guard_id="marketplace-integrations-package-format-precedence",
+        rule_id="marketplace-integrations-package-format-precedence",
+        path="src/apm_cli/bundle/local_bundle.py",
+        old="package_type, _ = detect_package_type(",
+        new="package_type, _ = bypass_package_type_precedence(",
+        intent="Agent Plugin ingress bypasses the package-format precedence owner.",
+    ),
+    MutationCase(
         guard_id="marketplace-integrations-package-projection",
         rule_id="marketplace-integrations-package-projection",
         path="src/apm_cli/agent_plugins/projection.py",

--- a/tests/integration/test_architecture_package_format_precedence.py
+++ b/tests/integration/test_architecture_package_format_precedence.py
@@ -1,0 +1,37 @@
+"""Architecture guard for centralized package-format precedence."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.architecture_linter.runner import run_selected_rules
+
+ROOT = Path(__file__).resolve().parents[2]
+RULE_ID = "marketplace-integrations-agent-plugin-contract"
+
+
+def test_agent_plugin_ingress_routes_through_package_format_precedence() -> None:
+    report = run_selected_rules(ROOT, (RULE_ID,))
+
+    assert report.failures == ()
+    assert report.violations == ()
+
+
+def test_agent_plugin_ingress_cannot_bypass_package_format_precedence() -> None:
+    path = "src/apm_cli/bundle/local_bundle.py"
+    source = (ROOT / path).read_text(encoding="utf-8")
+    mutated = source.replace(
+        "package_type, _ = detect_package_type(",
+        "package_type, _ = bypass_package_type_precedence(",
+        1,
+    )
+    assert mutated != source
+
+    report = run_selected_rules(
+        ROOT,
+        (RULE_ID,),
+        source_overrides={path: mutated},
+    )
+
+    assert report.failures == ()
+    assert any(violation.rule_id == RULE_ID for violation in report.violations)

--- a/tests/integration/test_architecture_package_format_precedence.py
+++ b/tests/integration/test_architecture_package_format_precedence.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from scripts.architecture_linter.runner import run_selected_rules
 
 ROOT = Path(__file__).resolve().parents[2]
-RULE_ID = "marketplace-integrations-agent-plugin-contract"
+RULE_ID = "marketplace-integrations-package-format-precedence"
 
 
 def test_agent_plugin_ingress_routes_through_package_format_precedence() -> None:

--- a/tests/integration/test_required_lifecycle_state_machine.py
+++ b/tests/integration/test_required_lifecycle_state_machine.py
@@ -257,6 +257,99 @@ def _hook_commands(settings_path: Path) -> list[str]:
     return commands
 
 
+def test_required_hybrid_manifest_installs_as_apm_package_through_cli_state_machine(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    scenario = _new_scenario(tmp_path / "hybrid-precedence", apm_binary_path)
+    source = _publish(
+        scenario,
+        "hybrid-apm-kit",
+        instruction="authoritative",
+    )
+    (source.repository.worktree / "plugin.json").write_text(
+        json.dumps(
+            {
+                "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+                "name": "hybrid.agent.plugin",
+                "version": "1.0.0",
+                "description": "Competing Agent Plugin fixture",
+                "author": {"name": "APM Test"},
+                "license": "MIT",
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    (source.repository.worktree / ".claude-plugin").mkdir()
+    source_commit = scenario.repositories.commit(
+        source.repository,
+        message="add competing plugin surfaces",
+    )
+    dependency = dict(source.dependency)
+    dependency["ref"] = source_commit.sha
+    consumer = scenario.consumers.create(
+        "hybrid-precedence-consumer",
+        dependencies=(dependency,),
+        targets=("copilot",),
+    )
+    deployed_instruction = ".github/instructions/authoritative.instructions.md"
+    capture_args = {
+        "targets": ("copilot",),
+        "config_paths": (PurePosixPath(deployed_instruction),),
+    }
+    before_install = LifecycleStateSnapshot.capture(consumer.root, **capture_args)
+
+    install_result = _run_success(
+        scenario,
+        consumer,
+        _INSTALL_ARGS,
+        environment=source.environment,
+        scenario_id="hybrid-precedence-install",
+    )
+    after_install = LifecycleStateSnapshot.capture(consumer.root, **capture_args)
+    _lockfile, locked_dep = _single_locked_dependency(consumer.root)
+
+    assert install_result.command == (str(apm_binary_path), *_INSTALL_ARGS)
+    assert before_install.file(deployed_instruction).kind == "missing"
+    assert (
+        after_install.file(deployed_instruction).content == _instruction("authoritative").encode()
+    )
+    assert deployed_instruction in _deployment_paths(after_install)
+    assert locked_dep.package_type == "apm_package"
+    assert locked_dep.resolved_commit == source_commit.sha
+    assert locked_dep.name == "hybrid-apm-kit"
+    assert deployed_instruction in locked_dep.deployed_files
+    assert deployed_instruction in locked_dep.deployed_file_hashes
+    assert locked_dep.marketplace_plugin_name is None
+    assert locked_dep.discovered_via is None
+    assert locked_dep.source_url is None
+    assert locked_dep.source_digest is None
+
+    _run_success(
+        scenario,
+        consumer,
+        ("uninstall", f"{_OWNER}/hybrid-apm-kit"),
+        environment=scenario.environment,
+        scenario_id="hybrid-precedence-uninstall",
+    )
+    after_uninstall = LifecycleStateSnapshot.capture(consumer.root, **capture_args)
+    _, audit = _audit(
+        scenario,
+        consumer,
+        environment=scenario.environment,
+        scenario_id="hybrid-precedence-audit",
+    )
+    after_audit = LifecycleStateSnapshot.capture(consumer.root, **capture_args)
+
+    assert after_uninstall.file(deployed_instruction).kind == "missing"
+    assert after_uninstall.lockfile_bytes is None
+    assert not after_uninstall.deployment_records
+    assert audit["passed"] is True
+    assert audit["summary"]["failed"] == 0
+    _assert_same_state(after_uninstall, after_audit)
+
+
 def test_required_pack_install_compile_audit_closes_regular_package_state(
     tmp_path: Path,
     apm_binary_path: Path,

--- a/tests/test_apm_package_models.py
+++ b/tests/test_apm_package_models.py
@@ -1256,6 +1256,28 @@ class TestDetectPackageType:
         pkg_type, _ = detect_package_type(tmp_path)
         assert pkg_type == PackageType.MARKETPLACE_PLUGIN
 
+    @pytest.mark.parametrize(
+        "manifest_setup",
+        [
+            pytest.param("apm-dir", id="apm-directory"),
+            pytest.param("dependencies", id="declared-dependencies"),
+        ],
+    )
+    def test_eligible_apm_yml_wins_over_plugin_selection(self, tmp_path, manifest_setup):
+        """An eligible apm.yml remains authoritative over plugin.json."""
+        manifest = "name: test"
+        if manifest_setup == "apm-dir":
+            (tmp_path / ".apm").mkdir()
+        else:
+            manifest += "\ndependencies:\n  apm:\n    - owner/package"
+        (tmp_path / "apm.yml").write_text(manifest)
+        (tmp_path / "plugin.json").write_text('{"name": "test"}')
+
+        pkg_type, plugin_path = detect_package_type(tmp_path)
+
+        assert pkg_type == PackageType.APM_PACKAGE
+        assert plugin_path is None
+
     def test_hook_package_apm_yml_precedence(self, tmp_path):
         """apm.yml + hooks/ but no .apm/ -> INVALID (needs .apm/ for APM_PACKAGE)."""
         (tmp_path / "apm.yml").write_text("name: test")

--- a/tests/test_apm_package_models.py
+++ b/tests/test_apm_package_models.py
@@ -1278,6 +1278,21 @@ class TestDetectPackageType:
         assert pkg_type == PackageType.APM_PACKAGE
         assert plugin_path is None
 
+    def test_eligible_apm_yml_wins_during_agent_plugin_validation(self, tmp_path):
+        """Validation honors APM intent over a schema-bearing Agent Plugin."""
+        (tmp_path / ".apm").mkdir()
+        (tmp_path / "apm.yml").write_text("name: test\nversion: 1.0.0")
+        (tmp_path / "plugin.json").write_text(
+            '{"$schema":"https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",'
+            '"name":"test.plugin","version":"1.0.0"}'
+        )
+
+        result = validate_apm_package(tmp_path)
+
+        assert result.is_valid
+        assert result.package_type == PackageType.APM_PACKAGE
+        assert result.agent_plugin is None
+
     def test_hook_package_apm_yml_precedence(self, tmp_path):
         """apm.yml + hooks/ but no .apm/ -> INVALID (needs .apm/ for APM_PACKAGE)."""
         (tmp_path / "apm.yml").write_text("name: test")

--- a/tests/test_apm_package_models.py
+++ b/tests/test_apm_package_models.py
@@ -1249,12 +1249,11 @@ class TestDetectPackageType:
         assert pkg_type == PackageType.INVALID
         assert pj_path is None
 
-    def test_apm_yml_takes_precedence_over_plugin_json(self, tmp_path):
-        """plugin.json (manifest) now takes priority over apm.yml."""
+    def test_metadata_only_apm_yml_preserves_plugin_selection(self, tmp_path):
+        """A metadata-only apm.yml leaves plugin.json authoritative."""
         (tmp_path / "apm.yml").write_text("name: test")
         (tmp_path / "plugin.json").write_text('{"name": "test"}')
         pkg_type, _ = detect_package_type(tmp_path)
-        # In the new cascade, plugin manifest wins (step 1)
         assert pkg_type == PackageType.MARKETPLACE_PLUGIN
 
     def test_hook_package_apm_yml_precedence(self, tmp_path):

--- a/tests/unit/agent_plugins/test_package_projection.py
+++ b/tests/unit/agent_plugins/test_package_projection.py
@@ -13,6 +13,7 @@ from apm_cli.agent_plugins import (
     project_agent_plugin_package,
 )
 from apm_cli.agent_plugins.loader import detect_agent_plugin
+from apm_cli.bundle.local_bundle import route_agent_plugin_package
 from apm_cli.deps.package_validator import PackageValidator, stamp_plugin_version
 from apm_cli.models.apm_package import APMPackage
 from apm_cli.models.validation import PackageType, validate_apm_package
@@ -67,7 +68,8 @@ def test_native_validation_projects_ir_without_filesystem_mutation(tmp_path: Pat
     apm_yml = tmp_path / "apm.yml"
     dump_yaml(
         {
-            "dependencies": {"apm": ["owner/repo#v1.0.0"]},
+            "name": "bridge.plugin",
+            "version": "1.2.3",
             "targets": ["copilot"],
             "type": "skill",
         },
@@ -92,7 +94,6 @@ def test_native_validation_projects_ir_without_filesystem_mutation(tmp_path: Pat
     assert result.package.package_path == result.agent_plugin.root
     assert result.package.source_path == result.agent_plugin.root
     assert result.package.canonical_targets == ("copilot",)
-    assert [dep.repo_url for dep in result.package.get_apm_dependencies()] == ["owner/repo"]
     assert tuple(skill.name for skill in result.package.agent_plugin.components.skills) == (
         "bridge-skill",
     )
@@ -105,6 +106,23 @@ def test_native_validation_projects_ir_without_filesystem_mutation(tmp_path: Pat
         if path.is_file()
     }
     assert after == before
+
+
+def test_eligible_apm_manifest_bypasses_agent_plugin_projection(tmp_path: Path) -> None:
+    _write_plugin(tmp_path)
+    (tmp_path / ".apm").mkdir()
+    dump_yaml(
+        {"name": "bridge.plugin", "version": "1.2.3"},
+        tmp_path / "apm.yml",
+    )
+
+    detection = route_agent_plugin_package(tmp_path)
+    result = validate_apm_package(tmp_path)
+
+    assert detection is None
+    assert result.is_valid
+    assert result.package_type == PackageType.APM_PACKAGE
+    assert result.agent_plugin is None
 
 
 def test_native_validation_isolates_component_error(tmp_path: Path) -> None:

--- a/tests/unit/deps/test_apm_resolver_edge_cases.py
+++ b/tests/unit/deps/test_apm_resolver_edge_cases.py
@@ -612,7 +612,7 @@ class TestTryLoadDependencyPackage:
         assert pkg.agent_plugin is not None
         assert not (pkg_dir / "apm.yml").exists()
 
-    def test_native_agent_plugin_retains_projected_transitive_apm_dependencies(
+    def test_eligible_apm_manifest_wins_and_retains_transitive_dependencies(
         self, tmp_path: Path
     ) -> None:
         from apm_cli.agent_plugins import PLUGIN_SCHEMA_ID
@@ -631,7 +631,13 @@ class TestTryLoadDependencyPackage:
             encoding="utf-8",
         )
         (pkg_dir / "apm.yml").write_text(
-            yaml.safe_dump({"dependencies": {"apm": ["org/child#v1.0.0"]}}),
+            yaml.safe_dump(
+                {
+                    "name": "apm-native",
+                    "version": "3.0.0",
+                    "dependencies": {"apm": ["org/child#v1.0.0"]},
+                }
+            ),
             encoding="utf-8",
         )
         ref = _make_dep_ref("org/native")
@@ -640,6 +646,9 @@ class TestTryLoadDependencyPackage:
         pkg = APMDependencyResolver(apm_modules_dir=mods)._try_load_dependency_package(ref)
 
         assert pkg is not None
+        assert pkg.name == "apm-native"
+        assert pkg.version == "3.0.0"
+        assert pkg.agent_plugin is None
         assert [dep.repo_url for dep in pkg.get_apm_dependencies()] == ["org/child"]
 
     def test_malformed_root_plugin_fails_closed_without_apm_yml(self, tmp_path: Path) -> None:

--- a/tests/unit/scripts/test_architecture_runner.py
+++ b/tests/unit/scripts/test_architecture_runner.py
@@ -663,6 +663,7 @@ marketplace-integrations-metadata-enrichment
 marketplace-integrations-native-registration
 marketplace-integrations-output-path
 marketplace-integrations-package-construction
+marketplace-integrations-package-format-precedence
 marketplace-integrations-package-projection
 marketplace-integrations-producer-admission
 marketplace-integrations-projection-boundary

--- a/tests/unit/test_format_detection.py
+++ b/tests/unit/test_format_detection.py
@@ -421,6 +421,44 @@ class TestNormalizationPlanner:
         assert pkg_type == PackageType.AGENT_PLUGIN
         assert plugin_json == plugin_path
 
+    @pytest.mark.parametrize(
+        ("has_apm_dir", "declares_dependencies"),
+        [(True, False), (False, True)],
+    )
+    def test_eligible_apm_package_wins_over_plugin_formats(
+        self,
+        tmp_path: Path,
+        has_apm_dir: bool,
+        declares_dependencies: bool,
+    ) -> None:
+        plugin_path = tmp_path / "plugin.json"
+        report = self._make_report(
+            apm_yml=self._apm_yml_evidence(
+                has_apm_dir=has_apm_dir,
+                declares_dependencies=declares_dependencies,
+            ),
+            agent_plugin=self._agent_plugin_evidence(plugin_json_path=plugin_path, supported=True),
+            claude_plugin=self._plugin_evidence(plugin_json_path=plugin_path),
+        )
+
+        pkg_type, plugin_json = NormalizationPlanner().plan(report)
+
+        assert pkg_type == PackageType.APM_PACKAGE
+        assert plugin_json is None
+
+    def test_metadata_only_apm_yml_preserves_plugin_selection(self, tmp_path: Path) -> None:
+        plugin_path = tmp_path / "plugin.json"
+        report = self._make_report(
+            apm_yml=self._apm_yml_evidence(),
+            agent_plugin=self._agent_plugin_evidence(plugin_json_path=plugin_path, supported=True),
+            claude_plugin=self._plugin_evidence(plugin_json_path=plugin_path),
+        )
+
+        pkg_type, plugin_json = NormalizationPlanner().plan(report)
+
+        assert pkg_type == PackageType.AGENT_PLUGIN
+        assert plugin_json == plugin_path
+
     def test_unsupported_agent_plugin_rejected(self, tmp_path: Path) -> None:
         plugin_path = tmp_path / "plugin.json"
         report = self._make_report(
@@ -480,15 +518,14 @@ class TestNormalizationPlanner:
         pkg_type, _ = NormalizationPlanner().plan(report)
         assert pkg_type == PackageType.INVALID
 
-    def test_plugin_wins_over_hybrid_signals(self) -> None:
-        """Claude plugin beats hybrid when all signals present (cascade step 1 wins)."""
+    def test_hybrid_wins_over_plugin_signal_when_apm_yml_is_eligible(self) -> None:
         report = self._make_report(
             claude_plugin=self._plugin_evidence(plugin_json_path=Path("/fake/plugin.json")),
             apm_yml=self._apm_yml_evidence(has_apm_dir=True),
             skill_md=self._skill_md_evidence(has_root=True),
         )
         pkg_type, _ = NormalizationPlanner().plan(report)
-        assert pkg_type == PackageType.MARKETPLACE_PLUGIN
+        assert pkg_type == PackageType.HYBRID
 
     def test_skill_bundle_wins_over_apm_only(self) -> None:
         """Nested skills beat plain apm.yml (cascade step 4 before step 5)."""


### PR DESCRIPTION
An eligible root `apm.yml` now wins by default over co-located Agent Plugin and Claude plugin signals when `.apm/` exists or APM/MCP dependencies are declared. Metadata-only manifests preserve a clear, deterministic way to select a plugin format intentionally: a schema-bearing `plugin.json` selects Agent Plugin, while an unversioned manifest selects the legacy plugin collection.

Architecture classification: `new-owner`. `NormalizationPlanner` is registered as the sole package-format precedence owner; validation, dependency loading, and Agent Plugin ingress delegate that decision instead of creating competing authorities. A dedicated static rule and mutation test guard this boundary.

## Validation

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|---|---|---|---|
| 1 | A package with an eligible root `apm.yml` installs as an APM package even when plugin metadata is co-located | Portability by manifest, DevX (pragmatic as npm) | `tests/test_apm_package_models.py::TestDetectPackageType::test_eligible_apm_yml_wins_over_plugin_selection` (regression-trap for #2735)<br/>`tests/test_apm_package_models.py::TestDetectPackageType::test_eligible_apm_yml_wins_during_agent_plugin_validation`<br/>`tests/unit/deps/test_apm_resolver_edge_cases.py::TestTryLoadDependencyPackage::test_eligible_apm_manifest_wins_and_retains_transitive_dependencies` | integration |
| 2 | A metadata-only `apm.yml` still lets an author intentionally select a plugin format | DevX (pragmatic as npm) | `tests/test_apm_package_models.py::TestDetectPackageType::test_metadata_only_apm_yml_preserves_plugin_selection` | integration |
| 3 | Agent Plugin admission cannot bypass the same manifest-first precedence used by validation | Portability by manifest, Secure by default | `tests/unit/agent_plugins/test_package_projection.py::test_eligible_apm_manifest_bypasses_agent_plugin_projection`<br/>`tests/integration/test_architecture_package_format_precedence.py` | integration |

```text
9 passed in 7.54s
Ruff: All checks passed; 1775 files already formatted
Pylint R0801: 10.00/10
Auth-signal lint: clean
Architecture boundary lint: clean
```

Mutation-break evidence:
- Disabling the eligible-APM precedence branch makes both filesystem precedence regressions fail; restoring it makes them pass.
- Disabling the Agent Plugin ingress delegation guard makes both the behavioral ingress regression and architecture boundary test fail; restoring it makes them pass.

## How to test

```bash
uv run --extra dev pytest -q \
  tests/test_apm_package_models.py \
  tests/unit/agent_plugins/test_package_projection.py \
  tests/unit/deps/test_apm_resolver_edge_cases.py \
  tests/integration/test_architecture_package_format_precedence.py
uv run --extra dev python scripts/lint_architecture_boundaries.py --root .
```

Closes #2735

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

