### PR TITLE
fix(install): record published package paths, never resolution-staging paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `apm install` now records the published `apm_modules/<owner>/<repo>` path for
+  a dependency fetched through the resolution-staging replacement path, so MCP
+  server arguments in `apm.lock.yaml` and client configs no longer point at the
+  `.apm-resolution-staging` directory that is removed when the install
+  finishes. Writing a lockfile or client MCP configuration that still names a
+  staging path is now refused outright. (by @lkshrk, #2827)
+
 ## [0.29.1] - 2026-09-05
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `apm install` now records the published `apm_modules/<owner>/<repo>` path for
-  a dependency fetched through the resolution-staging replacement path, so MCP
-  server arguments in `apm.lock.yaml` and client configs no longer point at the
-  `.apm-resolution-staging` directory that is removed when the install
-  finishes. Writing a lockfile or client MCP configuration that still names a
-  staging path is now refused outright. (by @lkshrk, #2827)
+- `apm install` now keeps transitive plugin MCP launchers usable after
+  publication and cached replay by resolving plugin-root placeholders from the
+  published package directory. Lockfile writes and self-defined MCP
+  configuration construction reject remaining resolution-staging references
+  without echoing configuration values. (by @lkshrk, #2827)
 
 ## [0.29.1] - 2026-09-05
 

--- a/docs/src/content/docs/troubleshooting/install-failures.md
+++ b/docs/src/content/docs/troubleshooting/install-failures.md
@@ -251,6 +251,13 @@ The cache short-circuits already-downloaded packages and the integrate phase ove
 
 If resolution rejects a cyclic dependency graph, fix the package manifests and run `apm install` again. APM rolls back only the package snapshots staged by the rejected resolution, so no manual `apm_modules/` deletion is required.
 
+If an MCP command names `.apm-resolution-staging`, upgrade to a release that
+contains the staging-path fix and retry the same `apm install` command once. If
+the reference or refusal repeats, stop and report the redacted error plus the
+named MCP entry. Do not edit package files, delete the lockfile, or use
+`--refresh` or `--force` solely to repair this path; those actions can move pins
+or bypass unrelated protections.
+
 If files in `apm_modules/` or under target harness directories look corrupt, force a fresh deploy by combining cache bypass with overwrite:
 
 ```bash

--- a/packages/apm-guide/.apm/skills/apm-usage/troubleshooting.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/troubleshooting.md
@@ -6,6 +6,7 @@
 | Authentication errors (401/403) | Set the correct token. Run `apm install --verbose` to see which token source is used. See [Authentication](./authentication.md). |
 | File collision on install | A local file conflicts with a dependency file. Use `--force` to overwrite, or rename the local file. |
 | Stale dependencies | Run `apm install --update` to refresh to latest refs. |
+| MCP path contains `.apm-resolution-staging` | Upgrade APM and retry the same install once. If it repeats, stop and report the redacted error and named MCP entry. Do not edit package files, delete the lockfile, or use `--refresh`/`--force` solely for this repair. |
 | TLS verification failed | Install your corporate CA into the OS trust store. For a per-shell override, set `REQUESTS_CA_BUNDLE=/path/to/ca-bundle.pem`; `SSL_CERT_FILE` alone is not a reliable requests override. |
 | Orphaned packages in lockfile | Run `apm prune` to remove packages no longer in apm.yml. |
 | Security findings block install | Run `apm audit` to review findings, then `apm install --force` if acceptable. |

--- a/src/apm_cli/deps/apm_resolver.py
+++ b/src/apm_cli/deps/apm_resolver.py
@@ -7,7 +7,7 @@ import threading
 from collections import deque
 from collections.abc import Iterable
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import replace
+from dataclasses import fields, is_dataclass, replace
 from pathlib import Path, PureWindowsPath
 from typing import TYPE_CHECKING, NoReturn, Optional, Protocol
 
@@ -1343,7 +1343,28 @@ class APMDependencyResolver:
             downloaded_candidate,
             live_path,
         )
+        self._remap_dependency_configs(package, downloaded_candidate, live_path)
         return package
+
+    @staticmethod
+    def _remap_dependency_configs(
+        package: APMPackage,
+        candidate: Path,
+        live_path: Path,
+    ) -> None:
+        """Repoint plugin-root paths that were substituted while staged."""
+        from apm_cli.deps.plugin_parser import rebase_plugin_root_paths
+
+        for group in (package.dependencies, package.dev_dependencies):
+            for entries in (group or {}).values():
+                for entry in entries or ():
+                    if not is_dataclass(entry) or isinstance(entry, type):
+                        continue
+                    for spec in fields(entry):
+                        current = getattr(entry, spec.name, None)
+                        rebased = rebase_plugin_root_paths(current, candidate, live_path)
+                        if rebased != current:
+                            setattr(entry, spec.name, rebased)
 
     @staticmethod
     def _raise_downloaded_package_error(

--- a/src/apm_cli/deps/lockfile.py
+++ b/src/apm_cli/deps/lockfile.py
@@ -976,6 +976,7 @@ class LockFile:
         to avoid parsing the same bytes again.
         """
         from ..utils.atomic_io import atomic_write_text
+        from ..utils.staging_guard import assert_no_staging_paths
         from ..utils.yaml_io import load_yaml_str
 
         existing: LockFile | None
@@ -1010,7 +1011,9 @@ class LockFile:
             self.generated_at = datetime.now(timezone.utc).isoformat()
         else:
             self.generated_at = None
-        atomic_write_text(path, self.to_yaml())
+        serialized = self.to_yaml()
+        assert_no_staging_paths(serialized, path.name)
+        atomic_write_text(path, serialized)
 
     @classmethod
     def read(cls, path: Path) -> LockFile | None:

--- a/src/apm_cli/deps/plugin_parser.py
+++ b/src/apm_cli/deps/plugin_parser.py
@@ -779,6 +779,24 @@ def resolve_plugin_root_placeholders(value: Any, plugin_path: Path) -> Any:
     return value
 
 
+def rebase_plugin_root_paths(value: Any, old_root: Path, new_root: Path) -> Any:
+    """Repoint already-substituted plugin-root paths at a new package root.
+
+    Exact inverse of :func:`resolve_plugin_root_placeholders`: the placeholder
+    may sit anywhere in a string and appear more than once, so every occurrence
+    of *old_root* is swapped rather than only a leading path prefix.
+    """
+    if isinstance(value, str):
+        return value.replace(str(old_root), str(new_root))
+    if isinstance(value, dict):
+        return {
+            key: rebase_plugin_root_paths(item, old_root, new_root) for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [rebase_plugin_root_paths(item, old_root, new_root) for item in value]
+    return value
+
+
 def _mcp_servers_to_apm_deps(
     servers: dict[str, Any],
     plugin_path: Path,

--- a/src/apm_cli/deps/plugin_parser.py
+++ b/src/apm_cli/deps/plugin_parser.py
@@ -504,7 +504,13 @@ def normalize_plugin_directory(plugin_path: Path, plugin_json_path: Path | None 
             raise ValueError("Present root plugin.json must declare a non-empty name")
         manifest["name"] = plugin_path.name
 
-    return synthesize_apm_yml_from_plugin(plugin_path, manifest)
+    # Keep the generated manifest portable. APMPackage expands the placeholder
+    # when it loads the manifest, using the package's current published root.
+    return synthesize_apm_yml_from_plugin(
+        plugin_path,
+        manifest,
+        substitute_plugin_root=False,
+    )
 
 
 def _validate_declared_component_paths(plugin_path: Path, manifest: dict[str, Any]) -> None:

--- a/src/apm_cli/install/resolution_staging.py
+++ b/src/apm_cli/install/resolution_staging.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from filelock import FileLock, Timeout
 
 from apm_cli.utils.path_security import ensure_path_within, safe_rmtree
+from apm_cli.utils.staging_guard import STAGING_DIR_NAME
 
 _STAGING_NAME = re.compile(r"[0-9a-f]{32}")
 
@@ -24,7 +25,7 @@ class ResolutionStagingSession:
         """Create an empty staging session rooted below ``apm_modules``."""
         self._modules_dir = apm_modules_dir
         self._modules_existed = apm_modules_dir.exists()
-        self._staging_root = apm_modules_dir / ".apm-resolution-staging" / uuid.uuid4().hex
+        self._staging_root = apm_modules_dir / STAGING_DIR_NAME / uuid.uuid4().hex
         self._staging_lock_path = self._staging_root.with_suffix(".lock")
         self._staging_lock: FileLock | None = None
         self._backups: dict[Path, Path | None] = {}

--- a/src/apm_cli/integration/mcp_integrator.py
+++ b/src/apm_cli/integration/mcp_integrator.py
@@ -44,6 +44,7 @@ from apm_cli.utils.console import (
     _rich_success,
     _rich_warning,
 )
+from apm_cli.utils.staging_guard import assert_no_staging_paths
 from apm_cli.utils.yaml_io import load_yaml, yaml_to_str
 
 if TYPE_CHECKING:
@@ -484,6 +485,7 @@ class MCPIntegrator:
         if dep.extra:
             info["_extra"] = dict(dep.extra)
 
+        assert_no_staging_paths(info, f"MCP client configuration for '{dep.name}'")
         return info
 
     @staticmethod

--- a/src/apm_cli/utils/staging_guard.py
+++ b/src/apm_cli/utils/staging_guard.py
@@ -1,0 +1,71 @@
+"""Refusal guard for durable artifacts that still name a staging path."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+STAGING_DIR_NAME = ".apm-resolution-staging"
+
+_EXCERPT_MARGIN = 120
+_ROOT_LOCATION = "its serialized content"
+
+
+class StagingPathLeakError(RuntimeError):
+    """A durable artifact still points inside a resolution staging root."""
+
+
+def assert_no_staging_paths(payload: Any, artifact: str) -> None:
+    """Refuse to persist *payload* while it references a staging path."""
+    offender = _find_staging_reference(payload, "")
+    if offender is None:
+        return
+    location, text = offender
+    raise StagingPathLeakError(
+        f"Refusing to write {artifact}: {location or _ROOT_LOCATION} references the "
+        f"resolution staging directory, which is removed once the install finishes, "
+        f"so the recorded path would never resolve again ({_excerpt(text)}). "
+        f"Re-run the install."
+    )
+
+
+def _find_staging_reference(payload: Any, location: str) -> tuple[str, str] | None:
+    """Return the location and text of the first value naming a staging directory."""
+    if isinstance(payload, (str, Path)):
+        text = str(payload)
+        return (location, text) if STAGING_DIR_NAME in text else None
+    for candidate_location, candidate in _child_values(payload, location):
+        found = _find_staging_reference(candidate, candidate_location)
+        if found is not None:
+            return found
+    return None
+
+
+def _child_values(payload: Any, location: str) -> list[tuple[str, Any]]:
+    """Return the (location, value) pairs to search below *payload*."""
+    if isinstance(payload, dict):
+        children: list[tuple[str, Any]] = []
+        for key, value in payload.items():
+            children.append((location, key))
+            children.append((_key_location(location, key), value))
+        return children
+    if isinstance(payload, (set, frozenset)):
+        # Sort so a failure reports the same member on every run.
+        return [(location, item) for item in sorted(payload, key=repr)]
+    if isinstance(payload, (list, tuple)):
+        return [(f"{location}[{index}]", item) for index, item in enumerate(payload)]
+    return []
+
+
+def _key_location(location: str, key: Any) -> str:
+    """Return the dotted location of *key* below *location*."""
+    name = key if isinstance(key, str) else repr(key)
+    return f"{location}.{name}" if location else name
+
+
+def _excerpt(text: str) -> str:
+    """Return a bounded window around the staging marker for error messages."""
+    index = text.find(STAGING_DIR_NAME)
+    start = max(0, index - _EXCERPT_MARGIN)
+    end = min(len(text), index + len(STAGING_DIR_NAME) + _EXCERPT_MARGIN)
+    return text[start:end].strip()

--- a/src/apm_cli/utils/staging_guard.py
+++ b/src/apm_cli/utils/staging_guard.py
@@ -7,7 +7,6 @@ from typing import Any
 
 STAGING_DIR_NAME = ".apm-resolution-staging"
 
-_EXCERPT_MARGIN = 120
 _ROOT_LOCATION = "its serialized content"
 
 
@@ -20,12 +19,13 @@ def assert_no_staging_paths(payload: Any, artifact: str) -> None:
     offender = _find_staging_reference(payload, "")
     if offender is None:
         return
-    location, text = offender
+    location, _ = offender
     raise StagingPathLeakError(
         f"Refusing to write {artifact}: {location or _ROOT_LOCATION} references the "
         f"resolution staging directory, which is removed once the install finishes, "
-        f"so the recorded path would never resolve again ({_excerpt(text)}). "
-        f"Re-run the install."
+        "so the recorded path would never resolve again. Upgrade APM and re-run the "
+        "same install once. If the error repeats, stop and report the artifact and "
+        "field named above; do not edit integrity-protected package files."
     )
 
 
@@ -61,11 +61,3 @@ def _key_location(location: str, key: Any) -> str:
     """Return the dotted location of *key* below *location*."""
     name = key if isinstance(key, str) else repr(key)
     return f"{location}.{name}" if location else name
-
-
-def _excerpt(text: str) -> str:
-    """Return a bounded window around the staging marker for error messages."""
-    index = text.find(STAGING_DIR_NAME)
-    start = max(0, index - _EXCERPT_MARGIN)
-    end = min(len(text), index + len(STAGING_DIR_NAME) + _EXCERPT_MARGIN)
-    return text[start:end].strip()

--- a/tests/integration/test_resolution_staging_mcp_lifecycle.py
+++ b/tests/integration/test_resolution_staging_mcp_lifecycle.py
@@ -1,0 +1,182 @@
+"""Resolution-staging MCP paths remain valid after publication and replay."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import tomlkit
+
+from apm_cli.adapters.client.claude import ClaudeClientAdapter
+from apm_cli.adapters.client.codex import CodexClientAdapter
+from apm_cli.deps.apm_resolver import APMDependencyResolver
+from apm_cli.deps.lockfile import LockedDependency, LockFile
+from apm_cli.install.resolution_staging import ResolutionStagingSession
+from apm_cli.integration.mcp_integrator import MCPIntegrator
+from apm_cli.models.apm_package import APMPackage
+from apm_cli.models.dependency.reference import DependencyReference
+from apm_cli.utils.content_hash import compute_package_hash
+from apm_cli.utils.staging_guard import STAGING_DIR_NAME
+from apm_cli.utils.yaml_io import load_yaml
+
+pytestmark = pytest.mark.component
+
+_PLUGIN_ROOT = "${CLAUDE_PLUGIN_ROOT}"
+
+
+def _plugin_manifest() -> dict[str, object]:
+    return {
+        "name": "tool",
+        "version": "1.0.0",
+        "mcpServers": {
+            "toolsrv": {
+                "command": "node",
+                "args": [
+                    f"{_PLUGIN_ROOT}/start.mjs",
+                    f"--root={_PLUGIN_ROOT}/data",
+                ],
+                "env": {"TOOL_HOME": _PLUGIN_ROOT},
+            }
+        },
+    }
+
+
+def _publish_plugin(tmp_path: Path) -> tuple[Path, DependencyReference, APMPackage]:
+    modules = tmp_path / "apm_modules"
+    modules.mkdir()
+    staging = ResolutionStagingSession(modules)
+    dep_ref = DependencyReference(repo_url="acme/tool", reference="main")
+
+    def download_callback(
+        dependency: DependencyReference,
+        apm_modules_dir: Path,
+        parent_chain: str = "",
+        parent_pkg: APMPackage | None = None,
+    ) -> Path:
+        del parent_chain, parent_pkg
+        replacement = staging.prepare_replacement(dependency.get_install_path(apm_modules_dir))
+        replacement.mkdir(parents=True)
+        (replacement / "plugin.json").write_text(
+            json.dumps(_plugin_manifest()),
+            encoding="utf-8",
+        )
+        (replacement / "start.mjs").write_text("// inert fixture\n", encoding="utf-8")
+        return replacement
+
+    resolver = APMDependencyResolver(
+        apm_modules_dir=modules,
+        download_callback=download_callback,
+        activation_callback=staging.publish_replacement,
+        max_parallel=1,
+    )
+    package = resolver._try_load_dependency_package(dep_ref, parent_chain="acme/parent")
+    assert package is not None
+    staging.commit()
+    return dep_ref.get_install_path(modules).resolve(), dep_ref, package
+
+
+def _assert_published_server(package: APMPackage, live_path: Path) -> dict[str, object]:
+    server = package.get_all_mcp_dependencies()[0]
+    assert server.args == [
+        str(live_path / "start.mjs"),
+        f"--root={live_path}/data",
+    ]
+    assert server.env == {"TOOL_HOME": str(live_path)}
+    assert Path(server.args[0]).is_file()
+    return MCPIntegrator._build_self_defined_info(server)
+
+
+def test_generated_plugin_manifest_survives_publication_and_cached_replay(
+    tmp_path: Path,
+) -> None:
+    live_path, dep_ref, fresh_package = _publish_plugin(tmp_path)
+    generated_manifest = live_path / "apm.yml"
+
+    manifest_text = generated_manifest.read_text(encoding="utf-8")
+    assert _PLUGIN_ROOT in manifest_text
+    assert STAGING_DIR_NAME not in manifest_text
+    fresh_server_info = _assert_published_server(fresh_package, live_path)
+    published_hash = compute_package_hash(live_path)
+
+    cached_resolver = APMDependencyResolver(
+        apm_modules_dir=live_path.parents[1],
+        max_parallel=1,
+    )
+    replayed_package = cached_resolver._try_load_dependency_package(
+        dep_ref,
+        parent_chain="acme/parent",
+    )
+
+    assert replayed_package is not None
+    replayed_server_info = _assert_published_server(replayed_package, live_path)
+    assert replayed_server_info == fresh_server_info
+    assert compute_package_hash(live_path) == published_hash
+
+
+def test_replayed_plugin_writes_lock_claude_and_codex_configs(tmp_path: Path) -> None:
+    live_path, dep_ref, _ = _publish_plugin(tmp_path)
+    cached_resolver = APMDependencyResolver(
+        apm_modules_dir=live_path.parents[1],
+        max_parallel=1,
+    )
+    replayed_package = cached_resolver._try_load_dependency_package(
+        dep_ref,
+        parent_chain="acme/parent",
+    )
+    assert replayed_package is not None
+    server_info = _assert_published_server(replayed_package, live_path)
+    server_cache = {"toolsrv": server_info}
+
+    project = tmp_path / "consumer"
+    (project / ".claude").mkdir(parents=True)
+    claude = ClaudeClientAdapter(project_root=project)
+    codex = CodexClientAdapter(project_root=project)
+    assert claude.configure_mcp_server(
+        "toolsrv",
+        server_name="toolsrv",
+        server_info_cache=server_cache,
+    )
+    assert codex.configure_mcp_server(
+        "toolsrv",
+        server_name="toolsrv",
+        server_info_cache=server_cache,
+    )
+
+    lock = LockFile()
+    locked_dependency = LockedDependency.from_dependency_ref(
+        dep_ref=dep_ref,
+        resolved_commit="a" * 40,
+        depth=2,
+        resolved_by="acme/parent",
+    )
+    locked_dependency.content_hash = compute_package_hash(live_path)
+    lock.add_dependency(locked_dependency)
+    lock.mcp_servers = ["toolsrv"]
+    lock.mcp_configs = {"toolsrv": server_info}
+    lock_path = project / "apm.lock.yaml"
+    lock.write(lock_path)
+
+    claude_config = json.loads((project / ".mcp.json").read_text(encoding="utf-8"))
+    codex_config = tomlkit.parse((project / ".codex" / "config.toml").read_text(encoding="utf-8"))
+    lock_data = load_yaml(lock_path)
+    expected_script = str(live_path / "start.mjs")
+    expected_home = str(live_path)
+
+    lock_server = lock_data["mcp_configs"]["toolsrv"]["_raw_stdio"]
+    assert lock_server["args"][0] == expected_script
+    assert lock_server["env"]["TOOL_HOME"] == expected_home
+    assert lock_data["dependencies"][0]["content_hash"] == compute_package_hash(live_path)
+
+    claude_server = claude_config["mcpServers"]["toolsrv"]
+    assert claude_server["args"][0] == expected_script
+    assert claude_server["env"]["TOOL_HOME"] == expected_home
+
+    codex_server = codex_config["mcp_servers"]["toolsrv"]
+    assert codex_server["args"][0] == expected_script
+    assert codex_server["env"]["TOOL_HOME"] == expected_home
+
+    durable_text = "\n".join(
+        [lock_path.read_text(), json.dumps(claude_config), tomlkit.dumps(codex_config)]
+    )
+    assert STAGING_DIR_NAME not in durable_text

--- a/tests/unit/deps/test_apm_resolver_staging_paths.py
+++ b/tests/unit/deps/test_apm_resolver_staging_paths.py
@@ -1,0 +1,98 @@
+"""Regression tests for issue #2825.
+
+A dependency fetched through the resolution-staging replacement path must be
+recorded at its published ``apm_modules/<owner>/<repo>`` location, never at the
+``.apm-resolution-staging`` path the download landed in.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from apm_cli.deps.apm_resolver import APMDependencyResolver
+from apm_cli.install.resolution_staging import ResolutionStagingSession
+from apm_cli.models.dependency.reference import DependencyReference
+from apm_cli.utils.staging_guard import STAGING_DIR_NAME
+
+_ROOT = "${CLAUDE_PLUGIN_ROOT}"
+_MANIFEST = {
+    "name": "tool",
+    "version": "1.0.0",
+    "dependencies": {
+        "mcp": [
+            {
+                "name": "toolsrv",
+                "registry": False,
+                "transport": "stdio",
+                "command": "node",
+                "args": [
+                    f"{_ROOT}/start.mjs",
+                    f"--root={_ROOT}/data",
+                    f"--search={_ROOT}/a:{_ROOT}/b",
+                ],
+                "env": {"TOOL_HOME": _ROOT, "TOOL_PREFIX": f"PREFIX={_ROOT}"},
+            }
+        ]
+    },
+}
+
+
+def _resolve_through_staging(tmp_path: Path) -> tuple[Path, object]:
+    modules = tmp_path / "apm_modules"
+    modules.mkdir()
+    staging = ResolutionStagingSession(modules)
+    dep_ref = DependencyReference(repo_url="acme/tool", reference="main")
+
+    def download_callback(dependency, apm_modules_dir, parent_chain="", parent_pkg=None):
+        replacement = staging.prepare_replacement(dependency.get_install_path(apm_modules_dir))
+        replacement.mkdir(parents=True, exist_ok=True)
+        (replacement / "apm.yml").write_text(yaml.safe_dump(_MANIFEST), encoding="utf-8")
+        (replacement / "start.mjs").write_text("//\n", encoding="utf-8")
+        return replacement
+
+    resolver = APMDependencyResolver(
+        apm_modules_dir=modules,
+        download_callback=download_callback,
+        activation_callback=staging.publish_replacement,
+        max_parallel=1,
+    )
+    package = resolver._try_load_dependency_package(dep_ref)
+    return dep_ref.get_install_path(modules).resolve(), package
+
+
+def test_staged_download_records_published_package_path(tmp_path: Path) -> None:
+    live_path, package = _resolve_through_staging(tmp_path)
+
+    assert package is not None
+    assert package.package_path == live_path
+    assert STAGING_DIR_NAME not in str(package.package_path)
+
+
+def test_staged_download_records_published_mcp_args(tmp_path: Path) -> None:
+    live_path, package = _resolve_through_staging(tmp_path)
+
+    servers = package.get_all_mcp_dependencies()
+    assert [server.name for server in servers] == ["toolsrv"]
+    server = servers[0]
+    assert server.args[0] == str(live_path / "start.mjs")
+    assert Path(server.args[0]).exists()
+    assert server.env["TOOL_HOME"] == str(live_path)
+
+
+def test_staged_download_rebases_mid_token_and_repeated_roots(tmp_path: Path) -> None:
+    live_path, package = _resolve_through_staging(tmp_path)
+
+    server = package.get_all_mcp_dependencies()[0]
+    assert server.args[1] == f"--root={live_path}/data"
+    assert server.args[2] == f"--search={live_path}/a:{live_path}/b"
+    assert server.env["TOOL_PREFIX"] == f"PREFIX={live_path}"
+
+
+def test_staged_download_leaves_no_staging_reference(tmp_path: Path) -> None:
+    _, package = _resolve_through_staging(tmp_path)
+
+    server = package.get_all_mcp_dependencies()[0]
+    rendered = [*server.args, *server.env.values(), str(package.package_path)]
+    assert not [value for value in rendered if STAGING_DIR_NAME in value]

--- a/tests/unit/install/test_legacy_plugin_compat.py
+++ b/tests/unit/install/test_legacy_plugin_compat.py
@@ -319,7 +319,7 @@ def test_failed_normalization_does_not_partially_mutate_cache(tmp_path: Path) ->
     assert_unchanged(before_external, ArtifactSnapshot.capture(external_prompts))
 
 
-def test_normalization_persists_live_plugin_root_paths(tmp_path: Path) -> None:
+def test_normalization_persists_portable_plugin_root_paths(tmp_path: Path) -> None:
     package = _legacy_cache(tmp_path)
     (package / "plugin.json").write_text(
         (
@@ -341,7 +341,9 @@ def test_normalization_persists_live_plugin_root_paths(tmp_path: Path) -> None:
     manifest = (package / "apm.yml").read_text(encoding="utf-8")
     assert result is not None
     assert ".apm-resolution-staging" not in manifest
-    assert str(package.resolve()) in manifest
+    assert "${CLAUDE_PLUGIN_ROOT}/server" in manifest
+    server = result.get_all_mcp_dependencies()[0]
+    assert server.command == str(package.resolve() / "server")
 
 
 def test_fresh_hash_accepts_only_the_parser_receipt_delta(tmp_path: Path) -> None:

--- a/tests/unit/install/test_staging_path_guard.py
+++ b/tests/unit/install/test_staging_path_guard.py
@@ -1,0 +1,85 @@
+"""Guard tests for issue #2825: never persist a resolution-staging path."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from apm_cli.deps.lockfile import LockFile
+from apm_cli.integration.mcp_integrator import MCPIntegrator
+from apm_cli.models.dependency.mcp import MCPDependency
+from apm_cli.utils.staging_guard import (
+    STAGING_DIR_NAME,
+    StagingPathLeakError,
+    assert_no_staging_paths,
+)
+
+_STAGED_NAME = re.escape(STAGING_DIR_NAME)
+_STAGED_SCRIPT = f"/home/dev/.apm/apm_modules/{STAGING_DIR_NAME}/abc123/replacements/de/start.mjs"
+
+
+def test_lockfile_write_rejects_staging_paths(tmp_path: Path) -> None:
+    lock = LockFile()
+    lock.mcp_servers = ["toolsrv"]
+    lock.mcp_configs = {"toolsrv": {"command": "node", "args": [_STAGED_SCRIPT]}}
+    lockfile_path = tmp_path / "apm.lock.yaml"
+
+    with pytest.raises(StagingPathLeakError, match=_STAGED_NAME):
+        lock.write(lockfile_path)
+
+    assert not lockfile_path.exists()
+
+
+def test_self_defined_server_info_rejects_staging_paths() -> None:
+    dependency = MCPDependency(
+        name="toolsrv",
+        registry=False,
+        transport="stdio",
+        command="node",
+        args=[_STAGED_SCRIPT],
+    )
+
+    with pytest.raises(StagingPathLeakError, match=_STAGED_NAME):
+        MCPIntegrator._build_self_defined_info(dependency)
+
+
+def test_self_defined_server_info_accepts_published_paths() -> None:
+    dependency = MCPDependency(
+        name="toolsrv",
+        registry=False,
+        transport="stdio",
+        command="node",
+        args=["/home/dev/.apm/apm_modules/acme/tool/start.mjs"],
+    )
+
+    info = MCPIntegrator._build_self_defined_info(dependency)
+
+    assert info["_raw_stdio"]["args"] == ["/home/dev/.apm/apm_modules/acme/tool/start.mjs"]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        _STAGED_SCRIPT,
+        Path(_STAGED_SCRIPT),
+        {"args": [_STAGED_SCRIPT]},
+        [{"env": {"TOOL_HOME": _STAGED_SCRIPT}}],
+        {_STAGED_SCRIPT: "value"},
+    ],
+)
+def test_guard_walks_nested_payloads(payload: object) -> None:
+    with pytest.raises(StagingPathLeakError, match=_STAGED_NAME):
+        assert_no_staging_paths(payload, "apm.lock.yaml")
+
+
+def test_guard_error_names_the_offending_field() -> None:
+    payload = {"_raw_stdio": {"command": "node", "args": ["ok", _STAGED_SCRIPT]}}
+
+    with pytest.raises(StagingPathLeakError, match=r"_raw_stdio\.args\[1\] references"):
+        assert_no_staging_paths(payload, "MCP client configuration for 'toolsrv'")
+
+
+def test_guard_allows_clean_payloads() -> None:
+    assert_no_staging_paths({"args": ["/home/dev/.apm/apm_modules/acme/tool/start.mjs"]}, "x")

--- a/tests/unit/install/test_staging_path_guard.py
+++ b/tests/unit/install/test_staging_path_guard.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
 
 import pytest
@@ -16,8 +15,8 @@ from apm_cli.utils.staging_guard import (
     assert_no_staging_paths,
 )
 
-_STAGED_NAME = re.escape(STAGING_DIR_NAME)
 _STAGED_SCRIPT = f"/home/dev/.apm/apm_modules/{STAGING_DIR_NAME}/abc123/replacements/de/start.mjs"
+_REFUSAL = "references the resolution staging directory"
 
 
 def test_lockfile_write_rejects_staging_paths(tmp_path: Path) -> None:
@@ -26,7 +25,7 @@ def test_lockfile_write_rejects_staging_paths(tmp_path: Path) -> None:
     lock.mcp_configs = {"toolsrv": {"command": "node", "args": [_STAGED_SCRIPT]}}
     lockfile_path = tmp_path / "apm.lock.yaml"
 
-    with pytest.raises(StagingPathLeakError, match=_STAGED_NAME):
+    with pytest.raises(StagingPathLeakError, match=_REFUSAL):
         lock.write(lockfile_path)
 
     assert not lockfile_path.exists()
@@ -41,7 +40,7 @@ def test_self_defined_server_info_rejects_staging_paths() -> None:
         args=[_STAGED_SCRIPT],
     )
 
-    with pytest.raises(StagingPathLeakError, match=_STAGED_NAME):
+    with pytest.raises(StagingPathLeakError, match=_REFUSAL):
         MCPIntegrator._build_self_defined_info(dependency)
 
 
@@ -70,7 +69,7 @@ def test_self_defined_server_info_accepts_published_paths() -> None:
     ],
 )
 def test_guard_walks_nested_payloads(payload: object) -> None:
-    with pytest.raises(StagingPathLeakError, match=_STAGED_NAME):
+    with pytest.raises(StagingPathLeakError, match=_REFUSAL):
         assert_no_staging_paths(payload, "apm.lock.yaml")
 
 
@@ -79,6 +78,19 @@ def test_guard_error_names_the_offending_field() -> None:
 
     with pytest.raises(StagingPathLeakError, match=r"_raw_stdio\.args\[1\] references"):
         assert_no_staging_paths(payload, "MCP client configuration for 'toolsrv'")
+
+
+def test_guard_error_does_not_echo_serialized_credentials() -> None:
+    secret = "SYNTHETIC_SECRET_123"
+    payload = f"env:\n  API_TOKEN: {secret}\nargs:\n  - {_STAGED_SCRIPT}\n"
+
+    with pytest.raises(StagingPathLeakError) as exc_info:
+        assert_no_staging_paths(payload, "apm.lock.yaml")
+
+    message = str(exc_info.value)
+    assert secret not in message
+    assert _STAGED_SCRIPT not in message
+    assert "its serialized content references" in message
 
 
 def test_guard_allows_clean_payloads() -> None:

--- a/tests/unit/scripts/test_architecture_runner.py
+++ b/tests/unit/scripts/test_architecture_runner.py
@@ -710,6 +710,7 @@ registry_delegation.runtime_descriptors
 registry_delegation.target_vocabulary
 transport-platform-artifactory-full-commit-sha
 transport-platform-artifactory-netrc-isolation
+transport-platform-clone-connect-retry
 transport-platform-git-cache-identity
 transport-platform-git-child-environment
 transport-platform-git-semver-preflight


### PR DESCRIPTION
## Description

A dependency fetched through the resolution-staging "replacement" path lands in
`<apm_modules>/.apm-resolution-staging/<session>/replacements/...` and is only
moved to its live `apm_modules/<owner>/<repo>` location by
`publish_replacement()`. `APMPackage.from_manifest_data` substitutes
`${CLAUDE_PLUGIN_ROOT}` in the manifest's dependency block against the package
path it is handed, so a package validated while still staged had the staging
directory baked into its self-defined MCP server `command`, `args`, `cwd` and
`env` values.

`APMDependencyResolver._activate_validated_package` already remapped
`package_path` and `source_path` onto the published tree, but left those
already-substituted strings alone. The staging path therefore reached
`apm.lock.yaml`, `~/.claude.json` and `~/.codex/config.toml`. Because the
staging root is deleted when the transaction commits, the MCP server could
never start again (`handshaking with MCP server failed: connection closed`)
while `apm install` kept reporting success.

This PR:

- Rebases the substituted plugin-root strings onto the published path at the
  same point the package paths are remapped, so every recorded path refers to
  `apm_modules/<owner>/<repo>`. `rebase_plugin_root_paths()` lives beside
  `resolve_plugin_root_placeholders()` in `deps/plugin_parser.py`, which owns
  the placeholder contract.
- Preserves `${CLAUDE_PLUGIN_ROOT}` in generated plugin manifests so cached
  replay resolves against the package's current published location rather than
  a deleted staging directory.
- Adds a defensive guard (`utils/staging_guard.py`) that refuses to write a
  lockfile or a client MCP configuration whose values still name
  `.apm-resolution-staging`, so a future regression fails loudly instead of
  persisting a path that is about to be removed. `resolution_staging.py` now
  takes the directory name from that single owner.

The lifecycle regression demonstrates portable generated manifests, published
MCP paths, cached replay, and unchanged fixture content hashes. The separately
reported external-only content-hash mismatch remains unconfirmed; integrity
validation remains strict and generated manifests remain hash-covered.

Fixes #2825

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Maintenance / refactor

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [x] Added tests for new functionality

### Scenario evidence

| User scenario | Evidence | Tier | Principles |
|---|---|---|---|
| A generated plugin manifest survives publication and cached replay without staging paths | `tests/integration/test_resolution_staging_mcp_lifecycle.py::test_generated_plugin_manifest_survives_publication_and_cached_replay` | Integration with fixtures | Portability by manifest, governed by policy, DevX |
| Lockfile plus real Claude and Codex writers persist published package paths and the package content hash | `tests/integration/test_resolution_staging_mcp_lifecycle.py::test_replayed_plugin_writes_lock_claude_and_codex_configs` | Integration with fixtures | Portability by manifest, multi-harness support, governed by policy |
| A staging-path refusal does not expose adjacent serialized credentials | `tests/unit/install/test_staging_path_guard.py::test_guard_error_does_not_echo_serialized_credentials` | Unit | Secure by default, DevX |

Commands run on exact head `330827e14209ec23f2c63fb66916579d0262a092`:

```
uv run --frozen --extra dev pytest -q \
  tests/unit/scripts/test_architecture_runner.py::test_registered_rule_inventory_matches_frozen_semantic_contract \
  tests/unit/install/test_legacy_plugin_compat.py \
  tests/unit/deps/test_apm_resolver_staging_paths.py \
  tests/unit/install/test_staging_path_guard.py \
  tests/integration/test_resolution_staging_mcp_lifecycle.py \
  tests/unit/test_plugin_parser.py \
  tests/integration/test_deps_resolver_resolution.py
  -> 346 passed

uv run --frozen --extra dev ruff check src/ tests/ \
  scripts/lint_architecture_boundaries.py scripts/architecture_linter/
  -> All checks passed!

uv run --frozen --extra dev ruff format --check src/ tests/ \
  scripts/lint_architecture_boundaries.py scripts/architecture_linter/
  -> 1813 files already formatted

uv run --frozen --extra dev python -m pylint --disable=all --enable=R0801 \
  --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/ \
  scripts/lint_architecture_boundaries.py scripts/architecture_linter/
  -> 10.00/10

bash scripts/lint-auth-signals.sh
  -> auth-signal lint clean

bash scripts/lint-architecture-boundaries.sh
  -> clean
```

The YAML-I/O, `relative_to` and file-length guards also passed. All exact-head
GitHub Actions workflows are green.

## Spec conformance (OpenAPM v0.1)

- [ ] Spec edit
- [ ] Manifest edit
- [ ] Test edit
- [ ] `CONFORMANCE.{md,json}` regenerated
- [x] N/A - this restores existing portable plugin-root behavior without changing the OpenAPM contract.

`apm-spec-waiver: restores existing portable plugin-root behavior only`
