### PR TITLE
fix(tests): repair Windows auth failures and credential-helper stalls

### DIFF
--- a/tests/unit/marketplace/test_client_local.py
+++ b/tests/unit/marketplace/test_client_local.py
@@ -25,12 +25,14 @@ from apm_cli.marketplace.client import (
 )
 from apm_cli.marketplace.errors import MarketplaceFetchError
 from apm_cli.marketplace.models import MarketplaceSource
+from apm_cli.utils.git_env import get_git_executable
 
 
 def _local_source(name: str, path: Path, ref: str = "main") -> MarketplaceSource:
     return MarketplaceSource(name=name, url=f"file://{path}", ref=ref)
 
 
+@pytest.mark.windows_compat
 def test_fetch_local_bare_repo_via_git_show(tmp_path: Path) -> None:
     """Bare repo: ``git show`` returns blob content, parsed as JSON."""
     bare = tmp_path / "mkt.git"
@@ -47,7 +49,7 @@ def test_fetch_local_bare_repo_via_git_show(tmp_path: Path) -> None:
 
     assert result == manifest
     args = run_mock.call_args.args[0]
-    assert Path(args[0]).name == "git"
+    assert args[0] == get_git_executable()
     assert "--git-dir" in args
     assert "core.hooksPath=/dev/null" in args
     assert "main:marketplace.json" in args

--- a/tests/unit/marketplace/test_ref_resolver.py
+++ b/tests/unit/marketplace/test_ref_resolver.py
@@ -7,7 +7,6 @@ import os
 import subprocess
 import time
 import urllib.parse
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -20,6 +19,7 @@ from apm_cli.marketplace.ref_resolver import (
     _parse_ls_remote_output,
     _redact_token,
 )
+from apm_cli.utils.git_env import get_git_executable
 
 # ---------------------------------------------------------------------------
 # _parse_ls_remote_output
@@ -464,6 +464,7 @@ class TestRefResolver:
         assert refs == []
         resolver.close()
 
+    @pytest.mark.windows_compat
     @patch("apm_cli.marketplace.ref_resolver.subprocess.run")
     def test_correct_command_args(self, mock_run: MagicMock) -> None:
         mock_run.return_value = _make_completed(stdout="")
@@ -471,7 +472,7 @@ class TestRefResolver:
         resolver.list_remote_refs("acme/tools")
         args, kwargs = mock_run.call_args
         cmd = args[0]
-        assert Path(cmd[0]).name == "git"
+        assert cmd[0] == get_git_executable()
         assert cmd[1:4] == ["ls-remote", "--tags", "--heads"]
         parsed = urllib.parse.urlparse(cmd[4])
         assert parsed.hostname == "github.com"
@@ -633,6 +634,7 @@ class TestResolveRefSha:
         assert sha == _SHA_A
         resolver.close()
 
