### PR TITLE
fix(install): release abandoned transaction lock acquisitions

### DIFF
--- a/docs/src/content/docs/contributing/development-guide.md
+++ b/docs/src/content/docs/contributing/development-guide.md
@@ -195,6 +195,16 @@ bash scripts/lint-architecture-boundaries.sh
 The check fails closed when metadata is malformed, missing, or not listed in the
 index.
 
+`InstallTransaction` owns one acquisition of the shared lifecycle `FileLock`.
+Commit, rollback, and context exit are the normal release paths; explicit release
+invokes the same `weakref.finalize` callback used for abandoned transactions.
+This fallback releases only the transaction's outstanding acquisition, never
+runs filesystem rollback, and leaves other owners' acquisitions intact. Keep
+transaction lifetime and completion on the acquiring thread: filelock uses
+thread-local state, so there is no cross-thread lifecycle guarantee. In lifecycle
+release regression tests, retain the shared lock handle so `FileLock` destruction
+cannot mask a missed release.
+
 ### Optional: local pre-commit hooks
 
 For instant feedback before pushing, install the pre-commit hooks:

--- a/src/apm_cli/install/transaction.py
+++ b/src/apm_cli/install/transaction.py
@@ -6,6 +6,7 @@ import contextlib
 import os
 import tempfile
 import threading
+import weakref
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, cast
 
@@ -93,7 +94,12 @@ class InstallTransaction:
         self._validation = validation
         self._logger = logger
         self._workspace_lock = acquire_lifecycle_lock() if acquire_lock else None
-        self._workspace_lock_held = self._workspace_lock is not None
+        # Finalize this acquisition, not the shared FileLock object's lifetime.
+        self._workspace_lock_finalizer = (
+            weakref.finalize(self, self._workspace_lock.release)
+            if self._workspace_lock is not None
+            else None
+        )
         try:
             self._manifest_existed = manifest_path.exists()
             self._manifest_snapshot = manifest_path.read_bytes() if self._manifest_existed else None
@@ -239,10 +245,8 @@ class InstallTransaction:
 
     def _release_workspace_lock(self) -> None:
         """Release this transaction's nested lifecycle acquisition once."""
-        lock = self._workspace_lock
-        if self._workspace_lock_held and lock is not None:
-            self._workspace_lock_held = False
-            lock.release()
+        if self._workspace_lock_finalizer is not None:
+            self._workspace_lock_finalizer()
 
 
 def resolution_for_context(ctx: Any) -> ResolutionStagingSession:

--- a/tests/unit/install/test_install_transaction.py
+++ b/tests/unit/install/test_install_transaction.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import gc
 import multiprocessing
+import weakref
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from types import SimpleNamespace
@@ -483,6 +484,7 @@ def test_workspace_lock_releases_after_interruption(tmp_path: Path) -> None:
 
 def test_workspace_lock_releases_when_initialization_fails(tmp_path: Path) -> None:
     """A constructor failure cannot strand the cross-process lock."""
+    lock = lifecycle_lock()
     manifest = tmp_path / "apm.yml"
     manifest.write_text("name: fixture\nversion: 1.0.0\n", encoding="ascii")
     modules = tmp_path / "apm_modules"
@@ -493,7 +495,7 @@ def test_workspace_lock_releases_when_initialization_fails(tmp_path: Path) -> No
             "apm_cli.install.transaction.ResolutionStagingSession",
             side_effect=RuntimeError("boom"),
         ),
-        pytest.raises(RuntimeError, match="boom"),
+        pytest.raises(RuntimeError, match="boom") as caught,
     ):
         InstallTransaction(
             manifest_path=manifest,
@@ -502,6 +504,9 @@ def test_workspace_lock_releases_when_initialization_fails(tmp_path: Path) -> No
             logger=MagicMock(),
         )
 
