### PR TITLE
fix(lockfile): gate inactive experimental target resolvers

### DIFF
--- a/src/apm_cli/install/manifest_reconcile.py
+++ b/src/apm_cli/install/manifest_reconcile.py
@@ -25,7 +25,7 @@ Both import :func:`union_preserving` so the behaviour stays identical.
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -37,6 +37,77 @@ if TYPE_CHECKING:
     from apm_cli.integration.cleanup import CleanupResult
     from apm_cli.integration.targets import TargetProfile
     from apm_cli.utils.diagnostics import DiagnosticCollector
+
+
+def _profiles_by_name(
+    targets: Iterable[TargetProfile] | None,
+) -> dict[str, TargetProfile]:
+    """Return profiles keyed by catalog target name."""
+    by_name: dict[str, TargetProfile] = {}
+    for target in targets or ():
+        name = getattr(target, "name", None)
+        if isinstance(name, str) and name not in by_name:
+            by_name[name] = target
+    return by_name
+
+
+def _has_gated_resolver(profile: TargetProfile) -> bool:
+    """Return whether an inactive supplemental target must not resolve."""
+    return profile.requires_flag is not None and profile.user_root_resolver is not None
+
+
+def _record_inactive_resolver_skip(
+    profile: TargetProfile,
+    diagnostics: DiagnosticCollector | None,
+) -> None:
+    """Record the intentional skip of an inactive experimental resolver."""
+    if diagnostics is None:
+        return
+    from apm_cli.utils.diagnostics import CATEGORY_INFO
+
+    message = (
+        f"Skipped inactive experimental resolver for target '{profile.name}' "
+        "during lockfile reconciliation."
+    )
+    if any(
+        diagnostic.message == message
+        for diagnostic in diagnostics.by_category().get(CATEGORY_INFO, ())
+    ):
+        return
+    flag = profile.requires_flag or profile.name
+    diagnostics.info(
+        message,
+        detail=(
+            f"To include it, enable '{flag.replace('_', '-')}' and select "
+            f"target '{profile.name}' for this install."
+        ),
+    )
+
+
+def _scoped_known_targets_for_reconciliation(
+    *,
+    user_scope: bool,
+    active_targets: Iterable[TargetProfile],
+    declared_targets: Iterable[TargetProfile] | None,
+) -> dict[str, TargetProfile]:
+    """Return known targets without running inactive experimental resolvers."""
+    from apm_cli.integration.targets import KNOWN_TARGETS
+
+    active_by_name = _profiles_by_name(active_targets)
+    declared_by_name = _profiles_by_name(declared_targets)
+    scoped_known_targets: dict[str, TargetProfile] = {}
+    for name, profile in KNOWN_TARGETS.items():
+        resolved = active_by_name.get(name) or declared_by_name.get(name)
+        if resolved is not None:
+            scoped_known_targets[name] = resolved
+            continue
+        if _has_gated_resolver(profile):
+            scoped_known_targets[name] = profile
+            continue
+        scoped = profile.for_scope(user_scope=user_scope)
+        if scoped is not None:
+            scoped_known_targets[name] = scoped
+    return scoped_known_targets
 
 
 def _surface_target_cleanup(
@@ -191,8 +262,9 @@ def union_preserving(
     same-target reinstall still drops files removed from the package.
 
     ``declared_targets`` is the consumer's legitimate target universe --
-    apm.yml-declared canonical targets plus the always-legitimate gated/dynamic
-    targets -- independent of any ``--target`` narrowing (see
+    apm.yml-declared canonical targets plus gated/dynamic target metadata
+    that can be included without probing inactive roots -- independent of any
+    ``--target`` narrowing (see
     ``phases.targets.declared_target_profiles``). When provided, a prior entry
     that belongs to NEITHER this install's targets NOR any of those targets is
     an inactive-target *ghost* (e.g. a dependency's
@@ -217,15 +289,14 @@ def union_preserving(
         MaterializationStatus,
         NativePayloadValidation,
     )
-    from apm_cli.integration.targets import KNOWN_TARGETS
     from apm_cli.utils.diagnostics import DiagnosticCollector
 
-    scoped_known_targets = {
-        name: scoped_target
-        for name, target in KNOWN_TARGETS.items()
-        if (scoped_target := target.for_scope(user_scope=user_scope)) is not None
-    }
-    active_by_name = {target.name: target for target in targets}
+    scoped_known_targets = _scoped_known_targets_for_reconciliation(
+        user_scope=user_scope,
+        active_targets=targets,
+        declared_targets=declared_targets,
+    )
+    active_by_name = _profiles_by_name(targets)
     declared_by_name = (
         {target.name: target for target in declared_targets}
         if declared_targets is not None
@@ -335,7 +406,7 @@ def union_preserving(
         for locator in reconciled.removed:
             if (
                 locator.value not in current_set
-                and locator.target in KNOWN_TARGETS
+                and locator.target in scoped_known_targets
                 and locator.target not in active_by_name
             ):
                 on_ghost_drop(locator.value)
@@ -359,6 +430,8 @@ def declared_target_profiles(
     project_root: Path,
     *,
     user_scope: bool = False,
+    active_targets: Iterable[TargetProfile] | None = None,
+    diagnostics: DiagnosticCollector | None = None,
 ) -> list[TargetProfile] | None:
     """Resolve the target universe declared by a project manifest."""
     from apm_cli.core.apm_yml import CANONICAL_TARGETS, parse_targets_field
@@ -376,19 +449,29 @@ def declared_target_profiles(
         names = parse_targets_field(data)
     except TargetResolutionError:
         return None
-    if not names:
+    active_by_name = _profiles_by_name(active_targets)
+    if not names and not active_by_name:
         return None
 
     profiles: list[TargetProfile] = []
-    for name in dict.fromkeys(names):
-        profile = KNOWN_TARGETS.get(name)
-        if profile is None:
-            continue
-        scoped = profile.for_scope(user_scope=user_scope)
-        if scoped is not None:
-            profiles.append(scoped)
+    if names:
+        for name in dict.fromkeys(names):
+            profile = KNOWN_TARGETS.get(name)
+            if profile is None:
+                continue
+            scoped = profile.for_scope(user_scope=user_scope)
+            if scoped is not None:
+                profiles.append(scoped)
     for name, profile in KNOWN_TARGETS.items():
         if name in CANONICAL_TARGETS:
+            continue
+        active_profile = active_by_name.get(name)
+        if _has_gated_resolver(profile):
+            if active_profile is None:
+                _record_inactive_resolver_skip(profile, diagnostics)
+                profiles.append(profile)
+            else:
+                profiles.append(active_profile)
             continue
         scoped = profile.for_scope(user_scope=user_scope)
         profiles.append(scoped if scoped is not None else profile)
@@ -615,7 +698,6 @@ def reconcile_target_deployed_files(
     from apm_cli.core.deployment_ledger import DeploymentLedgerCodec
     from apm_cli.core.deployment_state import DeploymentLedger
     from apm_cli.deps.lockfile import _SELF_KEY
-    from apm_cli.integration.targets import KNOWN_TARGETS
 
     selected_owner_removal = remove_selected_ownership and dependency_keys is not None
     survivor_files = {
@@ -634,11 +716,13 @@ def reconcile_target_deployed_files(
     )
     allowed_targets = [*active_targets, *(declared_targets or [])]
     allowed_prefixes, allowed_schemes = install_governance(allowed_targets)
-    known_targets = [
-        scoped_target
-        for target in KNOWN_TARGETS.values()
-        if (scoped_target := target.for_scope(user_scope=user_scope)) is not None
-    ]
+    known_targets = list(
+        _scoped_known_targets_for_reconciliation(
+            user_scope=user_scope,
+            active_targets=active_targets,
+            declared_targets=declared_targets,
+        ).values()
+    )
     known_prefixes, known_schemes = install_governance(known_targets)
 
     def _retained(files: list[str]) -> list[str]:
@@ -789,19 +873,31 @@ def reconcile_project_deployed_state(
     lockfile = LockFile.read(lock_path)
     if lockfile is None:
         return False
-    declared = declared_target_profiles(manifest_root, user_scope=user_scope)
+    diagnostics = DiagnosticCollector(verbose=verbose)
+    declared = declared_target_profiles(
+        manifest_root,
+        user_scope=user_scope,
+        diagnostics=diagnostics,
+    )
     if explicit_target is None and declared is not None:
         targets = declared
     elif user_scope:
         targets = active_targets_user_scope(explicit_target=explicit_target)
     else:
         targets = active_targets(deploy_root, explicit_target=explicit_target)
+    if explicit_target is not None:
+        declared = declared_target_profiles(
+            manifest_root,
+            user_scope=user_scope,
+            active_targets=targets,
+            diagnostics=diagnostics,
+        )
     changed = reconcile_deployed_state(
         project_root=deploy_root,
         lockfile=lockfile,
         active_targets=targets,
         declared_targets=declared,
-        diagnostics=DiagnosticCollector(verbose=verbose),
+        diagnostics=diagnostics,
         user_scope=user_scope,
     )
     if changed:

--- a/src/apm_cli/install/phases/targets.py
+++ b/src/apm_cli/install/phases/targets.py
@@ -118,10 +118,11 @@ def declared_target_profiles(ctx: InstallContext) -> list[TargetProfile] | None:
 
     Reads ``targets:``/``target:`` from the consumer's ``apm.yml``, maps the
     canonical names to :class:`~apm_cli.integration.targets.TargetProfile`
-    instances scoped the same way ``ctx.targets`` is, and augments them with the
-    non-canonical gated/dynamic targets (see below). Returns ``None`` when the
-    manifest declares no targets (auto-detect or ``--target``-only consumers) --
-    the signal for lockfile reconciliation to fall back to legacy preserve-all.
+    instances scoped the same way ``ctx.targets`` is, and augments them with
+    non-canonical gated/dynamic target metadata without probing inactive roots
+    (see below). Returns ``None`` when the manifest declares no targets
+    (auto-detect or ``--target``-only consumers) -- the signal for lockfile
+    reconciliation to fall back to legacy preserve-all.
 
     Motivation (issue #2059): ``union_preserving`` must distinguish a target the
     consumer legitimately uses but did not install in THIS run (e.g. a
@@ -138,19 +139,17 @@ def declared_target_profiles(ctx: InstallContext) -> list[TargetProfile] | None:
         declared_target_profiles as profiles_for_project,
     )
 
-    try:
-        names = _read_yaml_targets(ctx)
-    except (AttributeError, KeyError, OSError, TypeError, ValueError):
-        # Any resolution error (missing apm_package, conflicting keys already
-        # surfaced by the targets phase) -> unknown universe, preserve-all.
-        return None
-    if not names:
-        return None
     is_user = getattr(ctx, "scope", None) is InstallScope.USER
-    package_path = getattr(ctx.apm_package, "package_path", None)
+    apm_package = getattr(ctx, "apm_package", None)
+    package_path = getattr(apm_package, "package_path", None)
     if package_path is None:
         return None
-    return profiles_for_project(Path(package_path), user_scope=is_user)
+    return profiles_for_project(
+        Path(package_path),
+        user_scope=is_user,
+        active_targets=getattr(ctx, "targets", None),
+        diagnostics=getattr(ctx, "diagnostics", None),
+    )
 
 
 def _create_target_dirs(

--- a/tests/integration/test_required_lifecycle_state_machine.py
+++ b/tests/integration/test_required_lifecycle_state_machine.py
@@ -1169,6 +1169,66 @@ def test_required_tamper_is_detected_and_repair_restores_last_good_state(
     assert clean_audit["passed"] is True
 
 
+def test_required_global_lock_ignores_inactive_experimental_resolver(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    """Global lockfile generation must not run inactive experimental resolvers."""
+    scenario = _new_scenario(tmp_path / "global-inactive-resolver", apm_binary_path)
+    source = _publish(scenario, "inactive-resolver-kit", skill="inactive-resolver")
+    cwd = scenario.isolated.work_root
+    cloud_storage = scenario.isolated.home / "Library" / "CloudStorage"
+    cowork_mounts = (
+        cloud_storage / "OneDrive-Org",
+        cloud_storage / "OneDrive-SharedLibraries-Team",
+    )
+    for mount in cowork_mounts:
+        mount.mkdir(parents=True)
+    targets = ("copilot", "claude", "codex")
+    scenario.isolated.config_root.mkdir(parents=True, exist_ok=True)
+    dump_yaml(
+        {
+            "name": "global-inactive-resolver-consumer",
+            "version": "0.1.0",
+            "dependencies": {"apm": [source.dependency]},
+            "targets": list(targets),
+        },
+        scenario.isolated.config_root / "apm.yml",
+    )
+
+    install = scenario.runner.run(
+        (
+            "install",
+            "--global",
+            "--no-policy",
+            "--parallel-downloads",
+            "0",
+        ),
+        scenario_id="global-inactive-resolver-install",
+        cwd=cwd,
+        env=source.environment,
+    )
+
+    assert install.returncode == 0, _result_evidence(install)
+    lockfile = LockFile.read(scenario.isolated.config_root / "apm.lock.yaml")
+    assert lockfile is not None
+    dependencies = lockfile.get_package_dependencies()
+    assert len(dependencies) == 1
+    deployed_files = dependencies[0].deployed_files
+    assert deployed_files
+    assert all(not path.startswith("cowork://") for path in deployed_files)
+    copilot_skill_path = (
+        scenario.isolated.home / ".agents" / "skills" / "inactive-resolver" / "SKILL.md"
+    )
+    claude_skill_path = (
+        scenario.isolated.home / ".claude" / "skills" / "inactive-resolver" / "SKILL.md"
+    )
+    assert copilot_skill_path.is_file()
+    assert claude_skill_path.is_file()
+    for mount in cowork_mounts:
+        assert not (mount / "Documents" / "Cowork" / "skills" / "inactive-resolver").exists()
+
+
 def test_required_global_audit_rule_matrix_for_external_roots(
     tmp_path: Path,
     apm_binary_path: Path,

--- a/tests/unit/install/phases/test_lockfile_union.py
+++ b/tests/unit/install/phases/test_lockfile_union.py
@@ -13,6 +13,7 @@ gate (deployed-files-present, content-integrity, drift).
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -730,6 +731,100 @@ def _known(name):
     from apm_cli.integration.targets import KNOWN_TARGETS
 
     return KNOWN_TARGETS[name]
+
+
+def _seed_multiple_cowork_mounts(home: Path) -> None:
+    cloud_storage = home / "Library" / "CloudStorage"
+    for dirname in ("OneDrive-Org", "OneDrive-SharedLibraries-Team"):
+        (cloud_storage / dirname).mkdir(parents=True)
+
+
+def _isolate_cowork_config(monkeypatch: pytest.MonkeyPatch, home: Path) -> None:
+    from apm_cli import config
+
+    config_dir = home / ".apm"
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("APM_COPILOT_COWORK_SKILLS_DIR", raising=False)
+    monkeypatch.delenv("ONEDRIVECOMMERCIAL", raising=False)
+    monkeypatch.delenv("ONEDRIVE", raising=False)
+    monkeypatch.setattr(config, "CONFIG_DIR", str(config_dir))
+    monkeypatch.setattr(config, "CONFIG_FILE", str(config_dir / "config.json"))
+    monkeypatch.setattr(config, "_config_cache", None)
+
+
+class TestInactiveExperimentalResolverGating:
+    def test_declared_profiles_skip_inactive_resolvers_with_multiple_mounts(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from apm_cli.install.manifest_reconcile import declared_target_profiles
+        from apm_cli.utils.diagnostics import CATEGORY_INFO, DiagnosticCollector
+
+        home = tmp_path / "home"
+        _seed_multiple_cowork_mounts(home)
+        _isolate_cowork_config(monkeypatch, home)
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / "apm.yml").write_text(
+            "name: inactive-resolver-consumer\n"
+            "version: 0.1.0\n"
+            "targets:\n"
+            "  - copilot\n"
+            "  - claude\n"
+            "  - codex\n",
+            encoding="utf-8",
+        )
+        diagnostics = DiagnosticCollector(verbose=True)
+
+        profiles = declared_target_profiles(
+            project,
+            user_scope=True,
+            active_targets=[_known("copilot"), _known("claude"), _known("codex")],
+            diagnostics=diagnostics,
+        )
+
+        names = {profile.name for profile in profiles or []}
+        assert {"copilot", "claude", "codex"} <= names
+        cowork_profile = next(
+            profile for profile in profiles or [] if profile.name == "copilot-cowork"
+        )
+        assert cowork_profile.resolved_deploy_root is None
+        info_messages = {
+            diagnostic.message for diagnostic in diagnostics.by_category().get(CATEGORY_INFO, ())
+        }
+        assert (
+            "Skipped inactive experimental resolver for target 'copilot-cowork' "
+            "during lockfile reconciliation."
+        ) in info_messages
+
+    def test_explicit_experimental_resolver_failure_is_not_silenced(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from apm_cli.integration.copilot_cowork_paths import CoworkResolutionError
+        from apm_cli.integration.targets import resolve_targets
+
+        home = tmp_path / "home"
+        _seed_multiple_cowork_mounts(home)
+        _isolate_cowork_config(monkeypatch, home)
+        config_dir = home / ".apm"
+        config_dir.mkdir(parents=True)
+        (config_dir / "config.json").write_text(
+            '{"default_client":"vscode","experimental":{"copilot_cowork":true}}',
+            encoding="utf-8",
+        )
+
+        with pytest.raises(
+            CoworkResolutionError,
+            match="Multiple OneDrive mounts detected",
+        ):
+            resolve_targets(
+                tmp_path,
+                user_scope=True,
+                explicit_target="copilot-cowork",
+            )
 
 
 class TestInactiveTargetGhostDrop:


### PR DESCRIPTION
# fix(lockfile): gate inactive experimental target resolvers

## TL;DR

Lockfile reconciliation no longer executes experimental dynamic target resolvers for targets that are not active in the current install. The fix keeps static target metadata available for URI governance, but only reuses scoped resolver output from `ctx.targets` when the target was actually selected and resolved. This fixes #2782 without hiding real `copilot-cowork` resolver failures for users who opt in.

> [!NOTE]
> The reporter title understates the scope: OneDrive is only the symptom; the root cause was an ungated experimental resolver in lockfile generation.

## Problem (WHY)

- [x] `apm install --global` could fail while generating `apm.lock.yaml` even when `copilot-cowork` was not selected.
- [x] The verified chain was: `install/phases/lockfile.py:242` -> `install/manifest_reconcile.py:465-477` -> `integration/targets.py:390-404` -> `integration/copilot_cowork_paths.py:154-165` -> `install/phases/lockfile.py:546-550`.
- [x] The old supplemental-target loop treated every non-canonical target as eligible and called `TargetProfile.for_scope(user_scope=True)`, which invoked resolver I/O for inactive experimental targets.
- [!] Swallowing the OneDrive exception in `copilot_cowork_paths.py` would mask the correct failure for users who explicitly selected `copilot-cowork`.
- [!] This is a concrete edge case that belongs in tests because Agent Skills notes that "agents pattern-match well against concrete structures" (https://agentskills.io/skill-creation/best-practices).

## Approach (WHAT)

| # | Fix | Principle | Source |
|---:|---|---|---|
| 1 | Gate resolver execution from `TargetProfile` catalog data: `requires_flag` plus `user_root_resolver`, not a hardcoded target-name list. | "Add what the agent lacks, omit what it knows" | https://agentskills.io/skill-creation/best-practices |
| 2 | Preserve static metadata for inactive dynamic targets so existing `copilot-app-db://` and `cowork://` lockfile rows remain governable without probing roots. | "agents pattern-match well against concrete structures" | https://agentskills.io/skill-creation/best-practices |
| 3 | Reuse active scoped profiles from `ctx.targets` when a dynamic target is actually selected, so explicit resolver failures still surface before lockfile reconciliation. | "Refine with real execution" | https://agentskills.io/skill-creation/best-practices |

## Implementation (HOW)

- **`src/apm_cli/install/manifest_reconcile.py`** -- Adds catalog-driven helper functions that distinguish active scoped profiles from inactive experimental resolver profiles. `declared_target_profiles()` now records an actionable info diagnostic when it skips an inactive resolver, includes only static metadata for that target, and avoids `for_scope()` on inactive resolver-backed profiles.
- **`src/apm_cli/install/phases/targets.py`** -- Passes `ctx.targets` and `ctx.diagnostics` into manifest reconciliation so lockfile generation can tell which dynamic targets were truly active in this install.
- **`tests/unit/install/phases/test_lockfile_union.py`** -- Adds a focused fake-Home multiple-OneDrive regression: inactive resolver metadata is retained without setting `resolved_deploy_root`, and explicit `copilot-cowork` selection still raises.
- **`tests/integration/test_required_lifecycle_state_machine.py`** -- Extends the canonical ApmLifecycle engine because this bug crosses real `apm install --global`, lockfile bytes, deployed files, and exit-code state.

## Diagrams

Legend: The new gate keeps inactive resolver I/O out of lockfile reconciliation while preserving static metadata for URI governance.

```mermaid
flowchart LR
    subgraph Before[Before]
        B1["declared_target_profiles"]
        B2["TargetProfile.for_scope user_scope"]
        B3["copilot-cowork resolver"]
        B4["CoworkResolutionError"]
    end
    subgraph After[After]
        A1["ctx.targets active profiles"]:::new
        A2["inactive resolver gate"]:::new
        A3["static target metadata"]
        A4["lockfile reconciliation"]
    end
    B1 --> B2 --> B3 --> B4
    A1 --> A2
    A2 -->|"inactive target"| A3
    A2 -->|"active target"| A4
    A3 --> A4
    classDef new stroke-dasharray: 5 5;
    class A1,A2 new;
```

## Trade-offs

- **Gate instead of swallowing.** Chose to prevent inactive resolver calls in `manifest_reconcile.py`; rejected catching `CoworkResolutionError` in `copilot_cowork_paths.py` because active users still need that clear failure.
- **Static metadata still participates.** Chose static profile metadata for inactive dynamic targets; rejected dropping the profile entirely because existing dynamic URI rows must remain governable.
- **Catalog-derived predicate.** Chose `TargetProfile.requires_flag` plus `user_root_resolver`; rejected name checks so new experimental resolver targets inherit the same gate.

## Benefits

1. `apm install --global` with canonical targets and multiple OneDrive mounts exits 0 instead of failing in lockfile generation.
2. Inactive `copilot-cowork` no longer writes or records `cowork://` deployed files.
3. Explicit `--target copilot-cowork --global` still surfaces the multiple-mount resolver error.
4. Existing dynamic target URI preservation remains covered by the full lockfile union suite.

apm-spec-waiver: Bug fix only; prevents inactive experimental resolver execution, no OpenAPM contract added.

## Validation

`UV_FROZEN=1 uv run --extra dev pytest -q tests/unit/install/phases/test_lockfile_union.py`:

```text
38 passed in 0.64s
```

`APM_E2E_TESTS=1 UV_FROZEN=1 uv run --extra dev pytest -q tests/integration/test_required_lifecycle_state_machine.py`:

```text
13 passed in 42.98s
```

`UV_FROZEN=1 uv run --extra dev pytest -q tests/spec_conformance/`:

```text
196 passed, 2 skipped in 13.58s
```

<details><summary>Mutation-break evidence</summary>

Mutation: changed `_has_gated_resolver()` to `return False`, restoring eager inactive resolver execution.

```text
FAILED tests/integration/test_required_lifecycle_state_machine.py::test_required_global_lock_ignores_inactive_experimental_resolver
>       assert install.returncode == 0, _result_evidence(install)
E       AssertionError: cwd=/private/var/folders/1d/s61glgts17lgfr6_0j0mcrjh0000gn/T/pytest-of-danielmeppiel/pytest-2675/test_required_global_lock_igno0/global-inactive-resolver/work
E         command=('/Users/danielmeppiel/.copilot/session-state/8234f378-ddfd-467a-bbff-cf379fb71f6c/files/batch2/wt-fix-2782/.venv/bin/apm', 'install', '--global', '--no-policy', '--parallel-downloads', '0')
E         returncode=1
E         stdout='[i] Installing to user scope (~/.apm/)\n...\n[x] Could not generate apm.lock.yaml: Multiple OneDrive mounts detected:\n...\n[x] Installation failed with 1 error(s) in 0.4s. No install transaction changes \nwere committed.\n'
E         stderr=''
E       assert 1 == 0
```

Assertion fired: `install.returncode == 0`, an observable process exit-code state assertion, not a log-string-only check.

</details>

<details><summary>Lint and guard evidence</summary>

`UV_FROZEN=1 uv run --extra dev ruff check src/ tests/ scripts/lint_architecture_boundaries.py scripts/architecture_linter/`:

```text
All checks passed!
```

`UV_FROZEN=1 uv run --extra dev ruff format --check src/ tests/ scripts/lint_architecture_boundaries.py scripts/architecture_linter/`:

```text
1791 files already formatted
```

`UV_FROZEN=1 uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/ scripts/lint_architecture_boundaries.py scripts/architecture_linter/`:

```text
Your code has been rated at 10.00/10
```

`bash scripts/lint-auth-signals.sh`:

```text
[+] auth-signal lint clean
```

Additional guards:

```text
portable YAML/file-length/relative_to guards passed
bash scripts/lint-architecture-boundaries.sh: exit 0
```

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---:|---|---|---|---|
| 1 | `apm install --global` succeeds with canonical targets even when fake Home contains multiple OneDrive mounts and `copilot-cowork` is inactive. | DevX (pragmatic as npm), Governed by policy | `tests/integration/test_required_lifecycle_state_machine.py::test_required_global_lock_ignores_inactive_experimental_resolver` (regression-trap for #2782) | e2e |
| 2 | Inactive experimental resolver metadata is retained without resolving a Cowork deploy root. | Governed by policy, Multi-harness support | `tests/unit/install/phases/test_lockfile_union.py::TestInactiveExperimentalResolverGating::test_declared_profiles_skip_inactive_resolvers_with_multiple_mounts` | unit |
| 3 | A user who explicitly selects `copilot-cowork` still sees the real multiple-OneDrive error. | DevX (pragmatic as npm), Reliability over magic | `tests/unit/install/phases/test_lockfile_union.py::TestInactiveExperimentalResolverGating::test_explicit_experimental_resolver_failure_is_not_silenced` | unit |

## How to test

- [ ] Create two fake `~/Library/CloudStorage/OneDrive*` directories, leave `copilot-cowork` inactive, and run `apm install --global` with canonical targets; expect exit 0 and `apm.lock.yaml`.
- [ ] Enable `copilot_cowork` and run `--target copilot-cowork --global` with the same fake mounts; expect the multiple-mount error.
- [ ] Inspect the lockfile; expect no `cowork://` deployed file rows unless Cowork was active.
- [ ] Run the validation commands above.

Fixes #2782

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
