### PR TITLE
chore: release v0.29.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.29.1] - 2026-09-04
+## [0.29.1] - 2026-09-05
+
+### Security
+
+- `apm install` and registry access now bind credentials to user-configured
+  HTTPS destinations and reject redirects, insecure credential transport, and
+  lockfile-altered endpoints. Inherited policy restrictions are preserved,
+  executable approvals bind to canonical dependency identities, symlinked
+  project deployment roots are rejected, and `git`/`gh` resolve outside the
+  project tree. (#2810)
 
 ### Changed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apm-cli"
-version = "0.29.0"
+version = "0.29.1"
 description = "MCP configuration tool"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -203,7 +203,7 @@ wheels = [
 
 [[package]]
 name = "apm-cli"
-version = "0.29.0"
+version = "0.29.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Finish cutting release 0.29.1. PR #2808 sanitized the changelog into a `[0.29.1]` block but did not bump the version, and two PRs merged after it.

- Bump `pyproject.toml` and the `apm-cli` entry in `uv.lock` from 0.29.0 to 0.29.1.
- Add a `### Security` entry for #2810 and re-date the block to 2026-09-05.

## What changed since #2808

Merged after the release-prep changelog:

- #2810 -- security hardening across registry credentials, transport, policy inheritance, executable trust, and deployment roots. **Included** (new `### Security` section).
- #2809 -- lifecycle test coverage, CI wiring, and contributing docs only. **Dropped** as internal per the entry-sanitizer DROP list.

Also intentionally excluded: #2805, #2807, #2762 (CI-only), #2786 (changelog housekeeping), #2777, #2739 (maintainer tooling), and dependabot bumps.

## Why patch (0.29.1), not minor (0.30.0)

Every PR in the cycle is a bug fix, security patch, or internal change. No new CLI command, flag, manifest field, schema, resolution mode, or target was added, and nothing is marked BREAKING -- semver rubric row 7.

The #2810 hardening narrows previously-permissive behavior (rejects insecure credential transport, redirects, symlinked deployment roots), but those paths were unsafe rather than contracted surfaces, so they land under Security as fixes rather than a breaking change.

## Validation

Lint mirror green locally: ruff check, ruff format --check, pylint R0801, auth-signals boundary -- all PASS. See `.apm/instructions/linting.instructions.md` for the contract this mirrors.

`uv lock` in this environment rewrites every package URL to an internal feed proxy, so `uv.lock` was hand-edited to the single `apm-cli` version line instead; the diff is one line.

## Post-merge

Tag `v0.29.1` to trigger the release workflow:

```
git tag v0.29.1
git push origin v0.29.1
```
