### PR TITLE
fix(ci): make daily release smoke actionable

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -14,13 +14,7 @@ on:
   schedule:
     # Run daily at 04:00 UTC (6 AM CEST)
     - cron: '0 4 * * *'
-  workflow_dispatch:
-    inputs:
-      test_build:
-        description: 'Test build (uploads as workflow artifacts instead of release assets)'
-        required: false
-        default: true
-        type: boolean
+  workflow_dispatch: {}
 
 # Restrict default GITHUB_TOKEN permissions for all jobs (principle of least privilege)
 permissions:
@@ -153,7 +147,7 @@ jobs:
   # Intel runners are plentiful (<1 min queue) so this runs on every push for
   # early macOS build-regression feedback. Integration and release-validation
   # phases are conditional on tag/schedule/dispatch.
-  # Root node — runs its own unit tests instead of waiting for build-and-test.
+  # Root node - runs its own unit tests instead of waiting for build-and-test.
   build-and-validate-macos-intel:
     name: Build & Validate (macOS x86_64)
     runs-on: macos-15-intel
@@ -193,7 +187,7 @@ jobs:
       - name: Run unit tests
         run: uv run pytest tests/unit tests/test_console.py -n auto --dist worksteal
 
-      # ── PHASE 1: BUILD BINARY ──
+      # PHASE 1: BUILD BINARY
       - name: Build binary
         run: |
           chmod +x scripts/build-binary.sh
@@ -224,7 +218,7 @@ jobs:
           retention-days: 30
           if-no-files-found: error
 
-      # ── PHASE 2: FOCUSED INTEGRATION TESTS (tag/schedule/dispatch only) ──
+      # PHASE 2: FOCUSED INTEGRATION TESTS (tag/schedule/dispatch only)
       - name: Run focused Intel integration tests
         if: github.ref_type == 'tag' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         env:
@@ -241,7 +235,7 @@ jobs:
           uv run ./scripts/test-integration.sh
         timeout-minutes: 30
 
-      # ── PHASE 3: RELEASE VALIDATION (tag/schedule/dispatch only) ──
+      # PHASE 3: RELEASE VALIDATION (tag/schedule/dispatch only)
       - name: Prepare isolated release-validation environment
         if: github.ref_type == 'tag' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         run: |
@@ -255,7 +249,7 @@ jobs:
           cd /tmp/apm-isolated-test
           chmod +x ./dist/apm-darwin-x86_64/apm
           ln -s "$(pwd)/dist/apm-darwin-x86_64/apm" "$(pwd)/apm"
-          echo "/tmp/apm-isolated-test" >> $GITHUB_PATH
+          echo "/tmp/apm-isolated-test" >> "$GITHUB_PATH"
 
       - name: Run release validation tests
         if: github.ref_type == 'tag' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
@@ -270,11 +264,11 @@ jobs:
         timeout-minutes: 20
 
   # Consolidated macOS ARM build + validation.
-  # ARM runners (macos-latest) are extremely scarce — 2-4+ hour queue waits are
+  # ARM runners (macos-latest) are extremely scarce - 2-4+ hour queue waits are
   # common. This job is gated to tag/schedule/dispatch only so push-to-main never
   # blocks on ARM availability. All phases run unconditionally since the job itself
   # is already release-gated.
-  # Root node — runs its own unit tests instead of waiting for build-and-test.
+  # Root node - runs its own unit tests instead of waiting for build-and-test.
   build-and-validate-macos-arm:
     name: Build & Validate (macOS arm64)
     if: github.ref_type == 'tag' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
@@ -310,7 +304,7 @@ jobs:
       - name: Run unit tests
         run: uv run pytest tests/unit tests/test_console.py -n auto --dist worksteal
 
-      # ── PHASE 1: BUILD BINARY ──
+      # PHASE 1: BUILD BINARY
       - name: Build binary
         run: |
           chmod +x scripts/build-binary.sh
@@ -341,7 +335,7 @@ jobs:
           retention-days: 30
           if-no-files-found: error
 
-      # ── PHASE 2: INTEGRATION TESTS ──
+      # PHASE 2: INTEGRATION TESTS
       - name: Run integration tests
         env:
           APM_E2E_TESTS: "1"
@@ -359,7 +353,7 @@ jobs:
           uv run ./scripts/test-integration.sh
         timeout-minutes: 60
 
-      # ── PHASE 3: RELEASE VALIDATION ──
+      # PHASE 3: RELEASE VALIDATION
       - name: Prepare isolated release-validation environment
         run: |
           mkdir -p /tmp/apm-isolated-test/dist
