### PR TITLE
fix(install): centralize declaration-first primitive classification

### DIFF
--- a/.apm/architecture/owners/install-deployment.json
+++ b/.apm/architecture/owners/install-deployment.json
@@ -65,6 +65,13 @@
       "guards": ["install-deployment-source-plan"]
     },
     {
+      "id": "primitive-kind-classification",
+      "decision": "Primitive artifact kind classification precedence",
+      "owner": "install/primitive_classification.py (classify_plugin_manifest, classify_agent_source_file)",
+      "selectors": ["src/apm_cli/install/primitive_classification.py"],
+      "guards": ["install-deployment-primitive-classification"]
+    },
+    {
       "id": "bundle-native-layout-lowering",
       "decision": "Bundle-native directory and filename lowering to APM primitive kinds and target deploy layout",
       "owner": "bundle/plugin_layout.py (PLUGIN_LAYOUT, plugin_command_prompt_name) consumed by install/local_bundle_paths.py (_lower_to_target)",

--- a/docs/src/content/docs/reference/package-types.md
+++ b/docs/src/content/docs/reference/package-types.md
@@ -15,8 +15,8 @@ Pick the form that matches the author's intent -- APM preserves it.
 | `SKILL.md` (alone or with apm.yml -- HYBRID) | "I am one skill bundle" | Copy the whole bundle to `<target>/skills/<name>/` |
 | `skills/<name>/SKILL.md` (nested) | "I ship many skills in one repo" | Promote each nested skill to `<target>/skills/<name>/` |
 | `hooks/*.json` only (no apm.yml or SKILL.md) | "I ship a set of harness hooks" | Deploy each hook to the target's `hooks/` directory |
-| `plugin.json` (no `$schema`) / `.claude-plugin/` | Claude plugin collection | Dissect via plugin artifact mapping |
-| `plugin.json` with an Agent Plugins `$schema` | Portable Agent Plugin | Installed whole and registered when the effective targets include Copilot |
+| `plugin.json` (no `$schema`, or unrecognized `$schema`) / `.claude-plugin/` | Claude plugin collection | Dissect via plugin artifact mapping |
+| `plugin.json` with the recognized Agent Plugins `$schema` | Portable Agent Plugin | Installed whole and registered when the effective targets include Copilot |
 | Marketplace entry with inline `lspServers` or `mcpServers` | Catalog owns server metadata | Synthesize and validate `apm.yml`, then deploy servers |
 
 When plugin signals coexist with an eligible `apm.yml`, the APM layout wins.
@@ -215,10 +215,11 @@ metadata variant changes.
 
 ## Plugin collection (`plugin.json`)
 
-A Claude-native plugin layout. A `plugin.json` with no `$schema` field is
-detected as this layout. APM dissects the plugin artifacts and maps them into
-runtime directories. A schema-bearing manifest never falls through to this
-legacy route.
+A Claude-native plugin layout. A `plugin.json` with no `$schema` field, or with
+an unrecognized `$schema`, is detected by its structure as this layout. APM
+dissects the plugin artifacts and maps them into runtime directories. An
+unrecognized schema is a warning, not a rejection; only the recognized Agent
+Plugins schema selects the portable Agent Plugin route.
 
 ```
 my-plugin/
@@ -265,12 +266,10 @@ of `apm pack` and `apm plugin init`.
 
 ## Agent Plugin (`plugin.json` with an Agent Plugins schema)
 
-A `plugin.json` that declares `"$schema"` under the Agent Plugins v1 schema
-prefix is a distinct package type from the Claude plugin collection above.
-Only the exact `1.0.0` schema is recognized. Another Agent Plugins version is
-a typed unsupported-version error. A foreign or non-string `$schema` is a
-typed manifest error. Only a `plugin.json` with no `$schema` falls through to
-the Claude plugin collection above.
+A `plugin.json` that declares the exact Agent Plugins v1 `"$schema"` is a
+distinct package type from the Claude plugin collection above. Other schema
+identifiers are identification misses: APM warns, then classifies by structure.
+A non-string `$schema` remains a manifest error.
 
 ```
 my-plugin/

--- a/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
@@ -11,8 +11,8 @@ how to install it:
 | `SKILL.md` (alone, or with apm.yml = HYBRID) | One skill bundle | Copy whole tree to `<target>/skills/<name>/` |
 | `skills/<name>/SKILL.md` | Many skills in one repo | Promote each nested skill to `<target>/skills/<name>/` |
 | `hooks/*.json` only | Harness hook package | Deploy hooks to the target's hooks directory |
-| `plugin.json` (no `$schema`) / `.claude-plugin/` | Claude plugin collection | Dissect via plugin artifact mapping |
-| `plugin.json` with an Agent Plugins `$schema` | Portable Agent Plugin | Acquired and locked as one opaque unit; registered when effective targets include Copilot and admission gates pass. Excluded targets create no native registration or loose primitive projection. APM does not require the runtime during lifecycle operations; loading requires supported Copilot CLI 1.0.81 or newer |
+| `plugin.json` (no `$schema`, or unrecognized `$schema`) / `.claude-plugin/` | Claude plugin collection | Dissect via plugin artifact mapping |
+| `plugin.json` with the recognized Agent Plugins `$schema` | Portable Agent Plugin | Acquired and locked as one opaque unit; registered when effective targets include Copilot and admission gates pass. Excluded targets create no native registration or loose primitive projection. APM does not require the runtime during lifecycle operations; loading requires supported Copilot CLI 1.0.81 or newer |
 
 When plugin signals coexist with an eligible `apm.yml`, the APM layout wins.
 An `apm.yml` is eligible when the root also has `.apm/` or the manifest
@@ -551,6 +551,10 @@ complete deploy list: declare each skill directory or an immediate container.
 An omitted key discovers root `skills/`; an explicit `[]` deploys none. If APM
 reports `plugin.json declares no deployable skills`, add the intended paths or
 remove the key to restore discovery.
+
+APM treats an unrecognized `plugin.json` `$schema` as an identification miss,
+not a rejection. It warns, then classifies by structure. Only the recognized
+Agent Plugins schema selects the portable Agent Plugin route.
 
 #### Shipping `bin/` executables (Claude Code only)
 

--- a/scripts/architecture_linter/checks/install_deployment_analyzers.py
+++ b/scripts/architecture_linter/checks/install_deployment_analyzers.py
@@ -54,10 +54,12 @@ from scripts.architecture_linter.checks.install_policy_intent import EXTRA_RULES
 from scripts.architecture_linter.checks.install_request_and_source import (
     _GUARD_INSTALL_SCOPE,
     _GUARD_OUTCOME,
+    _GUARD_PRIMITIVE_CLASSIFICATION,
     _GUARD_REQUEST_DEFAULTS,
     _GUARD_SOURCE_PLAN,
     check_install_scope_selection,
     check_outcome,
+    check_primitive_classification,
     check_request_defaults,
     check_source_plan,
 )
@@ -114,6 +116,11 @@ RULES: tuple[Rule, ...] = (
         _GUARD_SOURCE_PLAN,
         "Authorized deployable source paths come from install/deployable_source_plan.py.",
         check_source_plan,
+    ),
+    _rule(
+        _GUARD_PRIMITIVE_CLASSIFICATION,
+        "Primitive kind classification is declaration-first and has one owner.",
+        check_primitive_classification,
     ),
     _rule(
         _GUARD_REQUEST_DEFAULTS,

--- a/scripts/architecture_linter/checks/install_request_and_source.py
+++ b/scripts/architecture_linter/checks/install_request_and_source.py
@@ -37,6 +37,9 @@ _GUARD_OUTCOME = "install-deployment-outcome"
 _GUARD_SOURCE_PLAN = "install-deployment-source-plan"
 
 
+_GUARD_PRIMITIVE_CLASSIFICATION = "install-deployment-primitive-classification"
+
+
 _GUARD_REQUEST_DEFAULTS = "install-deployment-request-defaults"
 
 
@@ -399,6 +402,92 @@ def check_source_plan(provider: FactsProvider) -> tuple[Violation, ...]:
                     "Primitive materializers must consume the canonical deployable source plan",
                 )
             )
