### PR TITLE
fix: admit schema-bearing Claude plugin manifests (closes #2780)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `apm install` now accepts a conforming Claude Code plugin whose
+  `.claude-plugin/plugin.json` carries the official Claude Code `$schema`.
+  The root-manifest schema router was reused as the predicate on the nested
+  legacy manifest, and that router raises on an unrecognised `$schema` rather
+  than answering, so the legacy path could never be reached. Strict admission
+  for a root `plugin.json` is unchanged, and an Agent Plugin manifest placed
+  outside the package root is still rejected. (closes #2780) (#2798)
 - Windows users no longer get repeated line-ending churn when APM rewrites
   `apm.yml`: install, uninstall, dependency resolution, and revision-pin
   updates now produce deterministic LF output. An `apm.yml` that already uses

--- a/src/apm_cli/deps/plugin_parser.py
+++ b/src/apm_cli/deps/plugin_parser.py
@@ -480,11 +480,17 @@ def normalize_plugin_directory(plugin_path: Path, plugin_json_path: Path | None 
     ):
         manifest = parse_plugin_manifest(plugin_json_path)
         from ..agent_plugins.errors import AgentPluginLegacyBoundaryError
-        from ..bundle.local_bundle import PluginSchemaRoute, classify_plugin_manifest_schema
+        from ..agent_plugins.validation import is_agent_plugin_schema_id
 
-        if classify_plugin_manifest_schema(manifest) is PluginSchemaRoute.AGENT_PLUGIN:
+        # Only an Agent Plugin manifest is barred here.  A foreign $schema,
+        # including the Claude Code schemastore URL that conforming Claude
+        # plugins carry, is legacy metadata.  classify_plugin_manifest_schema()
+        # is scoped to root manifests and raises rather than answers for an
+        # unrecognised $schema, so it cannot serve as the predicate (#2780).
+        schema_id = manifest.get("$schema")
+        if isinstance(schema_id, str) and is_agent_plugin_schema_id(schema_id):
             raise AgentPluginLegacyBoundaryError(
-                "Schema-bearing plugin.json must be admitted from the package root, "
+                "An Agent Plugin manifest must be admitted from the package root, "
                 "not Claude plugin normalization"
             )
 

--- a/tests/unit/agent_plugins/test_loader.py
+++ b/tests/unit/agent_plugins/test_loader.py
@@ -926,13 +926,18 @@ def test_schema_bearing_manifest_never_falls_back_to_legacy_normalization(
     [
         PLUGIN_SCHEMA_ID,
         "https://agent-plugins.org/schemas/2.0.0/plugin.schema.json",
-        "https://example.com/plugin.schema.json",
     ],
 )
 def test_nested_marketplace_manifest_cannot_bypass_root_schema_admission(
     tmp_path: Path,
     schema_id: str,
 ) -> None:
+    """Only an Agent Plugin manifest is barred from the nested legacy path.
+
+    A foreign ``$schema``, such as the Claude Code schemastore URL, is legacy
+    metadata and normalizes.  ``TestNormalizePluginDirectory`` in
+    ``tests/unit/test_plugin_parser.py`` covers that case (#2780).
+    """
     manifest = tmp_path / ".claude-plugin" / "plugin.json"
     manifest.parent.mkdir()
     manifest.write_text(

--- a/tests/unit/test_plugin_parser.py
+++ b/tests/unit/test_plugin_parser.py
@@ -933,6 +933,65 @@ class TestNormalizePluginDirectory:
         assert parsed["name"] == "dir-name-plugin"
         assert (plugin_dir / ".apm" / "prompts" / "go.prompt.md").exists()
 
+    @pytest.mark.parametrize(
+        "schema_id",
+        [
+            "https://json.schemastore.org/claude-code-plugin-manifest.json",
+            "https://example.com/plugin.schema.json",
+            "https://agent-plugins.org.example.com/schemas/1.0.0/plugin.schema.json",
+            42,
+            None,
+        ],
+    )
+    def test_nested_manifest_with_foreign_schema_normalizes_as_legacy(self, tmp_path, schema_id):
+        """A .claude-plugin/plugin.json carrying a non-Agent-Plugins $schema is legacy.
+
+        Regression test for #2780.  The root-manifest router was reused as the
+        predicate here, and it raises on a Claude Code schemastore $schema
+        instead of answering, so the legacy path could never be reached.
+
+        A near-miss hostname and a non-string $schema resolve the same way.
+        The legacy route grants no Agent Plugins semantics, so declining to
+        claim the manifest is the safe answer.
+        """
+        plugin_dir = tmp_path / "hello"
+        plugin_dir.mkdir()
+        (plugin_dir / "SKILL.md").write_text("---\nname: hello\n---\n\n# hello\n")
+        claude_dir = plugin_dir / ".claude-plugin"
+        claude_dir.mkdir()
+        pj = claude_dir / "plugin.json"
+        pj.write_text(json.dumps({"$schema": schema_id, "name": "hello", "version": "1.0.0"}))
+
+        result = normalize_plugin_directory(plugin_dir, pj)
+
+        assert result == plugin_dir / "apm.yml"
+        parsed = yaml.safe_load(result.read_text())
+        assert parsed["name"] == "hello"
+
+    @pytest.mark.parametrize(
+        "schema_id",
+        [
+            "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+            "https://agent-plugins.org/schemas/2.0.0/plugin.schema.json",
+        ],
+    )
+    def test_nested_agent_plugin_manifest_stays_outside_legacy_normalization(
+        self, tmp_path, schema_id
+    ):
+        """An Agent Plugin manifest outside the package root is rejected."""
+        from apm_cli.agent_plugins.errors import AgentPluginLegacyBoundaryError
+
+        plugin_dir = tmp_path / "hello"
+        plugin_dir.mkdir()
+        claude_dir = plugin_dir / ".claude-plugin"
+        claude_dir.mkdir()
+        pj = claude_dir / "plugin.json"
+        pj.write_text(json.dumps({"$schema": schema_id, "name": "hello", "version": "1.0.0"}))
+
+        with pytest.raises(AgentPluginLegacyBoundaryError, match="admitted from the package root"):
+            normalize_plugin_directory(plugin_dir, pj)
+        assert not (plugin_dir / "apm.yml").exists()
+
 
 class TestValidatePluginPackage:
     def test_validate_with_plugin_json(self, tmp_path):


### PR DESCRIPTION
## Problem

`apm install` refuses any Claude Code plugin whose `.claude-plugin/plugin.json` carries the official Claude Code schemastore `$schema`. Deleting that one line makes the identical package install cleanly, so the error text asks authors to stop conforming to their own ecosystem's schema.

```
[x] Failed to install APM dependencies: Local package is invalid: Failed to
process Claude plugin: Unsupported schema-bearing plugin manifest:
https://json.schemastore.org/claude-code-plugin-manifest.json.
```

`classify_plugin_manifest_schema` (`src/apm_cli/bundle/local_bundle.py:79`) is a router for root manifests, as its own docstring states: "Admission route selected exclusively by root plugin.json". It returns `LEGACY` only when `$schema` is absent, and raises for every `$schema` it does not recognise.

`normalize_plugin_directory` (`src/apm_cli/deps/plugin_parser.py:485`) reused that router as a boolean predicate on the nested legacy manifest, for one purpose: rejecting an Agent Plugin manifest placed outside the package root. A Claude Code `$schema` makes the call raise before the comparison can evaluate, so the legacy path is unreachable.

## Solution

Use the existing `is_agent_plugin_schema_id` helper (`src/apm_cli/agent_plugins/validation.py:118`) at that call site. It answers Agent Plugins namespace ownership without raising, which is all the legacy boundary check needs. Seven lines of source change, no new public API.

The router itself is untouched, so admission for a root `plugin.json` keeps its current strictness, and an Agent Plugin manifest outside the package root is still rejected. A schema-bearing `.claude-plugin/plugin.json` now deploys the same file set as a schema-less one.

| `plugin.json` location | `$schema` | Before | After |
|---|---|---|---|
| `.claude-plugin/` | Claude Code, or any foreign URL | `Unsupported schema-bearing plugin manifest` | installs as a legacy Claude plugin |
| `.claude-plugin/` | agent-plugins.org | `must be admitted from the package root` | unchanged, message reworded |
| `.claude-plugin/` | none | installs | unchanged |
| root `plugin.json` | any | unchanged | unchanged |

Both failure directions of the predicate are safe. A near-miss hostname such as `https://agent-plugins.org.example.com/schemas/1.0.0/...` does not match `AGENT_PLUGINS_SCHEMA_PREFIX`, so it routes to legacy and gains no privilege. A URL that does match can only produce a rejection here, never an admission. `$schema` is never propagated into the synthesized `apm.yml`.

## One existing test row removed

The `https://example.com/plugin.schema.json` case in `test_nested_marketplace_manifest_cannot_bypass_root_schema_admission` encoded the bug rather than the gate: a foreign `$schema` is not an Agent Plugin manifest, so it has no root admission to bypass. The two Agent Plugins rows, which are what the test guards, remain.

Fixes #2780

## Type of change

- [x] Bug fix

## Spec conformance (OpenAPM v0.1)

- [x] N/A -- this PR does not change OpenAPM-observable behaviour.

The commit carries an `apm-spec-waiver:` line.