@@ -372,7 +366,7 @@ jobs:
           cd /tmp/apm-isolated-test
           chmod +x ./dist/apm-darwin-arm64/apm
           ln -s "$(pwd)/dist/apm-darwin-arm64/apm" "$(pwd)/apm"
-          echo "/tmp/apm-isolated-test" >> $GITHUB_PATH
+          echo "/tmp/apm-isolated-test" >> "$GITHUB_PATH"
 
       - name: Run release validation tests
         env:
@@ -391,7 +385,10 @@ jobs:
   # Run on tags (release gate), schedule (regression), and dispatch (manual).
   integration-tests:
     name: Integration Tests
-    if: github.ref_type == 'tag' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: >
+      always() &&
+      (github.ref_type == 'tag' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
+      (github.event_name == 'schedule' || needs.build-and-test.result == 'success')
     needs: [build-and-test]
     strategy:
       matrix:
@@ -418,31 +415,48 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Download APM binary from build artifacts
+        continue-on-error: ${{ github.event_name == 'schedule' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ matrix.binary_name }}
           path: ./
 
+      - name: Check downloaded binary artifact
+        id: artifact
+        if: always()
+        shell: bash
+        run: |
+          if [ -d "./dist/${{ matrix.binary_name }}" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::No ${{ matrix.binary_name }} artifact; skipping scheduled integration validation for this platform."
+          fi
+
       - name: Set up Node.js
+        if: github.event_name != 'schedule' || steps.artifact.outputs.available == 'true'
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
 
       - name: Set up Python
+        if: github.event_name != 'schedule' || steps.artifact.outputs.available == 'true'
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install uv
+        if: github.event_name != 'schedule' || steps.artifact.outputs.available == 'true'
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
 
       - name: Install test dependencies
+        if: github.event_name != 'schedule' || steps.artifact.outputs.available == 'true'
         run: uv sync --frozen --extra dev
 
       - name: Run integration tests (Unix)
-        if: matrix.platform != 'windows'
+        if: matrix.platform != 'windows' && (github.event_name != 'schedule' || steps.artifact.outputs.available == 'true')
         env:
           APM_E2E_TESTS: "1"
           GITHUB_API_TOKEN: ${{ github.token }}
@@ -458,7 +472,7 @@ jobs:
         timeout-minutes: 60
 
       - name: Run integration tests (Windows)
-        if: matrix.platform == 'windows'
+        if: matrix.platform == 'windows' && (github.event_name != 'schedule' || steps.artifact.outputs.available == 'true')
         shell: pwsh
         env:
           APM_E2E_TESTS: "1"
@@ -472,7 +486,11 @@ jobs:
   # macOS release validation runs inside the consolidated macOS jobs.
   release-validation:
     name: Release Validation
-    if: github.ref_type == 'tag' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: >
+      always() &&
+      (github.ref_type == 'tag' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
+      (github.event_name == 'schedule' ||
+        (needs.build-and-test.result == 'success' && needs.integration-tests.result == 'success'))
     needs: [build-and-test, integration-tests]
     strategy:
       matrix:
@@ -506,13 +524,37 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Download APM binary from build artifacts
+        continue-on-error: ${{ github.event_name == 'schedule' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ matrix.binary_name }}
           path: ${{ matrix.platform == 'windows' && 'D:\apm-isolated-test' || '/tmp/apm-isolated-test/' }}
 
+      - name: Check downloaded binary artifact (Unix)
+        id: artifact_unix
+        if: always() && matrix.platform != 'windows'
+        run: |
+          if [ -d "/tmp/apm-isolated-test/dist/${{ matrix.binary_name }}" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::No ${{ matrix.binary_name }} artifact; skipping scheduled release validation for this platform."
+          fi
+
+      - name: Check downloaded binary artifact (Windows)
+        id: artifact_windows
+        if: always() && matrix.platform == 'windows'
+        shell: pwsh
+        run: |
+          if (Test-Path "D:\apm-isolated-test\dist\${{ matrix.binary_name }}") {
+            "available=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          } else {
+            "available=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+            Write-Warning "No ${{ matrix.binary_name }} artifact; skipping scheduled release validation for this platform."
+          }
+
       - name: Make binary executable and verify isolation (Unix)
-        if: matrix.platform != 'windows'
+        if: matrix.platform != 'windows' && (github.event_name != 'schedule' || steps.artifact_unix.outputs.available == 'true')
         run: |
           cd /tmp/apm-isolated-test
 
@@ -525,14 +567,14 @@ jobs:
           chmod +x ./dist/${{ matrix.binary_name }}/apm
 
       - name: Create APM symlink for testing (Unix)
-        if: matrix.platform != 'windows'
+        if: matrix.platform != 'windows' && (github.event_name != 'schedule' || steps.artifact_unix.outputs.available == 'true')
         run: |
           cd /tmp/apm-isolated-test
           ln -s "$(pwd)/dist/${{ matrix.binary_name }}/apm" "$(pwd)/apm"
-          echo "/tmp/apm-isolated-test" >> $GITHUB_PATH
+          echo "/tmp/apm-isolated-test" >> "$GITHUB_PATH"
 
       - name: Verify binary and add to PATH (Windows)
-        if: matrix.platform == 'windows'
+        if: matrix.platform == 'windows' && (github.event_name != 'schedule' || steps.artifact_windows.outputs.available == 'true')
         shell: pwsh
         run: |
           cd D:\apm-isolated-test
@@ -547,7 +589,7 @@ jobs:
           echo $binDir | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Run release validation tests (Unix)
-        if: matrix.platform != 'windows'
+        if: matrix.platform != 'windows' && (github.event_name != 'schedule' || steps.artifact_unix.outputs.available == 'true')
         env:
           APM_E2E_TESTS: "1"
           GITHUB_API_TOKEN: ${{ github.token }}
@@ -559,7 +601,7 @@ jobs:
         timeout-minutes: 20
 
       - name: Run release validation tests (Windows)
-        if: matrix.platform == 'windows'
+        if: matrix.platform == 'windows' && (github.event_name != 'schedule' || steps.artifact_windows.outputs.available == 'true')
         shell: pwsh
         env:
           APM_E2E_TESTS: "1"
@@ -570,11 +612,39 @@ jobs:
           .\scripts\windows\test-release-validation.ps1
         timeout-minutes: 20
 
+  daily-release-smoke-signal:
+    name: Daily Release Smoke Signal
+    needs:
+      - build-and-test
+      - build-and-validate-macos-intel
+      - build-and-validate-macos-arm
+      - integration-tests
+      - release-validation
+    if: always() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: File or recover daily smoke issue
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { main } = require('./scripts/daily-release-smoke-signal.cjs');
+            await main({ github, context, core });
+
 
   create-release:
     name: Create GitHub Release
     needs: [build-and-test, build-and-validate-macos-intel, build-and-validate-macos-arm, integration-tests, release-validation]
-    if: github.ref_type == 'tag'  # All tags create GitHub releases
+    if: github.event_name == 'push' && github.ref_type == 'tag'  # Only pushed tags create GitHub releases
     runs-on: ubuntu-latest
     permissions:
       contents: write  # Required for release creation
@@ -660,14 +730,14 @@ jobs:
           # Check if tag matches stable semver pattern (e.g., v1.2.3, v0.2.0)
           # Stable: starts with v, followed by digits.digits.digits, then end of string
           if [[ "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "is_prerelease=false" >> $GITHUB_OUTPUT
+            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
             echo "Detected stable release: $TAG_NAME"
           # Check PEP 440 prerelease patterns: v1.2.3a1, v1.2.3b1, v1.2.3rc1, etc.
           elif [[ "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(a|b|rc)[0-9]+$ ]]; then
-            echo "is_prerelease=true" >> $GITHUB_OUTPUT
+            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
             echo "Detected PEP 440 prerelease: $TAG_NAME"
           else
-            echo "is_prerelease=true" >> $GITHUB_OUTPUT
+            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
             echo "Detected other prerelease: $TAG_NAME"
           fi
 
@@ -698,7 +768,7 @@ jobs:
   deploy-docs:
     name: Deploy Docs
     needs: [create-release]
-    if: github.ref_type == 'tag' && needs.create-release.outputs.is_prerelease != 'true'
+    if: github.event_name == 'push' && github.ref_type == 'tag' && needs.create-release.outputs.is_prerelease != 'true'
     uses: ./.github/workflows/docs.yml
     permissions:
       contents: read
@@ -707,7 +777,7 @@ jobs:
     with:
       is_prerelease: false
 
-  # GH-AW Compatibility — validates the released binary works in the
+  # GH-AW Compatibility - validates the released binary works in the
   # exact flow GitHub Agentic Workflows uses (isolated install + pack, no token).
   # Informational: runs as continue-on-error because it depends on external services
   # (GitHub API, npm, microsoft/apm-action, microsoft/apm-sample-package) that can
@@ -715,7 +785,7 @@ jobs:
   gh-aw-compat:
     name: GH-AW Compatibility
     needs: [create-release]
-    if: github.ref_type == 'tag'
+    if: github.event_name == 'push' && github.ref_type == 'tag'
     runs-on: ubuntu-24.04
     continue-on-error: true
     steps:
@@ -735,19 +805,19 @@ jobs:
       - name: Verify bundle
         run: |
           test -f "${{ steps.pack.outputs.bundle-path }}"
-          echo "✅ GH-AW compatibility test passed"
+          echo "[+] GH-AW compatibility test passed"
 
       - name: Warn on failure
         if: failure()
         run: |
-          echo "::warning::GH-AW compatibility test failed. This is informational — external dependency may be unavailable. Investigate before next release."
+          echo "::warning::GH-AW compatibility test failed. This is informational - external dependency may be unavailable. Investigate before next release."
 
   # Publish to PyPI (only stable releases from public repo)
   publish-pypi:
     name: Publish to PyPI
     runs-on: ubuntu-latest
     needs: [build-and-test, build-and-validate-macos-intel, build-and-validate-macos-arm, integration-tests, release-validation, create-release]
-    if: github.ref_type == 'tag' && needs.create-release.outputs.is_private_repo != 'true' && needs.create-release.outputs.is_prerelease != 'true'
+    if: github.event_name == 'push' && github.ref_type == 'tag' && needs.create-release.outputs.is_private_repo != 'true' && needs.create-release.outputs.is_prerelease != 'true'
     environment:
       name: pypi
       url: https://pypi.org/p/apm-cli

--- a/docs/src/content/docs/contributing/integration-testing.md
+++ b/docs/src/content/docs/contributing/integration-testing.md
@@ -331,16 +331,22 @@ environment end-to-end; for local iteration prefer the direct
 **On PR and merge queue:**
 1. PR-time unit checks and the hermetic Lifecycle Smoke gate run first; merge queue adds Linux smoke, integration, and release-validation gates.
 
-**On version tag releases:**
+**On pushed version tag releases:**
 1. Unit tests + Smoke tests
 2. Build binaries (cross-platform)
 3. **E2E golden scenario tests** (using built binaries). Linux and macOS Apple Silicon retain the full non-live integration corpus; macOS Intel runs the marker-bounded `lifecycle_smoke and not live` subset plus native startup and isolated release validation.
 4. Create GitHub Release
 5. Publish to PyPI 
 
+**Daily scheduled release smoke:**
+- Runs the same promotion validation path once per day.
+- If a build matrix leg fails, downstream Linux/Windows integration and release-validation jobs still run for any platform artifact that was produced.
+- Failing scheduled runs update one `ci/daily-smoke` tracking issue; a later recovered run closes it.
+- This signal is advisory and is not a required PR check.
+
 **Manual workflow dispatch:**
 - Test builds (uploads as workflow artifacts)
-- Allows testing the full build pipeline without creating a release
+- Allows testing the full build pipeline without creating a release, even when dispatched from a tag ref
 - Useful for validating changes before tagging
 
 ### GitHub Actions Authentication
@@ -387,26 +393,26 @@ Promotion integration tests run on:
 ## What the Tests Verify
 
 ### Smoke Tests Verify:
-- ✅ Runtime setup scripts execute successfully
-- ✅ Binaries are downloaded and installed correctly
-- ✅ Binaries respond to basic commands
-- ✅ APM can detect installed runtimes
-- ✅ Configuration files are created properly
-- ✅ Workflow compilation works (without execution)
+- [+] Runtime setup scripts execute successfully
+- [+] Binaries are downloaded and installed correctly
+- [+] Binaries respond to basic commands
+- [+] APM can detect installed runtimes
+- [+] Configuration files are created properly
+- [+] Workflow compilation works (without execution)
 
 ### E2E Tests Verify:
-- ✅ Complete golden scenario from README works
-- ✅ `apm runtime setup copilot` installs and configures GitHub Copilot CLI
-- ✅ `apm runtime setup codex` installs and configures Codex
-- ✅ `apm runtime setup llm` installs and configures LLM
-- ✅ `apm init my-hello-world` creates project correctly
-- ✅ `apm install` handles dependencies
-- ✅ `apm run start --param name="Tester"` executes successfully
-- ✅ Real API calls to GitHub Models work
-- ✅ Parameter substitution works correctly
-- ✅ MCP integration functions (GitHub tools)
-- ✅ Binary artifacts work across platforms
-- ✅ Release pipeline integrity (GitHub Release → PyPI)
+- [+] Complete golden scenario from README works
+- [+] `apm runtime setup copilot` installs and configures GitHub Copilot CLI
+- [+] `apm runtime setup codex` installs and configures Codex
+- [+] `apm runtime setup llm` installs and configures LLM
+- [+] `apm init my-hello-world` creates project correctly
+- [+] `apm install` handles dependencies
+- [+] `apm run start --param name="Tester"` executes successfully
+- [+] Real API calls to GitHub Models work
+- [+] Parameter substitution works correctly
+- [+] MCP integration functions (GitHub tools)
+- [+] Binary artifacts work across platforms
+- [+] Release pipeline integrity (GitHub Release -> PyPI)
 
 ### Lifecycle Smoke Verifies:
 - Install content-hash roundtrip (Consume contract)

--- a/scripts/daily-release-smoke-signal.cjs
+++ b/scripts/daily-release-smoke-signal.cjs
@@ -1,0 +1,216 @@
+const MARKER = '<!-- apm-daily-release-smoke -->';
+const LABEL = 'ci/daily-smoke';
+const TITLE = '[ci] Daily release smoke is failing';
+const BAD_CONCLUSIONS = new Set(['failure', 'cancelled', 'timed_out', 'action_required']);
+
+async function ensureLabel({ github, owner, repo }) {
+  try {
+    await github.rest.issues.getLabel({ owner, repo, name: LABEL });
+  } catch (error) {
+    if (error.status !== 404) {
+      throw error;
+    }
+    await github.rest.issues.createLabel({
+      owner,
+      repo,
+      name: LABEL,
+      color: 'D93F0B',
+      description: 'Daily release smoke validation signal',
+    });
+  }
+}
+
+async function findTrackingIssue({ github, owner, repo }) {
+  const issues = await github.paginate(github.rest.issues.listForRepo, {
+    owner,
+    repo,
+    state: 'open',
+    labels: LABEL,
+    per_page: 100,
+  });
+  return issues.find((issue) => !issue.pull_request && (issue.body || '').includes(MARKER));
+}
+
+function stripAnsi(value) {
+  return value.replace(/\u001b\[[0-9;]*m/g, '');
+}
+
+function extractFailedTests(logText) {
+  const tests = new Set();
+  const cleanLog = stripAnsi(logText);
+  const patterns = [
+    /\b(?:FAILED|ERROR)\s+(tests\/[^\s]+(?:::[^\s]+)*)/g,
+    /\b(tests\/[^\s]+(?:::[^\s]+)*)\s+(?:FAILED|ERROR)\b/g,
+  ];
+  for (const pattern of patterns) {
+    for (const match of cleanLog.matchAll(pattern)) {
+      tests.add(match[1].replace(/[,\]]$/, ''));
+      if (tests.size >= 30) {
+        return [...tests];
+      }
+    }
+  }
+  return [...tests];
+}
+
+async function collectFailedTests({ github, core, owner, repo, failedJobs }) {
+  const tests = new Set();
+  for (const job of failedJobs.slice(0, 10)) {
+    try {
+      const response = await github.rest.actions.downloadJobLogsForWorkflowRun({
+        owner,
+        repo,
+        job_id: job.id,
+      });
+      const logText = typeof response.data === 'string'
+        ? response.data
+        : Buffer.from(response.data).toString('utf8');
+      for (const testName of extractFailedTests(logText)) {
+        tests.add(testName);
+        if (tests.size >= 30) {
+          return [...tests];
+        }
+      }
+    } catch (error) {
+      core.warning('Could not inspect logs for job ' + job.name + ': ' + error.message);
+    }
+  }
+  return [...tests];
+}
+
+function failureBody({ context, runUrl, failedJobs, failedTests }) {
+  const failedJobLines = failedJobs.map((job) => {
+    const name = job.html_url ? '[' + job.name + '](' + job.html_url + ')' : job.name;
+    return '- ' + name + ' - ' + job.conclusion;
+  });
+  const failedTestLines = failedTests.length
+    ? failedTests.map((testName) => '- `' + testName + '`')
+    : ['- Not extractable from failed job logs.'];
+  return [
+    MARKER,
+    'The scheduled release smoke validation is currently failing.',
+    '',
+    '### Current failing run',
+    '',
+    '- Run: [' + context.runNumber + '](' + runUrl + ')',
+    '- Head SHA: `' + context.sha + '`',
+    '- Workflow: ' + context.workflow,
+    '',
+    '### Failed jobs',
+    '',
+    ...failedJobLines,
+    '',
+    '### Failing tests',
+    '',
+    ...failedTestLines,
+    '',
+    'This advisory issue is updated by the daily scheduled CI/CD Pipeline run. It does not gate PR merges.',
+  ].join('\n');
+}
+
+async function listFailedJobs({ github, context, owner, repo }) {
+  const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+    owner,
+    repo,
+    run_id: context.runId,
+    per_page: 100,
+  });
+  return jobs
+    .filter((job) => job.name !== 'Daily Release Smoke Signal')
+    .filter((job) => BAD_CONCLUSIONS.has(job.conclusion));
+}
+
+async function closeRecoveredIssue({ github, core, owner, repo, context, runUrl, trackingIssue }) {
+  if (!trackingIssue) {
+    core.info('Daily release smoke recovered; no open tracking issue exists.');
+    return;
+  }
+  const comment = [
+    'Recovered in scheduled run [' + context.runNumber + '](' + runUrl + ').',
+    '',
+    'Head SHA: `' + context.sha + '`',
+  ].join('\n');
+  await github.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: trackingIssue.number,
+    body: comment,
+  });
+  await github.rest.issues.update({
+    owner,
+    repo,
+    issue_number: trackingIssue.number,
+    state: 'closed',
+    state_reason: 'completed',
+  });
+  core.info('Closed recovered daily smoke issue #' + trackingIssue.number + '.');
+}
+
+async function upsertFailureIssue({
+  github,
+  core,
+  owner,
+  repo,
+  context,
+  runUrl,
+  trackingIssue,
+  failedJobs,
+  failedTests,
+}) {
+  const body = failureBody({ context, runUrl, failedJobs, failedTests });
+  if (trackingIssue) {
+    await github.rest.issues.update({
+      owner,
+      repo,
+      issue_number: trackingIssue.number,
+      body,
+    });
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: trackingIssue.number,
+      body: 'Still failing in scheduled run [' + context.runNumber + '](' + runUrl + ') at `' + context.sha + '`.',
+    });
+    core.info('Updated daily smoke issue #' + trackingIssue.number + '.');
+    return;
+  }
+  const issue = await github.rest.issues.create({
+    owner,
+    repo,
+    title: TITLE,
+    body,
+    labels: [LABEL],
+  });
+  core.info('Created daily smoke issue #' + issue.data.number + ': ' + issue.data.html_url);
+}
+
+async function main({ github, context, core }) {
+  const owner = context.repo.owner;
+  const repo = context.repo.repo;
+  const serverUrl = context.serverUrl || process.env.GITHUB_SERVER_URL || 'https://github.com';
+  const runUrl = serverUrl + '/' + owner + '/' + repo + '/actions/runs/' + context.runId;
+
+  await ensureLabel({ github, owner, repo });
+  const failedJobs = await listFailedJobs({ github, context, owner, repo });
+  const trackingIssue = await findTrackingIssue({ github, owner, repo });
+
+  if (failedJobs.length === 0) {
+    await closeRecoveredIssue({ github, core, owner, repo, context, runUrl, trackingIssue });
+    return;
+  }
+
+  const failedTests = await collectFailedTests({ github, core, owner, repo, failedJobs });
+  await upsertFailureIssue({
+    github,
+    core,
+    owner,
+    repo,
+    context,
+    runUrl,
+    trackingIssue,
+    failedJobs,
+    failedTests,
+  });
+}
+
+module.exports = { main };


### PR DESCRIPTION
# fix(ci): make daily release smoke actionable

## TL;DR

This PR keeps the existing daily release-validation cadence, but turns its failures into one maintained tracking issue instead of silent red workflow runs. It removes the dead `test_build` dispatch input and makes publication possible only from pushed tags. It also lets the daily schedule keep collecting Linux/Windows integration and release-validation signal for any matrix artifacts that did build, while tag releases remain fail-fast.

> [!NOTE]
> The daily smoke signal is advisory only. This PR does not edit branch protection or `merge-gate.yml`, so PR merges remain gated only by the existing `gate` check.

## Problem (WHY)

- [x] The cadence already existed, but the scheduled run was not actionable: `.github/workflows/build-release.yml` already had `schedule: cron: '0 4 * * *'`, and `gh run list --repo microsoft/apm --workflow=build-release.yml --limit 20` showed the 2026-09-04 scheduled run failing at `https://github.com/microsoft/apm/actions/runs/33835733228`.
- [x] The workflow had no failure issue/notification path. `rg "issues: write|github.rest.issues|gh issue|actions/github-script" .github/workflows/build-release.yml` returned no matches before this change.
- [x] `test_build` was declared but unused. `rg "test_build" .github/workflows/` returned only `.github/workflows/build-release.yml:19:test_build`, so the documented behavior did nothing.
- [!] A scheduled build matrix failure skipped downstream Linux/Windows integration and release-validation jobs, leaving the day with narrower signal than the maintainer requested.
- [!] Manual dispatch from a tag ref depended on `github.ref_type == 'tag'` release guards, so this PR makes the safety property explicit with `github.event_name == 'push' && github.ref_type == 'tag'`.

Why this matters: release validation should be grounded in deterministic evidence, not silent workflow state; PROSE says ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/). The change stays intentionally small because PROSE also says ["Favor small, chainable primitives over monolithic frameworks."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/).

## Approach (WHAT)

| # | Fix | Result |
|---|-----|--------|
| 1 | Add a scheduled-only `daily-release-smoke-signal` job. | Failed daily runs create or update one `ci/daily-smoke` issue; recovered runs comment and close it. |
| 2 | Move the issue body/log parsing into `scripts/daily-release-smoke-signal.cjs`. | The workflow stays readable and the issue logic is syntax-checkable with Node. |
| 3 | Remove the dead `workflow_dispatch.inputs.test_build` field. | Manual dispatch is unambiguous: it uploads workflow artifacts and cannot publish. |
| 4 | Gate release, docs deploy, GH-AW compatibility, and PyPI on pushed tags only. | Scheduled and manually dispatched runs cannot publish GitHub release assets or PyPI packages. |
| 5 | Let scheduled Linux/Windows validation jobs run under `always()` and skip only legs with missing artifacts. | A failed matrix leg does not prevent daily validation on platforms whose binaries were produced. |
| 6 | Update contributing docs. | Maintainers can see how daily smoke, manual dispatch, and pushed tag release paths differ. |

## Implementation (HOW)

- **`.github/workflows/build-release.yml`** -- Adds the scheduled-only advisory issue job, removes the dead dispatch input, scopes downstream daily continuation to `github.event_name == 'schedule'`, and tightens publish guards to `github.event_name == 'push' && github.ref_type == 'tag'`. Tag and push-to-main behavior otherwise stays unchanged.
- **`scripts/daily-release-smoke-signal.cjs`** -- Ensures the `ci/daily-smoke` label exists, finds the open marker issue, lists failed jobs for the current run, extracts failing pytest names from up to ten failed job logs when available, updates/creates one issue on failure, and closes it on recovery.
- **`docs/src/content/docs/contributing/integration-testing.md`** -- Documents pushed-tag releases, the daily advisory smoke path, manual dispatch as artifact-only validation, and keeps the touched page within printable ASCII.

## Diagrams

Legend: This shows the scheduled run path added by the PR; the highlighted region is the new advisory issue behavior.

```mermaid
sequenceDiagram
    participant S as Daily schedule
    participant B as Build matrix
    participant V as Validation jobs
    participant I as Tracking issue

    S->>B: Run build and unit tests
    B-->>V: Upload artifacts that succeeded
    V->>V: Run integration and release validation where artifacts exist
    rect rgb(255, 247, 200)
        S->>I: Create or update ci/daily-smoke issue on failure
        S->>I: Comment and close issue on recovery
    end
    Note over I: Advisory signal only, not a required check
```

Legend: This shows the unchanged release safety boundary: only pushed tags can reach publishing jobs.

```mermaid
flowchart LR
    subgraph Inputs[Workflow inputs]
        P[push tag]
        D[workflow dispatch]
        C[daily schedule]
    end
    subgraph Validate[Validation]
        A[build artifacts]
        R[release validation]
        Q{event is pushed tag?}
        S[stop after validation]
    end
    subgraph Publish[Publish]
        G[GitHub release]
        Y[PyPI]
    end
    P --> A
    D --> A
    C --> A
    A --> R
    R --> Q
    Q -->|yes| G
    G --> Y
    Q -->|no| S
```

## Trade-offs

- **Removed `test_build` instead of implementing branching release uploads.** The pipeline already uploads workflow artifacts for schedule/dispatch, and now publish jobs require pushed tags; keeping a boolean would preserve a misleading knob.
- **Used one helper script instead of inline workflow JavaScript.** This adds one file, but keeps the workflow reviewable and lets `node --check` cover the issue logic.
- **Continued only scheduled downstream jobs after matrix failure.** Tags and manual dispatch still require successful upstream jobs before release-validation; real releases remain fail-fast.
- **Skipped new pytest coverage.** The changed behavior is GitHub Actions orchestration, so validation uses YAML parsing, actionlint, Node syntax/mocked helper execution, and existing CI lint gates.

## Benefits

1. One open `ci/daily-smoke` issue represents the current daily release smoke state instead of one silent failing run per day.
2. Every failure issue includes failed jobs, run URL, head SHA, and up to 30 extracted failing pytest node IDs when logs contain them.
3. Scheduled and manually dispatched runs cannot publish GitHub releases, release assets, docs deploys, GH-AW compatibility jobs, or PyPI packages because publish jobs now require `github.event_name == 'push' && github.ref_type == 'tag'`.
4. Daily Linux/Windows validation can still run on produced artifacts when another build matrix leg fails.
5. Branch protection remains unchanged: `gh api repos/microsoft/apm/rulesets/9294522` still reports required status checks as only `gate`.

## Validation

`python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/build-release.yml'))" && actionlint .github/workflows/build-release.yml && node --check scripts/daily-release-smoke-signal.cjs`:

```
```

`node` mocked helper smoke:

```
daily smoke helper OK
```

`python3` guard equivalents:

```
YAML encoding safety OK
File length guardrail OK
relative_to guard OK
```

<details><summary>CI lint mirror</summary>

```
All checks passed!
1795 files already formatted

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

[*] Rule A: get_bearer_provider boundary (any reference)
[*] Rule B: git ls-remote auth-delegated annotation
[+] auth-signal lint clean
```

</details>

<details><summary>Gap verification evidence</summary>

Recent scheduled failure:

```
2026-09-04T04:09:00Z schedule failure c6fde64188c86ed2e6047a35e9ea4716df9eb1fc https://github.com/microsoft/apm/actions/runs/33835733228
```

Failed jobs in that scheduled run:

```
Build & Validate (macOS x86_64) Run focused Intel integration tests
Build & Validate (macOS arm64) Run integration tests
Build & Test (windows-latest, x86_64, windows, apm-windows-x86_64) Run unit tests
```

Sample extractable failed tests from the same run:

```
FAILED tests/unit/compilation/test_compile_global_flag.py::TestGlobalCompileHonorsDeclaredTargets::test_invalid_target_name_has_global_manifest_recovery
FAILED tests/unit/compilation/test_project_root_context_protection.py::test_case_variant_output_preserves_root_agents_on_insensitive_filesystem
FAILED tests/unit/install/phases/test_lockfile_union.py::TestInactiveExperimentalResolverGating::test_explicit_experimental_resolver_failure_is_not_silenced
FAILED tests/unit/integration/test_deployed_files_manifest.py::TestHookSync::test_sync_rejects_absolute_managed_hook_parent_symlink
FAILED tests/unit/integration/test_deployed_files_manifest.py::TestHookSync::test_sync_unlinks_absolute_final_managed_symlink_without_following_target[False]
FAILED tests/unit/integration/test_deployed_files_manifest.py::TestHookSync::test_sync_unlinks_absolute_final_managed_symlink_without_following_target[True]
```

Required check evidence:

```
{"enforcement":"active","name":"main-protection","required_status_checks":[[{"context":"gate","integration_id":15368}]]}
```

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|------------------------|--------------|--------------------|------|
| 1 | A failed scheduled release smoke run creates or updates one actionable issue instead of staying silent. | Governed by policy, DevX | `node` mocked helper smoke over `scripts/daily-release-smoke-signal.cjs` | integration |
| 2 | A recovered scheduled release smoke run marks the current issue recovered and closes it. | Governed by policy, DevX | `node` mocked helper smoke over `scripts/daily-release-smoke-signal.cjs` | integration |
| 3 | Manual dispatch and schedule validate artifacts but never publish release assets or PyPI packages. | Governed by policy, Secure by default | `python3` YAML parse, `actionlint .github/workflows/build-release.yml`, publish guard review | integration |
| 4 | Daily validation reaches platforms with produced artifacts even when another build matrix leg failed. | OSS / community-driven, DevX | `actionlint .github/workflows/build-release.yml`, artifact-skip guard review | integration |

## How to test

- [ ] Run `gh workflow run build-release.yml --repo microsoft/apm --ref <this-branch>` and confirm build artifacts upload without any release or PyPI publication jobs running.
- [ ] Inspect a scheduled failure after merge and confirm there is one open issue labeled `ci/daily-smoke` with failed jobs, run URL, head SHA, and any extractable failed pytest names.
- [ ] Re-run after the scheduled workflow goes green and confirm the same issue receives a recovery comment and closes.
- [ ] Confirm tag pushes still fail fast by checking that `integration-tests` and `release-validation` require successful upstream needs outside the scheduled event.
- [ ] Confirm branch protection still requires only `gate` and does not include `Daily Release Smoke Signal`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