+    return tuple(findings)
+
+
+_PRIMITIVE_CLASSIFICATION_OWNER = "src/apm_cli/install/primitive_classification.py"
+_PRIMITIVE_CLASSIFICATION_CONSUMERS = (
+    "src/apm_cli/agent_plugins/loader.py",
+    "src/apm_cli/bundle/local_bundle.py",
+    "src/apm_cli/deps/plugin_parser.py",
+    "src/apm_cli/install/sources.py",
+    "src/apm_cli/integration/agent_integrator.py",
+)
+_SCHEMA_REJECTION_STRINGS = (
+    "Unsupported schema-bearing plugin manifest",
+    "Unsupported Agent Plugins manifest schema",
+)
+
+
+def check_primitive_classification(provider: FactsProvider) -> tuple[Violation, ...]:
+    """Artifact kind decisions must route through primitive_classification.py."""
+    rule_id = _GUARD_PRIMITIVE_CLASSIFICATION
+    findings: list[Violation] = []
+    owner, owner_fail = _facts_for(provider, _PRIMITIVE_CLASSIFICATION_OWNER, rule_id)
+    if owner_fail:
+        return tuple(owner_fail)
+
+    required_owner_fragments = (
+        "def classify_plugin_manifest(",
+        "def classify_plugin_manifest_schema(",
+        "def plugin_manifest_schema_warning(",
+        "def classify_agent_source_file(",
+        "Unknown ``$schema`` values are identification misses",
+    )
+    missing = [fragment for fragment in required_owner_fragments if not _present(owner, fragment)]
+    if missing:
+        findings.append(
+            _summary(
+                rule_id,
+                _PRIMITIVE_CLASSIFICATION_OWNER,
+                "Primitive classification owner is missing required declaration-first APIs",
+            )
+        )
+
+    for consumer in _PRIMITIVE_CLASSIFICATION_CONSUMERS:
+        facts, fail = _facts_for(provider, consumer, rule_id)
+        if fail:
+            findings.extend(fail)
+            continue
+        text = "\n".join(_lines(facts))
+        for rejection in _SCHEMA_REJECTION_STRINGS:
+            if rejection in text:
+                findings.append(
+                    _summary(
+                        rule_id,
+                        consumer,
+                        "Plugin schema classification misses must not be local fatal rejections",
+                    )
+                )
+        if consumer == "src/apm_cli/integration/agent_integrator.py" and not _present(
+            facts,
+            "classify_agent_source_file(",
+        ):
+            findings.append(
+                _summary(
+                    rule_id,
+                    consumer,
+                    "AgentIntegrator must route agent source classification through the owner",
+                )
+            )
+        if consumer != _PRIMITIVE_CLASSIFICATION_OWNER and "plugin_manifest" in text:
+            if (
+                consumer
+                in {
+                    "src/apm_cli/agent_plugins/loader.py",
+                    "src/apm_cli/bundle/local_bundle.py",
+                    "src/apm_cli/deps/plugin_parser.py",
+                    "src/apm_cli/install/sources.py",
+                }
+                and "primitive_classification" not in text
+            ):
+                findings.append(
+                    _summary(
+                        rule_id,
+                        consumer,
+                        "Plugin manifest route consumers must import primitive_classification",
+                    )
+                )
     return tuple(findings)
 
 

--- a/scripts/architecture_linter/checks/marketplace_catalog_and_contract.py
+++ b/scripts/architecture_linter/checks/marketplace_catalog_and_contract.py
@@ -164,6 +164,9 @@ _ASSETS = "src/apm_cli/agent_plugins/assets.py"
 _LOCAL_BUNDLE = "src/apm_cli/bundle/local_bundle.py"
 
 
+_PRIMITIVE_CLASSIFICATION = "src/apm_cli/install/primitive_classification.py"
+
+
 _FORMAT_DETECTION = "src/apm_cli/models/format_detection.py"
 
 
@@ -506,13 +509,23 @@ def _check_loader_ownership(provider: FactsProvider, inv: frozenset[str]) -> tup
             provider,
             inv,
             _RID_CONTRACT,
-            _LOCAL_BUNDLE,
+            _PRIMITIVE_CLASSIFICATION,
             (
                 re.compile(r"^class PluginSchemaRoute\(Enum\):"),
                 re.compile(r"^def classify_plugin_manifest_schema\("),
-                re.compile(r"^def route_agent_plugin_package\("),
+                re.compile(r"^def classify_plugin_manifest\("),
             ),
-            "bundle/local_bundle.py must own plugin schema routing",
+            "primitive_classification.py must own plugin schema routing",
+        )
+    )
+    findings.extend(
+        _require_res(
+            provider,
+            inv,
+            _RID_CONTRACT,
+            _LOCAL_BUNDLE,
+            (re.compile(r"^def route_agent_plugin_package\("),),
+            "bundle/local_bundle.py must route package admission through the classifier",
         )
     )
     findings.extend(
@@ -520,11 +533,11 @@ def _check_loader_ownership(provider: FactsProvider, inv: frozenset[str]) -> tup
             provider,
             inv,
             _RID_CONTRACT,
-            _LOCAL_BUNDLE,
+            _PRIMITIVE_CLASSIFICATION,
             (
                 "if schema_id == PLUGIN_SCHEMA_ID:",
-                "package_type, _ = detect_package_type(",
-                "if package_type != PackageType.AGENT_PLUGIN:",
+                "PluginSchemaRoute.AGENT_PLUGIN",
+                "PluginSchemaRoute.LEGACY",
             ),
             "plugin schema routing must select exact schema IDs",
         )
@@ -534,7 +547,7 @@ def _check_loader_ownership(provider: FactsProvider, inv: frozenset[str]) -> tup
             provider,
             inv,
             _RID_CONTRACT,
-            (_LOCAL_BUNDLE,),
+            (_PRIMITIVE_CLASSIFICATION,),
             re.compile(
                 r"is_agent_plugin_schema_id|supports_plugin_schema_id|validate_plugin_manifest_document"
             ),
@@ -547,7 +560,7 @@ def _check_loader_ownership(provider: FactsProvider, inv: frozenset[str]) -> tup
             provider,
             inv,
             _RID_CONTRACT,
-            (_LOCAL_BUNDLE,),
+            (_PRIMITIVE_CLASSIFICATION,),
             re.compile(
                 r"agent_plugin_(runtime|state)|install\.mcp|security\.executables|lockfile.*v3"
             ),
@@ -561,7 +574,7 @@ def _check_loader_ownership(provider: FactsProvider, inv: frozenset[str]) -> tup
             inv,
             _RID_CONTRACT,
             _LOADER,
-            (("sub", "classify_plugin_manifest_schema", 4, "ge"),),
+            (("sub", "classify_plugin_manifest", 4, "ge"),),
             "Agent Plugin loading and legacy admission must share the schema router",
         )
     )

--- a/scripts/architecture_linter/checks/registry_semantic_rules.py
+++ b/scripts/architecture_linter/checks/registry_semantic_rules.py
@@ -234,6 +234,7 @@ _MANIFEST_SCHEMA_OWNERS = (
     _MANIFEST_CONTRACT_OWNER,
     "src/apm_cli/agent_plugins/loader.py",
     "src/apm_cli/agent_plugins/validation.py",
+    "src/apm_cli/install/primitive_classification.py",
 )
 
 

--- a/src/apm_cli/agent_plugins/loader.py
+++ b/src/apm_cli/agent_plugins/loader.py
@@ -110,7 +110,7 @@ class _CandidateResolution:
 
 def detect_agent_plugin(package_root: Path) -> AgentPluginDetection | None:
     """Classify and interpret a native Agent Plugin from its exact root manifest."""
-    from ..bundle.local_bundle import PluginSchemaRoute, classify_plugin_manifest_schema
+    from ..install.primitive_classification import PluginSchemaRoute, classify_plugin_manifest
 
     manifest_path = package_root / "plugin.json"
     try:
@@ -124,8 +124,8 @@ def detect_agent_plugin(package_root: Path) -> AgentPluginDetection | None:
         return None
     document = dict(evidence.document)
     try:
-        route = classify_plugin_manifest_schema(document)
-        if route is PluginSchemaRoute.LEGACY:
+        classification = classify_plugin_manifest(document)
+        if classification.route is PluginSchemaRoute.LEGACY:
             return None
         schema_id = document["$schema"]
         loader = _VERSION_LOADERS[schema_id]
@@ -175,7 +175,7 @@ def reject_agent_plugin_legacy_normalization(package_root: Path) -> None:
 
 def admit_legacy_plugin_manifest(package_root: Path) -> dict[str, Any] | None:
     """Return one admissible schema-less legacy manifest or reject fallback."""
-    from ..bundle.local_bundle import PluginSchemaRoute, classify_plugin_manifest_schema
+    from ..install.primitive_classification import PluginSchemaRoute, classify_plugin_manifest
 
     try:
         evidence = _read_admissible_root_manifest(package_root)
@@ -186,12 +186,12 @@ def admit_legacy_plugin_manifest(package_root: Path) -> dict[str, Any] | None:
     if evidence is None:
         return None
     try:
-        route = classify_plugin_manifest_schema(evidence.document)
+        classification = classify_plugin_manifest(evidence.document)
     except AgentPluginError as exc:
         raise AgentPluginLegacyBoundaryError(
             f"Schema-bearing plugin.json cannot enter Claude plugin normalization: {exc}"
         ) from exc
