### PR TITLE
fix(tests): tolerate Rich wrapping in lifecycle assertions

### DIFF
--- a/tests/integration/test_global_scope_e2e.py
+++ b/tests/integration/test_global_scope_e2e.py
@@ -337,7 +337,7 @@ class TestGlobalManifestPlacement:
         assert result.returncode == 0, combined
         assert "Dry run: Would create" in combined
         assert str(user_manifest) in unwrapped
-        assert local_package.name in combined
+        assert local_package.name in unwrapped
         assert not (fake_home / ".apm").exists()
         assert not (work_dir / "apm.yml").exists()
 

--- a/tests/integration/test_intellij_mcp_config_lifecycle.py
+++ b/tests/integration/test_intellij_mcp_config_lifecycle.py
@@ -682,7 +682,7 @@ def test_uninstall_continues_after_intellij_cleanup_failure(
     assert "managed-server" not in json.loads(vscode_path.read_text(encoding="utf-8"))["servers"]
     output = uninstall.stderr + uninstall.stdout
     assert "Uninstall incomplete" in output
-    assert "run 'apm install'" in output
+    assert "run 'apm install'" in " ".join(output.split())
 
 
 def test_uninstall_preserves_legacy_ownership_for_surviving_server(


### PR DESCRIPTION
## TL;DR

Fix exactly two integration assertions that failed in the Linux ARM release job despite the intended content being present. Two test-only lines change; production output, terminal width, and lifecycle checks are unchanged.

> [!NOTE]
> Follow-up to [release run 33963789015](https://github.com/microsoft/apm/actions/runs/33963789015), tested at `9cb174b2704c0d770110c9af7bf9ae8e24863f31`. No release dispatch, publication, tagging, or merging is included.

## Problem (WHY)

[Job 101301462187](https://github.com/microsoft/apm/actions/runs/33963789015/job/101301462187) printed `local-p\nkg` inside the absolute package path and `run \n'apm install'` in the uninstall recovery instruction. Both raw substring assertions failed even though the intended content was present. The job finished with 2 failed, 9415 passed, 74 skipped, and 2 xfailed.

## Approach (WHAT)

| Assertion | Wrapping-safe comparison |
| :--- | :--- |
| Package identity | Reuse the existing `unwrapped` buffer already used for the manifest path. |
| Recovery command | Reuse the module's `" ".join(output.split())` pattern, retaining the exact `run 'apm install'` expectation. |

## Implementation (HOW)

| File | Change and retained contract |
| :--- | :--- |
| [`test_global_scope_e2e.py:340`](https://github.com/microsoft/apm/blob/44c50fecfde42ddf27656c5328f64fbf411c062a/tests/integration/test_global_scope_e2e.py#L334-L342) | Match the complete package name against `unwrapped`; retain success, preview, manifest identity, and both no-write assertions. |
| [`test_intellij_mcp_config_lifecycle.py`](https://github.com/microsoft/apm/blob/44c50fecfde42ddf27656c5328f64fbf411c062a/tests/integration/test_intellij_mcp_config_lifecycle.py) | Normalize whitespace only for the recovery assertion; retain nonzero exit, incomplete-uninstall diagnostic, and VS Code cleanup checks. Ownership/lifecycle coverage is untouched. |

## Trade-offs

- Normalize assertions locally instead of changing production rendering, widening terminals, or adding a framework.
- Replay exact release captures rather than depend on temporary-path length to reproduce wrapping. No runtime behavior or documentation changes; a diagram adds no useful relationship for these two independent comparisons.

## Benefits

1. Both captured wrapped outputs satisfy their intended semantic assertions.
2. Missing or mutated package/command content still fails.
3. Exactly two assertion lines change; all state, ownership, cleanup, and exit-code checks remain.

## Validation

`APM_BINARY_PATH="$PWD/.venv/bin/apm" uv run --extra dev pytest -q tests/integration/test_global_scope_e2e.py tests/integration/test_intellij_mcp_config_lifecycle.py`

```text
38 passed in 42.15s
```

Local execution used this worktree's installed entrypoint, not a packaged Linux ARM binary. Hosted PR checks are separate from the parent-owned release rerun.

<details><summary>Exact-capture regression and guardrail evidence</summary>

AST-based replay extracted the full output strings from the job log and evaluated old and patched assertions; each case also removed and mutated the semantic content:

```text
test_global_scope_e2e.py: exact CI capture old=FAIL new=PASS; mutated=FAIL missing=FAIL
test_intellij_mcp_config_lifecycle.py: exact CI capture old=FAIL new=PASS; mutated=FAIL missing=FAIL
```

Canonical latest-main lint passed: Ruff check/format, pylint R0801, auth boundaries, YAML I/O, portable paths, and the 2100-line guard. Architecture boundaries and both test-quality ratchets also passed.

```text
All checks passed!
1808 files already formatted
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)
[+] auth-signal lint clean
YAML I/O, portable paths, and 2100-line guards: PASS
[+] assertion-quality ratchet clean: AQ001=4, AQ002=12
[+] exact test duplicate ratchet clean: 1185 files, 0 allowed duplicate group(s)
```

</details>

### Scenario Evidence

| Scenario | Principle | Existing test | Type |
| :--- | :--- | :--- | :--- |
| Global dry-run identifies the package without creating user state | DevX | `tests/integration/test_global_scope_e2e.py::TestGlobalManifestPlacement::test_global_dry_run_with_absent_manifest_does_not_create_user_state` | e2e |
| Failed IntelliJ cleanup still cleans VS Code and gives the exact recovery command | Multi-harness, DevX | `tests/integration/test_intellij_mcp_config_lifecycle.py::test_uninstall_continues_after_intellij_cleanup_failure` | e2e |

## How to test

- [ ] Run both modules with the command above (or set `APM_BINARY_PATH` to the expected packaged artifact).
- [ ] Fetch the failure log with `gh api repos/microsoft/apm/actions/jobs/101301462187/logs --allow-escape-sequences`; confirm `local-p\nkg` and `run \n'apm install'`.
- [ ] Replay those strings: raw assertions fail; patched comparisons pass. Replacing `local-p\nkg` with `other-p\nkg`, replacing `apm install` with `apm uninstall`, or deleting the expected content makes the corresponding patched assertion fail.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>