+    assert caught.value.__traceback__ is not None
+    assert lock.lock_counter == 0
+    assert not lock.is_locked
     replacement = InstallTransaction(
         manifest_path=manifest,
         apm_modules_dir=modules,
@@ -558,13 +563,22 @@ def test_repeated_dry_run_releases_only_transaction_acquisition(tmp_path: Path) 
         outer_lock.release()
 
 
-def test_abandoned_transaction_does_not_strand_lifecycle_lock(tmp_path: Path) -> None:
+@pytest.mark.parametrize("cyclic", [False, True])
+def test_abandoned_transaction_does_not_strand_lifecycle_lock(tmp_path: Path, cyclic: bool) -> None:
     """Dropping the last transaction owner releases its FileLock acquisition."""
+    lock = lifecycle_lock()
     transaction = _transaction(tmp_path)
+    if cyclic:
+        transaction._logger.transaction = transaction
+    owner = weakref.ref(transaction)
+    assert lock.is_locked
     del transaction
     gc.collect()
 
-    assert not lifecycle_lock().is_locked
+    assert owner() is None
+    assert not lock.is_locked
+    with FileLock(lock.lock_file).acquire(timeout=0) as probe:
+        assert probe.is_locked
     replacement = InstallTransaction(
         manifest_path=tmp_path / "apm.yml",
         apm_modules_dir=tmp_path / "apm_modules",
@@ -572,6 +586,31 @@ def test_abandoned_transaction_does_not_strand_lifecycle_lock(tmp_path: Path) ->
         logger=MagicMock(),
     )
     replacement.commit(InstallResult())
+
+
+@pytest.mark.parametrize("completion", ["abandon", "commit", "rollback", "dry-run"])
+def test_transaction_finalization_preserves_outer_lock(tmp_path: Path, completion: str) -> None:
+    """Collection releases only an outstanding acquisition, never an outer owner."""
+    outer_lock = acquire_lifecycle_lock()
+    try:
+        transaction = _transaction(tmp_path)
+        assert outer_lock.lock_counter == 2
+        if completion == "commit":
+            transaction.commit(InstallResult())
+        elif completion == "rollback":
+            transaction.rollback()
+        elif completion == "dry-run":
+            transaction.complete(InstallResult(disposition=InstallDisposition.DRY_RUN))
+        if completion != "abandon":
+            assert outer_lock.lock_counter == 1
+        del transaction
+        gc.collect()
+
+        assert outer_lock.lock_counter == 1
+        assert outer_lock.is_locked
+    finally:
+        outer_lock.release()
+    assert not outer_lock.is_locked
 
 
 def test_phase_compatibility_journal_does_not_own_lifecycle_lock(tmp_path: Path) -> None:


### PR DESCRIPTION
## TL;DR

Release an abandoned `InstallTransaction`'s lifecycle-lock acquisition even when another reference keeps the shared `FileLock` alive. Explicit completion and collection now use the same one-shot finalizer, preserving outer acquisitions and immediate normal-path release.

> [!NOTE]
> Fixes the macOS ARM unit failure in non-publishing [build-release run 33949945516](https://github.com/microsoft/apm/actions/runs/33949945516/job/101262695215). A connection to the separately observed Windows unit hangs remains **unproven**. This PR does not dispatch, merge, tag, or publish a release.

## Problem (WHY)

- [x] At main `f307e51`, `test_abandoned_transaction_does_not_strand_lifecycle_lock` failed with `assert not lifecycle_lock().is_locked`: the shared `UnixFileLock` was still locked.
- [x] `InstallTransaction` acquired the shared lock but had no abandonment cleanup. The weak-value cache allowed `FileLock.__del__` to mask the missing release when no other reference survived. Retaining the shared lock deterministically exposes the leak; no sleep or scheduling assumption is needed.
- [!] An ordinary replacement transaction can reacquire the same lock reentrantly, so replacement success alone cannot prove release.

The regression tests follow the concrete validation loop described by Agent Skills: ["do the work, run a validator (a script, a reference checklist, or a self-check), fix any issues, and repeat until validation passes."](https://agentskills.io/skill-creation/best-practices#validation-loops) Here, the observable contract is an actual lock counter, lock state, and independent OS-lock acquisition, not a mocked release call.

## Approach (WHAT)

- Register `weakref.finalize` on the transaction, bound to the shared lock's `release` method, not a method retaining the transaction.
- Invoke that same finalizer on explicit release; it consumes exactly one outstanding acquisition and cannot release again at collection.
- Keep a strong reference to the shared lock in regression tests, including a transaction reference cycle.
- Assert normal-path release before GC, and assert outer ownership survives after GC.

## Implementation (HOW)

| File | Change |
| :--- | :--- |
| [`src/apm_cli/install/transaction.py`](https://github.com/microsoft/apm/blob/c47b3234c2ba55b43838cac946a00ee210cff785/src/apm_cli/install/transaction.py#L94-L104) | Replace the held-state boolean with an acquisition-specific finalizer; all existing release paths remain routed through `_release_workspace_lock`. |
| [`tests/unit/install/test_install_transaction.py`](https://github.com/microsoft/apm/blob/c47b3234c2ba55b43838cac946a00ee210cff785/tests/unit/install/test_install_transaction.py#L563-L616) | Retained-handle and cyclic abandonment, independent OS-lock probe, exact nested counters, immediate completion, and retained constructor-failure traceback assertions. Existing Windows compatibility marker includes these tests. |
| `docs/src/content/docs/contributing/development-guide.md` | Document acquisition ownership, finalizer limits, acquiring-thread lifetime, and the retained-handle regression technique. |

No dependency, lockfile, CLI, workflow, README, or changelog changes.

## Diagrams

Each transaction acquisition can transition to released only once; later completion or collection leaves other owners untouched.

```mermaid
stateDiagram-v2
    [*] --> Held: acquire once
    Held --> Released: explicit completion
    Held --> Released: abandoned owner collected
    note right of Released
        NEW: one finalizer consumes only this acquisition
    end note
    Released --> Released: repeated completion or collection
    Released --> [*]
```

## Trade-offs

- Finalization is a fallback, not normal transaction management. Commit, rollback, and context exit still release immediately; collection does not perform filesystem rollback.
- Preserve filelock's existing thread-local lifecycle contract: transaction lifetime and completion remain on the acquiring thread. This does not introduce cross-thread handoff support.
- Release one acquisition, never `force=True`; an active outer owner must continue excluding competing operations.
- The specific reference retaining the lock in the hosted worker was not captured. The retained-reference defect is independently reproduced; the original worker's exact object graph and any Windows-hang connection are not claimed.

## Benefits

1. A collected transaction no longer strands its acquisition when the shared lock survives.
2. Nested ownership remains exactly one outer acquisition after transaction completion or abandonment.
3. Regression tests detect both missing abandonment release and incorrectly delaying explicit release until GC.

## Validation

macOS, Python 3.12.10, based on current main `f307e51`.

<details><summary>Before/after and mutation evidence</summary>

Original transaction module at main:

```text
32 passed in 6.13s
```

Pre-fix retained-handle regression:

```text
FAILED tests/unit/install/test_install_transaction.py::test_abandoned_transaction_does_not_strand_lifecycle_lock
1 failed in 0.65s
```

`uv run --frozen --extra dev pytest tests/unit/install/test_install_transaction.py tests/unit/install/test_workspace_locking.py -q`

```text
45 passed in 3.54s
```

`uv run --extra dev pytest tests/unit/install -n 2 --dist worksteal -q`

```text
2215 passed in 38.00s
```

An in-memory mutation making `_release_workspace_lock` a no-op was rejected by the commit case before GC:

```text
E               assert 2 == 1
1 failed in 0.59s
Mutation rejected: completion must release before GC
```

The mutation was not written to the source tree.

</details>

Full current-main lint mirror passed: Ruff check/format, pylint R0801, YAML I/O guard, 2100-line guard, portable-relative-path guard, auth signals, and architecture boundaries. The grep guards were run via the tool-provided ripgrep because shell `rg` is unavailable. Mermaid rendered successfully with `mmdc`.

The full local macOS unit sequence and hosted PR checks are tracked separately; the targeted results above do not claim those runs have finished.

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
| :---: | :--- | :--- | :--- | :--- |
| 1 | A later operation can acquire the lock after an abandoned in-process install owner is collected. | DevX (pragmatic as npm) | `tests/unit/install/test_install_transaction.py::test_abandoned_transaction_does_not_strand_lifecycle_lock` (regression-trap for run 33949945516; real FileLock, cyclic and noncyclic cases) | unit |
| 2 | Completing or abandoning a nested install cannot unlock an operation still in progress. | DevX (pragmatic as npm) | `tests/unit/install/test_install_transaction.py::test_transaction_finalization_preserves_outer_lock` | unit |
| 3 | An initialization error releases its lock immediately, even while its traceback remains available. | DevX (pragmatic as npm) | `tests/unit/install/test_install_transaction.py::test_workspace_lock_releases_when_initialization_fails` | unit |
| 4 | Concurrent install processes remain serialized. | DevX (pragmatic as npm) | `tests/unit/install/test_install_transaction.py::test_workspace_lock_serializes_concurrent_processes` (real spawned-process boundary) | integration |

## How to test

- [ ] Run `uv run --frozen --extra dev pytest tests/unit/install/test_install_transaction.py tests/unit/install/test_workspace_locking.py -q`; all cases pass without added waits.
- [ ] Run `uv run --frozen --extra dev pytest tests/unit/install -n 2 --dist worksteal -q`; install sequences pass.
- [ ] Inspect the hosted Windows Compatibility Gate, which selects the regression tests through their existing `windows_compat` marker.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>