-    if route is PluginSchemaRoute.AGENT_PLUGIN:
+    if classification.route is PluginSchemaRoute.AGENT_PLUGIN:
         raise AgentPluginLegacyBoundaryError(
             "Agent Plugin input must be interpreted by load_agent_plugin(), "
             "not Claude plugin normalization"

--- a/src/apm_cli/bundle/local_bundle.py
+++ b/src/apm_cli/bundle/local_bundle.py
@@ -29,22 +29,18 @@ import shutil
 import tempfile
 import zipfile
 from dataclasses import dataclass, field
-from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import yaml
 
-from ..agent_plugins.constants import (
-    AGENT_PLUGINS_SCHEMA_PREFIX,
-    COM_MICROSOFT_APM_NAMESPACE,
-    PLUGIN_SCHEMA_ID,
-)
-from ..agent_plugins.errors import (
-    AgentPluginManifestError,
-    UnsupportedAgentPluginVersionError,
-)
+from ..agent_plugins.constants import COM_MICROSOFT_APM_NAMESPACE
+from ..agent_plugins.errors import AgentPluginManifestError
 from ..agent_plugins.io import read_json_document
+from ..install.primitive_classification import (
+    PluginSchemaRoute,
+    classify_plugin_manifest_schema,
+)
 from ..utils.archive import (
     MAX_ZIP_ENTRIES,
     MAX_ZIP_UNCOMPRESSED,
@@ -61,40 +57,10 @@ from ..utils.yaml_io import load_yaml_str
 from .formats import BundleFormat
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
-
     from ..agent_plugins.ir import AgentPlugin, AgentPluginDetection
 
 _MAX_ZIP_ENTRIES = MAX_ZIP_ENTRIES
 _MAX_ZIP_UNCOMPRESSED = MAX_ZIP_UNCOMPRESSED
-
-
-class PluginSchemaRoute(Enum):
-    """Admission route selected exclusively by root plugin.json."""
-
-    LEGACY = "legacy"
-    AGENT_PLUGIN = "agent_plugin"
-
-
-def classify_plugin_manifest_schema(document: Mapping[str, Any]) -> PluginSchemaRoute:
-    """Select native admission only for the exact supported schema identifier."""
-    if "$schema" not in document:
-        return PluginSchemaRoute.LEGACY
-    schema_id = document["$schema"]
-    if not isinstance(schema_id, str):
-        raise AgentPluginManifestError("Invalid root plugin.json: $schema must be a string")
-    if schema_id == PLUGIN_SCHEMA_ID:
-        return PluginSchemaRoute.AGENT_PLUGIN
-    if schema_id.startswith(AGENT_PLUGINS_SCHEMA_PREFIX):
-        raise UnsupportedAgentPluginVersionError(
-            f"Unsupported Agent Plugins manifest schema: {schema_id}. "
-            f"This APM version supports only {PLUGIN_SCHEMA_ID}."
-        )
-    raise AgentPluginManifestError(
-        f"Unsupported schema-bearing plugin manifest: {schema_id}. "
-        f"APM accepts schema-bearing plugin.json only with {PLUGIN_SCHEMA_ID}; "
-        "remove $schema only for a schema-less legacy plugin."
-    )
 
 
 def route_agent_plugin_package(package_root: Path) -> AgentPluginDetection | None:

--- a/src/apm_cli/deps/plugin_parser.py
+++ b/src/apm_cli/deps/plugin_parser.py
@@ -480,7 +480,10 @@ def normalize_plugin_directory(plugin_path: Path, plugin_json_path: Path | None 
     ):
         manifest = parse_plugin_manifest(plugin_json_path)
         from ..agent_plugins.errors import AgentPluginLegacyBoundaryError
-        from ..bundle.local_bundle import PluginSchemaRoute, classify_plugin_manifest_schema
+        from ..install.primitive_classification import (
+            PluginSchemaRoute,
+            classify_plugin_manifest_schema,
+        )
 
         if classify_plugin_manifest_schema(manifest) is PluginSchemaRoute.AGENT_PLUGIN:
             raise AgentPluginLegacyBoundaryError(

--- a/src/apm_cli/install/primitive_classification.py
+++ b/src/apm_cli/install/primitive_classification.py
@@ -1,0 +1,245 @@
+"""Canonical declaration-first primitive classification."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from apm_cli.agent_plugins.constants import PLUGIN_SCHEMA_ID
+from apm_cli.agent_plugins.errors import AgentPluginManifestError
+from apm_cli.utils.diagnostics import printable_ascii_text
+from apm_cli.utils.paths import portable_relpath
+from apm_cli.utils.yaml_io import loads_frontmatter
+
+
+class PluginSchemaRoute(Enum):
+    """Plugin manifest route selected by declaration before structure fallback."""
+
+    LEGACY = "legacy"
+    AGENT_PLUGIN = "agent_plugin"
+
+
+class PrimitiveKind(Enum):
+    """Deployable primitive kind selected by the canonical resolver."""
+
+    AGENT = "agent"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class PluginManifestClassification:
+    """Declaration-first classification of one plugin manifest."""
+
+    route: PluginSchemaRoute
+    schema_id: str | None = None
+    warning: str | None = None
+
+
+@dataclass(frozen=True)
+class AgentSourceClassification:
+    """Classification result for a file found below an agent source root."""
+
+    kind: PrimitiveKind
+    warning: str | None = None
+
+
+_AGENT_DECLARATION_FIELDS = frozenset(
+    {
+        "allowed-tools",
+        "argument-hint",
+        "color",
+        "description",
+        "input",
+        "mcp_servers",
+        "model",
+        "name",
+        "tools",
+    }
+)
+_DOCUMENT_DECLARATION_FIELDS = frozenset(
+    {
+        "draft",
+        "sidebar",
+        "sidebar_position",
+        "tags",
+        "title",
+    }
+)
+
+
+def classify_plugin_manifest(document: Mapping[str, Any]) -> PluginManifestClassification:
+    """Classify a plugin manifest by declaration, then allow structure fallback.
+
+    Unknown ``$schema`` values are identification misses, not validation
+    rejections. Callers should fall back to structural Claude plugin handling and
+    surface ``warning`` to the user when present.
+    """
+    if "$schema" not in document:
+        return PluginManifestClassification(PluginSchemaRoute.LEGACY)
+
+    schema_id = document["$schema"]
+    if not isinstance(schema_id, str):
+        raise AgentPluginManifestError("Invalid root plugin.json: $schema must be a string")
+    if schema_id == PLUGIN_SCHEMA_ID:
+        return PluginManifestClassification(
+            PluginSchemaRoute.AGENT_PLUGIN,
+            schema_id=schema_id,
+        )
+    return PluginManifestClassification(
+        PluginSchemaRoute.LEGACY,
+        schema_id=schema_id,
+        warning=(
+            f"Unrecognized plugin manifest $schema: {printable_ascii_text(schema_id)}. "
+            "APM classified the plugin by structure instead. Action: keep the "
+            "legacy plugin fields valid for the target harness, or update APM when "
+            "native support exists."
+        ),
+    )
+
+
+def classify_plugin_manifest_schema(document: Mapping[str, Any]) -> PluginSchemaRoute:
+    """Return only the route for callers that do not render diagnostics."""
+    return classify_plugin_manifest(document).route
+
+
+def plugin_manifest_schema_warning(document: Mapping[str, Any]) -> str | None:
+    """Return the non-fatal warning for an unrecognized schema declaration."""
+    return classify_plugin_manifest(document).warning
+
+
+def warn_unrecognized_plugin_schema(diagnostics, package_key: str, install_path: Path) -> None:
+    """Surface non-fatal plugin schema identification misses."""
+    if diagnostics is None:
+        return
+    from apm_cli.agent_plugins.io import read_json_document
+    from apm_cli.utils.helpers import find_plugin_json
+
+    plugin_json_path = find_plugin_json(install_path)
+    if plugin_json_path is None or not plugin_json_path.is_file():
+        return
+    try:
+        document = read_json_document(plugin_json_path)
+    except (OSError, ValueError):
+        return
+    if not isinstance(document, dict):
+        return
+    warning = plugin_manifest_schema_warning(document)
+    if warning:
+        diagnostics.warn(warning, package=package_key)
+
+
+def classify_agent_source_file(source: Path, source_root: Path) -> AgentSourceClassification:
+    """Classify one source-tree file as an agent or a non-deployable miss.
+
+    Precedence is declaration first, then Markdown structure, then the caller's
+    source-location and extension signal. The final fallback preserves legacy
+    ``.apm/agents/*.md`` behavior only when the file has no contrary
+    declaration.
+    """
+    if not source.is_file():
+        return AgentSourceClassification(PrimitiveKind.UNKNOWN)
+    if not _is_markdown(source):
+        return AgentSourceClassification(
+            PrimitiveKind.UNKNOWN,
+            warning=_skipped_asset_warning(source, source_root),
+        )
+
+    try:
+        content = source.read_text(encoding="utf-8")
+    except OSError:
+        return AgentSourceClassification(
+            PrimitiveKind.UNKNOWN,
+            warning=_skipped_markdown_warning(
+                source,
+                source_root,
+                "could not be read",
+                "fix the file permissions, then rerun 'apm install'",
+            ),
+        )
+
+    try:
+        post = loads_frontmatter(content)
+    except yaml.YAMLError:
+        return AgentSourceClassification(PrimitiveKind.AGENT)
+
+    metadata = getattr(post, "metadata", None)
+    if isinstance(metadata, dict) and metadata:
+        schema = metadata.get("$schema")
+        schema_warning = None
+        if "$schema" in metadata:
+            if not isinstance(schema, str):
+                return AgentSourceClassification(
+                    PrimitiveKind.UNKNOWN,
+                    warning=_skipped_markdown_warning(
+                        source,
+                        source_root,
+                        "declares a non-string $schema",
+                        "use a string $schema or move the file outside the agents source tree",
+                    ),
+                )
+            schema_warning = _unknown_agent_schema_warning(source, source_root, schema)
+
+        keys = frozenset(str(key) for key in metadata)
+        if keys & _AGENT_DECLARATION_FIELDS:
+            return AgentSourceClassification(PrimitiveKind.AGENT, warning=schema_warning)
+        if keys & _DOCUMENT_DECLARATION_FIELDS:
+            return AgentSourceClassification(
+                PrimitiveKind.UNKNOWN,
+                warning=_skipped_markdown_warning(
+                    source,
+                    source_root,
+                    "declares document frontmatter but no agent fields",
+                    "move documentation outside the agents source tree or add agent "
+                    "description frontmatter if this file is an agent",
+                ),
+            )
+        return AgentSourceClassification(
+            PrimitiveKind.UNKNOWN,
+            warning=_skipped_markdown_warning(
+                source,
+                source_root,
+                "declares frontmatter but no recognized agent fields",
+                "add description/name frontmatter or move the file outside the agents source tree",
+            ),
+        )
+
+    return AgentSourceClassification(PrimitiveKind.AGENT)
+
+
+def _is_markdown(path: Path) -> bool:
+    return path.name.endswith(".agent.md") or path.suffix == ".md"
+
+
+def _display_path(path: Path, source_root: Path) -> str:
+    try:
+        return printable_ascii_text(portable_relpath(path, source_root))
+    except ValueError:
+        return printable_ascii_text(path.name)
+
+
+def _skipped_asset_warning(source: Path, source_root: Path) -> str:
+    return (
+        f"Skipped non-agent asset in agents source tree: {_display_path(source, source_root)}. "
+        "APM deploys agent sources as flat Markdown files for this target, so sibling "
+        "assets would not be readable at runtime. Action: move the asset to a supported "
+        "package surface or inline the content, then rerun 'apm install'."
+    )
+
+
+def _skipped_markdown_warning(source: Path, source_root: Path, reason: str, action: str) -> str:
+    return (
+        f"Skipped non-agent Markdown in agents source tree: {_display_path(source, source_root)} "
+        f"{reason}. Action: {action}."
+    )
+
+
+def _unknown_agent_schema_warning(source: Path, source_root: Path, schema: str) -> str:
+    return (
+        f"Unrecognized agent source $schema in {_display_path(source, source_root)}: "
+        f"{printable_ascii_text(schema)}. APM classified the file by structure instead."
+    )

--- a/src/apm_cli/install/sources.py
+++ b/src/apm_cli/install/sources.py
@@ -33,6 +33,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from apm_cli.install.errors import DirectDependencyError
+from apm_cli.install.primitive_classification import warn_unrecognized_plugin_schema
 from apm_cli.install.registry_wiring import (
     get_registry_resolver,
     registry_resolution_for_cached_registry_dep,
@@ -288,6 +289,7 @@ class LocalDependencySource(DependencySource):
         else:
             details = "; ".join(validation.errors) or "validator returned no package"
             raise DirectDependencyError(f"Local package is invalid: {details}")
+        warn_unrecognized_plugin_schema(diagnostics, dep_key, install_path)
         if not local_pkg.source:
             local_pkg.source = dep_ref.local_path
 
@@ -619,6 +621,7 @@ class CachedDependencySource(DependencySource):
         if cached_package_info.package_type:
             ctx.package_types[dep_key] = cached_package_info.package_type.value
         _record_declared_license(ctx, dep_key, install_path)
+        warn_unrecognized_plugin_schema(ctx.diagnostics, dep_key, install_path)
 
         # Return without deploying integration files when the target set is empty.
         if not ctx.targets and native_validation is None:
@@ -729,7 +732,7 @@ class FreshDependencySource(DependencySource):
                         f"no registry resolver was constructed (apm.yml may "
                         f"be missing a 'registries:' block)."
                     )
-                # Lockfile re-install path: registry_name might be absent —
+                # Lockfile re-install path: registry_name might be absent -
                 # look it up from the lockfile's resolved_url.
                 from apm_cli.deps.registry.auth import (
                     dependency_ref_with_registry_name_from_lockfile,
@@ -832,7 +835,7 @@ class FreshDependencySource(DependencySource):
             _is_dev = node.is_dev if node else False
             # Registry-sourced deps: pull the captured resolution out of
             # the resolver's per-graph map so the lockfile records
-            # resolved_url + resolved_hash + version (design §6.1).
+            # resolved_url + resolved_hash + version (design sec. 6.1).
             _registry_resolution = (
                 resolver_last_registry_resolution(ctx, dep_key)
                 if dep_ref.source == "registry"
@@ -894,6 +897,7 @@ class FreshDependencySource(DependencySource):
             if hasattr(package_info, "package_type") and package_info.package_type:
                 ctx.package_types[dep_key] = package_info.package_type.value
             _record_declared_license(ctx, dep_key, install_path)
+            warn_unrecognized_plugin_schema(diagnostics, dep_key, install_path)
 
             if hasattr(package_info, "package_type"):
                 package_type = package_info.package_type

--- a/src/apm_cli/integration/agent_integrator.py
+++ b/src/apm_cli/integration/agent_integrator.py
@@ -13,6 +13,11 @@ from typing import TYPE_CHECKING
 
 import yaml
 
+from apm_cli.install.primitive_classification import (
+    AgentSourceClassification,
+    PrimitiveKind,
+    classify_agent_source_file,
+)
 from apm_cli.integration.base_integrator import BaseIntegrator, IntegrationResult
 from apm_cli.integration.opencode_frontmatter import validate_opencode_frontmatter
 from apm_cli.utils.atomic_io import normalize_crlf_to_lf, write_text_lf
@@ -51,7 +56,25 @@ class AgentIntegrator(BaseIntegrator):
     # Deploys via write_text_lf -> compare adopt candidates in LF mode.
     _LF_NORMALIZED_DEPLOY = True
 
-    def find_agent_files(self, package_path: Path, source_plan=None) -> list[Path]:
+    @staticmethod
+    def _warn_agent_classification(
+        classification: AgentSourceClassification,
+        diagnostics: DiagnosticCollector | None,
+        package_name: str,
+    ) -> None:
+        if classification.warning and diagnostics is not None:
+            diagnostics.warn(
+                message=classification.warning,
+                package=printable_ascii_text(package_name),
+            )
+
+    def find_agent_files(
+        self,
+        package_path: Path,
+        source_plan=None,
+        diagnostics=None,
+        package_name: str = "",
+    ) -> list[Path]:
         """Find all agent files in a package.
 
         Searches in:
@@ -65,16 +88,28 @@ class AgentIntegrator(BaseIntegrator):
             List[Path]: List of absolute paths to agent files
         """
         files: list[Path] = []
-        # Flat search in package root
-        files += self.find_files_by_glob(package_path, "*.agent.md")
-        # Recursive search in .apm/agents/ (use ** glob for subdirectories)
+        # Flat search in package root. The extension is only the final
+        # fallback; declarations inside the file still route through the owner.
+        for candidate in self.find_files_by_glob(package_path, "*.agent.md"):
+            classification = classify_agent_source_file(candidate, package_path)
+            self._warn_agent_classification(classification, diagnostics, package_name)
+            if classification.kind is PrimitiveKind.AGENT:
+                files.append(candidate)
+        # Recursive search in .apm/agents/; the classification owner decides
+        # whether each file is an agent before target layout derives a name.
         apm_agents = package_path / ".apm" / "agents"
         if apm_agents.exists():
-            files += self.find_files_by_glob(apm_agents, "**/*.agent.md")
-            # Also pick up plain .md files; the directory name implies type
-            for f in self.find_files_by_glob(apm_agents, "**/*.md"):
-                if not f.name.endswith(".agent.md") and f not in files:
-                    files.append(f)
+            candidates = [f for f in self.find_files_by_glob(apm_agents, "**/*") if f.is_file()]
+            authorized = set(self.filter_authorized_files(candidates, source_plan))
+            for candidate in candidates:
+                classification = classify_agent_source_file(candidate, apm_agents)
+                self._warn_agent_classification(classification, diagnostics, package_name)
+                if (
+                    classification.kind is PrimitiveKind.AGENT
+                    and candidate in authorized
+                    and candidate not in files
+                ):
+                    files.append(candidate)
         return self.filter_authorized_files(files, source_plan)
 
     # NOTE: find_skill_file(), integrate_skill(), and _generate_skill_agent_content()
@@ -129,7 +164,12 @@ class AgentIntegrator(BaseIntegrator):
             return IntegrationResult(0, 0, 0, [])
 
         self.init_link_resolver(package_info, project_root)
-        agent_files = self.find_agent_files(package_info.install_path, source_plan)
+        agent_files = self.find_agent_files(
+            package_info.install_path,
+            source_plan,
+            diagnostics,
+            package_info.package.name,
+        )
         if not agent_files:
             return IntegrationResult(0, 0, 0, [])
 
@@ -668,7 +708,11 @@ class AgentIntegrator(BaseIntegrator):
         copilot = KNOWN_TARGETS["copilot"]
 
         self.init_link_resolver(package_info, project_root)
-        agent_files = self.find_agent_files(package_info.install_path)
+        agent_files = self.find_agent_files(
+            package_info.install_path,
+            diagnostics=diagnostics,
+            package_name=package_info.package.name,
+        )
         if not agent_files:
             return IntegrationResult(0, 0, 0, [])
 

--- a/tests/integration/test_ownership_invariant_lifecycle.py
+++ b/tests/integration/test_ownership_invariant_lifecycle.py
@@ -11,6 +11,7 @@ import pytest
 
 from apm_cli.core.target_catalog import manifest_target_names
 from apm_cli.deps.lockfile import LockFile
+from apm_cli.integration.agent_integrator import AgentIntegrator
 from apm_cli.integration.targets import KNOWN_TARGETS, PrimitiveMapping, TargetProfile
 from apm_cli.utils.yaml_io import dump_yaml
 from tests.integration.test_required_lifecycle_state_machine import (
@@ -20,6 +21,7 @@ from tests.integration.test_required_lifecycle_state_machine import (
     _hook,
     _instruction,
     _new_scenario,
+    _result_evidence,
     _run_success,
     _skill,
 )
@@ -467,6 +469,149 @@ def _seed_unowned_mcp_config(project_root: Path, target: str) -> Path:
         encoding="utf-8",
     )
     return config
+
+
+def _write_claude_plugin_manifest(plugin_root: Path, manifest: Mapping[str, object]) -> None:
+    manifest_dir = plugin_root / ".claude-plugin"
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    (manifest_dir / "plugin.json").write_text(
+        json.dumps(dict(manifest), indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
+def _direct_install_args(plugin_root: Path, target: str) -> tuple[str, ...]:
+    return (
+        "install",
+        str(plugin_root),
+        "--target",
+        target,
+        "--no-policy",
+        "--parallel-downloads",
+        "0",
+        "--verbose",
+    )
+
+
+def _agent_classification_targets() -> tuple[TargetProfile, ...]:
+    """Derive the markdown agent classification targets from the live catalog."""
+    return tuple(
+        profile
+        for profile in KNOWN_TARGETS.values()
+        if (mapping := profile.primitives.get("agents")) is not None
+        and mapping.format_id in {"github_agent", "claude_agent"}
+        and profile.requires_flag is None
+    )
+
+
+def _prepare_target_root(project_root: Path, profile: TargetProfile) -> None:
+    if not profile.auto_create:
+        (project_root / profile.root_dir).mkdir(parents=True, exist_ok=True)
+
+
+def _agent_target_path(project_root: Path, profile: TargetProfile, source_name: str) -> Path:
+    mapping = profile.primitives["agents"]
+    target_root = project_root / (mapping.deploy_root or profile.root_dir)
+    target_name = AgentIntegrator().get_target_filename_for_target(
+        Path(source_name),
+        "classification-plugin",
+        profile,
+    )
+    return target_root / mapping.subdir / target_name
+
+
+def test_unrecognized_claude_plugin_schema_falls_back_to_legacy_structure(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    """A foreign schema declaration is a classification miss, not rejection."""
+    scenario = _new_scenario(tmp_path / "foreign-schema-plugin", apm_binary_path)
+    plugin_root = scenario.isolated.package_root / "schema-plugin"
+    plugin_root.mkdir(parents=True)
+    skill_bytes = b"---\nname: schema-skill\ndescription: Schema skill\n---\n# Schema skill\n"
+    (plugin_root / "SKILL.md").write_bytes(skill_bytes)
+    _write_claude_plugin_manifest(
+        plugin_root,
+        {
+            "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+            "name": "schema-plugin",
+            "version": "1.0.0",
+        },
+    )
+    project = scenario.consumers.create("schema-consumer")
+    claude = KNOWN_TARGETS["claude"]
+    _prepare_target_root(project.root, claude)
+
+    result = scenario.runner.run(
+        _direct_install_args(plugin_root, claude.name),
+        cwd=project.root,
+        env=scenario.environment,
+        scenario_id="foreign-schema-plugin-install",
+    )
+
+    skill_path = project.root / ".claude" / "skills" / "schema-plugin" / "SKILL.md"
+    assert skill_path.is_file(), _result_evidence(result)
+    assert skill_path.read_bytes() == skill_bytes
+    assert result.returncode == 0, _result_evidence(result)
+    assert "Unrecognized plugin manifest $schema" in result.stdout + result.stderr
+
+
+@pytest.mark.parametrize(
+    "profile",
+    _agent_classification_targets(),
+    ids=lambda profile: profile.name,
+)
+def test_legacy_plugin_agent_source_classification_uses_declaration_before_path(
+    tmp_path: Path,
+    apm_binary_path: Path,
+    profile: TargetProfile,
+) -> None:
+    """Only declared agents deploy; doc markdown and sibling assets are skipped."""
+    scenario = _new_scenario(tmp_path / f"agent-classification-{profile.name}", apm_binary_path)
+    plugin_root = scenario.isolated.package_root / "classification-plugin"
+    agent_root = plugin_root / "agents" / "my-agent"
+    (agent_root / "guides").mkdir(parents=True)
+    (agent_root / "scripts").mkdir(parents=True)
+    (agent_root / "templates").mkdir(parents=True)
+    agent_bytes = b"---\ndescription: Real agent\n---\n# Real agent\n"
+    doc_bytes = (
+        b"---\ntitle: Reference document\n---\nThis is documentation, not an invokable agent.\n"
+    )
+    helper_bytes = b"print('helper')\n"
+    starter_bytes = b"pptx-bytes\n"
+    (agent_root / "my-agent.agent.md").write_bytes(agent_bytes)
+    (agent_root / "guides" / "reference-doc.agent.md").write_bytes(doc_bytes)
+    (agent_root / "scripts" / "helper.py").write_bytes(helper_bytes)
+    (agent_root / "templates" / "starter.pptx").write_bytes(starter_bytes)
+    _write_claude_plugin_manifest(
+        plugin_root,
+        {
+            "name": "classification-plugin",
+            "version": "1.0.0",
+            "agents": ["./agents/my-agent"],
+        },
+    )
+    project = scenario.consumers.create(f"agent-consumer-{profile.name}")
+    _prepare_target_root(project.root, profile)
+
+    result = _run_success(
+        scenario,
+        project,
+        _direct_install_args(plugin_root, profile.name),
+        environment=scenario.environment,
+        scenario_id=f"agent-classification-{profile.name}-install",
+    )
+
+    deployed_agent = _agent_target_path(project.root, profile, "my-agent.agent.md")
+    deployed_doc = _agent_target_path(project.root, profile, "reference-doc.agent.md")
+    target_agents_dir = deployed_agent.parent
+    assert deployed_agent.read_bytes() == agent_bytes
+    assert not deployed_doc.exists()
+    assert not (target_agents_dir / "scripts" / "helper.py").exists()
+    assert not (target_agents_dir / "templates" / "starter.pptx").exists()
+    combined_output = result.stdout + result.stderr
+    assert "Skipped non-agent Markdown in agents source tree" in combined_output
+    assert "Skipped non-agent asset in agents source tree" in combined_output
 
 
 @pytest.mark.parametrize("case", _OWNERSHIP_CASES, ids=lambda case: case.id)

--- a/tests/unit/agent_plugins/test_loader.py
+++ b/tests/unit/agent_plugins/test_loader.py
@@ -20,13 +20,11 @@ from apm_cli.agent_plugins import (
     AgentPluginError,
     AgentPluginLegacyBoundaryError,
     AgentPluginManifestAuthorityError,
-    AgentPluginManifestError,
     AssetInventoryError,
     FrozenJsonArray,
     FrozenJsonObject,
     FrozenJsonValue,
     NotAgentPluginError,
-    UnsupportedAgentPluginVersionError,
     detect_agent_plugin,
     load_agent_plugin,
     open_verified_asset,
@@ -884,59 +882,34 @@ def test_claude_normalizer_preserves_explicit_legacy_plugin_behavior(tmp_path: P
 
 
 @pytest.mark.parametrize(
-    ("schema_id", "error_type", "message"),
+    "schema_id",
     [
-        (
-            "https://agent-plugins.org/schemas/2.0.0/plugin.schema.json",
-            UnsupportedAgentPluginVersionError,
-            "supports only",
-        ),
-        (
-            f"{PLUGIN_SCHEMA_ID}/",
-            UnsupportedAgentPluginVersionError,
-            "supports only",
-        ),
-        (
-            "https://example.com/plugin.schema.json",
-            AgentPluginManifestError,
-            "Unsupported schema-bearing plugin manifest",
-        ),
+        "https://agent-plugins.org/schemas/2.0.0/plugin.schema.json",
+        f"{PLUGIN_SCHEMA_ID}/",
+        "https://example.com/plugin.schema.json",
     ],
 )
-def test_schema_bearing_manifest_never_falls_back_to_legacy_normalization(
+def test_unrecognized_schema_bearing_manifest_falls_back_to_legacy_normalization(
     tmp_path: Path,
     schema_id: str,
-    error_type: type[AgentPluginError],
-    message: str,
 ) -> None:
     _write_manifest(tmp_path, **{"$schema": schema_id})
 
     detection = detect_agent_plugin(tmp_path)
 
-    assert detection is not None
-    assert isinstance(detection.error, error_type)
-    assert message in str(detection.error)
-    with pytest.raises(AgentPluginLegacyBoundaryError, match=message):
-        normalize_plugin_directory(tmp_path, tmp_path / "plugin.json")
-    assert not (tmp_path / "apm.yml").exists()
+    assert detection is None
+    apm_yml = normalize_plugin_directory(tmp_path, tmp_path / "plugin.json")
+    assert apm_yml == tmp_path / "apm.yml"
+    assert apm_yml.is_file()
 
 
-@pytest.mark.parametrize(
-    "schema_id",
-    [
-        PLUGIN_SCHEMA_ID,
-        "https://agent-plugins.org/schemas/2.0.0/plugin.schema.json",
-        "https://example.com/plugin.schema.json",
-    ],
-)
-def test_nested_marketplace_manifest_cannot_bypass_root_schema_admission(
+def test_nested_agent_plugin_manifest_cannot_bypass_root_schema_admission(
     tmp_path: Path,
-    schema_id: str,
 ) -> None:
     manifest = tmp_path / ".claude-plugin" / "plugin.json"
     manifest.parent.mkdir()
     manifest.write_text(
-        json.dumps({"$schema": schema_id, "name": "nested"}),
+        json.dumps({"$schema": PLUGIN_SCHEMA_ID, "name": "nested"}),
         encoding="utf-8",
     )
 

--- a/tests/unit/bundle/test_local_bundle.py
+++ b/tests/unit/bundle/test_local_bundle.py
@@ -239,7 +239,9 @@ class TestDetectLocalBundle:
         assert result is not None
         assert result.package_id == "Test Plugin"
 
-    def test_detect_rejects_unsupported_agent_plugin_schema(self, tmp_path: Path) -> None:
+    def test_detect_treats_unsupported_agent_plugin_schema_as_legacy_miss(
+        self, tmp_path: Path
+    ) -> None:
         bundle = _make_plugin_bundle(tmp_path)
         (bundle / "plugin.json").write_text(
             json.dumps(
@@ -251,10 +253,15 @@ class TestDetectLocalBundle:
             encoding="utf-8",
         )
 
-        with pytest.raises(ValueError, match="Unsupported Agent Plugins manifest schema"):
-            detect_local_bundle(bundle)
+        result = detect_local_bundle(bundle)
 
-    def test_detect_rejects_foreign_schema_bearing_manifest(self, tmp_path: Path) -> None:
+        assert result is not None
+        assert result.format == BundleFormat.CLAUDE_PLUGIN.value
+        assert result.agent_plugin is None
+
+    def test_detect_treats_foreign_schema_bearing_manifest_as_legacy_miss(
+        self, tmp_path: Path
+    ) -> None:
         bundle = _make_plugin_bundle(tmp_path)
         (bundle / "plugin.json").write_text(
             json.dumps(
@@ -266,11 +273,14 @@ class TestDetectLocalBundle:
             encoding="utf-8",
         )
 
-        with pytest.raises(ValueError, match="Unsupported schema-bearing plugin manifest"):
-            detect_local_bundle(bundle)
+        result = detect_local_bundle(bundle)
+
+        assert result is not None
+        assert result.format == BundleFormat.CLAUDE_PLUGIN.value
+        assert result.agent_plugin is None
 
     @pytest.mark.parametrize("container", ("zip", "tar"))
-    def test_rejected_schema_archive_cleans_temporary_extraction(
+    def test_schema_miss_archive_cleans_temporary_extraction(
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
@@ -297,10 +307,12 @@ class TestDetectLocalBundle:
             lambda **_kwargs: str(extraction),
         )
 
-        with pytest.raises(ValueError, match="Unsupported Agent Plugins manifest schema"):
-            detect_local_bundle(archive)
+        result = detect_local_bundle(archive)
 
-        assert not extraction.exists()
+        assert result is not None
+        assert result.format == BundleFormat.CLAUDE_PLUGIN.value
+        assert result.temp_dir == extraction
+        assert extraction.exists()
 
     @pytest.mark.parametrize("container", ("directory", "zip", "tar"))
     def test_exact_schema_routes_every_local_bundle_container_through_canonical_ir(

--- a/tests/unit/deps/test_github_downloader_phase3.py
+++ b/tests/unit/deps/test_github_downloader_phase3.py
@@ -1,6 +1,6 @@
-"""Comprehensive unit tests for github_downloader.py — phase-3 coverage push.
+"""Comprehensive unit tests for github_downloader.py - phase-3 coverage push.
 
-Target: push coverage from ~54 % to ≥ 85 %.
+Target: push coverage from ~54 % to >= 85 %.
 
 All HTTP requests, git subprocess calls, and filesystem mutations are mocked so
 the suite is fully hermetic and requires no network access or git installation.
@@ -114,7 +114,7 @@ class TestDebug:
 class TestCloseRepo:
     def test_none_repo_is_a_no_op(self) -> None:
         """_close_repo(None) must not raise."""
-        _close_repo(None)  # no assertion needed — must not raise
+        _close_repo(None)  # no assertion needed - must not raise
 
     def test_repo_close_called(self) -> None:
         repo = MagicMock()
@@ -125,7 +125,7 @@ class TestCloseRepo:
         repo = MagicMock()
         repo.git.clear_cache.side_effect = OSError("locked")
         repo.close.side_effect = RuntimeError("already closed")
-        # Both exceptions must be suppressed — function must not raise.
+        # Both exceptions must be suppressed - function must not raise.
         _close_repo(repo)
 
     def test_exception_in_close_is_suppressed(self) -> None:
@@ -617,7 +617,7 @@ class TestValidateVirtualPackageExistsShim:
 
 
 # ---------------------------------------------------------------------------
-# download_virtual_file_package — error paths
+# download_virtual_file_package - error paths
 # ---------------------------------------------------------------------------
 
 
@@ -740,7 +740,7 @@ class TestDownloadVirtualFilePackageErrors:
 
 
 # ---------------------------------------------------------------------------
-# download_subdirectory_package — error paths
+# download_subdirectory_package - error paths
 # ---------------------------------------------------------------------------
 
 
@@ -911,7 +911,7 @@ class TestDownloadSubdirectoryPackageErrors:
             patch("apm_cli.utils.file_ops.robust_copy2"),
         ):
             pkg_info = downloader.download_subdirectory_package(dep, tmp_path / "out")
-        # ws2 path — resolved_commit comes from _materialize_from_bare, not Repo()
+        # ws2 path - resolved_commit comes from _materialize_from_bare, not Repo()
         assert pkg_info.resolved_reference.resolved_commit == sha
 
 
@@ -1161,10 +1161,10 @@ class TestDownloadPackage:
             result = downloader.download_package(dep, tmp_path / "pkg")
         assert result.package is pkg
 
-    def test_cache_hit_with_unsupported_schema_fails_instead_of_cloning(
+    def test_cache_hit_with_unrecognized_schema_falls_back_without_cloning(
         self, downloader: GitHubPackageDownloader, tmp_path: Path
     ) -> None:
-        from apm_cli.agent_plugins import UnsupportedAgentPluginVersionError
+        from apm_cli.models.validation import PackageType
 
         dep = _make_dep()
         resolved = _make_resolved(ref_type=GitReferenceType.BRANCH)
@@ -1184,16 +1184,19 @@ class TestDownloadPackage:
         downloader.persistent_git_cache = cache
         clone = MagicMock()
 
+        target = tmp_path / "pkg"
         with (
             patch.object(downloader, "_is_artifactory_only", return_value=False),
             patch.object(downloader, "_parse_artifactory_base_url", return_value=None),
             patch.object(downloader, "_should_use_artifactory_proxy", return_value=False),
             patch.object(downloader, "resolve_git_reference", return_value=resolved),
             patch.object(downloader, "_clone_with_fallback", clone),
-            pytest.raises(UnsupportedAgentPluginVersionError, match="supports only"),
         ):
-            downloader.download_package(dep, tmp_path / "pkg")
+            result = downloader.download_package(dep, target)
 
+        assert result.package_type == PackageType.MARKETPLACE_PLUGIN
+        assert result.package.name == "future.plugin"
+        assert (target / "apm.yml").exists()
         clone.assert_not_called()
 
     def test_native_agent_plugin_clone_returns_projected_package_without_apm_yml(
@@ -1235,10 +1238,10 @@ class TestDownloadPackage:
         assert result.package.agent_plugin is not None
         assert not (target / "apm.yml").exists()
 
-    def test_unsupported_agent_plugin_clone_fails_before_legacy_projection(
+    def test_unrecognized_agent_plugin_schema_clone_falls_back_to_legacy_projection(
         self, downloader: GitHubPackageDownloader, tmp_path: Path
     ) -> None:
-        from apm_cli.agent_plugins import UnsupportedAgentPluginVersionError
+        from apm_cli.models.validation import PackageType
 
         dep = _make_dep()
         resolved = _make_resolved(ref_type=GitReferenceType.BRANCH)
@@ -1264,11 +1267,12 @@ class TestDownloadPackage:
             patch.object(downloader, "_should_use_artifactory_proxy", return_value=False),
             patch.object(downloader, "resolve_git_reference", return_value=resolved),
             patch.object(downloader, "_clone_with_fallback", side_effect=clone_unsupported),
-            pytest.raises(UnsupportedAgentPluginVersionError, match="supports only"),
         ):
-            downloader.download_package(dep, target)
+            result = downloader.download_package(dep, target)
 
-        assert not (target / "apm.yml").exists()
+        assert result.package_type == PackageType.MARKETPLACE_PLUGIN
+        assert result.package.name == "future.plugin"
+        assert (target / "apm.yml").exists()
 
     def test_git_command_error_auth_failure_raises_runtime(
         self, downloader: GitHubPackageDownloader, tmp_path: Path

--- a/tests/unit/scripts/test_architecture_runner.py
+++ b/tests/unit/scripts/test_architecture_runner.py
@@ -640,6 +640,7 @@ install-deployment-mcp-registry-resolution
 install-deployment-outcome
 install-deployment-package-target-authorization
 install-deployment-plugin-bin-eligibility
+install-deployment-primitive-classification
 install-deployment-prospective-dry-run-plan
 install-deployment-provenance-state
 install-deployment-ref-recheck-ownership

--- a/tests/unit/test_format_detection.py
+++ b/tests/unit/test_format_detection.py
@@ -98,13 +98,12 @@ class TestAgentPluginDetector:
         assert isinstance(ev, AgentPluginFormatEvidence)
         assert ev.supported is True
 
-    def test_returns_unsupported_evidence_for_unknown_agent_version(self, tmp_path: Path) -> None:
+    def test_returns_no_native_evidence_for_unknown_agent_schema(self, tmp_path: Path) -> None:
         (tmp_path / "plugin.json").write_text(
             '{"$schema":"https://agent-plugins.org/schemas/2.0.0/plugin.schema.json"}'
         )
         ev = AgentPluginDetector().detect(tmp_path)
-        assert isinstance(ev, AgentPluginFormatEvidence)
-        assert ev.supported is False
+        assert ev is None
 
     def test_manifest_authority_conflict_is_invalid_evidence(self, tmp_path: Path) -> None:
         (tmp_path / "plugin.json").write_text(


### PR DESCRIPTION
# fix(install): centralize declaration-first primitive classification

## TL;DR

This PR makes primitive classification a single declaration-first owner for plugin manifests and agent source files. It fixes #2780 by treating unknown `plugin.json` `$schema` values as identification misses, not fatal validation errors, and partially addresses #2692 by skipping non-agent Markdown plus sibling assets with named diagnostics. #2692(a), nested agent layout preservation, is deliberately out of scope because no target harness contract in this PR proves nested agent directories are load-bearing.

> [!NOTE]
> Fixes #2780. Partially addresses #2692(b) and #2692(c) only.

## Problem (WHY)

- [x] #2780: a conforming Claude plugin with `https://json.schemastore.org/claude-code-plugin-manifest.json` was rejected before the legacy Claude plugin path could run.
- [x] #2692(b): `reference-doc.agent.md` under an agent directory was deployed as an invokable agent even when its frontmatter declared document intent.
- [x] #2692(c): sibling files such as `helper.py` and `starter.pptx` were omitted while install summaries still reported only the deployed agent count.
- [!] The same durable question, "what kind of thing is this?", was being answered in multiple places; the repo architecture rule says, "Every durable decision, vocabulary, outcome, write, or contract has exactly ONE canonical owner."
- [!] Reviewers need the boundary to be explicit because agents "pattern-match well against concrete structures" and this change crosses loader, bundle, parser, source, and integration paths.

### Bug file:line chains

- **#2780 schema miss path:** `src/apm_cli/bundle/local_bundle.py:213` calls `classify_plugin_manifest_schema()`, which routes through `src/apm_cli/install/primitive_classification.py:75-132`; `src/apm_cli/install/primitive_classification.py:115-132` renders the non-fatal warning from local/cached/fresh call sites `src/apm_cli/install/sources.py:292`, `src/apm_cli/install/sources.py:624`, and `src/apm_cli/install/sources.py:900`; `src/apm_cli/agent_plugins/loader.py:127` and `src/apm_cli/agent_plugins/loader.py:189` consume the same classification for native/legacy admission.
- **#2692(b)/(c) agent source path:** `src/apm_cli/integration/agent_integrator.py:93-113` routes root and `.apm/agents/**` candidates through `classify_agent_source_file()`; `src/apm_cli/install/primitive_classification.py:136-211` classifies non-Markdown assets and document-shaped Markdown as misses with actionable warnings; `src/apm_cli/integration/agent_integrator.py:60-69` emits those warnings through diagnostics instead of silently dropping the files.
- **Owner registration:** `.apm/architecture/owners/install-deployment.json:68-72` registers `primitive-kind-classification`; `scripts/architecture_linter/checks/install_request_and_source.py:40` names the `install-deployment-primitive-classification` guard.

## Approach (WHAT)

| # | Fix | Principle | Source |
|---:|---|---|---|
| 1 | Add `install/primitive_classification.py` as the declaration-first classifier for plugin manifests and agent source files. | "Every durable decision... has exactly ONE canonical owner." | `.github/instructions/architecture.instructions.md` |
| 2 | Route loader, local bundle, parser, install sources, and agent integration through that owner. | "Add what the agent lacks, omit what it knows" | https://agentskills.io/skill-creation/best-practices |
| 3 | Register a static guard so schema classification cannot drift back into local rejections. | "do the work, run a validator... and repeat until validation passes" | https://agentskills.io/skill-creation/best-practices |
| 4 | Preserve nested agent layout work as a follow-up instead of inventing an unsupported target shape. | "When you find yourself covering every edge case, consider whether most are better handled by the agent's own judgment." | https://agentskills.io/skill-creation/best-practices |

## Implementation (HOW)

- **`src/apm_cli/install/primitive_classification.py`** -- New canonical owner. Plugin manifest precedence is declaration first, then structure fallback: exact Agent Plugins schema routes native; no schema or unrecognized schema routes legacy with a warning; non-string `$schema` remains invalid. Agent source precedence is declaration first, Markdown structure second, location/extension last.
- **`src/apm_cli/agent_plugins/loader.py`** -- Native detection and legacy admission now call `classify_plugin_manifest()` instead of importing schema routing from `bundle/local_bundle.py`.
- **`src/apm_cli/bundle/local_bundle.py`** -- Removes the local `PluginSchemaRoute` owner and consumes `classify_plugin_manifest_schema()` so unknown schemas no longer reject local bundles by themselves.
- **`src/apm_cli/deps/plugin_parser.py`** -- Keeps the nested Agent Plugins boundary check, but only exact supported Agent Plugins schema blocks Claude normalization.
- **`src/apm_cli/install/sources.py`** -- Emits the non-fatal unknown-schema warning after local, cached, and fresh package acquisition paths.
- **`src/apm_cli/integration/agent_integrator.py`** -- Routes `.agent.md`, `.md`, and non-Markdown candidates under agent source roots through `classify_agent_source_file()` and records actionable diagnostics for skipped docs/assets.
- **Architecture linter and owner registry** -- Adds `primitive-kind-classification` to `.apm/architecture/owners/install-deployment.json` and wires `install-deployment-primitive-classification` plus legacy guard updates.
- **Docs and apm-usage skill** -- Updates package type docs to say unknown schema identifiers warn and fall back to structure, while only the recognized Agent Plugins schema selects the portable route.
- **Tests** -- Adds lifecycle-level regression traps for the schema fallback and agent source classification, plus unit updates for loader/local-bundle behavior.

## Diagrams

Legend: the new classifier is the only place that decides the route; callers consume its route and warning instead of rejecting unknown schemas locally.

```mermaid
flowchart LR
    subgraph Declaration[Declaration]
        M[plugin.json]
        A[agent source file]
    end
    subgraph Owner[New owner]
        C[classify_plugin_manifest]
        F[classify_agent_source_file]
    end
    subgraph Consumers[Consumers]
        L[loader]
        B[local_bundle]
        P[plugin_parser]
        S[install_sources]
        I[agent_integrator]
    end
    M --> C
    A --> F
    C --> L
    C --> B
    C --> P
    C --> S
    F --> I
    class C,F new;
    classDef new stroke-dasharray: 5 5;
```

Legend: unknown schema values now warn and fall back to structural Claude plugin handling; only exact recognized Agent Plugins schema selects native loading.

```mermaid
flowchart LR
    Start[plugin manifest] --> HasSchema{has schema}
    HasSchema -->|no| Legacy[legacy Claude structure]
    HasSchema -->|exact Agent Plugins v1| Native[native Agent Plugin]
    HasSchema -->|unrecognized string| Warn[warn]
    Warn --> Legacy
    HasSchema -->|non-string| Error[manifest error]
    class Warn new;
    classDef new stroke-dasharray: 5 5;
```

## Trade-offs

- **Declaration-first owner, not call-site patches.** Chose one resolver consumed by all affected paths; rejected separate fixes in `agent_integrator.py` and `local_bundle.py` because they would preserve split authority.
- **Unknown schema warns instead of rejects.** Chose structural fallback for unrecognized strings; kept non-string `$schema` as a manifest error because it is malformed declaration data, not an unknown identifier.
- **Skip assets loudly, do not invent nested layout.** Chose named warnings for non-Markdown assets; rejected nested deployment for #2692(a) because no harness contract in this PR proves those layouts are read at runtime.
- **Lifecycle tests over log-only assertions.** The tests assert file bytes and absence/presence first; log text is secondary proof that the skip was actionable.
- **No changelog entry.** This is a bug-fix PR tied to GitHub issues; user-facing package type docs and the apm-usage skill were updated instead.

## Benefits

1. A conforming Claude schemastore `$schema` no longer blocks install; the exact lifecycle regression deploys `schema-plugin/SKILL.md` bytes.
2. Document-shaped Markdown under `.apm/agents/` no longer becomes an invokable agent; lifecycle tests assert the bogus target file is absent.
3. Non-Markdown sibling assets are no longer silent drops; install output contains a named "Skipped non-agent asset in agents source tree" diagnostic.
4. The `primitive-kind-classification` owner plus architecture linter prevents future schema-route decisions from reappearing in local consumers.
5. Docs now match the resolver: unknown schema strings warn and fall back to structure; only recognized Agent Plugins schema selects native portable loading.

## Spec conformance waiver

apm-spec-waiver: Correction to existing Section 8.1 and req-pr-006 plugin collection contract; plugin.json/.claude-plugin layout already identifies Claude plugins.

I am using a waiver rather than adding a new requirement because the spec already defines the observable plugin behavior this PR restores:

- Section 3 defines a package as "A unit identified by a manifest (`apm.yml`) or by a recognised package layout (see [Section 8.1](#81-primitive-types))."
- Section 8.1 lists the relevant recognised layout as "Plugin collection (`plugin.json` / `.claude-plugin/`). Artifacts are mapped into deploy directories per the plugin manifest."
- [req-pr-006] already says, "For a Plugin collection, a conforming **consumer** MUST resolve `plugin.json` `skills` as follows."
- [req-tg-011] reserves the opaque native lifecycle for a "schema-bearing Agent Plugins v1 dependency" and its note ties applicability to "successful Agent Plugins schema parsing"; a foreign Claude `$schema` is therefore not an Agent Plugins v1 discriminator and must fall back to the existing Plugin collection layout contract.

## Validation

`uv run --frozen --extra dev ruff check src/ tests/ scripts/lint_architecture_boundaries.py scripts/architecture_linter/ && uv run --frozen --extra dev ruff format --check src/ tests/ scripts/lint_architecture_boundaries.py scripts/architecture_linter/ && uv run --frozen --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/ scripts/lint_architecture_boundaries.py scripts/architecture_linter/ && bash scripts/lint-auth-signals.sh && ... && bash scripts/lint-architecture-boundaries.sh`:

```
All checks passed!
1795 files already formatted

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

[*] Rule A: get_bearer_provider boundary (any reference)
[*] Rule B: git ls-remote auth-delegated annotation
[+] auth-signal lint clean
```

`uv run --frozen --extra dev pytest -q tests/unit/agent_plugins/test_loader.py tests/unit/bundle/test_local_bundle.py && uv run --frozen --extra dev pytest -q tests/spec_conformance/`:

```
........................................................................ [ 55%]
...........................s..............................               [100%]
129 passed, 1 skipped in 1.30s
................................s.......................s............... [ 36%]
........................................................................ [ 72%]
......................................................                   [100%]
196 passed, 2 skipped in 15.25s
```

`uv run --frozen --extra dev pytest -q tests/unit/deps/test_github_downloader_phase3.py tests/unit/test_format_detection.py tests/unit/scripts/test_architecture_runner.py tests/unit/install/test_architecture_invariants.py`:

```
246 passed in 2.63s
```

`BASE_REF=origin/main bash tests/spec_conformance/mode_b_detector.sh`:

```
[!] mode_b: WAIVED (214 substantive added lines) -- Correction to existing Section 8.1 and req-pr-006 plugin collection contract; plugin.json/.claude-plugin layout already identifies Claude plugins.
```

`APM_E2E_TESTS=1 uv run --frozen --extra dev pytest -q tests/integration/test_required_lifecycle_state_machine.py tests/integration/test_ownership_invariant_lifecycle.py`:

```
....................                                                     [100%]
20 passed in 55.94s
```

<details><summary>Mutation-break evidence</summary>

Schema fix reverted independently:

```
E       AssertionError: cwd=/private/var/folders/1d/s61glgts17lgfr6_0j0mcrjh0000gn/T/pytest-of-danielmeppiel/pytest-2737/test_unrecognized_claude_plugi0/foreign-schema-plugin/work/schema-consumer
E         returncode=1
E         stdout="[*] Validating 1 package...\n[+] \n...\n[x] Failed to install APM dependencies: Downloaded dependency ... is invalid: Failed to process Claude plugin: Unsupported \nschema-bearing plugin manifest: \nhttps://json.schemastore.org/claude-code-plugin-manifest.json.. The downloaded \ncandidate was not activated; fix the cause and retry the install.\n[x] Install failed after 0.1s.\n"
E       assert False
E        +  where False = is_file()
```

Assertion that fired: `assert skill_path.is_file(), _result_evidence(result)` in `test_unrecognized_claude_plugin_schema_falls_back_to_legacy_structure`.

Agent document classification reverted independently:

```
E       AssertionError: assert not True
E        +  where True = exists()
E        +    where exists = PosixPath('.../.github/agents/reference-doc.agent.md').exists
```

Assertion that fired: `assert not deployed_doc.exists()` in `test_legacy_plugin_agent_source_classification_uses_declaration_before_path[copilot]` and `[claude]`.

Asset warning reverted independently:

```
E       assert 'Skipped non-agent asset in agents source tree' in "[*] Validating 1 package...\n...\n[*] Installed 1 APM dependency in 0.2s.\n"
```

Assertion that fired: `assert "Skipped non-agent asset in agents source tree" in combined_output` in both target-parametrized lifecycle cases.

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---:|---|---|---|---|
| 1 | `apm install --target claude` accepts a Claude plugin that declares the official schemastore `$schema` and deploys the skill bytes. | DevX, Multi-harness support, OSS / community-driven | `tests/integration/test_ownership_invariant_lifecycle.py::test_unrecognized_claude_plugin_schema_falls_back_to_legacy_structure` (regression-trap for #2780) | e2e |
| 2 | Installing an agent directory deploys only declared agents, not reference docs, across supported GitHub/Claude-style agent targets. | Portability by manifest, Multi-harness support | `tests/integration/test_ownership_invariant_lifecycle.py::test_legacy_plugin_agent_source_classification_uses_declaration_before_path` (regression-trap for #2692(b)) | e2e |
| 3 | Installing an agent directory reports skipped sibling assets instead of silently dropping them. | DevX, OSS / community-driven | `tests/integration/test_ownership_invariant_lifecycle.py::test_legacy_plugin_agent_source_classification_uses_declaration_before_path` (regression-trap for #2692(c)) | e2e |
| 4 | Local bundles with unknown schema strings still classify structurally while exact Agent Plugins schema routes native. | Secure by default, DevX | `tests/unit/bundle/test_local_bundle.py::TestDetectLocalBundle::test_detect_treats_unsupported_agent_plugin_schema_as_legacy_miss`<br/>`tests/unit/bundle/test_local_bundle.py::TestDetectLocalBundle::test_exact_schema_routes_every_local_bundle_container_through_canonical_ir` | unit |
| 5 | The classification owner remains registered and consumers cannot reintroduce schema-fatal local routing. | Governed by policy | `bash scripts/lint-architecture-boundaries.sh` via `install-deployment-primitive-classification` | static |

## How to test

- [ ] Run `APM_E2E_TESTS=1 uv run --frozen --extra dev pytest -q tests/integration/test_ownership_invariant_lifecycle.py::test_unrecognized_claude_plugin_schema_falls_back_to_legacy_structure` -> one pass and `.claude/skills/schema-plugin/SKILL.md` byte assertion succeeds.
- [ ] Run `APM_E2E_TESTS=1 uv run --frozen --extra dev pytest -q tests/integration/test_ownership_invariant_lifecycle.py::test_legacy_plugin_agent_source_classification_uses_declaration_before_path` -> two passes for catalog-derived targets.
- [ ] Run `uv run --frozen --extra dev pytest -q tests/unit/agent_plugins/test_loader.py tests/unit/bundle/test_local_bundle.py` -> `129 passed, 1 skipped`.
- [ ] Run `bash scripts/lint-architecture-boundaries.sh` -> no architecture violations.
- [ ] Manually install a Claude plugin with `https://json.schemastore.org/claude-code-plugin-manifest.json` -> install succeeds with an unknown-schema warning.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>