+    @pytest.mark.windows_compat
     @patch("apm_cli.marketplace.ref_resolver.subprocess.run")
     def test_resolves_specific_ref(self, mock_run: MagicMock) -> None:
         mock_run.return_value = _make_completed(
@@ -644,7 +646,7 @@ class TestResolveRefSha:
         # Verify command uses the ref directly (no --tags --heads).
         args, kwargs = mock_run.call_args  # noqa: RUF059
         cmd = args[0]
-        assert Path(cmd[0]).name == "git"
+        assert cmd[0] == get_git_executable()
         assert cmd[1] == "ls-remote"
         assert cmd[-1] == "main"
         parsed = urllib.parse.urlparse(cmd[2])

--- a/tests/unit/policy/test_discovery.py
+++ b/tests/unit/policy/test_discovery.py
@@ -13,6 +13,8 @@ from pathlib import Path
 from unittest.mock import ANY, MagicMock, patch
 from urllib.parse import parse_qs, quote, urlparse, urlsplit
 
+import pytest
+
 from apm_cli.cache.paths import get_cache_root
 from apm_cli.core.auth import AuthResolver as _RealAuthResolver
 from apm_cli.policy._gitlab import (
@@ -47,6 +49,7 @@ from apm_cli.policy.discovery import (
 )
 from apm_cli.policy.parser import PolicyValidationError, load_policy  # noqa: F401
 from apm_cli.policy.schema import ApmPolicy
+from apm_cli.utils.git_env import get_git_executable
 
 # Minimal valid YAML that produces a valid ApmPolicy
 VALID_POLICY_YAML = "name: test-policy\nversion: '1.0'\nenforcement: warn\n"
@@ -1920,6 +1923,7 @@ class TestFetchFromGitlabRepo(unittest.TestCase):
         self.assertFalse((root / ".apm").exists())
         mock_project_state.assert_called_once()
 
+    @pytest.mark.windows_compat
     @patch("apm_cli.policy._gitlab.subprocess.run")
     @patch("apm_cli.core.auth.AuthResolver")
     def test_git_reachability_probe_uses_bounded_auth_resolver_credentials(
@@ -1952,7 +1956,7 @@ class TestFetchFromGitlabRepo(unittest.TestCase):
         self.assertTrue(state)
         mock_run.assert_called_once()
         command = mock_run.call_args.args[0]
-        self.assertEqual(Path(command[0]).name, "git")
+        self.assertEqual(command[0], get_git_executable())
         self.assertEqual(
             command[1:],
             [

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -92,12 +92,23 @@ class TestClassifyHost:
         with pytest.raises(ValueError, match="Supported values: gitlab"):
             AuthResolver.classify_host("code.acme.com", host_type="gitea")
 
+    @pytest.mark.windows_compat
     def test_gitlab_host_type_hint_reuses_gitlab_cache_entry(self):
-        with patch.dict(os.environ, {}, clear=True):
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch.object(
+                GitHubTokenManager, "resolve_credential_from_git", return_value=None
+            ) as mock_cred,
+            patch(
+                "apm_cli.core.token_manager.subprocess.run",
+                side_effect=AssertionError("Cache identity must not launch credential helpers"),
+            ),
+        ):
             resolver = AuthResolver()
             ctx_a = resolver.resolve("gitlab.com")
             ctx_b = resolver.resolve("gitlab.com", host_type="gitlab")
         assert ctx_a is ctx_b
+        mock_cred.assert_called_once_with("gitlab.com", port=None)
 
     def test_gitlab_self_managed_apm_gitlab_hosts_env(self):
         with patch.dict(
@@ -1305,12 +1316,24 @@ class TestResolvePortDiscrimination:
         assert ctx.host_info.port == 7990
         mock_cred.assert_called_once_with("bitbucket.corp.com", port=7990, env=ANY)
 
+    @pytest.mark.windows_compat
     def test_host_info_carries_port(self):
-        with patch.dict(os.environ, {"GITHUB_APM_PAT": "t"}, clear=True):
+        with (
+            patch.dict(os.environ, {"GITHUB_APM_PAT": "t"}, clear=True),
+            patch.object(
+                GitHubTokenManager, "resolve_credential_from_git", return_value=None
+            ) as mock_cred,
+            patch(
+                "apm_cli.core.token_manager.subprocess.run",
+                side_effect=AssertionError("Port metadata must not launch credential helpers"),
+            ),
+        ):
             resolver = AuthResolver()
             ctx = resolver.resolve("gitlab.corp.com", port=8443)
             assert ctx.host_info.port == 8443
             assert ctx.host_info.display_name == "gitlab.corp.com:8443"
+            assert ctx.token is None
+        mock_cred.assert_called_once_with("gitlab.corp.com", port=8443, env=ANY)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_auth_scoping.py
+++ b/tests/unit/test_auth_scoping.py
@@ -19,6 +19,7 @@ from git.exc import GitCommandError
 
 from apm_cli.deps.github_downloader import GitHubPackageDownloader
 from apm_cli.models.apm_package import APMPackage, DependencyReference
+from apm_cli.utils.git_env import get_git_executable
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -1090,6 +1091,7 @@ class TestValidatePackageExistsEnv:
     )
     @patch("subprocess.run")
     @patch.dict(os.environ, {}, clear=True)
+    @pytest.mark.windows_compat
     def test_gitlab_virtual_subdirectory_uses_git_ls_remote(self, mock_run, _mock_cred):
         """Dict git+path subdirectory on GitLab validates the repo root via git ls-remote."""
         from apm_cli.commands.install import _validate_package_exists
@@ -1109,7 +1111,7 @@ class TestValidatePackageExistsEnv:
         assert ok is True
         assert mock_run.called
         cmd = mock_run.call_args[0][0]
-        assert Path(cmd[0]).name == "git"
+        assert cmd[0] == get_git_executable()
         assert cmd[1:3] == ["ls-remote", "--heads"]
 
     @patch(
@@ -1282,6 +1284,7 @@ class TestIsGitHubClassification:
 class TestSparseCheckoutTokenResolution:
     """Verify sparse checkout follows public GitHub anonymous-first auth."""
 
+    @pytest.mark.windows_compat
     def test_sparse_checkout_starts_anonymous_before_per_org_token(self, tmp_path):
         """Sparse checkout does not present either configured token initially."""
         org_token = "ghp_ORG_SPECIFIC"
@@ -1310,7 +1313,7 @@ class TestSparseCheckoutTokenResolution:
             def capture_run(cmd, **kwargs):
                 if (
                     len(cmd) >= 5
-                    and Path(cmd[0]).name == "git"
+                    and cmd[0] == get_git_executable()
                     and cmd[1:4] == ["remote", "add", "origin"]
                 ):
                     captured_urls.append(cmd[4])  # The URL argument (after 'origin')

--- a/tests/unit/test_azure_cli.py
+++ b/tests/unit/test_azure_cli.py
@@ -3,6 +3,7 @@
 import subprocess
 import threading  # noqa: F401
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -22,10 +23,26 @@ FAKE_JWT = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9." + "a" * 200
 
 
 class TestIsAvailable:
-    def test_is_available_when_az_on_path(self):
-        with patch("apm_cli.core.azure_cli.shutil.which", return_value="/usr/bin/az"):
+    @pytest.mark.windows_compat
+    def test_is_available_when_az_on_path(self) -> None:
+        """Availability must not launch az, even when it resolves to az.cmd.
+
+        A final xdist PASSED line can remain unterminated until another worker
+        finishes. Its CI log timestamp is not evidence that this probe ran a
+        slow subprocess; pin the no-subprocess contract directly.
+        """
+        with (
+            patch(
+                "apm_cli.core.azure_cli.shutil.which",
+                return_value=r"C:\Program Files\Azure CLI\az.cmd",
+            ),
+            patch("apm_cli.core.azure_cli.subprocess.run") as mock_run,
+            patch("apm_cli.core.azure_cli.subprocess.Popen") as mock_popen,
+        ):
             provider = AzureCliBearerProvider()
             assert provider.is_available() is True
+            mock_run.assert_not_called()
+            mock_popen.assert_not_called()
 
     def test_is_available_when_az_missing(self):
         with patch("apm_cli.core.azure_cli.shutil.which", return_value=None):
@@ -53,6 +70,7 @@ class TestIsAvailable:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.windows_compat
 class TestWindowsAzCmdResolution:
     """Regression: subprocess.run must receive the shutil.which-resolved
     path, not the bare "az" token. On Windows the resolver returns
@@ -73,12 +91,17 @@ class TestWindowsAzCmdResolution:
             provider = AzureCliBearerProvider()
             assert provider._az_command is None
 
-    def test_init_absolute_path_skips_resolution(self):
-        """Caller passed an explicit absolute path -- trust verbatim."""
+    def test_init_absolute_path_skips_resolution(self, tmp_path: Path) -> None:
+        """Trust a native absolute path, not a POSIX-only rooted spelling.
+
+        On Python 3.13+ Windows, /opt/custom/az is rooted but not absolute:
+        it has no drive. Use a real platform-native absolute path here.
+        """
+        az_command = str(tmp_path / "custom" / "az")
         with patch("apm_cli.core.azure_cli.shutil.which") as mock_which:
-            provider = AzureCliBearerProvider(az_command="/opt/custom/az")
+            provider = AzureCliBearerProvider(az_command=az_command)
             mock_which.assert_not_called()
-            assert provider._az_command == "/opt/custom/az"
+            assert provider._az_command == az_command
 
     def test_init_relative_with_separator_still_resolves(self):
         """A relative-with-separator token like 'subdir/az' must NOT bypass

--- a/tests/unit/test_generic_host_error_port.py
+++ b/tests/unit/test_generic_host_error_port.py
@@ -90,6 +90,7 @@ class TestGenericHostCloneErrorPort:
         prefix = _diagnostic_prefix(self._clone_error(dep))
         assert "For private repositories on bitbucket.example.com:7999," in prefix
 
+    @pytest.mark.windows_compat
     def test_https_custom_port_surfaces_in_error(self):
         """https://host:7990/... -> hint names host:7990."""
         dep = DependencyReference.parse("https://bitbucket.example.com:7990/project/repo.git")
@@ -98,6 +99,7 @@ class TestGenericHostCloneErrorPort:
         prefix = _diagnostic_prefix(self._clone_error(dep))
         assert "For private repositories on bitbucket.example.com:7990," in prefix
 
+    @pytest.mark.windows_compat
     def test_no_port_renders_bare_host(self):
         """Default-port dep has no port suffix -- no regression for common case."""
         dep = DependencyReference.parse("https://gitlab.example.com/team/repo.git")

--- a/tests/unit/test_generic_host_error_port.py
+++ b/tests/unit/test_generic_host_error_port.py
@@ -24,6 +24,7 @@ from git.exc import GitCommandError
 
 from apm_cli.deps.github_downloader import GitHubPackageDownloader
 from apm_cli.models.apm_package import DependencyReference
+from apm_cli.utils.git_env import _GitConfigSnapshot
 
 
 def _make_downloader():
@@ -71,6 +72,16 @@ class TestGenericHostCloneErrorPort:
                 "apm_cli.core.token_manager.GitHubTokenManager.resolve_credential_from_git",
                 return_value=None,
             ),
+            # HTTPS policy inspection must not depend on a warmed Git cache
+            # after clear=True removes PATH on Windows.
+            patch(
+                "apm_cli.utils.git_env._read_effective_git_config",
+                return_value=_GitConfigSnapshot((), (), ()),
+            ),
+            patch(
+                "apm_cli.utils.git_env.get_git_executable",
+                side_effect=AssertionError("Diagnostic tests must not launch Git"),
+            ),
             patch("apm_cli.deps.github_downloader.Repo") as MockRepo,
         ):
             MockRepo.clone_from.side_effect = _fake_clone
@@ -78,6 +89,7 @@ class TestGenericHostCloneErrorPort:
             try:
                 with pytest.raises(RuntimeError) as exc_info:
                     dl._clone_with_fallback(dep.repo_url, target, dep_ref=dep)
+                MockRepo.clone_from.assert_called_once()
                 return str(exc_info.value)
             finally:
                 shutil.rmtree(target, ignore_errors=True)

--- a/tests/unit/test_windows_compat_gate_workflow.py
+++ b/tests/unit/test_windows_compat_gate_workflow.py
@@ -55,8 +55,9 @@ FULL_SUITE_ROOTS = ("tests/unit", "tests/test_console.py", "tests/red_team")
 # A generous but real ceiling: the gate is a "load-bearing contract
 # family", not a second full-suite run. If the marked set ever grows
 # past this, that is a signal to re-examine scope. The current ceiling
-# includes the cross-platform Git environment isolation matrix.
-MAX_BOUNDED_FAMILY_SIZE = 325
+# includes the Git environment matrix plus 19 release regressions:
+# eight failures, two unmocked credential lookups, and nine Azure CLI contracts.
+MAX_BOUNDED_FAMILY_SIZE = 344
 
 
 def _ci_workflow() -> dict:


### PR DESCRIPTION
# fix(tests): repair Windows auth failures and credential-helper stalls

## TL;DR

Repair all eight named Windows unit failures and isolate the two unfinished tests that were invoking real credential helpers. Production authentication is unchanged. The final PR head has green native Windows coverage, both full Linux shards, and every reported check including the aggregate gate.

> [!IMPORTANT]
> This is test repair, not an Azure CLI timeout fix. The full post-merge Windows release matrix has **not** been rerun for this head. Maintainer review/merge and the ordinary post-merge release validation remain prerequisites; nothing was merged, tagged, published, dispatched, or cancelled.

## Problem (WHY)

- [x] Release run [33955869341](https://github.com/microsoft/apm/actions/runs/33955869341) reported eight Windows failures and timed out after 60 minutes.
- [x] Six tests rejected a correctly resolved `git.exe`: five executable assertions and one sparse-checkout capture predicate assumed the POSIX basename `git`. A real Git executable exposed as `git.exe` reproduced all six failures locally.
- [x] Two generic HTTPS diagnostic tests cleared `PATH` but still reached a real Git config probe before their mocked clone. A warm executable cache hid the defect; a cold cache with no default Git path reproduced exactly those two failures while SSH passed.
- [x] The two **unmatched starts** were `TestClassifyHost::test_gitlab_host_type_hint_reuses_gitlab_cache_entry` and `TestResolvePortDiscrimination::test_host_info_carries_port`, both in `test_auth.py`. Hermetic interception confirmed both reached unmocked `git credential fill`.
- [!] The Azure availability `PASSED` record appeared at timeout because xdist can leave its final result line unterminated. A real xdist reproduction completed the call and teardown before a line-oriented reader emitted that result. The log does not establish the precise blocked credential-helper/timeout-cleanup stack.

This repair follows real execution rather than a guessed platform exception: ["Even a single pass of execute-then-revise noticeably improves quality, and complex domains often benefit from several."](https://agentskills.io/skill-creation/best-practices#refine-with-real-execution)

## Approach (WHAT)

- Compare the complete argv executable with the canonical `get_git_executable()` result.
- Mock only unrelated config-read and credential-fill I/O; retain real resolver, classification, URL-rewrite safety, cache, and diagnostic behavior.
- Fail immediately if those metadata/diagnostic tests attempt live subprocess work.
- Pin Azure availability to no subprocess and use a native absolute path in its path-resolution test.
- Select nineteen focused Windows contracts: eight failures, two unfinished tests, and nine Azure contracts.

## Implementation (HOW)

| File | Intent |
| :--- | :--- |
| `tests/unit/marketplace/test_ref_resolver.py` | Correct both ls-remote executable assertions without changing arguments or deadlines. |
| `tests/unit/marketplace/test_client_local.py` | Correct the bare-repository git-show executable assertion. |
| `tests/unit/policy/test_discovery.py` | Keep bounded AuthResolver credential checks; correct executable equality. |
| `tests/unit/test_auth_scoping.py` | Correct validation argv and sparse remote capture; retain anonymous-first token assertions. |
| `tests/unit/test_generic_host_error_port.py` | Supply a concrete empty config snapshot, forbid executable lookup, and prove the mocked clone was reached. |
| `tests/unit/test_auth.py` | Isolate the two unfinished tests from OS credential helpers; assert one cache lookup, port propagation, and no foreign token use. |
| `tests/unit/test_azure_cli.py` | Assert no subprocess for availability, use a native absolute path, and select nine Windows contracts. |
| `tests/unit/test_windows_compat_gate_workflow.py` | Admit exactly nineteen additional contracts: ceiling 325 to 344, with 342 collected and the previous two-test headroom retained. |

Implementation: [13e2c3a30](https://github.com/microsoft/apm/commit/13e2c3a300609878b316f9692c1c32ec5f7c5139), [1030470c6](https://github.com/microsoft/apm/commit/1030470c600ac2764de176554ad29cdfa7d71d0c).

No source, documentation, workflow, dependency, or CHANGELOG changes: runtime behavior and documented authentication contracts are unchanged. Docs impact is `no_change` under the deterministic test-only rule.

## Trade-offs

- Exact canonical equality is stronger than accepting `git` or `git.exe` by basename; it also rejects an unintended executable directory.
- Config and credential I/O are outside metadata/diagnostic test intent. Isolating them avoids machine state without bypassing production auth decisions or weakening security assertions.
- Native Windows evidence is required and included below. It validates the focused contract family, not the entire post-merge Windows release suite.
- No diagram: this PR changes test boundaries and selection, not application control flow.

## Benefits

1. All eight reported failures have deterministic reproductions and repaired assertions/fixtures.
2. Both unfinished auth tests now reject unintended subprocess work and complete on native Windows.
3. Nineteen regression contracts run in the existing PR-time Windows job; no tests were skipped or removed.

## Validation

**Final head:** `1030470c600ac2764de176554ad29cdfa7d71d0c`.

**Hosted CI:** [33959686677](https://github.com/microsoft/apm/actions/runs/33959686677) is green, including both full Linux shards, Windows, lint, architecture ratchets, lifecycle smoke, binary smoke, and coverage. CodeQL, NOTICE, CLA, and the [aggregate gate](https://github.com/microsoft/apm/actions/runs/33959686815) are also green.

<details><summary>Deterministic reproduction and execution evidence</summary>

Real Git executable exposed as `git.exe`, before and after:
```text
6 failed in 0.80s
6 passed in 0.69s
```
Cold executable cache plus no default Git path, generic clone class before and after:
```text
2 failed, 1 passed in 0.74s
3 passed in 0.44s
```
Unfinished auth tests with live subprocess interception before repair:
```text
2 failed in 0.64s
AssertionError: Unexpected live credential subprocess
```
All affected modules plus the Windows gate contract, with `-n 4 --dist worksteal`:
```text
463 passed, 2 subtests passed in 20.59s
```
Final native Windows job [101289271229](https://github.com/microsoft/apm/actions/runs/33959686677/job/101289271229):
```text
340 passed, 2 skipped, 21066 deselected, 4 warnings in 152.96s (0:02:32)
```
The two skips are existing gate contracts; this PR adds no skips. Both previously unmatched auth tests passed at `10:06:14 UTC`, followed by all nine Azure contracts and both generic HTTPS diagnostics.

Latest-main lint mirror: Ruff check/format, pylint R0801, YAML I/O, file length, portable paths, auth signals, and architecture boundaries passed. Strict assertion and exact-duplicate ratchets passed. Independent test-coverage and auth reviews found no required fixes.

</details>

### Scenario Evidence

| Scenario | Principle | Proof | Type |
| :--- | :--- | :--- | :--- |
| Marketplace refs and bare local reads use the resolved executable | Portability | Two `test_ref_resolver.py` argv tests; `test_client_local.py::test_fetch_local_bare_repo_via_git_show` | Unit |
| Policy probes remain bounded and resolver-authenticated | Secure by default | `test_discovery.py::TestFetchFromGitlabRepo::test_git_reachability_probe_uses_bounded_auth_resolver_credentials` | Unit |
| GitLab validation and sparse checkout remain correctly scoped | Secure by default | The two marked `test_auth_scoping.py` tests | Unit |
| Generic clone diagnostics retain host/port without machine config dependence | Portability | The two marked `TestGenericHostCloneErrorPort` tests | Unit |
| Host cache identity and port metadata do not invoke OS helpers | Secure by default | The two marked `test_auth.py` tests | Unit |
| Azure availability performs no subprocess and command paths remain portable | Portability | Marked `TestIsAvailable` test and `TestWindowsAzCmdResolution` | Unit |

## How to test

- [ ] Run `uv run --frozen --extra dev pytest -n 4 --dist worksteal -q tests/unit/test_auth.py tests/unit/test_azure_cli.py tests/unit/test_generic_host_error_port.py tests/unit/marketplace/test_ref_resolver.py tests/unit/policy/test_discovery.py tests/unit/marketplace/test_client_local.py tests/unit/test_auth_scoping.py tests/unit/test_windows_compat_gate_workflow.py`.
- [ ] Run `uv run --frozen --extra dev pytest -m windows_compat tests/unit tests/integration/test_lifecycle_workspace_lock.py --collect-only -q`; expect 342 selected contracts.
- [ ] Inspect the linked final-head Windows job and both full Linux shards; require maintainer approval and normal post-merge full Windows release validation before releasing.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>