### PR TITLE
fix(tests): preserve agent-skills fixture bytes on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Write hash-bearing agent-skills test fixtures as UTF-8 bytes so their integrity checks pass on Windows. (by @dajiaohuang, #2830)
+
 ## [0.29.1] - 2026-09-05
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- Write hash-bearing `agent-skills` test fixtures as UTF-8 bytes so their integrity checks pass on Windows. — by @dajiaohuang (#2830)
-
 ## [0.29.1] - 2026-09-05
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Write hash-bearing agent-skills test fixtures as UTF-8 bytes so their integrity checks pass on Windows. (by @dajiaohuang, #2830)
+- Write hash-bearing `agent-skills` test fixtures as UTF-8 bytes so their integrity checks pass on Windows. — by @dajiaohuang (#2830)
 
 ## [0.29.1] - 2026-09-05
 

--- a/tests/integration/test_agent_skills_target.py
+++ b/tests/integration/test_agent_skills_target.py
@@ -66,7 +66,7 @@ def _make_plugin_bundle(
     rel = f"skills/{skill_name}/SKILL.md"
     skill_path = bundle / rel
     skill_path.parent.mkdir(parents=True, exist_ok=True)
-    skill_path.write_text(skill_body, encoding="utf-8")
+    skill_path.write_bytes(skill_body.encode("utf-8"))
 
     bundle_files = {rel: _sha256(skill_body)}
 
@@ -320,7 +320,7 @@ def test_uninstall_agent_skills_cleans_dir(tmp_path: Path, monkeypatch: pytest.M
     skill_rel = f".agents/skills/{SKILL_NAME}/SKILL.md"
     deployed = project / skill_rel
     deployed.parent.mkdir(parents=True, exist_ok=True)
-    deployed.write_text(SKILL_BODY, encoding="utf-8")
+    deployed.write_bytes(SKILL_BODY.encode("utf-8"))
 
     lock = {
         "dependencies": [
@@ -530,7 +530,7 @@ def _make_multi_target_bundle(
     rel = f"skills/{skill_name}/SKILL.md"
     skill_path = bundle / rel
     skill_path.parent.mkdir(parents=True, exist_ok=True)
-    skill_path.write_text(skill_body, encoding="utf-8")
+    skill_path.write_bytes(skill_body.encode("utf-8"))
 
     bundle_files = {rel: _sha256(skill_body)}
     lock_data = {


### PR DESCRIPTION
## Description

Write the three hash-bearing `agent-skills` test fixtures as UTF-8 bytes, so their recorded SHA-256 values describe the files actually written on Windows as well as POSIX.

Fixes #2829.

The two bundle helpers and the uninstall fixture hash an LF string. Native Windows text writes translate that string to CRLF, causing the real integrity verifier to reject the synthetic bundle before target behavior is exercised. This follows the byte-preserving fixture approach in #1108. Product verification, assertions, APIs, dependencies, CI configuration, and user-facing documentation are unchanged.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Maintenance / refactor

## Scenario evidence

| Scenario | Evidence | Principle |
|---|---|---|
| Contributors run the `agent-skills` integration suite without synthetic hash mismatches caused by host newline translation. | `tests/integration/test_agent_skills_target.py`: fixed fixture-only CRLF emulation passes 19/19; restoring the three original text writes under the same emulation fails 15/19 with expected hash `21a859...` versus actual CRLF hash `a06737...`. The uninstall test is one of the four mutant passes and is not claimed as an independent regression trap. | OSS / community-driven portability |

## Testing

- [x] Tested locally
- [x] All existing tests in the changed integration module pass
- [ ] Added tests for new functionality (not applicable: existing tests reproduce the fixture defect)

Author-reported native Windows validation, Python 3.12.13, base `9cb174b2704c0d770110c9af7bf9ae8e24863f31`:

- Before: `test_agent_skills_target.py` had 15 failures and 4 passes.
- After: all 19 pass, including an independent frozen-environment rerun.
- Related local-bundle tests: 165 passed, 3 failed, 2 skipped. One separate collision fixture remains CRLF-sensitive; two tests require symlink privileges unavailable on that host. These are not changed or hidden by this patch.

Shepherd validation on macOS at the current head:

- Deterministic fixture-only CRLF emulation: 19 passed with the fix; restoring the original text writes produced 15 failures and 4 passes with the expected integrity mismatch.
- Full current lint contract passed across source, tests, and architecture scripts, including Ruff, Pylint R0801, YAML/path/file-length safety guards, auth-signal lint, and architecture-boundary lint.
- Native Windows was not rerun by the shepherd; the native Windows results above are the contributor's report.
- The full repository test suite is not claimed green.

Supply-chain review: the patch makes synthetic fixture serialization deterministic without changing raw-byte integrity enforcement or weakening fail-closed behavior. To reproduce, run `uv run --frozen pytest tests/integration/test_agent_skills_target.py -q` on Windows.

## Spec conformance (OpenAPM v0.1)

- [ ] Spec edit
- [ ] Manifest edit
- [ ] Spec test edit
- [ ] Conformance statement regenerated
- [x] N/A -- this PR does not change OpenAPM-observable behaviour.
