### PR TITLE
feat(contracts): add native Copilot leaf execution

### DIFF
--- a/.apm/architecture/owners/contracts-tooling.json
+++ b/.apm/architecture/owners/contracts-tooling.json
@@ -2,6 +2,34 @@
   "version": 1,
   "owners": [
     {
+      "id": "contract-leaf-source",
+      "decision": "Strict leaf contract source selection and planning without legacy fallback",
+      "owner": "contracts/frontend.py with canonical yaml_io and dependency owners",
+      "selectors": ["src/apm_cli/contracts/frontend.py", "src/apm_cli/contracts/imports.py"],
+      "guards": ["contracts-leaf-source"]
+    },
+    {
+      "id": "contract-exact-subject",
+      "decision": "Raw-byte input, baseline and artifact identity for local contracts",
+      "owner": "contracts/workspace.py",
+      "selectors": ["src/apm_cli/contracts/workspace.py"],
+      "guards": ["contracts-leaf-subject"]
+    },
+    {
+      "id": "contract-process-observation",
+      "decision": "Managed contract process creation, cancellation and termination observations",
+      "owner": "contracts/process.py",
+      "selectors": ["src/apm_cli/contracts/process.py"],
+      "guards": ["contracts-leaf-process"]
+    },
+    {
+      "id": "contract-leaf-outcome",
+      "decision": "Contract check normalization, terminal reduction and atomic run records",
+      "owner": "contracts/records.py with outcome vocabulary in contracts/models.py",
+      "selectors": ["src/apm_cli/contracts/records.py", "src/apm_cli/contracts/models.py"],
+      "guards": ["contracts-leaf-outcome"]
+    },
+    {
       "id": "dependency-identity-materialization",
       "decision": "Dependency comparison identity vs display-cased materialization path; embedded git URL subpath validation",
       "owner": "models/dependency/identity.py + materialization.py + DependencyReference (_check_no_embedded_subpath consumes core/host_providers.py)",

--- a/.apm/docs-index.yml
+++ b/.apm/docs-index.yml
@@ -157,6 +157,33 @@ pages:
       flags: [--target, -g]
       schemas: [marketplace.json, settings.local.json, apm-registration.json]
 
+  - path: docs/src/content/docs/consumer/run-contracts.md
+    title: "Run a contract"
+    persona: consumer
+    promise: 1
+    documents_symbols:
+      cli: [apm plan, apm run]
+      flags: [--on, --model, --allow-advisory]
+      schemas: [.contract.md]
+
+  - path: docs/src/content/docs/reference/cli/plan.md
+    title: "apm plan"
+    persona: consumer
+    promise: 1
+    documents_symbols:
+      cli: [apm plan]
+      flags: [--on, --model, --verbose]
+      schemas: [.contract.md, apm.yml.dependencies, apm.lock.yaml]
+
+  - path: docs/src/content/docs/reference/cli/run.md
+    title: "apm run"
+    persona: consumer
+    promise: 1
+    documents_symbols:
+      cli: [apm run]
+      flags: [--param, --verbose, --on, --model, --allow-advisory]
+      schemas: [apm.yml.scripts, .contract.md]
+
   - path: docs/src/content/docs/producer/index.md
     title: "Producer overview"
     persona: producer

--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ WIP/
 skill-plan.md
 skill-strategy.md
 apm_modules/
+.apm/runs/
 build/tmp/
 scout-pipeline-result.png
 .copilot/

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -171,6 +171,7 @@ export default defineConfig({
 						{ label: 'Install packages', slug: 'consumer/install-packages' },
 						{ label: 'Manage dependencies', slug: 'consumer/manage-dependencies' },
 						{ label: 'Run scripts', slug: 'consumer/run-scripts' },
+						{ label: 'Run a contract', slug: 'consumer/run-contracts' },
 						{ label: 'Update and refresh', slug: 'consumer/update-and-refresh' },
 						{ label: 'Install MCP servers', slug: 'consumer/install-mcp-servers' },
 						{ label: 'Install LSP servers', slug: 'consumer/install-lsp-servers' },

--- a/docs/src/content/docs/consumer/run-contracts.md
+++ b/docs/src/content/docs/consumer/run-contracts.md
@@ -1,0 +1,87 @@
+---
+title: Run a contract
+description: Plan and run a local file-producing contract in a disposable workspace.
+sidebar:
+  order: 4
+---
+
+Use a contract when you need one generated file assessed by named checks.
+Existing [scripts](../run-scripts/) still use `apm run` without `--on`.
+
+## Prerequisites
+
+- macOS or Linux, an installed APM build with Contracts v0.1, and native Copilot
+  ready on `PATH` with access to your selected model.
+- Git and Python 3 on `PATH`; this fixture's checker uses only Python's standard
+  library.
+- An independent, disposable, secret-free local workspace with no Git remote or
+  configured policy requirement. Governed or unresolved policy is unsupported.
+
+Native Copilot `1.0.83-5` was exercised with these fixtures; `plan` does not
+probe versions.
+
+**Native execution is not isolated.** Read the
+[host-access, consent, and policy limits](../../reference/cli/run/#native-execution-boundary).
+Do not copy a governed repository or remove its remotes to obtain eligibility.
+
+## Copy the supplied fixture
+
+The APM source checkout supplies `examples/contracts/first-contract/`:
+`apm.yml` (no dependencies), `notes.md`, `handoff.contract.md`, and
+`checks/check_handoff.py`. From that checkout, copy only the authored fixtures
+to a fresh workspace, not the repository:
+
+```bash
+workspace="$(mktemp -d)"
+cp -R examples/contracts/. "$workspace/"
+cd "$workspace/first-contract"
+```
+
+Use your normal installed CLI; no install step is needed for this dependency-free
+fixture. Run from its `apm.yml` directory:
+
+```bash
+apm plan ./handoff.contract.md --on copilot --model gpt-6-astra
+apm run ./handoff.contract.md --on copilot --model gpt-6-astra --allow-advisory
+```
+
+The example explicitly requests `gpt-6-astra`, not an APM default. Requested and
+observed models are recorded separately. A
+[successful plan](../../reference/cli/plan/#read-only-planning) is not a completed
+assessment.
+
+## Inspect the result
+
+The contract asks Copilot to write a JSON array with `source_id`, `summary`,
+and `caution` strings, using the exact IDs in `notes.md`, without executing the
+commands described there. The helper checks JSON shape, exact ID coverage,
+duplicates, and nonempty strings. It does **not** guarantee factual accuracy
+or prose quality.
+
+Follow the reported artifact and record paths under `.apm/runs/<run-id>/`.
+The original project output is not overwritten. Use the
+[outcome table](../../reference/cli/run/#results-and-retained-files) to distinguish
+a failed criterion, missing/incomplete evidence, and an operational stop.
+Inspect private logs locally; they are not guaranteed safe to share.
+
+## Try installed context
+
+The sibling `reuse-contract` fixture declares the supplied local `handoff-style`
+skill and reuses the first fixture's maintained notes and checker. Prepare those
+resources in the copied workspace, then enter the fixture and install explicitly:
+
+```bash
+cd "$workspace"
+mkdir -p reuse-contract/checks
+cp first-contract/notes.md reuse-contract/notes.md
+cp first-contract/checks/check_handoff.py reuse-contract/checks/check_handoff.py
+cd reuse-contract
+apm install --only apm --target copilot
+apm plan ./handoff.contract.md --on copilot --model gpt-6-astra
+apm run ./handoff.contract.md --on copilot --model gpt-6-astra --allow-advisory
+```
+
+This supplies selected context, not trusted pinning or automatic native skill
+activation. See [import eligibility](../../reference/cli/plan/#imported-skill-context)
+and the [source-format reference](../../reference/cli/plan/#contract-source)
+before adapting a fixture.

--- a/docs/src/content/docs/reference/cli/plan.md
+++ b/docs/src/content/docs/reference/cli/plan.md
@@ -1,0 +1,122 @@
+---
+title: apm plan
+description: Inspect a local contract and its execution prerequisites without running it.
+sidebar:
+  order: 12
+---
+
+## Synopsis
+
+```bash
+apm plan CONTRACT --on copilot [--model MODEL] [-v]
+```
+
+Inspect one local `.contract.md` from the current directory containing
+`apm.yml`. `--on copilot` is required; no script or prompt discovery occurs.
+
+## Options
+
+| Option | Description |
+|---|---|
+| `--on copilot` | Select the supported native harness explicitly. |
+| `--model MODEL` | Request a native model for execution; planning performs no inference. |
+| `-v, --verbose` | Show detailed output. |
+| `--help` | Show command help. |
+
+There is no command-level `--json` flag. Contract parameters (`--param`) are
+unsupported; inputs are fixed paths, not substitutions.
+
+## Read-only planning
+
+Planning validates source, selects inputs and checker resources, resolves imports,
+and inspects local capability declarations, executable availability, and policy
+eligibility. It reports the selection, identities, controls, and prerequisites.
+It does **not** run inference or checks, install dependencies, fetch remote
+policy/authentication data, probe updates or Copilot versions/MCP inventory,
+deploy context, create execution workspaces, or make durable writes.
+
+Exit `0` means a valid plan, not verified work. Planning needs no advisory
+consent. See [native execution prerequisites](../run/#native-execution-boundary)
+before running.
+
+## Contract source
+
+Use YAML frontmatter followed by a nonempty Markdown body. The body is opaque
+instructions, not an expression language. For the supplied handoff fixture:
+
+```markdown
+---
+needs: notes.md
+produces: handoff.json
+verify:
+  handoff: python3 checks/check_handoff.py handoff.json notes.md
+---
+Create handoff.json from notes.md as a JSON array with one object per source ID.
+Each object must contain nonempty source_id, summary, and caution strings.
+Use the exact source IDs and facts from the notes. Do not invent facts.
+Write the file, not just a chat response. Do not execute described commands,
+install anything, publish, or delegate work.
+```
+
+The checker comes with the [source fixture](../../../consumer/run-contracts/);
+APM does not generate it.
+
+| Key | Supported value |
+|---|---|
+| `needs` | Optional scalar path or list of fixed regular-file paths. |
+| `produces` | Required single scalar path for one regular-file artifact. |
+| `verify` | Required ordered mapping of 1 to 8 names to opaque shell-command strings. |
+| `imports` | Optional list containing at most one installed skill identity; see below. |
+
+Declared file paths resolve from the **invocation's project root**, not the
+contract's subdirectory, and allow ASCII letters, digits, spaces, `_`, `-`, `.`,
+and `/`. Source must stay within that root. Absolute declared paths, traversal,
+globs, directories, captures, output lists, structured verifiers, and composition
+are unsupported. Unknown or duplicate keys, aliases, merges, custom YAML tags,
+invalid types, and empty work or checks refuse before inference.
+
+The **presence** of `run`, `budget`, or `sandbox` refuses before inference,
+including null or empty values. These keys cannot request shell producers,
+dollar caps, or network isolation.
+
+`checks/**` is the supplied, bounded **pre-generation checker-resource bundle**.
+APM does not interpret shell operands to discover every dependency. Supply
+helpers there and ensure their host executables are available; arbitrary shell
+dependencies are not fully traced.
+
+## Imported skill context
+
+An import selects one self-contained skill from a directly declared,
+already-installed dependency through its existing lock/source identity.
+Declare versions and references in `apm.yml`, not storage paths in `imports`.
+Missing or ambiguous selection refuses; plan and run never auto-install.
+
+APM supplies the selected skill bytes as labeled context, not native automatic
+activation. No transitive dependencies, companion resources, child invocation,
+or tool grants are included. Selection is revalidated before dispatch.
+
+For local packages, the existing lock identity plus the observed exact skill
+bytes is **not pinned or trusted provenance**: the local lock has no locked
+content hash. Eligible Git-backed imports also use existing ref-drift and
+package-hash integrity checks.
+
+## Bounds
+
+| Resource | Limit |
+|---|---|
+| Contract source | 256 KiB |
+| `needs` | 16 files, 16 MiB total, 8 MiB per file |
+| Effective baseline | 10,000 regular files, 128 MiB total, 8 MiB per file |
+| Checker resources | 256 files, 8 MiB total |
+| Artifact | One regular file, 4 MiB |
+| Native protocol frame / retained transcript | 1 MiB / 4 MiB per run |
+
+These are admission and retention bounds, not host quotas. See
+[execution timing and cleanup](../run/#native-execution-boundary) for watchdog
+limits.
+
+## Related
+
+- [Run a contract](../../../consumer/run-contracts/) -- disposable fixture walkthrough.
+- [`apm run`](../run/#contract-execution) -- execution, retained artifacts, and outcomes.
+- [`apm preview`](../preview/) -- script prompt compilation, not contract planning.

--- a/docs/src/content/docs/reference/cli/run.md
+++ b/docs/src/content/docs/reference/cli/run.md
@@ -1,11 +1,12 @@
 ---
 title: apm run
-description: Execute a script defined in apm.yml
+description: Execute a script or explicitly run a local contract on native Copilot.
 sidebar:
   order: 12
 ---
 
-Execute a script defined in the `scripts:` section of `apm.yml`. Modeled on `npm run`: script bodies are shell commands, typically a prompt piped to a runtime CLI (Copilot, Claude, Codex, llm, etc.).
+Execute a shell command from `apm.yml` `scripts:`, npm-style, or explicitly
+select a local contract with `--on copilot`.
 
 :::caution[Experimental]
 The `run` command surface is marked experimental. Flags and behavior may change before 1.0.
@@ -15,13 +16,19 @@ The `run` command surface is marked experimental. Flags and behavior may change 
 
 ```bash
 apm run [SCRIPT_NAME] [OPTIONS]
+apm run CONTRACT --on copilot [--model MODEL] --allow-advisory [-v]
 ```
 
-If `SCRIPT_NAME` is omitted, APM runs the `start` script. If no `start` script is defined, APM exits non-zero and prints the available scripts.
+Without `--on`, omitting `SCRIPT_NAME` runs `start`; if absent, APM exits
+non-zero and lists scripts. All legacy script and prompt behavior below
+remains unchanged, even for script names ending in `.contract.md`.
 
 ## Description
 
-`apm run` resolves `SCRIPT_NAME` against `apm.yml` `scripts:` and executes the matching shell command. Before execution, APM auto-compiles any `.prompt.md` file referenced in the command, substituting `${input:name}` placeholders with values from `--param`. Compiled output is written to `.apm/compiled/<name>.txt` and the final command is executed in the current shell.
+Without `--on`, APM resolves `SCRIPT_NAME` against `scripts:` and runs the
+matching shell command. It first compiles referenced `.prompt.md` files,
+substituting `${input:name}` from `--param` and writing
+`.apm/compiled/<name>.txt`.
 
 If `SCRIPT_NAME` does not match a script, APM falls back to:
 
@@ -36,7 +43,13 @@ If none of these resolve, the command exits non-zero with an error listing the a
 |---|---|
 | `-p, --param NAME=VALUE` | Set a parameter for prompt compilation. Repeat for multiple parameters. |
 | `-v, --verbose` | Show detailed compilation and execution output. |
+| `--on copilot` | Select contract mode; require a local `.contract.md`, without script/prompt discovery or installation. |
+| `--model MODEL` | Request a native model; requires `--on`. |
+| `--allow-advisory` | Accept native-host limits for this contract invocation; requires `--on`. |
 | `--help` | Show help for the command. |
+
+`--param` is rejected in contract mode. `--model` and `--allow-advisory` cannot
+alter legacy scripts. There is no command-level `--json` flag.
 
 ## Examples
 
@@ -90,7 +103,8 @@ $ apm run
 
 ## Argument forwarding
 
-`apm run` does not forward extra positional arguments to the underlying script (there is no `--` passthrough). To parameterize a script, use `--param NAME=VALUE` and reference the value inside your `.prompt.md` file:
+Scripts have no `--` argument passthrough. Use `--param NAME=VALUE` with
+`${input:name}` in a `.prompt.md` file:
 
 ```markdown
 Hello, ${input:name}. Today's target service is ${input:service}.
@@ -102,16 +116,113 @@ Then run:
 apm run start --param name="Alice" --param service=api
 ```
 
-Anything beyond `--param`-style substitution belongs in the script body itself, which is plain shell.
+Other parameterization belongs in the shell script body.
 
-## Exit codes
+## Script exit codes
 
 | Code | Meaning |
 |---|---|
 | `0` | Script executed successfully. |
 | `1` | Script failed, was not found, or no `start` script is defined when invoked without arguments. |
 
+## Contract execution
+
+Run from the current directory containing `apm.yml`. Read the
+[source format and read-only plan](../plan/) first, or follow the
+[disposable fixture walkthrough](../../../consumer/run-contracts/).
+
+### Native execution boundary
+
+- **macOS/Linux only initially.** Windows execution refuses before launch.
+  Native Copilot must be available and ready, with access to the requested
+  model; Git and the check's host executables must be available.
+- **No isolation.** Copilot and checks use your host identity and may access
+  host files, network, and ambient credentials. Native extensions remain
+  outside confinement.
+- **Invocation-only consent.** `--allow-advisory` is required in both terminals
+  and pipes. There is no prompt, saved/global consent, or policy override.
+- **Positively no-policy projects only.** Start with independent local fixtures
+  with no Git remote or configured policy requirement. Governed, unknown, or
+  disabled policy discovery refuses, as does `APM_NO_SCRIPTS`. Never remove
+  remotes or policy to evade a refusal.
+- **Bounded waiting, not confinement.** The whole-attempt watchdog is 1,200
+  seconds; each check gets at most 180 seconds, clipped to the remaining time.
+  Cleanup attempts take at most six seconds and target the original process
+  group. Escaped descendants are not confined.
+
+Run preflight supervises `copilot mcp list --json` without a model, for at most
+10 seconds within the attempt watchdog. APM uses Copilot's merged
+User/Workspace/Plugin/Builtin inventory, not hardcoded config paths.
+Only names are retained, not configuration values; each server is disabled through
+per-invocation `--disable-mcp-server`. Missing, unsupported, malformed, timed-out,
+or uncleanly stopped inventory refuses before the producer (`HALTED`, `22`).
+Planning never runs this inventory.
+
+The producer exposes only `view` and `apply_patch`, with an exact output-file
+write grant and `--no-bash-env`; shell and URL tools are denied.
+
+Package security remains separate: **built-in protection** automatically blocks
+critical findings during `install`, `compile`, and `unpack`, with zero
+configuration. **`apm audit`** is the explicit reporting (SARIF/JSON/markdown),
+remediation (`--strip`), and standalone scanning (`--file`) tool. Contract checks
+do not replace [either layer](../../../enterprise/security/).
+
+### Captured inputs and checks
+
+APM captures effective tracked working bytes, including dirty changes,
+additions, deletions, and executable modes, plus selected untracked source,
+needs, manifest, lock, and checker resources. Original Git `HEAD` alone is not
+the baseline. A non-Git fixture supplies only explicit selections, not arbitrary
+untracked or ignored files.
+
+The producer uses an independent copy without the declared output. APM captures
+the new output and gives each check a fresh baseline, the same frozen artifact,
+and pre-generation `checks/**` resources. It does not use producer-edited helpers
+or a previous check's workspace. If an artifact is a patch, the check applies it;
+the engine **never pre-applies patches**.
+
+Inputs and artifacts retain exact Unicode and raw bytes, including line endings.
+Terminal sanitization does not rewrite them.
+
+### Results and retained files
+
+Artifacts stay in `.apm/runs/<run-id>/artifacts/`, never over the original project
+output. The run directory contains `record.json` and private logs. Requested and
+observed models are separate; unobserved model/usage values remain unknown.
+
+Raw check exits `0`, `1`, and `2` mean pass, failure, and incomplete. Unknown
+statuses, missing tools, signals, or invalid subject/resource identity mean
+incomplete. A per-check timeout is incomplete unless the attempt watchdog
+expires. Empty stderr does not negate exit `1`.
+
+Apply these outcomes in order:
+
+| Code | Outcome | Meaning |
+|---|---|---|
+| `22` | `HALTED` | Operational stop, cancellation, whole-attempt watchdog, capture-integrity, cleanup, or final-recording failure. |
+| `20` | `REJECTED` | A substantive check exits `1`, including when another check is incomplete. |
+| `21` | `UNPROVEN` | Missing artifact, required incomplete check, or unavailable consent/assurance, with no preceding outcome. |
+| `0` | `VERIFIED` | Fresh artifact, all checks pass, accepted advisory controls, and completed record. |
+
+A lingering check child yields `HALTED`, even if subsequent cleanup succeeds.
+
+A missing artifact is not checked to manufacture rejection. Invalid source or
+a missing executable is a preflight `HALTED` diagnostic; unsupported assurance
+is `UNPROVEN`. CLI argument errors retain normal usage handling. Refusal before
+admission does not claim a run exists. A nonterminal record means incomplete or
+unknown, never permission to replay automatically.
+
+Terminal output is one append-only phase stream with bounded, attributed,
+untrusted activity and stderr. Controls are sanitized; private logs are
+retrievable, not guaranteed secret-free or safe to publish. A stop request is
+reported separately from observed original-group termination or uncertainty.
+
+`VERIFIED` means the declared checks passed under native-advisory controls,
+not prose correctness, merge approval, or protected attestation. There is no
+dollar cap, cache, retry/resume, composition, or delivery facility.
+
 ## Related
 
+- [`apm plan`](../plan/) -- inspect a contract without execution or durable writes.
 - [`apm list`](../list/) -- show installed primitives and available scripts.
 - [`apm preview`](../preview/) -- render the compiled command and prompt files without executing.

--- a/examples/contracts/README.md
+++ b/examples/contracts/README.md
@@ -1,0 +1,67 @@
+# First local contracts
+
+These are authored, secret-free fixtures, not copies of a governed project.
+Copy this directory to a fresh disposable directory outside another Git
+repository. Use an installed APM build containing Contracts v0.1, Python 3,
+and an authenticated native Copilot CLI with access to your selected model.
+Do not remove a project's remotes or policy to make it eligible.
+
+## Produce and assess a handoff
+
+From the copied `first-contract/` directory:
+
+```sh
+apm plan ./handoff.contract.md --on copilot --model gpt-6-astra
+apm run ./handoff.contract.md --on copilot --model gpt-6-astra --allow-advisory
+```
+
+The model is an explicit demonstration selection, not an APM default.
+Planning does not call a model, install packages or execute checks.
+`--allow-advisory` is required in terminals and pipes, with no prompt or
+remembered consent. Native processes use your host identity: this is not
+filesystem/network isolation or a hard spending cap.
+
+Inspect the artifact and record paths printed by APM. The captured handoff
+lives under `.apm/runs/<run-id>/`, not over an existing `handoff.json` in your
+project. The standard-library-only checker assesses JSON shape and source-ID
+coverage, not the complete factual correctness or quality of the prose.
+
+## Reuse an installed skill
+
+The second fixture shares the first fixture's source notes and parameterized
+checker. From the copied examples directory, prepare its explicit resources:
+
+```sh
+mkdir -p reuse-contract/checks
+cp first-contract/notes.md reuse-contract/notes.md
+cp first-contract/checks/check_handoff.py reuse-contract/checks/check_handoff.py
+cd reuse-contract
+apm install --only apm --target copilot
+apm plan ./handoff.contract.md --on copilot --model gpt-6-astra
+apm run ./handoff.contract.md --on copilot --model gpt-6-astra --allow-advisory
+```
+
+Installation is a separate, explicit action. The contract names the declared
+`handoff-style` skill, not an `apm_modules/` path. APM supplies its selected
+content without invoking another agent or granting tools. The extra check
+assesses its caution format. Local lock identity plus observed source bytes
+does not establish a cryptographic pin or protected provenance.
+
+## Read outcomes literally
+
+| Outcome | Meaning in this slice |
+| --- | --- |
+| VERIFIED / 0 | Captured output passed every required check under accepted native-advisory controls. |
+| REJECTED / 20 | A check returned a failed condition, even if another check was incomplete. |
+| UNPROVEN / 21 | Output or assessment is missing/incomplete, or required consent/assurance is unavailable. |
+| HALTED / 22 | Execution, cancellation, watchdog, capture or recording stopped the invocation. |
+
+Raw check exits are retained: 0 passes, 1 fails, 2 is incomplete; unknown exits,
+missing tools and signals are incomplete. No output does not mean `no_change`.
+Every check gets a fresh baseline and the captured file. Patch checks apply
+their own patch; APM does not apply it first.
+
+The first profile supports macOS/Linux and positively established no-policy
+projects. Governed/unresolved-policy projects, Windows execution, command
+leaves, `budget`, `sandbox`, captures, output alternatives and composed jobs
+refuse before inference. Passing checks never authorizes merge or delivery.

--- a/examples/contracts/first-contract/apm.yml
+++ b/examples/contracts/first-contract/apm.yml
@@ -1,0 +1,4 @@
+name: contracts-first-run
+version: 0.1.0
+dependencies:
+  apm: []

--- a/examples/contracts/first-contract/checks/check_handoff.py
+++ b/examples/contracts/first-contract/checks/check_handoff.py
@@ -1,0 +1,48 @@
+"""Assess JSON shape and source coverage, not complete prose correctness."""
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+
+def assess(output: Path, notes: Path, caution_prefix: str = "") -> tuple[int, str]:
+    """Return the contract check protocol: pass 0, failed 1, incomplete 2."""
+    try:
+        source = notes.read_text(encoding="utf-8")
+        candidate = json.loads(output.read_text(encoding="utf-8"))
+    except (OSError, ValueError, RecursionError):
+        return 2, "Could not read the source notes or parse the candidate JSON."
+    expected = re.findall(r"^- ([a-z][a-z0-9_-]*): ", source, flags=re.MULTILINE)
+    if not expected or len(set(expected)) != len(expected):
+        return 2, "Source notes need unique '- source_id: fact' entries."
+    if not isinstance(candidate, list):
+        return 1, "The handoff must be a JSON array."
+    actual = []
+    for item in candidate:
+        if not isinstance(item, dict) or set(item) != {"source_id", "summary", "caution"}:
+            return 1, "Every item must contain exactly source_id, summary and caution."
+        if any(not isinstance(value, str) or not value.strip() for value in item.values()):
+            return 1, "Every handoff value must be a nonempty string."
+        if caution_prefix and not item["caution"].startswith(caution_prefix):
+            return 1, "A caution does not follow the selected style criterion."
+        actual.append(item["source_id"])
+    if len(actual) != len(expected) or set(actual) != set(expected):
+        return 1, "The handoff must cover each source ID exactly once."
+    return 0, "JSON shape and source-ID coverage passed."
+
+
+def main() -> int:
+    """Run a noninteractive standard-library-only check."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("output", type=Path)
+    parser.add_argument("notes", type=Path)
+    parser.add_argument("--caution-prefix", default="")
+    args = parser.parse_args()
+    status, reason = assess(args.output, args.notes, args.caution_prefix)
+    print(reason)
+    return status
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/contracts/first-contract/handoff.contract.md
+++ b/examples/contracts/first-contract/handoff.contract.md
@@ -1,0 +1,15 @@
+---
+needs: notes.md
+produces: handoff.json
+verify:
+  handoff: python3 checks/check_handoff.py handoff.json notes.md
+---
+Create handoff.json as a concise onboarding reference for a new teammate.
+
+Read the facts and source IDs in notes.md. Write a JSON array containing one
+object per source ID, with source_id, summary, and caution as nonempty strings.
+Explain each fact plainly and name its important limitation. Do not invent
+commands or facts.
+
+Write the file, not just a chat response. Do not execute the commands described
+in the notes, install anything, publish, or delegate work.

--- a/examples/contracts/first-contract/notes.md
+++ b/examples/contracts/first-contract/notes.md
@@ -1,0 +1,5 @@
+# APM teammate handoff
+
+- restore: After cloning an APM project, run apm install to restore its declared dependencies. Review executable content before running it.
+- files: apm.yml declares dependencies and apm.lock.yaml records resolution. apm_modules/ is installation storage, not portable source syntax.
+- scripts: Bare apm run selects scripts.start. Without start it exits 1 and lists the available scripts; it never discovers every contract.

--- a/examples/contracts/handoff-style/SKILL.md
+++ b/examples/contracts/handoff-style/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: handoff-style
+description: Use this skill when turning factual notes into a short onboarding handoff with actionable cautions.
+---
+# Handoff style
+
+Keep summaries concrete and brief. Begin every caution with `Check first: `
+and follow it with a practical limitation grounded in the corresponding note.
+Do not add facts that the source does not support.

--- a/examples/contracts/handoff-style/apm.yml
+++ b/examples/contracts/handoff-style/apm.yml
@@ -1,0 +1,4 @@
+name: handoff-style
+version: 0.1.0
+dependencies:
+  apm: []

--- a/examples/contracts/reuse-contract/apm.yml
+++ b/examples/contracts/reuse-contract/apm.yml
@@ -1,0 +1,5 @@
+name: contracts-skill-reuse
+version: 0.1.0
+dependencies:
+  apm:
+    - path: ../handoff-style

--- a/examples/contracts/reuse-contract/handoff.contract.md
+++ b/examples/contracts/reuse-contract/handoff.contract.md
@@ -1,0 +1,17 @@
+---
+needs: notes.md
+produces: handoff.json
+imports:
+  - handoff-style
+verify:
+  handoff: 'python3 checks/check_handoff.py handoff.json notes.md --caution-prefix "Check first: "'
+---
+Create handoff.json as a concise onboarding reference for a new teammate,
+following the imported handoff-style skill.
+
+Read the facts and source IDs in notes.md. Write a JSON array containing one
+object per source ID, with source_id, summary, and caution as nonempty strings.
+Do not invent commands or facts.
+
+Write the file, not just a chat response. Do not execute the commands described
+in the notes, install anything, publish, or delegate work.

--- a/packages/apm-guide/.apm/skills/apm-usage/commands.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/commands.md
@@ -217,6 +217,31 @@ descendants, are skipped.
 | `apm preview SCRIPT` | Preview script without running | `-p name=value` |
 | `apm list` | List available scripts | -- |
 
+## Local contracts (v0.1)
+
+```bash
+apm plan CONTRACT --on copilot [--model MODEL] [-v]
+apm run CONTRACT --on copilot [--model MODEL] --allow-advisory [-v]
+```
+
+`--on` selects local `.contract.md` mode. Without it, bare `start`, named scripts
+(even `.contract.md` names), and prompt fallback are unchanged. Contracts reject
+`--param`; `--model` and `--allow-advisory` require `--on`. No command-level
+`--json` flag.
+
+Plan performs local reads only: no inference, checks, install, remote fetch,
+update/version/MCP probe, execution workspace, or durable writes. Run initially requires
+macOS/Linux, ready Copilot, a positively no-policy local/no-remote project, and
+invocation-only `--allow-advisory` in both TTY and pipes. Native host execution
+is not isolated; consent cannot override policy. Never remove remotes to bypass
+eligibility.
+
+Artifacts stay under `.apm/runs/<id>/artifacts/`, not the original output path.
+Use the [run reference](https://microsoft.github.io/apm/reference/cli/run/#results-and-retained-files)
+for `VERIFIED` 0, `REJECTED` 20, `UNPROVEN` 21, and `HALTED` 22 precedence.
+See [contract authoring](./package-authoring.md#local-contract-source-v01) for
+the bounded source format.
+
 ## Security and audit
 
 | Command | Purpose | Key flags |

--- a/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
@@ -579,6 +579,27 @@ target is present. Authoring rules:
   package (the legacy `bin_deploy` rule remains a deprecated alias).
   See the [policy schema](../../../../../docs/src/content/docs/reference/policy-schema.md#executables).
 
+## Local contract source (v0.1)
+
+A local `.contract.md` has YAML frontmatter and a nonempty Markdown body:
+optional fixed-file `needs`, one scalar regular-file `produces`, 1 to 8 named
+opaque shell strings in `verify`, and optionally one directly declared,
+already-installed self-contained skill in an `imports` list. Paths are relative to
+the invocation's `apm.yml` directory, not the contract directory.
+
+The **presence** of `run`, `budget`, or `sandbox` is unsupported, even null.
+No captures, output lists, globs, directories, structured verifiers, composition,
+transitive imports, companion resources, child invocation, or grants.
+`checks/**` supplies pre-generation checker resources; arbitrary shell
+dependencies are not fully traced. Exact Unicode/raw input and artifact bytes
+are retained; terminal escaping does not require ASCII-only content.
+
+Keep versions in `apm.yml`. Existing local lock identity plus observed skill
+bytes is not pinned/trusted provenance. Eligible Git imports use existing
+integrity checks. See the canonical [source and import reference](https://microsoft.github.io/apm/reference/cli/plan/#contract-source)
+and [commands](./commands.md#local-contracts-v01); this is not an additional
+install-time discovery layout.
+
 ## Canvas extensions (experimental, Copilot-only)
 
 Behind the `canvas` experimental flag (`apm experimental enable canvas`), a

--- a/scripts/architecture_linter/checks/contract_leaf_runtime.py
+++ b/scripts/architecture_linter/checks/contract_leaf_runtime.py
@@ -1,0 +1,76 @@
+"""Keep leaf contracts outside legacy fallback and duplicate authorities."""
+
+from scripts.architecture_linter.facts import FactsProvider
+from scripts.architecture_linter.groups.common import checked_facts, inventory_paths, violation
+from scripts.architecture_linter.models import Rule, Violation
+
+RULE_ID = "contracts-leaf-runtime-owners"
+PREFIX = "src/apm_cli/contracts/"
+GUARDS = (
+    "contracts-leaf-source",
+    "contracts-leaf-subject",
+    "contracts-leaf-process",
+    "contracts-leaf-outcome",
+)
+
+
+def check_contract_owners(provider: FactsProvider) -> tuple[Violation, ...]:
+    """Reject dangerous bypasses using the existing shared syntax facts."""
+    findings: list[Violation] = []
+    for path in inventory_paths(provider, prefixes=(PREFIX,)):
+        if not path.endswith(".py"):
+            continue
+        facts, failures = checked_facts(provider, path, RULE_ID, require_python=True)
+        findings.extend(failures)
+        if failures:
+            continue
+        for imported in facts.imports:
+            if (imported.module and imported.module.rsplit(".", 1)[-1] == "script_runner") or any(
+                name in {"ScriptRunner", "PromptCompiler"} for name in imported.names
+            ):
+                findings.append(
+                    violation(
+                        RULE_ID,
+                        path,
+                        "Contracts must not enter legacy prompt discovery, installation or compilation.",
+                        line=imported.line,
+                    )
+                )
+        for call in facts.calls:
+            name = call.qualname.rsplit(".", 1)[-1]
+            message = None
+            if name == "Popen" and path != PREFIX + "process.py":
+                message = "Managed contract child creation belongs to contracts/process.py."
+            elif name == "compute_file_hash":
+                message = "Exact contract subjects must not use normalized deployment hashes."
+            elif name in {"ScriptRunner", "PromptCompiler", "get_best_available_runtime"}:
+                message = (
+                    "Contracts require explicit source/runtime selection without legacy fallback."
+                )
+            if message:
+                findings.append(violation(RULE_ID, path, message, line=call.line))
+        for definition in facts.definitions:
+            if (
+                definition.name in {"normalize_check", "reduce_outcome"}
+                and path != PREFIX + "records.py"
+            ):
+                findings.append(
+                    violation(
+                        RULE_ID,
+                        path,
+                        "Contract check normalization and outcome reduction belong to records.py.",
+                        line=definition.line,
+                    )
+                )
+    return tuple(findings)
+
+
+RULES = (
+    Rule(
+        id=RULE_ID,
+        group="contracts_tests",
+        guard_ids=GUARDS,
+        description="Leaf source, exact subjects, process supervision and outcomes keep canonical owners.",
+        check=check_contract_owners,
+    ),
+)

--- a/scripts/architecture_linter/groups/contracts_tests.py
+++ b/scripts/architecture_linter/groups/contracts_tests.py
@@ -8,6 +8,10 @@ trees live in sibling modules purely so no single check module outgrows the
 module size budget; they own no RULES of their own.
 """
 
-from scripts.architecture_linter.checks.contracts_test_taxonomy import COLLECTORS, RULES
+from scripts.architecture_linter.checks.contract_leaf_runtime import RULES as LEAF_RULES
+from scripts.architecture_linter.checks.contracts_test_taxonomy import COLLECTORS
+from scripts.architecture_linter.checks.contracts_test_taxonomy import RULES as EXISTING_RULES
+
+RULES = (*EXISTING_RULES, *LEAF_RULES)
 
 __all__ = ["COLLECTORS", "RULES"]

--- a/src/apm_cli/cli.py
+++ b/src/apm_cli/cli.py
@@ -43,6 +43,7 @@ from apm_cli.commands.marketplace import search as marketplace_search
 from apm_cli.commands.mcp import mcp
 from apm_cli.commands.outdated import outdated as outdated_cmd
 from apm_cli.commands.pack import pack_cmd, unpack_cmd
+from apm_cli.commands.plan import plan
 from apm_cli.commands.plugin import plugin as plugin_cmd
 from apm_cli.commands.policy import policy
 from apm_cli.commands.prune import prune
@@ -173,6 +174,13 @@ def cli(ctx, verbose: bool) -> None:
     if (
         not ctx.resilient_parsing
         and ctx.invoked_subcommand is not None
+        and ctx.invoked_subcommand != "plan"
+        and not (
+            ctx.invoked_subcommand == "run"
+            and any(
+                arg == "--on" or arg.startswith("--on=") for arg in ctx.meta.get("apm_raw_args", ())
+            )
+        )
         and ctx.command.get_command(ctx, ctx.invoked_subcommand) is not None
     ):
         _check_and_notify_updates()
@@ -208,6 +216,7 @@ cli.add_command(self_update)
 cli.add_command(plugin_cmd, name="plugin")
 cli.add_command(compile_cmd, name="compile")
 cli.add_command(run)
+cli.add_command(plan)
 cli.add_command(preview)
 cli.add_command(list_cmd, name="list")
 cli.add_command(config)

--- a/src/apm_cli/commands/contracts.py
+++ b/src/apm_cli/commands/contracts.py
@@ -1,0 +1,59 @@
+"""Shared command boundary for explicit contracts, never script fallback."""
+
+from pathlib import Path
+
+import click
+
+
+def invoke_contract(
+    ctx: click.Context,
+    contract: str,
+    *,
+    harness: str,
+    model: str | None,
+    verbose: bool,
+    planning: bool,
+    allow_advisory: bool = False,
+) -> None:
+    """Plan or execute one leaf using the contract-specific error boundary."""
+    from ..contracts import frontend, workspace
+    from ..contracts.models import ContractError, Outcome
+    from ..core.contract_logger import ContractLogger
+
+    logger = ContractLogger(verbose=verbose)
+    try:
+        plan = frontend.plan_contract(
+            Path(contract),
+            Path.cwd(),
+            harness=harness,
+            model=model,
+        )
+        inventory = workspace.inspect_workspace(plan)
+        if planning:
+            logger.render_plan(plan, inventory)
+            return
+        from ..contracts.engine import run_contract
+
+        result = run_contract(plan, logger=logger, allow_advisory=allow_advisory)
+        ctx.exit(int(result.outcome))
+    except ContractError as exc:
+        logger.render_error(exc)
+        ctx.exit(int(exc.outcome))
+    except KeyboardInterrupt:
+        logger.render_error(
+            ContractError(
+                "Contract command interrupted. Inspect any printed run record before retrying.",
+                code="cancelled",
+            )
+        )
+        ctx.exit(int(Outcome.HALTED))
+    except OSError as exc:
+        logger.render_error(
+            ContractError(
+                f"Contract filesystem operation failed: {exc}. Inspect permissions and available space.",
+                code="filesystem_error",
+            )
+        )
+        ctx.exit(int(Outcome.HALTED))
+    finally:
+        logger.close()

--- a/src/apm_cli/commands/plan.py
+++ b/src/apm_cli/commands/plan.py
@@ -1,0 +1,29 @@
+"""Read-only contract planning."""
+
+import click
+
+from .contracts import invoke_contract
+
+
+@click.command(help="Inspect a contract without inference, installation or execution")
+@click.argument("contract")
+@click.option("--on", "harness", required=True, help="Explicit execution harness (copilot)")
+@click.option("--model", default=None, help="Native model selection; no inference during planning")
+@click.option("--verbose", "-v", is_flag=True, help="Show detailed output")
+@click.pass_context
+def plan(
+    ctx: click.Context,
+    contract: str,
+    harness: str,
+    model: str | None,
+    verbose: bool,
+) -> None:
+    """Explain one local .contract.md and its native-advisory prerequisites."""
+    invoke_contract(
+        ctx,
+        contract,
+        harness=harness,
+        model=model,
+        verbose=verbose or bool(ctx.find_root().obj and ctx.find_root().obj.get("verbose")),
+        planning=True,
+    )

--- a/src/apm_cli/commands/run.py
+++ b/src/apm_cli/commands/run.py
@@ -17,13 +17,49 @@ from ._helpers import (
 )
 
 
-@click.command(help="Run a script with parameters (experimental)")
+@click.command(help="Run a script, or an explicit contract with --on copilot")
 @click.argument("script_name", required=False)
 @click.option("--param", "-p", multiple=True, help="Parameter in format name=value")
 @click.option("--verbose", "-v", is_flag=True, help="Show detailed output")
+@click.option(
+    "--on", "harness", default=None, help="Select contract mode and its execution harness"
+)
+@click.option("--model", default=None, help="Native model for contract mode only")
+@click.option(
+    "--allow-advisory",
+    is_flag=True,
+    help="Consent to this native contract run without isolation; does not override policy",
+)
 @click.pass_context
-def run(ctx, script_name, param, verbose):
-    """Run a script from apm.yml (uses 'start' script if no name specified)."""
+def run(
+    ctx: click.Context,
+    script_name: str | None,
+    param: tuple[str, ...],
+    verbose: bool,
+    harness: str | None = None,
+    model: str | None = None,
+    allow_advisory: bool = False,
+) -> None:
+    """Run scripts unchanged, or select one .contract.md explicitly with --on."""
+    if harness is not None:
+        if not script_name:
+            raise click.UsageError("Contract mode requires a .contract.md path.", ctx)
+        if param:
+            raise click.UsageError("--param applies to scripts, not fixed-path contracts.", ctx)
+        from .contracts import invoke_contract
+
+        invoke_contract(
+            ctx,
+            script_name,
+            harness=harness,
+            model=model,
+            verbose=verbose or bool(ctx.find_root().obj and ctx.find_root().obj.get("verbose")),
+            planning=False,
+            allow_advisory=allow_advisory,
+        )
+        return
+    if model is not None or allow_advisory:
+        raise click.UsageError("--model and --allow-advisory require contract mode (--on).", ctx)
     logger = CommandLogger("run", verbose=verbose)
     try:
         # If no script name specified, use 'start' script

--- a/src/apm_cli/contracts/__init__.py
+++ b/src/apm_cli/contracts/__init__.py
@@ -1,0 +1,1 @@
+"""Explicit, local agent-contract execution."""

--- a/src/apm_cli/contracts/engine.py
+++ b/src/apm_cli/contracts/engine.py
@@ -1,0 +1,266 @@
+"""One per-command conductor for a captured, assessed agent leaf."""
+
+import shutil
+import time
+from dataclasses import replace
+
+from ..core.contract_logger import ContractLogger
+from ..runtime.factory import RuntimeFactory
+from . import frontend, process, records, workspace
+from .events import EventEmitter
+from .models import (
+    Artifact,
+    BaselineSnapshot,
+    CheckObservation,
+    ContractError,
+    LeafPlan,
+    Outcome,
+    ProcessObservation,
+    ProcessRequest,
+    RunResult,
+)
+from .stream import ContractStreamDecoder
+
+
+def _remaining(deadline: float) -> float:
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise ContractError("The attempt watchdog expired.", code="attempt_deadline")
+    return remaining
+
+
+def _producer_failure(observation: ProcessObservation) -> str | None:
+    if observation.stop_reason:
+        return observation.stop_reason
+    if not observation.cleanup_confirmed:
+        return "producer_stop_unconfirmed"
+    if observation.error or observation.returncode != 0:
+        return "producer_failed"
+    return None
+
+
+def _run_checks(
+    plan: LeafPlan,
+    snapshot: BaselineSnapshot,
+    artifact: Artifact,
+    store: records.AttemptStore,
+    events: EventEmitter,
+    deadline: float,
+    observations: list[CheckObservation],
+) -> str | None:
+    """Run every eligible criterion against an independent captured subject."""
+    shell = shutil.which("sh")
+    for check in plan.contract.checks:
+        _remaining(deadline)
+        events.emit("check_started", name=check.name)
+        check_root = workspace.prepare_check_workspace(
+            snapshot, artifact, store.directory, check.name
+        )
+        integrity_ok = workspace.verify_check_integrity(snapshot, artifact, check_root)
+        decoder = ContractStreamDecoder(
+            events,
+            limits=plan.limits,
+            source="checker",
+            label=check.name,
+            json_stdout=False,
+        )
+        if not integrity_ok:
+            observation = ProcessObservation(
+                returncode=None, error="The supplied subject or check resources changed."
+            )
+        elif shell is None:
+            observation = ProcessObservation(
+                returncode=None, error="Required check shell 'sh' was not found on PATH."
+            )
+        else:
+            store.update("checks", active_check=check.name)
+            request = ProcessRequest(
+                argv=(shell, "-c", check.command),
+                cwd=check_root,
+                timeout_seconds=min(plan.limits.check_seconds, _remaining(deadline)),
+            )
+            observation = process.supervise_process(
+                request,
+                on_bytes=decoder.feed,
+                on_started=lambda pid, pgid, name=check.name: store.update(
+                    "checks", active_check=name, child_pid=pid, child_pgid=pgid
+                ),
+                events=events,
+                limits=plan.limits,
+            )
+        decoder.finish()
+        integrity_ok = integrity_ok and workspace.verify_check_integrity(
+            snapshot, artifact, check_root
+        )
+        normalized = records.normalize_check(observation, integrity_ok=integrity_ok)
+        reason = (
+            observation.error
+            or observation.stop_reason
+            or (
+                f"Check '{check.name}' exited {observation.returncode}."
+                if integrity_ok
+                else "The supplied subject or check resources changed."
+            )
+        )
+        checked = CheckObservation(
+            name=check.name,
+            command=check.command,
+            process=observation,
+            normalized=normalized,
+            subject_digest=artifact.sha256,
+            resources_digest=snapshot.resources_digest,
+            reason=reason,
+        )
+        observations.append(checked)
+        store.update("checks", checks=tuple(observations), active_check=None)
+        events.emit("check_finished", observation=checked)
+        if observation.stop_reason and observation.stop_reason != "timeout":
+            return observation.stop_reason
+        if not observation.cleanup_confirmed:
+            return "checker_stop_unconfirmed"
+        if time.monotonic() >= deadline:
+            return "attempt_deadline"
+    return None
+
+
+def run_contract(
+    plan: LeafPlan,
+    *,
+    logger: ContractLogger,
+    allow_advisory: bool = False,
+) -> RunResult:
+    """Admit, execute, capture, assess and atomically record one fresh run."""
+    if not allow_advisory:
+        raise ContractError(
+            "Native execution is not isolated. Run again with --allow-advisory "
+            "only if host filesystem, network and ambient credential access are acceptable. "
+            "This consent does not override policy.",
+            code="advisory_consent_required",
+            outcome=Outcome.UNPROVEN,
+        )
+    current_plan = frontend.plan_contract(
+        plan.contract.path,
+        plan.project_root,
+        harness=plan.harness,
+        model=plan.model,
+        limits=plan.limits,
+    )
+    if current_plan != plan:
+        raise ContractError(
+            "Contract source, installed context or native prerequisites changed. Plan again.",
+            code="plan_changed",
+        )
+    store = records.AttemptStore.create(plan)
+    events = EventEmitter(store.run_id, logger.on_event)
+    artifact: Artifact | None = None
+    checks: list[CheckObservation] = []
+    stop_reason: str | None = None
+    observed_models: tuple[str, ...] = ()
+    deadline = time.monotonic() + plan.limits.attempt_seconds
+    try:
+        logger.attach_run(store.run_id, store.directory)
+        events.emit(
+            "selected",
+            contract=str(plan.contract.path),
+            harness=plan.harness,
+            model=plan.model,
+            run_directory=str(store.directory),
+        )
+        events.emit("phase", name="preflight")
+        store.update("preflight", advisory_consent="flag")
+        snapshot = workspace.capture_workspace(plan, store.directory)
+        store.update("execution", baseline=snapshot)
+        events.emit("phase", name="execution")
+        runtime = RuntimeFactory.get_runtime_by_name(plan.harness, plan.model)
+        request = runtime.build_contract_request(
+            plan, snapshot, store.directory, timeout_seconds=_remaining(deadline)
+        )
+        request = replace(
+            request, timeout_seconds=min(request.timeout_seconds, _remaining(deadline))
+        )
+        store.update("execution", native_controls=request.control_observations)
+        decoder = ContractStreamDecoder(events, limits=plan.limits)
+        producer = process.supervise_process(
+            request,
+            on_bytes=decoder.feed,
+            on_started=lambda pid, pgid: store.update("execution", child_pid=pid, child_pgid=pgid),
+            events=events,
+            limits=plan.limits,
+        )
+        decoder.finish()
+        observed_models = tuple(decoder.observed_models)
+        store.update(
+            "execution",
+            producer=producer,
+            observed_models=observed_models,
+            native_reported_exit_code=decoder.native_exit_code,
+        )
+        stop_reason = _producer_failure(producer)
+        if decoder.native_exit_code not in (None, 0):
+            stop_reason = stop_reason or "native_reported_failure"
+        if decoder.protocol_error:
+            stop_reason = stop_reason or "native_protocol_error"
+            events.emit(
+                "diagnostic",
+                severity="error",
+                message=decoder.protocol_error,
+                action="Inspect the retained native transcript before retrying.",
+            )
+        if not stop_reason and not decoder.completion_seen:
+            stop_reason = "native_completion_unobserved"
+        if stop_reason:
+            events.emit(
+                "diagnostic",
+                severity="error",
+                message=producer.error or f"Native execution did not complete: {stop_reason}.",
+                action="Inspect the native transcript and execution prerequisites.",
+            )
+        if producer.cleanup_confirmed:
+            if not stop_reason:
+                _remaining(deadline)
+            events.emit("phase", name="capture")
+            store.update("capture")
+            artifact = workspace.capture_output(
+                snapshot, plan.contract.produces, store.directory, plan.limits
+            )
+            store.update("capture", artifact=artifact)
+        if not stop_reason:
+            if artifact is not None:
+                events.emit("phase", name="checks")
+                stop_reason = _run_checks(plan, snapshot, artifact, store, events, deadline, checks)
+            else:
+                events.emit(
+                    "diagnostic",
+                    severity="warning",
+                    message=f"{plan.contract.produces} was not produced.",
+                    action="Inspect the contract and retained Copilot transcript, then rerun.",
+                )
+    except KeyboardInterrupt:
+        stop_reason = "cancelled"
+        events.emit("stop_requested", reason="cancelled")
+    except (ContractError, OSError) as exc:
+        stop_reason = stop_reason or (
+            exc.code if isinstance(exc, ContractError) else "filesystem_error"
+        )
+        events.emit(
+            "diagnostic",
+            severity="error",
+            message=str(exc),
+            action="Inspect the retained record and resolve the reported failure.",
+        )
+    events.emit("phase", name="record")
+    result = RunResult(
+        run_id=store.run_id,
+        run_directory=store.directory,
+        outcome=records.reduce_outcome(artifact, tuple(checks), stop_reason),
+        artifact=artifact,
+        checks=tuple(checks),
+        stop_reason=stop_reason,
+        requested_model=plan.model,
+        observed_models=observed_models,
+    )
+    logger.close()
+    store.update("record", transcript_retention=logger.transcript_metadata)
+    store.finish(result)
+    events.emit("finished", result=result)
+    return result

--- a/src/apm_cli/contracts/events.py
+++ b/src/apm_cli/contracts/events.py
@@ -1,0 +1,36 @@
+"""One ordered event handoff for a local invocation."""
+
+import time
+from typing import Literal
+
+from .models import EventSink, RunEvent
+
+
+class EventEmitter:
+    """Assign observation order in the conductor/supervisor thread."""
+
+    def __init__(self, run_id: str, sink: EventSink) -> None:
+        self.run_id = run_id
+        self.sink = sink
+        self.started = time.monotonic()
+        self.sequence = 0
+
+    def emit(
+        self,
+        kind: str,
+        *,
+        source: Literal["engine", "harness", "checker"] = "engine",
+        **data: object,
+    ) -> None:
+        """Deliver one observation without deriving assessment outcomes."""
+        self.sequence += 1
+        self.sink(
+            RunEvent(
+                run_id=self.run_id,
+                sequence=self.sequence,
+                elapsed_seconds=time.monotonic() - self.started,
+                kind=kind,
+                source=source,
+                data=data,
+            )
+        )

--- a/src/apm_cli/contracts/frontend.py
+++ b/src/apm_cli/contracts/frontend.py
@@ -1,0 +1,305 @@
+"""Strict leaf parsing and read-only admission; never execute or install."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import stat
+import sys
+from pathlib import Path
+
+from ..utils.path_security import (
+    PathTraversalError,
+    ensure_path_within,
+    has_symlink_component,
+    validate_path_segments,
+)
+from ..utils.yaml_io import FrontmatterSourceError, load_frontmatter_document
+from .models import (
+    CheckSpec,
+    ContractError,
+    ContractLimits,
+    LeafContract,
+    LeafPlan,
+    Outcome,
+    SourceLocation,
+)
+
+
+def _fixed_path(value: object, location: SourceLocation, field: str) -> str:
+    if (
+        not isinstance(value, str)
+        or not value.strip()
+        or value != value.strip()
+        or not re.fullmatch(r"[A-Za-z0-9_./ -]+", value)
+        or Path(value).is_absolute()
+    ):
+        raise ContractError(
+            f"{field} requires one fixed relative file path, without globs or captures.",
+            code="invalid_path",
+            location=location,
+        )
+    try:
+        validate_path_segments(value, context=field, reject_empty=True)
+    except PathTraversalError as exc:
+        raise ContractError(str(exc), code="invalid_path", location=location) from exc
+    if any(part.casefold() in {".git", ".apm", "apm_modules"} for part in Path(value).parts):
+        raise ContractError("Managed state cannot be a contract artifact.", location=location)
+    return value
+
+
+def _regular(path: Path, root: Path, location: SourceLocation) -> os.stat_result:
+    try:
+        ensure_path_within(path, root)
+        if has_symlink_component(root, path):
+            raise ValueError("Symlink paths are unsupported.")
+        info = path.stat()
+        if not stat.S_ISREG(info.st_mode):
+            raise ValueError("Expected a regular file.")
+        return info
+    except (OSError, ValueError) as exc:
+        raise ContractError(
+            f"Cannot select regular file {path.name}: {exc}",
+            code="invalid_file",
+            location=location,
+        ) from exc
+
+
+def parse_contract(path: Path, *, limits: ContractLimits | None = None) -> LeafContract:
+    """Parse one local agent-only source without resolving files or runtimes."""
+    limits = limits or ContractLimits()
+    path = path.absolute()
+    location = SourceLocation(path, 1)
+    if not path.name.endswith(".contract.md"):
+        raise ContractError("Expected a local .contract.md file.", location=location)
+    _regular(path, path.parent, location)
+    try:
+        document = load_frontmatter_document(path, max_bytes=limits.source_bytes)
+    except FrontmatterSourceError as exc:
+        raise ContractError(
+            str(exc), code=exc.code, location=SourceLocation(path, exc.line, exc.column)
+        ) from exc
+    except OSError as exc:
+        raise ContractError("Cannot read contract source.", location=location) from exc
+
+    def at(*key: str | int) -> SourceLocation:
+        mark = document.locations.get(key)
+        while mark is None and key:
+            key = key[:-1]
+            mark = document.locations.get(key)
+        return SourceLocation(path, mark.line, mark.column) if mark else location
+
+    data = document.metadata
+    allowed = {"needs", "produces", "verify", "imports", "run", "budget", "sandbox"}
+    for key in data:
+        if key not in allowed:
+            raise ContractError(f"Unknown contract field: {key}.", location=at(key))
+    for key in ("run", "budget", "sandbox"):
+        if key in data:
+            raise ContractError(
+                f"{key} is unsupported by the native agent-only contract profile.",
+                code="unsupported_control",
+                location=at(key),
+                outcome=Outcome.UNPROVEN,
+            )
+    if not document.body.strip() or "\0" in document.body:
+        raise ContractError("Contract Markdown body must not be empty.", location=at("$body"))
+    needs = data.get("needs", [])
+    if isinstance(needs, str):
+        needs = [needs]
+    if not isinstance(needs, list) or len(needs) > min(16, limits.input_files):
+        raise ContractError(
+            "needs must be a scalar or a list of at most 16 files.", location=at("needs")
+        )
+    paths = tuple(
+        _fixed_path(value, at("needs", index), "needs") for index, value in enumerate(needs)
+    )
+    if len({value.casefold() for value in paths}) != len(paths):
+        raise ContractError(
+            "needs contains duplicate or case-colliding paths.", location=at("needs")
+        )
+    produces = _fixed_path(data.get("produces"), at("produces"), "produces")
+    verify = data.get("verify")
+    if not isinstance(verify, dict) or not 1 <= len(verify) <= min(8, limits.check_count):
+        raise ContractError(
+            "verify must name between one and eight string commands.", location=at("verify")
+        )
+    checks = []
+    for name, command in verify.items():
+        if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_-]{0,63}", name):
+            raise ContractError(
+                "Check names must be simple nonempty identifiers.", location=at("verify", name)
+            )
+        if not isinstance(command, str) or not command.strip() or "\0" in command:
+            raise ContractError(
+                "Each check must be a nonempty command string.", location=at("verify", name)
+            )
+        checks.append(CheckSpec(name, command, at("verify", name)))
+    imports = data.get("imports", [])
+    if not isinstance(imports, list) or len(imports) > 1:
+        raise ContractError(
+            "imports must be a list containing at most one installed skill.", location=at("imports")
+        )
+    for name in imports:
+        if (
+            not isinstance(name, str)
+            or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_./-]*", name)
+            or name.startswith("apm_modules/")
+            or name.startswith("_local/")
+        ):
+            raise ContractError(
+                "An import names a declared skill/dependency, not a storage path or version.",
+                location=at("imports"),
+            )
+        try:
+            validate_path_segments(name, context="import", reject_empty=True)
+        except PathTraversalError as exc:
+            raise ContractError(str(exc), location=at("imports")) from exc
+    return LeafContract(
+        path=path,
+        source_digest=hashlib.sha256(document.raw).hexdigest(),
+        body=document.body,
+        needs=paths,
+        produces=produces,
+        checks=tuple(checks),
+        imports=tuple(imports),
+        locations={str(key[0]): at(*key) for key in document.locations if len(key) == 1},
+    )
+
+
+def plan_contract(
+    path: Path,
+    project_root: Path,
+    *,
+    harness: str,
+    model: str | None = None,
+    limits: ContractLimits | None = None,
+) -> LeafPlan:
+    """Resolve a bounded leaf using local reads only; no version/inference probe."""
+    from ..install.errors import PolicyViolationError
+    from ..policy.discovery import discover_contract_policy
+    from ..policy.outcome_routing import route_discovery_outcome
+    from ..policy.project_config import read_project_fetch_failure_default
+    from ..runtime.registry import get_runtime_descriptor
+    from ..runtime.utils import find_runtime_binary
+    from .imports import read_project_manifest, resolve_installed_skills
+
+    limits = limits or ContractLimits()
+    root = project_root.resolve()
+    source = path if path.is_absolute() else root / path
+    source_location = SourceLocation(source, 1)
+    try:
+        validate_path_segments(str(source), context="contract source", allow_current_dir=True)
+    except PathTraversalError as exc:
+        raise ContractError(str(exc), location=source_location) from exc
+    _regular(source, root, source_location)
+    contract = parse_contract(source, limits=limits)
+    location = contract.locations.get("produces", source_location)
+    output = root / contract.produces
+    try:
+        ensure_path_within(output, root)
+        if has_symlink_component(root, output):
+            raise ValueError("Output contains a symlink.")
+        if output.exists() and not output.is_file():
+            raise ValueError("Output must be a regular file path.")
+    except (OSError, ValueError) as exc:
+        raise ContractError(str(exc), location=location) from exc
+    occupied = {
+        *(value.casefold() for value in contract.needs),
+        contract.path.relative_to(root).as_posix().casefold(),
+        "apm.yml",
+        "apm.lock.yaml",
+        "apm.lock",
+    }
+    output_name = contract.produces.casefold()
+    if (
+        output_name == "checks"
+        or output_name.startswith("checks/")
+        or any(
+            output_name == item
+            or output_name.startswith(item + "/")
+            or item.startswith(output_name + "/")
+            for item in occupied
+        )
+    ):
+        raise ContractError(
+            "Output overlaps supplied input, source, manifest or checks.", location=location
+        )
+    size = 0
+    for name in contract.needs:
+        info = _regular(root / name, root, contract.locations.get("needs", source_location))
+        size += info.st_size
+        if info.st_size > limits.file_bytes or size > limits.input_bytes:
+            raise ContractError("Selected inputs exceed the byte limit.", code="input_limit")
+    package, manifest_data, manifest_digest = read_project_manifest(root, limits)
+    fetched = discover_contract_policy(root, manifest_data=manifest_data)
+    try:
+        effective = route_discovery_outcome(
+            fetched,
+            logger=None,
+            fetch_failure_default=read_project_fetch_failure_default(root),
+            raise_blocking_errors=True,
+        )
+    except PolicyViolationError as exc:
+        raise ContractError(
+            "Native contract policy prerequisite failed: " + str(exc),
+            code="policy_blocked",
+            outcome=Outcome.UNPROVEN,
+            location=source_location,
+        ) from exc
+    if effective is not None or fetched.outcome != "no_git_remote":
+        raise ContractError(
+            "Native contracts require positively established no-policy governance. "
+            f"Offline acquisition returned {fetched.outcome or 'unknown'}. "
+            "Configured, disabled and unresolved governance are unsupported.",
+            code="policy_unavailable",
+            outcome=Outcome.UNPROVEN,
+            location=source_location,
+        )
+    if os.environ.get("APM_NO_SCRIPTS"):
+        raise ContractError(
+            "APM_NO_SCRIPTS disables contract checks.",
+            code="scripts_disabled",
+            outcome=Outcome.UNPROVEN,
+            location=source_location,
+        )
+    if sys.platform == "win32":
+        raise ContractError(
+            "Native contracts currently require macOS or Linux.",
+            code="unsupported_platform",
+            outcome=Outcome.UNPROVEN,
+            location=source_location,
+        )
+    try:
+        descriptor = get_runtime_descriptor(harness)
+    except ValueError as exc:
+        raise ContractError(str(exc), code="unsupported_harness", outcome=Outcome.UNPROVEN) from exc
+    if not descriptor.supports_contracts:
+        raise ContractError(
+            f"Runtime {harness} does not support native contracts.",
+            code="unsupported_harness",
+            outcome=Outcome.UNPROVEN,
+        )
+    if model is not None and (not isinstance(model, str) or not model.strip() or "\0" in model):
+        raise ContractError("Model must be a nonempty native model identifier.")
+    binary = find_runtime_binary(descriptor.binary)
+    if binary is None:
+        raise ContractError(
+            "The selected native runtime executable is missing.", code="runtime_missing"
+        )
+    executable = Path(binary).resolve()
+    if not executable.is_file() or not os.access(executable, os.X_OK):
+        raise ContractError("The selected runtime is not executable.", code="runtime_missing")
+    skills, lock_digest = resolve_installed_skills(contract, root, package, limits=limits)
+    return LeafPlan(
+        contract=contract,
+        project_root=root,
+        executable=executable,
+        harness=harness,
+        model=model,
+        limits=limits,
+        imported_skills=skills,
+        manifest_digest=manifest_digest,
+        lock_digest=lock_digest,
+    )

--- a/src/apm_cli/contracts/imports.py
+++ b/src/apm_cli/contracts/imports.py
@@ -1,0 +1,329 @@
+"""Read-only linking of one directly declared, installed self-contained skill."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import stat
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from ..deps.lockfile import LockFile, resolve_lockfile_path_for_read
+from ..models.apm_package import APMPackage
+from ..models.dependency.reference import DependencyReference
+from ..models.dependency.selection import (
+    DependencySelectionStatus,
+    parse_dependency_entry,
+    select_manifest_dependency,
+)
+from ..utils.path_security import ensure_path_within, has_symlink_component
+from ..utils.yaml_io import FrontmatterDocument, load_yaml_str, loads_frontmatter_document
+from .models import ContractError, ContractLimits, ImportedSkill, LeafContract, SourceLocation
+
+
+def _read_bytes(path: Path, *, maximum: int, root: Path) -> bytes:
+    """Bound selected reads and reject symlinks, special files and observed drift."""
+    try:
+        ensure_path_within(path, root)
+        if has_symlink_component(root, path):
+            raise ValueError("Nested symlinks are unsupported.")
+        before = path.stat()
+        if not stat.S_ISREG(before.st_mode) or before.st_size > maximum:
+            raise ValueError("Expected a bounded regular file.")
+        flags = (
+            os.O_RDONLY
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_NONBLOCK", 0)
+            | getattr(os, "O_BINARY", 0)
+        )
+        with os.fdopen(os.open(path, flags), "rb") as stream:
+            opened = os.fstat(stream.fileno())
+            if not stat.S_ISREG(opened.st_mode) or (before.st_dev, before.st_ino) != (
+                opened.st_dev,
+                opened.st_ino,
+            ):
+                raise ValueError("Selected file changed before capture.")
+            raw = stream.read(maximum + 1)
+        after = path.stat()
+        if (
+            len(raw) > maximum
+            or len(raw) != before.st_size
+            or (
+                before.st_dev,
+                before.st_ino,
+                before.st_size,
+                before.st_mtime_ns,
+                before.st_ctime_ns,
+            )
+            != (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns, after.st_ctime_ns)
+        ):
+            raise ValueError("Selected file changed during capture.")
+        return raw
+    except (OSError, ValueError) as exc:
+        raise ContractError(
+            f"Cannot read selected file {path.name}: {exc}",
+            code="import_source",
+            location=SourceLocation(path, 1),
+        ) from exc
+
+
+def _package(raw: bytes, root: Path) -> tuple[APMPackage, dict[str, Any]]:
+    try:
+        data = load_yaml_str(raw.decode("utf-8"))
+        if not isinstance(data, dict):
+            raise ValueError("Manifest must be a mapping.")
+        package = APMPackage.from_mapping(
+            data, package_path=root, source_path=root, create_config=False
+        )
+        return package, data
+    except (ValueError, TypeError, KeyError, yaml.YAMLError) as exc:
+        raise ContractError(
+            f"Invalid selected manifest: {exc}",
+            code="invalid_manifest",
+            location=SourceLocation(root / "apm.yml", 1),
+        ) from exc
+
+
+def read_project_manifest(
+    root: Path, limits: ContractLimits
+) -> tuple[APMPackage, dict[str, Any], str]:
+    """Interpret project declarations through their no-config-write owner."""
+    raw = _read_bytes(root / "apm.yml", maximum=limits.source_bytes, root=root)
+    package, data = _package(raw, root)
+    return package, data, hashlib.sha256(raw).hexdigest()
+
+
+def _skill_document(path: Path, root: Path, limits: ContractLimits) -> FrontmatterDocument:
+    raw = _read_bytes(path, maximum=limits.source_bytes, root=root)
+    try:
+        document = loads_frontmatter_document(raw, max_bytes=limits.source_bytes)
+    except ValueError as exc:
+        raise ContractError(
+            f"Invalid installed skill frontmatter: {exc}",
+            code="invalid_import",
+            location=SourceLocation(path, getattr(exc, "line", 1), getattr(exc, "column", 1)),
+        ) from exc
+    if not document.body.strip():
+        raise ContractError("Installed skill body is empty.", code="invalid_import")
+    return document
+
+
+def _self_contained(root: Path, limits: ContractLimits) -> None:
+    """Reject companion content before calling the whole-package hash owner."""
+    # .git is transport administration, not imported content; hashes exclude it.
+    allowed = {"apm.yml", "SKILL.md", ".apm-pin"}
+    with os.scandir(root) as entries:
+        for entry in entries:
+            if entry.is_symlink():
+                raise ContractError("Installed skill contains a symlink.", code="invalid_import")
+            if entry.name == ".git" and entry.is_dir(follow_symlinks=False):
+                # The hash owner traverses then excludes Git administration;
+                # bound that otherwise-hidden traversal before delegating.
+                pending = [Path(entry.path)]
+                visited = 0
+                while pending:
+                    with os.scandir(pending.pop()) as metadata:
+                        for item in metadata:
+                            visited += 1
+                            if visited > limits.resource_files:
+                                raise ContractError(
+                                    "Git metadata exceeds the import scan limit.",
+                                    code="import_limit",
+                                )
+                            if item.is_symlink():
+                                raise ContractError(
+                                    "Installed Git metadata contains a symlink.",
+                                    code="invalid_import",
+                                )
+                            if item.is_dir(follow_symlinks=False):
+                                pending.append(Path(item.path))
+                continue
+            if entry.name not in allowed or not entry.is_file(follow_symlinks=False):
+                raise ContractError(
+                    "Only a self-contained root SKILL.md and apm.yml are supported; "
+                    "companion resources are unsupported.",
+                    code="unsupported_import",
+                )
+            if entry.stat(follow_symlinks=False).st_size > limits.source_bytes:
+                raise ContractError(
+                    "Installed skill package exceeds its byte limit.", code="import_limit"
+                )
+
+
+def resolve_installed_skills(
+    contract: LeafContract,
+    project_root: Path,
+    package: APMPackage,
+    *,
+    limits: ContractLimits | None = None,
+) -> tuple[tuple[ImportedSkill, ...], str | None]:
+    """Link declared names through lock identity and canonical materialization.
+
+    Local locks attest identity only. Git packages additionally require their
+    existing locked package-content hash and current declared-reference check.
+    No resolver/download/install/deployment lifecycle is invoked.
+    """
+    from ..drift import detect_ref_change
+    from ..utils.content_hash import verify_package_hash
+
+    limits = limits or ContractLimits()
+    lock_path = resolve_lockfile_path_for_read(project_root, read_only=True)
+    if not lock_path.exists():
+        if contract.imports:
+            raise ContractError(
+                "Import requires an existing lockfile; install explicitly first.",
+                code="missing_lock",
+            )
+        return (), None
+    raw_lock = _read_bytes(lock_path, maximum=limits.file_bytes, root=project_root)
+    lock_digest = hashlib.sha256(raw_lock).hexdigest()
+    # Parse the exact captured bytes with the lockfile's semantic owner.
+    try:
+        lock = LockFile.from_yaml(raw_lock.decode("utf-8"))
+    except (ValueError, KeyError, TypeError, yaml.YAMLError) as exc:
+        raise ContractError("Existing lockfile is malformed.", code="invalid_lock") from exc
+    if not contract.imports:
+        return (), lock_digest
+    name = contract.imports[0]
+    location = contract.locations.get("imports", SourceLocation(contract.path, 1))
+    declarations = list((package.dependencies or {}).get("apm", []))
+    declarations.extend((package.dev_dependencies or {}).get("apm", []))
+    if len(declarations) > 256:
+        raise ContractError(
+            "Too many direct dependencies for bounded import selection.", location=location
+        )
+    selected = select_manifest_dependency(name, declarations, lock)
+    if selected.status == DependencySelectionStatus.AMBIGUOUS:
+        raise ContractError(
+            "Import declaration is ambiguous.", code="ambiguous_import", location=location
+        )
+    modules = project_root / "apm_modules"
+    matches: list[tuple[DependencyReference, Path, FrontmatterDocument]] = []
+    for declaration in declarations:
+        dependency = parse_dependency_entry(declaration)
+        if not dependency.is_local and dependency.source not in {None, "git"}:
+            continue
+        if dependency.is_virtual_file() or dependency.is_marketplace:
+            continue
+        if (
+            selected.status == DependencySelectionStatus.MATCHED
+            and declaration != selected.manifest_entry
+        ):
+            continue
+        locked = lock.get_dependency(dependency.get_unique_key())
+        if locked is None:
+            if selected.status == DependencySelectionStatus.MATCHED or (
+                dependency.is_local and Path(dependency.local_path or "").name == name
+            ):
+                raise ContractError(
+                    "Selected import has no lock identity.", code="missing_lock", location=location
+                )
+            continue
+        try:
+            installed = locked.to_dependency_ref().get_install_path(modules)
+            if has_symlink_component(project_root, installed):
+                raise ValueError("Installed root is a symlink.")
+            skill_path = installed / "SKILL.md"
+            if not skill_path.exists():
+                if selected.status == DependencySelectionStatus.MATCHED or (
+                    dependency.is_local and Path(dependency.local_path or "").name == name
+                ):
+                    raise ContractError(
+                        "Selected skill is not installed.", code="missing_import", location=location
+                    )
+                continue
+            document = _skill_document(skill_path, installed, limits)
+            # Explicit dependency identities win selection. Short skill/package
+            # names are read from declared installations, never storage strings.
+            declared_name = None
+            if (installed / "apm.yml").exists():
+                installed_package, _ = _package(
+                    _read_bytes(installed / "apm.yml", maximum=limits.source_bytes, root=installed),
+                    installed,
+                )
+                declared_name = installed_package.name
+            if (
+                selected.status == DependencySelectionStatus.MATCHED
+                or document.metadata.get("name") == name
+                or declared_name == name
+            ):
+                matches.append((dependency, installed, document))
+        except (OSError, ValueError) as exc:
+            if isinstance(exc, ContractError):
+                raise
+            raise ContractError(
+                "Cannot safely select installed import.", location=location
+            ) from exc
+    if len(matches) != 1:
+        raise ContractError(
+            "Import must identify exactly one directly declared installed skill.",
+            code="ambiguous_import" if matches else "missing_import",
+            location=location,
+        )
+    dependency, installed, document = matches[0]
+    locked = lock.get_dependency(dependency.get_unique_key())
+    if locked is None:
+        raise ContractError(
+            "Selected lock identity disappeared.", code="missing_lock", location=location
+        )
+    if locked.depth != 1 or locked.resolved_by or locked.declaring_parent:
+        raise ContractError("Transitive skill imports are unsupported.", location=location)
+    if detect_ref_change(dependency, locked):
+        raise ContractError(
+            "Manifest and installed lock reference differ.", code="import_drift", location=location
+        )
+    locked_ref = locked.to_dependency_ref()
+    if locked_ref.get_identity() != dependency.get_identity():
+        raise ContractError(
+            "Installed host or dependency identity differs.", code="import_drift", location=location
+        )
+    _self_contained(installed, limits)
+    if (installed / "apm.yml").exists():
+        installed_package, _ = _package(
+            _read_bytes(installed / "apm.yml", maximum=limits.source_bytes, root=installed),
+            installed,
+        )
+        if any((installed_package.dependencies or {}).values()) or any(
+            (installed_package.dev_dependencies or {}).values()
+        ):
+            raise ContractError(
+                "Imported skills with dependencies are unsupported.", location=location
+            )
+    if dependency.is_local:
+        verified_hash = None
+        assurance = "observed-local-source"
+    else:
+        if not locked.resolved_commit or not locked.content_hash:
+            raise ContractError(
+                "Git import needs a locked commit and package hash.", location=location
+            )
+        if not verify_package_hash(installed, locked.content_hash):
+            raise ContractError(
+                "Installed package hash does not match its lock.",
+                code="import_drift",
+                location=location,
+            )
+        verified_hash = locked.content_hash
+        assurance = "locked-package-hash"
+    # Catch selected source replacement during manifest/integrity observations.
+    if (
+        _read_bytes(installed / "SKILL.md", maximum=limits.source_bytes, root=installed)
+        != document.raw
+    ):
+        raise ContractError(
+            "Imported skill changed during planning.", code="import_drift", location=location
+        )
+    return (
+        ImportedSkill(
+            name=name,
+            source_path=installed / "SKILL.md",
+            content=document.raw.decode("utf-8"),
+            source_digest=hashlib.sha256(document.raw).hexdigest(),
+            lock_identity=locked.get_unique_key(),
+            resolved_commit=locked.resolved_commit,
+            verified_package_hash=verified_hash,
+            assurance=assurance,
+        ),
+    ), lock_digest

--- a/src/apm_cli/contracts/models.py
+++ b/src/apm_cli/contracts/models.py
@@ -1,0 +1,220 @@
+"""Shared values for the bounded leaf-contract lifecycle."""
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from enum import IntEnum
+from pathlib import Path
+from typing import Literal
+
+
+class Outcome(IntEnum):
+    """Command outcomes; assessment precedence belongs to records.py."""
+
+    VERIFIED = 0
+    REJECTED = 20
+    UNPROVEN = 21
+    HALTED = 22
+
+
+@dataclass(frozen=True)
+class SourceLocation:
+    """A declaration location in the original contract."""
+
+    path: Path
+    line: int
+    column: int = 1
+
+
+class ContractError(ValueError):
+    """An actionable contract refusal, distinct from legacy script errors."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str = "invalid_contract",
+        location: SourceLocation | None = None,
+        outcome: Outcome = Outcome.HALTED,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.location = location
+        self.outcome = outcome
+
+
+@dataclass(frozen=True)
+class ContractLimits:
+    """Admission and supervision limits, not native-host confinement."""
+
+    source_bytes: int = 256 * 1024
+    input_files: int = 16
+    input_bytes: int = 16 * 1024 * 1024
+    baseline_files: int = 10_000
+    baseline_bytes: int = 128 * 1024 * 1024
+    file_bytes: int = 8 * 1024 * 1024
+    resource_files: int = 256
+    resource_bytes: int = 8 * 1024 * 1024
+    output_bytes: int = 4 * 1024 * 1024
+    check_count: int = 8
+    attempt_seconds: float = 1200
+    check_seconds: float = 180
+    cleanup_seconds: float = 6
+    frame_bytes: int = 1024 * 1024
+    transcript_bytes: int = 4 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class CheckSpec:
+    """An uninterpreted command and its source location."""
+
+    name: str
+    command: str
+    location: SourceLocation | None = None
+
+
+@dataclass(frozen=True)
+class LeafContract:
+    """The supported agent-only source subset."""
+
+    path: Path
+    source_digest: str
+    body: str
+    needs: tuple[str, ...]
+    produces: str
+    checks: tuple[CheckSpec, ...]
+    imports: tuple[str, ...] = ()
+    locations: Mapping[str, SourceLocation] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ImportedSkill:
+    """Selected installed context, with honest local-versus-pinned identity."""
+
+    name: str
+    source_path: Path
+    content: str
+    source_digest: str
+    lock_identity: str
+    resolved_commit: str | None = None
+    verified_package_hash: str | None = None
+    assurance: str = "observed-local-source"
+
+
+@dataclass(frozen=True)
+class LeafPlan:
+    """Read-only plan; admission revalidates mutable sources."""
+
+    contract: LeafContract
+    project_root: Path
+    executable: Path
+    harness: str = "copilot"
+    model: str | None = None
+    executable_version: str | None = None
+    imported_skills: tuple[ImportedSkill, ...] = ()
+    limits: ContractLimits = field(default_factory=ContractLimits)
+    policy_status: str = "no-policy"
+    manifest_digest: str | None = None
+    lock_digest: str | None = None
+
+
+@dataclass(frozen=True)
+class FileEntry:
+    """Exact captured regular-file identity."""
+
+    relative_path: str
+    sha256: str
+    size: int
+    mode: int
+
+
+@dataclass(frozen=True)
+class BaselineSnapshot:
+    """Independent captured baseline and producer working copy."""
+
+    root: Path
+    producer: Path
+    files: tuple[FileEntry, ...]
+    digest: str
+    original_head: str | None
+    synthetic_head: str
+    resources_digest: str
+
+
+@dataclass(frozen=True)
+class Artifact:
+    """Captured output, never a mutable producer-workspace alias."""
+
+    relative_path: str
+    path: Path
+    sha256: str
+    size: int
+
+
+@dataclass(frozen=True)
+class ProcessRequest:
+    """One managed child, with no shell interpolation of native arguments."""
+
+    argv: tuple[str, ...]
+    cwd: Path
+    timeout_seconds: float
+    env: Mapping[str, str] | None = None
+    control_observations: Mapping[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ProcessObservation:
+    """Observed termination and cleanup, not a full-tree containment claim."""
+
+    returncode: int | None
+    pid: int | None = None
+    pgid: int | None = None
+    elapsed_seconds: float = 0
+    stop_reason: str | None = None
+    error: str | None = None
+    cleanup_confirmed: bool = True
+    signals: tuple[str, ...] = ()
+    residual_group: tuple[Mapping[str, object], ...] = ()
+
+
+@dataclass(frozen=True)
+class CheckObservation:
+    """Raw process result alongside normalized assessment."""
+
+    name: str
+    command: str
+    process: ProcessObservation
+    normalized: int
+    subject_digest: str
+    resources_digest: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class RunResult:
+    """Terminal local observation, reduced and persisted by one owner."""
+
+    run_id: str
+    run_directory: Path
+    outcome: Outcome
+    artifact: Artifact | None
+    checks: tuple[CheckObservation, ...]
+    stop_reason: str | None = None
+    requested_model: str | None = None
+    observed_models: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class RunEvent:
+    """Small internal event; never the native harness's public protocol."""
+
+    run_id: str
+    sequence: int
+    elapsed_seconds: float
+    kind: str
+    source: Literal["engine", "harness", "checker"]
+    data: Mapping[str, object] = field(default_factory=dict)
+
+
+EventSink = Callable[[RunEvent], None]
+ByteSink = Callable[[str, bytes], None]
+StartedSink = Callable[[int, int | None], None]

--- a/src/apm_cli/contracts/process.py
+++ b/src/apm_cli/contracts/process.py
@@ -1,0 +1,277 @@
+"""Bounded POSIX process-group observation for native contract attempts."""
+
+import contextlib
+import os
+import selectors
+import shutil
+import signal
+import subprocess
+import time
+from pathlib import Path
+
+from .events import EventEmitter
+from .models import (
+    ByteSink,
+    ContractError,
+    ContractLimits,
+    ProcessObservation,
+    ProcessRequest,
+    StartedSink,
+)
+
+
+def _group_exists(pgid: int) -> bool:
+    try:
+        os.killpg(pgid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # POSIX EPERM proves existence, not termination or signal authority.
+        return True
+    return True
+
+
+def _signal_group(pgid: int, selected: signal.Signals) -> None:
+    with contextlib.suppress(ProcessLookupError):
+        os.killpg(pgid, selected)
+
+
+def _observe_group(pgid: int, timeout_seconds: float) -> tuple[dict[str, object], ...]:
+    """Retain only owned-group identity/state/name, never argv or environment."""
+    executable = shutil.which("ps")
+    if executable is None:
+        return ({"inspection": "ps unavailable"},)
+    try:
+        result = subprocess.run(
+            (executable, "-g", str(pgid), "-o", "pid=,ppid=,pgid=,stat=,comm="),
+            capture_output=True,
+            check=False,
+            timeout=timeout_seconds,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ({"inspection": "group inspection unavailable"},)
+    if result.returncode not in (0, 1):
+        return ({"inspection": "group inspection failed"},)
+    identities: list[dict[str, object]] = []
+    for line in result.stdout.decode("utf-8", errors="replace").splitlines()[:128]:
+        columns = line.split(None, 4)
+        if len(columns) == 5 and all(value.isdecimal() for value in columns[:3]):
+            pid, ppid, group = (int(value) for value in columns[:3])
+            if group == pgid:
+                identities.append(
+                    {
+                        "pid": pid,
+                        "ppid": ppid,
+                        "pgid": group,
+                        "state": columns[3],
+                        "name": Path(columns[4]).name[:128],
+                    }
+                )
+    return tuple(identities)
+
+
+def supervise_process(
+    request: ProcessRequest,
+    *,
+    on_bytes: ByteSink,
+    on_started: StartedSink | None = None,
+    events: EventEmitter | None = None,
+    limits: ContractLimits | None = None,
+) -> ProcessObservation:
+    """Drain both pipes while bounding deadlines and original-group cleanup.
+
+    This cannot contain descendants that leave the original process group.
+    Callback failures propagate only after bounded cleanup has been attempted.
+    """
+    limits = limits or ContractLimits()
+    started = time.monotonic()
+    if os.name != "posix":
+        return ProcessObservation(None, error="Managed native execution requires POSIX.")
+    if request.timeout_seconds <= 0:
+        return ProcessObservation(None, stop_reason="timeout")
+    try:
+        child = subprocess.Popen(
+            request.argv,
+            cwd=request.cwd,
+            env=request.env,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+        )
+    except OSError as exc:
+        return ProcessObservation(None, error=f"Could not start the selected process: {exc}")
+    pgid = child.pid
+    stop_reason = None
+    stop_started: float | None = None
+    sent: list[str] = []
+    cleanup_confirmed = False
+    next_heartbeat = started + 10
+    leader_exited_at: float | None = None
+    residual_group: tuple[dict[str, object], ...] = ()
+    selector = selectors.DefaultSelector()
+    try:
+        for stream, pipe in (("stdout", child.stdout), ("stderr", child.stderr)):
+            if pipe is None:
+                raise ContractError(
+                    "Managed child pipe was not created.", code="process_pipe_failed"
+                )
+            os.set_blocking(pipe.fileno(), False)
+            selector.register(pipe, selectors.EVENT_READ, stream)
+        if on_started is not None:
+            on_started(child.pid, pgid)
+        if events is not None:
+            events.emit("process_started", pid=child.pid, pgid=pgid)
+        while True:
+            try:
+                now = time.monotonic()
+                returncode = child.poll()
+                group_alive = _group_exists(pgid)
+                if returncode is not None and leader_exited_at is None:
+                    leader_exited_at = now
+                if now >= next_heartbeat and returncode is None and stop_started is None:
+                    if events is not None:
+                        events.emit("heartbeat", pid=child.pid)
+                    next_heartbeat = now + 10
+                if returncode is not None and not group_alive and not selector.get_map():
+                    cleanup_confirmed = True
+                    break
+                if stop_started is None:
+                    if now - started >= request.timeout_seconds:
+                        stop_reason = "timeout"
+                    elif (
+                        leader_exited_at is not None
+                        and group_alive
+                        and now - leader_exited_at >= min(0.5, limits.cleanup_seconds / 4)
+                    ):
+                        stop_reason = "lingering_children"
+                    if stop_reason is not None:
+                        stop_started = (
+                            leader_exited_at if stop_reason == "lingering_children" else now
+                        )
+                        if stop_reason == "lingering_children":
+                            residual_group = _observe_group(
+                                pgid, min(0.5, limits.cleanup_seconds / 4)
+                            )
+                        if events is not None:
+                            events.emit("stop_requested", reason=stop_reason)
+                        _signal_group(pgid, signal.SIGTERM)
+                        sent.append("SIGTERM")
+                if stop_started is not None:
+                    elapsed = now - stop_started
+                    if elapsed >= limits.cleanup_seconds / 2 and "SIGKILL" not in sent:
+                        _signal_group(pgid, signal.SIGKILL)
+                        sent.append("SIGKILL")
+                    if elapsed >= limits.cleanup_seconds:
+                        child.poll()
+                        cleanup_confirmed = child.returncode is not None and not _group_exists(pgid)
+                        break
+                for key, _ in selector.select(timeout=0.05):
+                    try:
+                        chunk = os.read(key.fd, 65536)
+                    except BlockingIOError:
+                        continue
+                    if chunk:
+                        on_bytes(key.data, chunk)
+                    else:
+                        selector.unregister(key.fileobj)
+                        key.fileobj.close()
+            except KeyboardInterrupt:
+                stop_reason = "cancelled"
+                if stop_started is None:
+                    stop_started = time.monotonic()
+                    if events is not None:
+                        events.emit("stop_requested", reason=stop_reason)
+                    _signal_group(pgid, signal.SIGTERM)
+                    sent.append("SIGTERM")
+    finally:
+        # An exception in a drain/record callback must not strand a child.
+        if not cleanup_confirmed:
+            _signal_group(pgid, signal.SIGKILL)
+            remainder = (
+                limits.cleanup_seconds
+                if stop_started is None
+                else max(0, limits.cleanup_seconds - (time.monotonic() - stop_started))
+            )
+            with contextlib.suppress(subprocess.TimeoutExpired):
+                child.wait(timeout=remainder)
+        selector.close()
+        for pipe in (child.stdout, child.stderr):
+            if pipe is not None:
+                pipe.close()
+    if events is not None and stop_reason is not None:
+        events.emit("stop_observed", confirmed=cleanup_confirmed, reason=stop_reason)
+    return ProcessObservation(
+        child.returncode,
+        pid=child.pid,
+        pgid=pgid,
+        elapsed_seconds=time.monotonic() - started,
+        stop_reason=stop_reason,
+        cleanup_confirmed=cleanup_confirmed,
+        signals=tuple(sent),
+        residual_group=residual_group,
+    )
+
+
+def local_git(
+    root: Path,
+    *arguments: str,
+    maximum_bytes: int = 8 * 1024 * 1024,
+    accepted_codes: tuple[int, ...] = (0,),
+) -> bytes:
+    """Run a bounded local Git operation without inherited hooks or Git overrides."""
+    executable = shutil.which("git")
+    if executable is None:
+        raise ContractError(
+            "Git is required for captured assessment workspaces.", code="git_missing"
+        )
+    env = {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+    env.update(
+        GIT_CONFIG_NOSYSTEM="1",
+        GIT_CONFIG_GLOBAL=os.devnull,
+        GIT_TERMINAL_PROMPT="0",
+        GIT_OPTIONAL_LOCKS="0",
+    )
+    output = bytearray()
+    errors = bytearray()
+
+    def receive(stream: str, chunk: bytes) -> None:
+        destination = output if stream == "stdout" else errors
+        if len(destination) + len(chunk) > maximum_bytes:
+            raise ContractError("Local Git output exceeded its limit.", code="git_output_limit")
+        destination.extend(chunk)
+
+    observation = supervise_process(
+        ProcessRequest(
+            (
+                executable,
+                "-c",
+                f"core.hooksPath={os.devnull}",
+                "-c",
+                "commit.gpgsign=false",
+                "-c",
+                "core.autocrlf=false",
+                "-c",
+                "core.fsmonitor=false",
+                "-c",
+                "user.name=APM captured baseline",
+                "-c",
+                "user.email=apm-local@invalid",
+                *arguments,
+            ),
+            root,
+            30,
+            env,
+        ),
+        on_bytes=receive,
+    )
+    if (
+        observation.returncode not in accepted_codes
+        or observation.stop_reason
+        or not observation.cleanup_confirmed
+    ):
+        raise ContractError(
+            "Local Git baseline operation failed. Check Git and the project files.",
+            code="baseline_git_failed",
+        )
+    return bytes(output)

--- a/src/apm_cli/contracts/records.py
+++ b/src/apm_cli/contracts/records.py
@@ -1,0 +1,179 @@
+"""One local authority for check normalization, outcomes and attempt records."""
+
+import json
+import os
+from dataclasses import fields, is_dataclass, replace
+from datetime import datetime, timezone
+from enum import IntEnum
+from pathlib import Path
+from uuid import uuid4
+
+from ..utils.atomic_io import atomic_write_text
+from ..utils.path_security import has_symlink_component
+from .models import (
+    Artifact,
+    CheckObservation,
+    ContractError,
+    ContractLimits,
+    LeafPlan,
+    Outcome,
+    ProcessObservation,
+    RunResult,
+)
+
+
+def normalize_check(process: ProcessObservation, *, integrity_ok: bool = True) -> int:
+    """Retain raw exit separately; absence of prose does not weaken exit one."""
+    if not integrity_ok or process.error or process.stop_reason or not process.cleanup_confirmed:
+        return 2
+    return process.returncode if process.returncode in (0, 1, 2) else 2
+
+
+def reduce_outcome(
+    artifact: Artifact | None,
+    checks: tuple[CheckObservation, ...],
+    stop_reason: str | None,
+) -> Outcome:
+    """Approved leaf-only precedence; this is not a general composition algebra."""
+    if stop_reason:
+        return Outcome.HALTED
+    if any(check.normalized == 1 for check in checks):
+        return Outcome.REJECTED
+    if artifact is None or not checks or any(check.normalized != 0 for check in checks):
+        return Outcome.UNPROVEN
+    return Outcome.VERIFIED
+
+
+def _json_value(value: object) -> object:
+    if isinstance(value, IntEnum):
+        return {"name": value.name, "exit_code": int(value)}
+    if isinstance(value, Path):
+        return str(value)
+    if is_dataclass(value) and not isinstance(value, type):
+        return {field.name: _json_value(getattr(value, field.name)) for field in fields(value)}
+    if isinstance(value, dict):
+        return {str(key): _json_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item) for item in value]
+    return value
+
+
+class AttemptStore:
+    """Private, atomically updated local observations, not protected provenance."""
+
+    def __init__(self, run_id: str, directory: Path, data: dict[str, object]) -> None:
+        self.run_id = run_id
+        self.directory = directory
+        self.record_path = directory / "record.json"
+        self._data = data
+
+    @classmethod
+    def create(cls, plan: LeafPlan) -> "AttemptStore":
+        """Allocate unique run/attempt identity only after admission."""
+        parent = plan.project_root / ".apm" / "runs"
+        if has_symlink_component(plan.project_root, parent):
+            raise ContractError("Run storage contains a symlink.", code="unsafe_run_directory")
+        parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        run_id = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ-") + uuid4().hex[:12]
+        directory = parent / run_id
+        directory.mkdir(mode=0o700)
+        os.chmod(directory, 0o700)
+        store = cls(
+            run_id,
+            directory,
+            {
+                "schema": "apm-contract-run/0.1",
+                "run_id": run_id,
+                "attempt_id": run_id + "/1",
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "profile": "native-advisory",
+                "provenance": "same-user local observations; not protected or signed",
+                "phase": "admitted",
+                "complete": False,
+                "source": {
+                    "path": str(plan.contract.path),
+                    "sha256": plan.contract.source_digest,
+                },
+                "manifest_sha256": plan.manifest_digest,
+                "lock_sha256": plan.lock_digest,
+                "harness": plan.harness,
+                "executable": str(plan.executable),
+                "executable_version": plan.executable_version,
+                "requested_model": plan.model,
+                "observed_models": [],
+                "imports": [
+                    {
+                        "name": skill.name,
+                        "sha256": skill.source_digest,
+                        "lock_identity": skill.lock_identity,
+                        "assurance": skill.assurance,
+                        "resolved_commit": skill.resolved_commit,
+                    }
+                    for skill in plan.imported_skills
+                ],
+                "limits": plan.limits,
+                "controls": {
+                    "isolation": "unavailable",
+                    "spend_cap": "unavailable",
+                    "process_cleanup": "original POSIX process group; escaped descendants unobserved",
+                },
+            },
+        )
+        store._write()
+        return store
+
+    def _write(self) -> None:
+        atomic_write_text(
+            self.record_path,
+            json.dumps(_json_value(self._data), ensure_ascii=True, indent=2) + "\n",
+            new_file_mode=0o600,
+            durable=True,
+        )
+
+    def update(self, phase: str, **observations: object) -> None:
+        """Commit observations without advertising a completed outcome."""
+        self._data.update(observations)
+        self._data["phase"] = phase
+        self._write()
+
+    def finish(self, result: RunResult) -> None:
+        """Persist the final result before any terminal success announcement."""
+        from .workspace import inspect_retained_log
+
+        if (self.directory / "transcript.log").exists():
+            self._data["transcript"] = inspect_retained_log(
+                self.directory, ContractLimits().transcript_bytes
+            )
+        elif result.outcome == Outcome.VERIFIED:
+            raise ContractError("Final transcript is missing.", code="transcript_missing")
+        self._data.update(
+            complete=True,
+            phase="finished",
+            child_pid=None,
+            child_pgid=None,
+            active_check=None,
+            finished_at=datetime.now(timezone.utc).isoformat(),
+            result=result,
+        )
+        try:
+            self._write()
+        except OSError as exc:
+            self._data.update(
+                complete=False,
+                phase="finalization_failed",
+                result=replace(result, outcome=Outcome.HALTED, stop_reason="finalization_failure"),
+            )
+            try:
+                self._write()
+            except OSError as repair_error:
+                raise ContractError(
+                    f"Run record finalization failed at {self.record_path}; failure-state "
+                    "persistence also failed. Treat this invocation as HALTED and do not "
+                    "rely on a visible success record.",
+                    code="finalization_failure",
+                ) from repair_error
+            raise ContractError(
+                f"Run record finalization failed at {self.record_path}. The attempt is "
+                "incomplete; inspect filesystem durability before retrying.",
+                code="finalization_failure",
+            ) from exc

--- a/src/apm_cli/contracts/stream.py
+++ b/src/apm_cli/contracts/stream.py
@@ -1,0 +1,469 @@
+"""Bounded native observations and one terminal/transcript safety path.
+
+Native protocol objects are never forwarded. Text is withheld until a complete
+line (or message) is available so redaction does not leak split credentials.
+This is best-effort diagnostic redaction, not a safe-to-publish guarantee.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Literal
+
+from apm_cli.utils.git_env import redact_git_diagnostic
+
+from .events import EventEmitter
+from .models import ContractLimits
+
+_TEXT_BYTES = 16 * 1024
+_DISPLAY_CHARS = 4096
+_CORRELATED_MESSAGES = 64
+
+
+def safe_text(text: str, *, limit: int = _DISPLAY_CHARS) -> str:
+    """Redact first, then visibly escape controls and Unicode without '?' loss.
+
+    Source and artifact bytes are untouched. Backslash escapes retain readable,
+    retrievable Unicode identity in the private diagnostic transcript.
+    """
+    redacted = redact_git_diagnostic(text)
+    escaped = redacted.encode("unicode_escape", errors="backslashreplace").decode("ascii")
+    # unicode_escape leaves a few ASCII controls (notably DEL) literal.
+    escaped = "".join(
+        character if " " <= character <= "~" else f"\\x{ord(character):02x}"
+        for character in escaped
+    )
+    if len(escaped) > limit:
+        suffix = " ... [text truncated]"
+        return escaped[: max(0, limit - len(suffix))] + suffix
+    return escaped
+
+
+class _Lines:
+    """Byte-bounded framing, draining oversized lines without exposing prefixes."""
+
+    def __init__(
+        self,
+        limit: int,
+        line: Callable[[bytes], None],
+        overflow: Callable[[], None],
+    ) -> None:
+        self.limit = max(1, limit)
+        self.line = line
+        self.overflow = overflow
+        self.pending = bytearray()
+        self.discarding = False
+
+    def feed(self, chunk: bytes) -> None:
+        start = 0
+        while start < len(chunk):
+            newline = chunk.find(b"\n", start)
+            end = len(chunk) if newline < 0 else newline
+            if not self.discarding:
+                if len(self.pending) + end - start > self.limit:
+                    self.pending.clear()
+                    self.discarding = True
+                    self.overflow()
+                else:
+                    self.pending.extend(memoryview(chunk)[start:end])
+            if newline < 0:
+                return
+            if not self.discarding:
+                self.line(bytes(self.pending))
+            self.pending.clear()
+            self.discarding = False
+            start = newline + 1
+
+    def finish(self) -> None:
+        if self.pending and not self.discarding:
+            self.line(bytes(self.pending))
+        self.pending.clear()
+        self.discarding = False
+
+
+@dataclass
+class _Message:
+    """Constant-space prefix correlation; no full-response accumulation."""
+
+    lines: _Lines
+    digest: object = field(default_factory=hashlib.sha256)
+    length: int = 0
+    complete: bool = False
+    phase: str | None = None
+    phase_known: bool = False
+    suppressed: bool = False
+    streamed: bool = False
+
+    def delta(self, content: bytes, *, allow_stream: bool) -> None:
+        # If the phase arrived late, the completion must provide the full text;
+        # streaming only a suffix now would lose the earlier unknown prefix.
+        can_stream = allow_stream and (self.length == 0 or self.streamed)
+        self.digest.update(content)
+        self.length += len(content)
+        if can_stream:
+            self.streamed = True
+            self.lines.feed(content)
+
+
+class ContractStreamDecoder:
+    """Decode serialized supervisor byte callbacks into allowlisted observations."""
+
+    def __init__(
+        self,
+        events: EventEmitter,
+        *,
+        limits: ContractLimits | None = None,
+        source: Literal["harness", "checker"] = "harness",
+        label: str | None = None,
+        json_stdout: bool = True,
+    ) -> None:
+        self.events = events
+        self.limits = limits or ContractLimits()
+        self.source = source
+        self.label = label
+        self.json_stdout = json_stdout
+        self.protocol_error: str | None = None
+        self.completion_seen = False
+        self._native_exit_code: int | None = None
+        self._models: list[str] = []
+        self._messages: dict[str, _Message] = {}
+        self._unknown: set[str] = set()
+        self._omission_notices: set[str] = set()
+        self._closed = False
+        self._stdout = (
+            _Lines(
+                min(self.limits.frame_bytes, 1024 * 1024),
+                self._frame,
+                lambda: self._protocol_failure("Native JSONL frame exceeded the byte limit."),
+            )
+            if json_stdout
+            else self._text_lines("stdout")
+        )
+        self._stderr = self._text_lines("stderr")
+
+    @property
+    def observed_models(self) -> tuple[str, ...]:
+        """Models explicitly reported by assistant, model-call or usage events."""
+        return tuple(self._models)
+
+    @property
+    def native_exit_code(self) -> int | None:
+        """Reported envelope status, not a child return code or APM outcome."""
+        return self._native_exit_code
+
+    def feed(self, stream: str, chunk: bytes) -> None:
+        """Keep draining both streams even after a protocol or retention failure."""
+        if self._closed:
+            return
+        if stream == "stdout":
+            self._stdout.feed(chunk)
+        elif stream == "stderr":
+            self._stderr.feed(chunk)
+        else:
+            raise ValueError("Contract stream must be stdout or stderr.")
+
+    def finish(self) -> None:
+        """Flush trailing complete text/JSON exactly once."""
+        if self._closed:
+            return
+        self._stdout.finish()
+        self._stderr.finish()
+        for message in self._messages.values():
+            if message.phase == "final_answer" and not message.suppressed:
+                message.lines.finish()
+        self._closed = True
+
+    def _emit(self, kind: str, **data: object) -> None:
+        self.events.emit(kind, source=self.source, label=self.label, **data)
+
+    def _activity(self, text: str, stream: str = "stdout") -> None:
+        if text:
+            # Both consumers use safe_text; keep raw bounded text in the
+            # transient event only, avoiding a second escape of literal paths.
+            self._emit("activity", text=text, stream=stream)
+
+    def _notice_once(self, key: str, message: str) -> None:
+        if key not in self._omission_notices:
+            self._omission_notices.add(key)
+            self._emit(
+                "diagnostic",
+                severity="info",
+                message=message,
+                action="Inspect the native session if more detail is needed.",
+            )
+
+    def _text_lines(self, stream: str) -> _Lines:
+        return _Lines(
+            _TEXT_BYTES,
+            lambda value: self._activity(value.decode("utf-8", errors="backslashreplace"), stream),
+            lambda: self._notice_once(
+                "long-text",
+                "Oversized native text lines omitted; stream draining continues.",
+            ),
+        )
+
+    def _protocol_failure(self, message: str) -> None:
+        if self.protocol_error is None:
+            self.protocol_error = message
+            self._emit(
+                "diagnostic",
+                severity="error",
+                message=message,
+                action="Inspect the native CLI version and retained transcript before retrying.",
+            )
+
+    def _frame(self, line: bytes) -> None:
+        if not line.strip():
+            return
+        try:
+            event = json.loads(line.decode("utf-8"))
+        except (ValueError, UnicodeError, RecursionError):
+            self._protocol_failure("Native stdout contained malformed JSONL.")
+            return
+        if not isinstance(event, dict) or not isinstance(event.get("type"), str):
+            self._protocol_failure("Native JSONL event is missing its type.")
+            return
+        kind = event["type"]
+        if len(kind) > 256:
+            self._protocol_failure("Native JSONL event type exceeded the metadata limit.")
+            return
+        if kind == "result":
+            self._native_result(event)
+            return
+        data = event.get("data", {})
+        if not isinstance(data, dict):
+            self._protocol_failure("Native JSONL event data must be an object.")
+            return
+        self._dispatch(kind, data)
+
+    def _dispatch(self, kind: str, data: dict) -> None:
+        handlers = {
+            "assistant.message_start": self._message_start,
+            "assistant.message_delta": self._delta,
+            "assistant.message": self._message,
+            "assistant.intent": self._intent,
+            "tool.execution_start": self._tool_started,
+            "tool.execution_complete": self._tool_finished,
+            "session.error": self._session_error,
+            "assistant.usage": self._observe_model,
+            "model.call_start": self._observe_model,
+            "session.usage": self._observe_model,
+            "session.usage_info": self._observe_model,
+        }
+        if kind in {"assistant.idle", "session.idle", "session.shutdown"}:
+            # The JSON CLI profile requires its final top-level result.
+            # Assistant/session liveness cannot substitute for that envelope.
+            self._emit("metadata", text=f"Native {kind.replace('.', ' ')}")
+        elif kind in handlers:
+            handlers[kind](data)
+        elif kind not in self._unknown:
+            if len(self._unknown) >= 32:
+                self._notice_once("unknown", "Further unknown native event types omitted.")
+                return
+            self._unknown.add(kind)
+            # No arbitrary data, keys, tool results, prompts or reasoning.
+            self._emit("metadata", text=f"Native event not interpreted: {kind}")
+
+    def _native_result(self, envelope: dict) -> None:
+        """Accept the top-level result observed with Copilot 1.0.83-5.
+
+        Only exitCode is retained. Session identity validates the envelope;
+        usage/timestamp and all extra fields are deliberately not forwarded.
+        In particular, no reasoning, encrypted content or raw JSON is logged.
+        """
+        code = envelope.get("exitCode")
+        session_id = envelope.get("sessionId")
+        if (
+            not isinstance(code, int)
+            or isinstance(code, bool)
+            or not isinstance(session_id, str)
+            or not session_id
+            or len(session_id) > 256
+            or not isinstance(envelope.get("usage"), dict)
+        ):
+            self._protocol_failure("Native result envelope has invalid completion metadata.")
+            return
+        if self._native_exit_code is not None:
+            if code != self._native_exit_code:
+                self._protocol_failure("Native result envelopes report conflicting exit codes.")
+            return
+        self._native_exit_code = code
+        # This flag records envelope observation, not successful execution.
+        # The conductor must also check protocol_error and the OS observation.
+        self.completion_seen = True
+        self._emit(
+            "metadata",
+            text=f"Native completion reported exit code {code}; not an APM assessment.",
+            native_exit_code=code,
+        )
+        if code != 0:
+            self._protocol_failure(
+                f"Native CLI reported exit code {code}; execution did not complete successfully."
+            )
+
+    def _get_message(self, data: dict) -> _Message | None:
+        identifier = data.get("messageId")
+        if not isinstance(identifier, str) or not identifier or len(identifier) > 256:
+            self._protocol_failure("Native assistant message is missing a valid messageId.")
+            return None
+        if identifier not in self._messages:
+            if len(self._messages) >= _CORRELATED_MESSAGES:
+                self._notice_once(
+                    "messages", "Message correlation limit reached; further response text omitted."
+                )
+                return None
+            self._messages[identifier] = _Message(self._text_lines("stdout"))
+        return self._messages[identifier]
+
+    def _message_phase(self, message: _Message, data: dict) -> None:
+        if "phase" not in data:
+            return
+        phase = data["phase"]
+        if phase is not None and (not isinstance(phase, str) or len(phase) > 64):
+            self._protocol_failure("Native assistant phase metadata is invalid.")
+            message.suppressed = True
+        elif message.phase_known and phase != message.phase:
+            self._notice_once(
+                "phase-change", "Native message phase changed; its response text is omitted."
+            )
+            message.suppressed = True
+        message.phase_known = True
+        message.phase = phase if isinstance(phase, str) else None
+        if message.phase != "final_answer" or message.suppressed:
+            # Explicit null/tool, analysis and unknown phases are not public
+            # assistant answers. Never release their content on finish().
+            message.lines.pending.clear()
+
+    def _message_start(self, data: dict) -> None:
+        self._observe_model(data)
+        message = self._get_message(data)
+        if message is not None and not message.complete:
+            self._message_phase(message, data)
+
+    def _delta(self, data: dict) -> None:
+        content = data.get("deltaContent")
+        if not isinstance(content, str):
+            self._protocol_failure("Native assistant delta is missing deltaContent text.")
+            return
+        message = self._get_message(data)
+        if message is not None and not message.complete:
+            self._message_phase(message, data)
+            message.delta(
+                content.encode("utf-8", errors="surrogatepass"),
+                allow_stream=message.phase == "final_answer" and not message.suppressed,
+            )
+
+    def _message(self, data: dict) -> None:
+        self._observe_model(data)
+        content = data.get("content")
+        if not isinstance(content, str):
+            self._protocol_failure("Native assistant message is missing content text.")
+            return
+        message = self._get_message(data)
+        if message is None or message.complete:
+            return
+        self._message_phase(message, data)
+        if message.suppressed or (message.phase_known and message.phase != "final_answer"):
+            message.complete = True
+            return
+        # Legacy complete-message events without any phase remain supported.
+        # Unknown-phase deltas are never released speculatively; a complete
+        # message with an explicit private/null phase is suppressed above.
+        encoded = content.encode("utf-8", errors="surrogatepass")
+        prefix = encoded[: message.length]
+        if not message.streamed:
+            message.lines.feed(encoded)
+        elif (
+            len(prefix) == message.length
+            and hashlib.sha256(prefix).digest() == message.digest.digest()
+        ):
+            message.lines.feed(encoded[message.length :])
+        else:
+            # Deltas are observations, not canonical final content. Keep the
+            # correction explicit without repeating the entire final response.
+            message.lines.pending.clear()
+            self._notice_once(
+                "correction",
+                "Native final response differs from streamed text; "
+                "bounded correction retained in the private transcript.",
+            )
+            # Verbose-only human detail, still retained through the same safety
+            # path. Do not repeat the whole response in ordinary output.
+            if len(encoded) <= _TEXT_BYTES:
+                self._emit("metadata", text=f"Corrected final response: {content}")
+            else:
+                self._emit("metadata", text="Corrected final response exceeded the text limit.")
+        message.lines.finish()
+        message.complete = True
+
+    def _intent(self, data: dict) -> None:
+        intent = data.get("intent")
+        if isinstance(intent, str):
+            self._bounded_activity(intent)
+        else:
+            self._protocol_failure("Native assistant intent is missing intent text.")
+
+    def _bounded_activity(self, text: str) -> None:
+        if len(text.encode("utf-8", errors="surrogatepass")) > _TEXT_BYTES:
+            self._notice_once("long-text", "Oversized native text omitted; draining continues.")
+        else:
+            self._activity(text)
+
+    def _tool_started(self, data: dict) -> None:
+        name = data.get("toolName")
+        if isinstance(name, str) and len(name) <= 256:
+            self._activity(f"Tool started: {name}")
+        else:
+            self._activity("Tool started")
+
+    def _tool_finished(self, data: dict) -> None:
+        status = {True: "completed", False: "failed"}.get(
+            data.get("success") if isinstance(data.get("success"), bool) else None,
+            "completion observed",
+        )
+        self._activity(f"Tool {status}")
+
+    def _session_error(self, data: dict) -> None:
+        message = data.get("message")
+        error_type = data.get("errorType")
+        if not isinstance(message, str) or not isinstance(error_type, str):
+            self._protocol_failure("Native session.error is missing its error type or message.")
+            return
+        # An explicit error cannot turn into success just because the process
+        # later exits zero. Keep this diagnostic bounded even for hostile data.
+        self.protocol_error = self.protocol_error or "Native session reported an error."
+        action = "Inspect the native error and execution prerequisites, then retry."
+        if error_type.lower() in {
+            "authentication",
+            "authentication_error",
+            "not_authenticated",
+            "unauthorized",
+        }:
+            action = "Run 'copilot login', then retry the contract."
+        if len(message) > _TEXT_BYTES or len(error_type) > 256:
+            message, error_type = "Error detail exceeded the text limit.", "native"
+        self._emit(
+            "diagnostic",
+            severity="error",
+            message=f"Native error ({error_type}): {message}",
+            action=action,
+        )
+
+    def _observe_model(self, data: dict) -> None:
+        model = data.get("model")
+        usage = data.get("usage")
+        if model is None and isinstance(usage, dict):
+            model = usage.get("model")
+        if model is None:
+            return
+        if not isinstance(model, str) or not model or len(model) > 256:
+            self._protocol_failure("Native execution model metadata is invalid.")
+        elif model not in self._models:
+            if len(self._models) >= 16:
+                self._protocol_failure("Native execution model count exceeded the metadata limit.")
+                return
+            self._models.append(model)
+            self._emit("metadata", text=f"Observed execution model: {model}")

--- a/src/apm_cli/contracts/workspace.py
+++ b/src/apm_cli/contracts/workspace.py
@@ -1,0 +1,266 @@
+"""Exact byte capture and independent assessment copies for a single leaf."""
+
+import hashlib
+import json
+import os
+import shutil
+import stat
+from pathlib import Path
+
+from ..utils.path_security import (
+    PathTraversalError,
+    ensure_path_within,
+    has_symlink_component,
+    validate_path_segments,
+)
+from .models import Artifact, BaselineSnapshot, ContractError, ContractLimits, FileEntry, LeafPlan
+from .process import local_git
+
+
+def _path(root: Path, name: str) -> Path:
+    target = root / name
+    try:
+        validate_path_segments(name, reject_empty=True, context="contract snapshot")
+        ensure_path_within(target, root)
+    except PathTraversalError as exc:
+        raise ContractError(
+            f"Snapshot path leaves its allowed directory: {name}", code="unsafe_snapshot_path"
+        ) from exc
+    if has_symlink_component(root, target):
+        raise ContractError(
+            f"Snapshot path contains a symlink: {name}", code="unsafe_snapshot_path"
+        )
+    return target
+
+
+def _read(root: Path, name: str, maximum: int) -> tuple[bytes, FileEntry]:
+    """Bounded no-follow read with descriptor identity checked before and after."""
+    path = _path(root, name)
+    fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
+    with os.fdopen(fd, "rb") as source:
+        before = os.fstat(source.fileno())
+        if not stat.S_ISREG(before.st_mode) or before.st_size > maximum:
+            raise ContractError(
+                f"Expected a bounded regular file: {name}", code="snapshot_file_limit"
+            )
+        data = source.read(maximum + 1)
+        after = os.fstat(source.fileno())
+
+    def identity(info: os.stat_result) -> tuple[int, int, int, int, int]:
+        return info.st_dev, info.st_ino, info.st_size, info.st_mtime_ns, info.st_ctime_ns
+
+    if (
+        len(data) > maximum
+        or identity(before) != identity(after)
+        or identity(after) != identity(path.stat(follow_symlinks=False))
+    ):
+        raise ContractError(f"File changed during capture: {name}", code="source_changed")
+    entry = FileEntry(
+        name, hashlib.sha256(data).hexdigest(), len(data), stat.S_IMODE(after.st_mode) & 0o777
+    )
+    return data, entry
+
+
+def _digest(entries: tuple[FileEntry, ...]) -> str:
+    content = [[item.relative_path, item.sha256, item.size, item.mode] for item in entries]
+    return hashlib.sha256(json.dumps(content, separators=(",", ":")).encode("utf-8")).hexdigest()
+
+
+def inspect_retained_log(run_directory: Path, maximum_bytes: int) -> FileEntry:
+    """Read the finalized bounded transcript through the exact-byte authority."""
+    return _read(run_directory, "transcript.log", maximum_bytes)[1]
+
+
+def _git_marker(root: Path) -> Path | None:
+    return next(
+        (parent / ".git" for parent in (root, *root.parents) if (parent / ".git").exists()), None
+    )
+
+
+def _selected_names(plan: LeafPlan) -> tuple[str, ...]:
+    root = plan.project_root
+    names = set(plan.contract.needs)
+    names.update((plan.contract.path.relative_to(root).as_posix(), "apm.yml"))
+    for lock in ("apm.lock.yaml", "apm.lock"):
+        if (root / lock).exists():
+            names.add(lock)
+    if _git_marker(root) is not None:
+        for line in local_git(root, "ls-files", "--stage", "-z").split(b"\0"):
+            if not line:
+                continue
+            metadata, encoded = line.split(b"\t", 1)
+            name = encoded.decode("utf-8")
+            if metadata.split()[0] == b"160000":
+                raise ContractError("Git submodules are unsupported in captured baselines.")
+            if name.split("/")[0] in {".apm", "apm_modules"}:
+                continue
+            path = _path(root, name)
+            if path.exists():
+                names.add(name)
+            if len(names) > plan.limits.baseline_files:
+                raise ContractError("Baseline file count exceeds the limit.", code="baseline_limit")
+    checks = _path(root, "checks")
+    if checks.exists():
+        if not checks.is_dir():
+            raise ContractError("The checks resource bundle must be a directory.")
+        for count, path in enumerate(checks.rglob("*"), start=1):
+            if count > plan.limits.resource_files * 2:
+                raise ContractError(
+                    "Check resource tree exceeds the entry limit.", code="resource_limit"
+                )
+            name = path.relative_to(root).as_posix()
+            path = _path(root, name)
+            if not path.is_dir():
+                names.add(name)
+    names.discard(plan.contract.produces)
+    if len(names) > plan.limits.baseline_files:
+        raise ContractError("Baseline file count exceeds the limit.", code="baseline_limit")
+    if len({name.casefold() for name in names}) != len(names):
+        raise ContractError("Case-colliding snapshot paths are unsupported.")
+    return tuple(sorted(names))
+
+
+def inspect_workspace(plan: LeafPlan) -> tuple[FileEntry, ...]:
+    """Read effective tracked bytes and explicit untracked resources without writes."""
+    entries = []
+    total = resource_total = resource_count = 0
+    for name in _selected_names(plan):
+        _, entry = _read(plan.project_root, name, plan.limits.file_bytes)
+        entries.append(entry)
+        total += entry.size
+        if name.startswith("checks/"):
+            resource_total += entry.size
+            resource_count += 1
+        if total > plan.limits.baseline_bytes:
+            raise ContractError("Baseline bytes exceed the limit.", code="baseline_limit")
+        if (
+            resource_total > plan.limits.resource_bytes
+            or resource_count > plan.limits.resource_files
+        ):
+            raise ContractError("Check resources exceed the limit.", code="resource_limit")
+    source = plan.contract.path.relative_to(plan.project_root).as_posix()
+    expected = {source: plan.contract.source_digest, "apm.yml": plan.manifest_digest}
+    if plan.lock_digest is not None:
+        lock_name = (
+            "apm.lock.yaml" if (plan.project_root / "apm.lock.yaml").exists() else "apm.lock"
+        )
+        expected[lock_name] = plan.lock_digest
+    for entry in entries:
+        digest = expected.get(entry.relative_path)
+        if digest is not None and digest != entry.sha256:
+            raise ContractError("Planned source identity changed. Plan again.", code="plan_changed")
+    return tuple(entries)
+
+
+def _write(root: Path, entry: FileEntry, data: bytes) -> None:
+    destination = _path(root, entry.relative_path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with destination.open("xb") as target:
+        target.write(data)
+    destination.chmod(entry.mode)
+
+
+def _copy_entries(source: Path, destination: Path, entries: tuple[FileEntry, ...]) -> None:
+    for expected in entries:
+        data, observed = _read(source, expected.relative_path, expected.size)
+        if observed != expected:
+            raise ContractError("Captured baseline identity changed.", code="baseline_changed")
+        _write(destination, expected, data)
+
+
+def _initialize_git(root: Path, template: Path) -> str:
+    local_git(root, "init", "--quiet", f"--template={template}")
+    info = root / ".git" / "info"
+    info.mkdir(exist_ok=True)
+    (info / "attributes").write_text(
+        "* -text -filter -ident -working-tree-encoding\n", encoding="ascii"
+    )
+    local_git(root, "add", "--all", "--force", "--", ".")
+    local_git(root, "commit", "--quiet", "--allow-empty", "-m", "Captured contract baseline")
+    return local_git(root, "rev-parse", "HEAD").decode("ascii").strip()
+
+
+def capture_workspace(plan: LeafPlan, run_directory: Path) -> BaselineSnapshot:
+    """Materialize the admitted effective tree and a fresh producer workspace."""
+    entries = inspect_workspace(plan)
+    baseline = run_directory / "baseline"
+    producer = run_directory / "producer"
+    baseline.mkdir(mode=0o700)
+    producer.mkdir(mode=0o700)
+    _copy_entries(plan.project_root, baseline, entries)
+    _copy_entries(baseline, producer, entries)
+    template = run_directory / "git-template"
+    template.mkdir(mode=0o700)
+    original_head = None
+    if _git_marker(plan.project_root) is not None:
+        refs = local_git(
+            plan.project_root, "rev-parse", "--verify", "--quiet", "HEAD", accepted_codes=(0, 1)
+        )
+        original_head = refs.decode("ascii").strip() or None
+    head = _initialize_git(baseline, template)
+    shutil.copytree(baseline / ".git", producer / ".git")
+    resources = tuple(entry for entry in entries if entry.relative_path.startswith("checks/"))
+    return BaselineSnapshot(
+        baseline, producer, entries, _digest(entries), original_head, head, _digest(resources)
+    )
+
+
+def capture_output(
+    snapshot: BaselineSnapshot,
+    declared_path: str,
+    run_directory: Path,
+    limits: ContractLimits,
+) -> Artifact | None:
+    """Capture only a newly produced file; absence remains absence, not an empty file."""
+    target = _path(snapshot.producer, declared_path)
+    if not target.exists():
+        return None
+    data, entry = _read(snapshot.producer, declared_path, limits.output_bytes)
+    output_root = run_directory / "artifacts"
+    output_root.mkdir(mode=0o700)
+    _write(output_root, entry, data)
+    captured = _path(output_root, declared_path)
+    captured.chmod(0o400)
+    return Artifact(declared_path, captured, entry.sha256, entry.size)
+
+
+def prepare_check_workspace(
+    snapshot: BaselineSnapshot,
+    artifact: Artifact,
+    run_directory: Path,
+    check_name: str,
+) -> Path:
+    """Fresh baseline plus captured bytes; never apply candidate patches here."""
+    parent = run_directory / "assessments"
+    parent.mkdir(exist_ok=True, mode=0o700)
+    root = _path(parent, check_name)
+    root.mkdir(mode=0o700)
+    _copy_entries(snapshot.root, root, snapshot.files)
+    shutil.copytree(snapshot.root / ".git", root / ".git", symlinks=False)
+    data, observed = _read(artifact.path.parent, artifact.path.name, artifact.size)
+    if observed.sha256 != artifact.sha256 or observed.size != artifact.size:
+        raise ContractError("Captured output identity changed.", code="artifact_changed")
+    _write(root, FileEntry(artifact.relative_path, artifact.sha256, artifact.size, 0o400), data)
+    return root
+
+
+def verify_check_integrity(
+    snapshot: BaselineSnapshot, artifact: Artifact, check_workspace: Path
+) -> bool:
+    """Check supplied identities; no claim against same-user mutation-and-restore."""
+    try:
+        _, captured = _read(artifact.path.parent, artifact.path.name, artifact.size)
+        _, subject = _read(check_workspace, artifact.relative_path, artifact.size)
+        if any(
+            entry.sha256 != artifact.sha256 or entry.size != artifact.size
+            for entry in (captured, subject)
+        ):
+            return False
+        for expected in snapshot.files:
+            if expected.relative_path.startswith("checks/"):
+                _, observed = _read(check_workspace, expected.relative_path, expected.size)
+                if observed != expected:
+                    return False
+        return True
+    except (OSError, ContractError):
+        return False

--- a/src/apm_cli/core/contract_logger.py
+++ b/src/apm_cli/core/contract_logger.py
@@ -1,0 +1,403 @@
+"""Line-oriented presentation for contract plans and run observations."""
+
+from __future__ import annotations
+
+import os
+import stat
+import sys
+from collections import deque
+from pathlib import Path
+from typing import BinaryIO
+
+from apm_cli.contracts.models import (
+    CheckObservation,
+    ContractError,
+    ContractLimits,
+    FileEntry,
+    LeafPlan,
+    Outcome,
+    RunEvent,
+    RunResult,
+)
+from apm_cli.contracts.stream import safe_text
+from apm_cli.utils import console
+
+from .command_logger import CommandLogger
+
+
+class _Transcript:
+    """Bounded beginning/tail retention with exact omitted byte/line counts."""
+
+    def __init__(self, limit: int) -> None:
+        # Reserve room for the ASCII omission marker, even at the retention cap.
+        self.budget = max(0, limit - 256)
+        self.head: list[bytes] = []
+        self.tail: deque[bytes] = deque()
+        self.head_bytes = 0
+        self.tail_bytes = 0
+        self.omitted_bytes = 0
+        self.omitted_lines = 0
+        self.head_full = False
+
+    def append(self, line: str) -> None:
+        encoded = (line + "\n").encode("ascii")
+        if not self.head_full and self.head_bytes + len(encoded) <= self.budget // 2:
+            self.head.append(encoded)
+            self.head_bytes += len(encoded)
+            return
+        self.head_full = True
+        self.tail.append(encoded)
+        self.tail_bytes += len(encoded)
+        while self.tail and self.head_bytes + self.tail_bytes > self.budget:
+            removed = self.tail.popleft()
+            self.tail_bytes -= len(removed)
+            self.omitted_bytes += len(removed)
+            self.omitted_lines += 1
+
+    def write(self, target: BinaryIO) -> None:
+        for line in self.head:
+            target.write(line)
+        if self.omitted_lines:
+            target.write(
+                (
+                    f"[i] Transcript truncated: {self.omitted_lines} lines / "
+                    f"{self.omitted_bytes} bytes omitted between beginning and tail.\n"
+                ).encode("ascii")
+            )
+        for line in self.tail:
+            target.write(line)
+
+
+class ContractLogger(CommandLogger):
+    """The only human renderer for plans, supervised observations and results.
+
+    close() freezes the transcript *before* the record owner hashes it. A later
+    finished event renders the already-recorded result without touching logs.
+    """
+
+    def __init__(self, verbose: bool = False) -> None:
+        super().__init__("contract", verbose=verbose)
+        self._transcript = _Transcript(ContractLimits().transcript_bytes)
+        self._file: BinaryIO | None = None
+        self._run_id: str | None = None
+        self._run_directory: Path | None = None
+        self._closed = False
+        self._finished = False
+        self._human_enabled = True
+        self._last_phase: str | None = None
+        self._last_activity = 0.0
+
+    @property
+    def transcript_metadata(self) -> dict[str, int | str]:
+        """Return owner-counted retention metadata, finalized by close().
+
+        Each access returns a fresh snapshot; no transcript content is read.
+        Omission counts refer to sanitized transcript bytes and logical lines.
+        """
+        return {
+            "omitted_bytes": self._transcript.omitted_bytes,
+            "omitted_lines": self._transcript.omitted_lines,
+            "retention": "bounded-beginning-tail",
+            "redaction": "best-effort",
+        }
+
+    def attach_run(self, run_id: str, run_directory: Path) -> None:
+        """Exclusively create a private transcript in the admitted run directory."""
+        if self._run_id is not None or self._closed:
+            raise RuntimeError("A contract logger can only attach one run.")
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(run_directory / "transcript.log", flags, 0o600)
+        self._file = os.fdopen(descriptor, "wb")
+        self._run_id = run_id
+        self._run_directory = run_directory
+
+    def close(self) -> None:
+        """Flush once; errors propagate so recording cannot announce success."""
+        if self._closed:
+            return
+        self._closed = True
+        if self._file is not None:
+            try:
+                self._transcript.write(self._file)
+                self._file.flush()
+                os.fsync(self._file.fileno())
+            finally:
+                self._file.close()
+
+    def _write(
+        self,
+        message: str,
+        *,
+        severity: str = "info",
+        detail: bool = False,
+        attribution: str | None = None,
+    ) -> None:
+        text = safe_text(message)
+        prefix = f"{safe_text(attribution, limit=256)}: " if attribution else ""
+        symbol, color = {
+            "start": ("running", "blue"),
+            "info": ("info", "blue"),
+            "warning": ("warning", "yellow"),
+            "error": ("error", "red"),
+            "success": ("check", "green"),
+            "detail": ("info", "dim"),
+        }[severity]
+        if not self._closed:
+            self._transcript.append(f"{console.STATUS_SYMBOLS[symbol]} {prefix}{text}")
+        if not self._human_enabled or (detail and not self.verbose):
+            return
+        try:
+            # Keep paths and messages as intact logical lines in pipes and
+            # terminals. The terminal may wrap visually; the renderer must not
+            # inject newlines or continuation prefixes into copyable paths.
+            console._rich_echo(
+                prefix + text,
+                color=color,
+                symbol=symbol,
+                propagate_broken_pipe=True,
+                plain="NO_COLOR" in os.environ,
+                natural_wrap=True,
+            )
+        except BrokenPipeError:
+            # Do not recursively try to print an error into the closed pipe.
+            # Observation, stream draining, recording and process cleanup remain.
+            self._disable_human_output()
+
+    def _disable_human_output(self) -> None:
+        self._human_enabled = False
+        # TextIO may retain a failed write and retry it during interpreter
+        # shutdown. Silence only the already-broken human descriptor (stderr
+        # in machine mode), without changing the healthy machine-output stream.
+        stream = sys.stderr if console._console_stderr else sys.stdout
+        try:
+            descriptor = stream.fileno()
+            mode = os.fstat(descriptor).st_mode
+            if not (stat.S_ISFIFO(mode) or stat.S_ISSOCK(mode)):
+                return
+        except (AttributeError, OSError, ValueError):
+            return
+        try:
+            null = os.open(os.devnull, os.O_WRONLY)
+            try:
+                os.dup2(null, descriptor)
+            finally:
+                os.close(null)
+        except OSError:
+            # Cleanup/recording still take precedence if the descriptor is
+            # already closed or a process has exhausted its open-file limit.
+            pass
+
+    def on_event(self, event: RunEvent) -> None:
+        """Consume the conductor's ordered stream; never derive an outcome."""
+        handlers = {
+            "selected": self._selected,
+            "phase": self._phase,
+            "activity": self._activity,
+            "diagnostic": self._diagnostic,
+            "metadata": self._metadata,
+            "process_started": self._process_started,
+            "stop_requested": self._stop_requested,
+            "stop_observed": self._stop_observed,
+            "check_started": self._check_started,
+            "check_finished": self._check_finished,
+            "finished": self._result,
+            "heartbeat": self._heartbeat,
+        }
+        handler = handlers.get(event.kind)
+        if handler is not None:
+            handler(event)
+            hidden_detail = event.kind in {"metadata", "process_started"} and not self.verbose
+            if event.kind != "heartbeat" and not hidden_detail:
+                self._last_activity = event.elapsed_seconds
+
+    @staticmethod
+    def _field(event: RunEvent, name: str, default: str = "unknown") -> str:
+        value = event.data.get(name)
+        return value if isinstance(value, str) else default
+
+    def _selected(self, event: RunEvent) -> None:
+        self._write(f"Contract: {self._field(event, 'contract')}", severity="start")
+        self._write(
+            f"Harness: {self._field(event, 'harness')}; "
+            f"requested model: {self._field(event, 'model', 'native default')}"
+        )
+        self._write(f"Run: {event.run_id}")
+        self._write(f"Record and logs: {self._field(event, 'run_directory')}")
+        self._write(
+            "Native host: advisory, not isolated. Consent does not override policy.",
+            severity="warning",
+        )
+
+    def _phase(self, event: RunEvent) -> None:
+        phase = self._field(event, "name")
+        if phase == self._last_phase:
+            return
+        self._last_phase = phase
+        self._write(phase.capitalize(), severity="start")
+
+    def _attribution(self, event: RunEvent) -> str:
+        source = "copilot" if event.source == "harness" else event.source
+        label = self._field(event, "label", "")
+        stream = self._field(event, "stream", "")
+        parts = [source]
+        if label:
+            parts.append(label)
+        if stream == "stderr":
+            parts.append("stderr")
+        return " ".join(parts) + " (untrusted)"
+
+    def _activity(self, event: RunEvent) -> None:
+        self._write(self._field(event, "text", ""), attribution=self._attribution(event))
+
+    def _metadata(self, event: RunEvent) -> None:
+        self._write(
+            self._field(event, "text", ""),
+            severity="detail",
+            detail=True,
+            attribution=self._attribution(event),
+        )
+
+    def _diagnostic(self, event: RunEvent) -> None:
+        severity = self._field(event, "severity", "info")
+        if severity not in {"info", "warning", "error"}:
+            severity = "info"
+        self._write(
+            self._field(event, "message"),
+            severity=severity,
+            attribution=self._attribution(event) if event.source != "engine" else None,
+        )
+        action = self._field(event, "action", "")
+        if action:
+            self._write(action)
+
+    def _process_started(self, event: RunEvent) -> None:
+        pid = event.data.get("pid")
+        pgid = event.data.get("pgid")
+        self._write(
+            f"Managed child started: pid={pid if isinstance(pid, int) else 'unknown'}, "
+            f"pgid={pgid if isinstance(pgid, int) else 'unknown'}",
+            severity="detail",
+            detail=True,
+        )
+
+    def _stop_requested(self, event: RunEvent) -> None:
+        self._write(
+            f"Stop requested -- {self._field(event, 'reason')}; waiting for confirmation.",
+            severity="warning",
+        )
+
+    def _stop_observed(self, event: RunEvent) -> None:
+        if event.data.get("confirmed") is True:
+            self._write("Original process-group stop confirmed; checking for provisional output.")
+            self._write("Escaped descendants are unobserved.", severity="detail", detail=True)
+        else:
+            self._write(
+                "Stop unconfirmed; a child may still be running. Inspect before retrying.",
+                severity="error",
+            )
+
+    def _check_started(self, event: RunEvent) -> None:
+        self._write(f"Check: {self._field(event, 'name')}", severity="start")
+
+    def _check_finished(self, event: RunEvent) -> None:
+        observation = event.data.get("observation")
+        if not isinstance(observation, CheckObservation):
+            raise TypeError("check_finished requires a CheckObservation.")
+        status, severity = {
+            0: ("passed", "success"),
+            1: ("failed", "error"),
+        }.get(observation.normalized, ("incomplete", "warning"))
+        raw = observation.process.returncode
+        raw_text = "no exit status" if raw is None else f"raw exit {raw}"
+        self._write(f"{observation.name}: {status} ({raw_text})", severity=severity)
+        if observation.normalized != 0:
+            self._write(observation.reason)
+            self._write("Inspect the check definition and retained transcript, then rerun.")
+
+    def _heartbeat(self, event: RunEvent) -> None:
+        elapsed = event.data.get("elapsed_seconds", event.elapsed_seconds)
+        if not isinstance(elapsed, (int, float)) or elapsed - self._last_activity < 15:
+            return
+        self._write(f"Execution still running; {elapsed:.0f}s elapsed.")
+        self._last_activity = elapsed
+
+    def _result(self, event: RunEvent) -> None:
+        if self._finished:
+            return
+        result = event.data.get("result")
+        if not isinstance(result, RunResult):
+            raise TypeError("finished requires a recorded RunResult.")
+        self._finished = True
+        passed = sum(check.normalized == 0 for check in result.checks)
+        headline = f"{result.outcome.name} -- {passed}/{len(result.checks)} checks passed"
+        if result.outcome == Outcome.VERIFIED:
+            headline += "; native-advisory assessment"
+        elif result.stop_reason:
+            headline += f"; {result.stop_reason}; assessment incomplete"
+        elif result.artifact is None:
+            headline += "; declared output was not captured"
+        self._write(
+            headline,
+            severity="success" if result.outcome == Outcome.VERIFIED else "error",
+        )
+        if result.artifact is not None:
+            label = "Artifact" if result.outcome == Outcome.VERIFIED else "Provisional artifact"
+            self._write(f"{label}: {result.artifact.path}")
+        if result.outcome != Outcome.VERIFIED:
+            self._write("Inspect the contract, retained record and transcript before retrying.")
+        self._write(
+            "Observed execution model: "
+            + (", ".join(result.observed_models) if result.observed_models else "unknown")
+        )
+        self._write(f"Record and logs: {result.run_directory}")
+        self._write("Private, best-effort redacted local logs; not protected provenance.")
+
+    def render_plan(self, plan: LeafPlan, inventory: tuple[FileEntry, ...]) -> None:
+        """Show the admitted surface without printing source bodies or prompts."""
+        self._write("Plan only -- no execution", severity="start")
+        self._write(f"Contract: {plan.contract.path}")
+        self._write(f"Harness: {plan.harness}; requested model: {plan.model or 'native default'}")
+        self._write(f"Native executable: {plan.executable}")
+        self._write(
+            f"Baseline: {len(inventory)} files, {sum(item.size for item in inventory)} bytes"
+        )
+        for name in plan.contract.needs:
+            self._write(f"Input: {name}")
+        self._write(f"Declared output: {plan.contract.produces}")
+        self._write(f"Checks: {len(plan.contract.checks)}")
+        for check in plan.contract.checks:
+            self._write(f"Check: {check.name}")
+            self._write(check.command, severity="detail", detail=True)
+        self._write(f"Installed skills: {len(plan.imported_skills)}")
+        for skill in plan.imported_skills:
+            self._write(f"Imported skill: {skill.name}")
+            identity = f"Source identity: {skill.lock_identity}; {skill.assurance}"
+            if skill.assurance == "observed-local-source":
+                identity += ", not a cryptographic pin"
+            self._write(identity)
+            self._write(
+                f"Observed source SHA-256: {skill.source_digest}", severity="detail", detail=True
+            )
+            if skill.resolved_commit:
+                self._write(
+                    f"Resolved commit: {skill.resolved_commit}", severity="detail", detail=True
+                )
+        self._write(f"Policy: {plan.policy_status}")
+        self._write(
+            f"Watchdogs: attempt {plan.limits.attempt_seconds:g}s; "
+            f"each check {plan.limits.check_seconds:g}s"
+        )
+        self._write(
+            "Native execution is not isolated: host files, network and ambient credentials "
+            "may be accessible. --allow-advisory is required in TTY and pipes; "
+            "it does not override mandatory policy.",
+            severity="warning",
+        )
+
+    def render_error(self, error: ContractError) -> None:
+        """Render a pre-admission refusal without inventing a run or a success."""
+        self._write(f"{error.outcome.name} -- {error.code}: {error}", severity="error")
+        if error.location is not None:
+            self._write(
+                f"Source: {error.location.path}:{error.location.line}:{error.location.column}"
+            )

--- a/src/apm_cli/policy/contract_prerequisite.py
+++ b/src/apm_cli/policy/contract_prerequisite.py
@@ -1,0 +1,78 @@
+"""Read-only native-contract prerequisite behind the policy discovery API."""
+
+import os
+import subprocess
+from pathlib import Path
+
+import yaml
+
+from ..utils.git_env import get_git_executable, git_subprocess_env
+from ..utils.yaml_io import load_yaml_str
+from .discovery import PolicyFetchResult, _unverifiable_cache_pin
+from .project_config import ProjectPolicyConfigError, parse_project_policy_hash_pin
+
+
+def discover_contract_prerequisite(
+    project_root: Path, *, manifest_data: dict | None = None
+) -> PolicyFetchResult:
+    """Require positive no-policy evidence without fetching or writing caches."""
+    if os.environ.get("APM_POLICY_DISABLE") == "1":
+        return PolicyFetchResult(outcome="disabled")
+    try:
+        if manifest_data is None:
+            with (project_root / "apm.yml").open("rb") as stream:
+                raw = stream.read(256 * 1024 + 1)
+            if len(raw) > 256 * 1024:
+                raise ValueError("Project manifest exceeds the contract read limit.")
+            manifest_data = load_yaml_str(raw.decode("utf-8"))
+        if not isinstance(manifest_data, dict):
+            raise ValueError("Project manifest must be a mapping.")
+        pin = parse_project_policy_hash_pin(manifest_data.get("policy"))
+    except ProjectPolicyConfigError as exc:
+        return PolicyFetchResult(outcome="hash_mismatch", source="apm.yml", error=str(exc))
+    except (OSError, UnicodeError, ValueError, yaml.YAMLError):
+        return PolicyFetchResult(
+            outcome="malformed", source="apm.yml", error="Cannot read project policy configuration."
+        )
+    if pin is not None:
+        return _unverifiable_cache_pin(pin.normalized, "apm.yml")
+    if "policy" in manifest_data:
+        return PolicyFetchResult(
+            outcome="cache_miss_fetch_fail",
+            source="apm.yml",
+            error="Configured governance is unsupported by native contracts.",
+        )
+
+    def has_git_administration(parent: Path) -> bool:
+        return (
+            (parent / ".git").exists()
+            or (parent / ".git").is_symlink()
+            or (
+                (parent / "HEAD").exists()
+                and ((parent / "objects").exists() or (parent / "config").exists())
+            )
+        )
+
+    if not any(has_git_administration(parent) for parent in (project_root, *project_root.parents)):
+        return PolicyFetchResult(outcome="no_git_remote")
+    try:
+        result = subprocess.run(
+            [get_git_executable(), "remote"],
+            cwd=project_root,
+            env=git_subprocess_env(),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=5,
+        )
+    except (OSError, ValueError, subprocess.SubprocessError):
+        return PolicyFetchResult(
+            outcome="cache_miss_fetch_fail",
+            error="Cannot establish Git remote configuration offline.",
+        )
+    if result.returncode == 0 and not result.stdout.strip():
+        return PolicyFetchResult(outcome="no_git_remote")
+    return PolicyFetchResult(
+        outcome="cache_miss_fetch_fail",
+        error="Remote governance cannot be established by the offline native-contract profile.",
+    )

--- a/src/apm_cli/policy/discovery.py
+++ b/src/apm_cli/policy/discovery.py
@@ -330,6 +330,15 @@ def discover_policy_with_chain(
     return fetch_result
 
 
+def discover_contract_policy(
+    project_root: Path, *, manifest_data: dict | None = None
+) -> PolicyFetchResult:
+    """Acquire positive no-policy evidence without ambiguous cache-only absence."""
+    from .contract_prerequisite import discover_contract_prerequisite
+
+    return discover_contract_prerequisite(project_root, manifest_data=manifest_data)
+
+
 def _strip_source_prefix(src: str) -> str:
     """Strip 'org:' / 'url:' / 'file:' prefix from a PolicyFetchResult.source."""
     return src.removeprefix("org:").removeprefix("url:").removeprefix("file:")

--- a/src/apm_cli/runtime/base.py
+++ b/src/apm_cli/runtime/base.py
@@ -8,9 +8,13 @@ import threading
 import time
 from abc import ABC, abstractmethod
 from contextlib import suppress
-from typing import Any
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 from ..core.tls_trust import build_child_tls_env
+
+if TYPE_CHECKING:
+    from ..contracts.models import BaselineSnapshot, LeafPlan, ProcessRequest
 
 
 def _terminate_and_reap(process: subprocess.Popen) -> None:
@@ -129,6 +133,23 @@ def _stream_subprocess_output(
 
 class RuntimeAdapter(ABC):
     """Base adapter interface for LLM runtimes."""
+
+    def build_contract_request(
+        self,
+        plan: "LeafPlan",
+        snapshot: "BaselineSnapshot",
+        run_directory: Path,
+        *,
+        timeout_seconds: float,
+    ) -> "ProcessRequest":
+        """Build a managed leaf invocation; legacy adapters are unsupported."""
+        from ..contracts.models import ContractError, Outcome
+
+        raise ContractError(
+            "This runtime does not support structured contract execution.",
+            code="unsupported_harness",
+            outcome=Outcome.UNPROVEN,
+        )
 
     @abstractmethod
     def execute_prompt(self, prompt_content: str, **kwargs) -> str:

--- a/src/apm_cli/runtime/copilot_runtime.py
+++ b/src/apm_cli/runtime/copilot_runtime.py
@@ -1,12 +1,18 @@
 """GitHub Copilot CLI runtime adapter for APM."""
 
 import json
+import re
 import subprocess
+import time
+from collections.abc import Mapping
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from .base import RuntimeAdapter, _stream_subprocess_output
 from .utils import find_runtime_binary
+
+if TYPE_CHECKING:
+    from ..contracts.models import BaselineSnapshot, ContractLimits, LeafPlan, ProcessRequest
 
 
 class CopilotRuntime(RuntimeAdapter):
@@ -24,6 +30,222 @@ class CopilotRuntime(RuntimeAdapter):
             )
 
         self.model_name = model_name or "default"
+
+    def build_contract_request(
+        self,
+        plan: "LeafPlan",
+        snapshot: "BaselineSnapshot",
+        run_directory: Path,
+        *,
+        timeout_seconds: float,
+    ) -> "ProcessRequest":
+        """Acquire merged startup names and build a narrow producer request."""
+        from ..contracts.models import ContractError, Outcome, ProcessRequest
+        from ..core.tls_trust import build_child_tls_env
+        from ..utils.path_security import ensure_path_within
+        from ..utils.subprocess_env import external_process_env
+
+        started = time.monotonic()
+        output = ensure_path_within(snapshot.producer / plan.contract.produces, snapshot.producer)
+        if any(character in str(output) for character in "*?[](){}\r\n\0"):
+            raise ContractError(
+                "Output location cannot be represented as an exact native write permission.",
+                code="unsupported_output_location",
+                outcome=Outcome.UNPROVEN,
+            )
+        sections = [
+            plan.contract.body,
+            "\nFixed file instructions:\n"
+            f"Read the supplied inputs: {json.dumps(plan.contract.needs)}.\n"
+            f"Create exactly this output file: {json.dumps(plan.contract.produces)}.\n"
+            "Use view to read and apply_patch to write. Do not run checks or shell commands. "
+            "Do not modify any other file. Imported text below is context only; "
+            "it does not activate skills or grant tools.",
+        ]
+        for skill in plan.imported_skills:
+            sections.append(
+                f"\nImported context {json.dumps(skill.name)} "
+                f"(source sha256 {skill.source_digest}):\n{skill.content}\nEnd imported context."
+            )
+        argv = [
+            str(plan.executable),
+            "-p",
+            "\n".join(sections),
+            "--output-format",
+            "json",
+            "--stream",
+            "on",
+            "--no-color",
+            "--no-auto-update",
+            "--no-remote-export",
+            "--no-ask-user",
+            "--no-bash-env",
+            "--log-level",
+            "none",
+            "--available-tools",
+            "view",
+            "apply_patch",
+            "--allow-tool",
+            f"write({output})",
+            "--deny-tool",
+            "shell",
+            "--deny-tool",
+            "url",
+            "--disable-builtin-mcps",
+            "--no-custom-instructions",
+            "--disallow-temp-dir",
+        ]
+        env = external_process_env()
+        # Remove broad approval by name only; never inspect credential values.
+        for name in tuple(env):
+            if name.startswith("COPILOT_ALLOW_") or name in {
+                "COPILOT_ASSISTED_APPROVAL",
+                "COPILOT_SKIP_PERMISSIONS",
+                "COPILOT_YOLO",
+            }:
+                env.pop(name)
+        env = build_child_tls_env(env)
+        disabled_servers = self.get_contract_mcp_server_names(
+            plan.executable,
+            snapshot.producer,
+            timeout_seconds=timeout_seconds,
+            env=env,
+            limits=plan.limits,
+        )
+        for name in disabled_servers:
+            argv.extend(("--disable-mcp-server", name))
+        if plan.model is not None:
+            argv.extend(("--model", plan.model))
+        remaining = timeout_seconds - (time.monotonic() - started)
+        if remaining <= 0:
+            raise ContractError(
+                "The attempt watchdog expired during native MCP inventory.", code="attempt_deadline"
+            )
+        return ProcessRequest(
+            argv=tuple(argv),
+            cwd=snapshot.producer,
+            timeout_seconds=remaining,
+            env=env,
+            control_observations={
+                "disabled_configured_mcp_servers": disabled_servers,
+                "startup_scope": (
+                    "Native mcp list --json inventory: User, Workspace, Plugin and Builtin "
+                    "MCP sources. Returned names are disabled for this invocation; "
+                    "extensions and the host environment are not isolated."
+                ),
+            },
+        )
+
+    @staticmethod
+    def get_contract_mcp_server_names(
+        executable: Path,
+        project_root: Path,
+        *,
+        timeout_seconds: float,
+        env: Mapping[str, str],
+        limits: "ContractLimits",
+    ) -> tuple[str, ...]:
+        """Acquire the native merged inventory under managed dispatch supervision.
+
+        No model, prompt, config crawler or plan-time native probe is involved.
+        Only names survive this call. JSON values and stderr never enter the
+        event/log/record pipeline. The native inventory owns source merging;
+        extensions and same-identity concurrent config changes remain outside
+        any isolation guarantee.
+        """
+        from ..contracts import process
+        from ..contracts.models import ContractError, Outcome, ProcessRequest
+
+        maximum = 256 * 1024
+        stdout = bytearray()
+        oversized = False
+
+        def receive(stream: str, chunk: bytes) -> None:
+            nonlocal oversized
+            if stream != "stdout" or oversized:
+                return
+            if len(stdout) + len(chunk) > maximum:
+                oversized = True
+                stdout.clear()
+                return
+            stdout.extend(chunk)
+
+        def refuse(*, operational: bool = False) -> ContractError:
+            return ContractError(
+                "Native merged MCP inventory could not be established safely. "
+                f"Check that the selected executable ({executable}) supports "
+                "'mcp list --json' and completes without lingering children. "
+                "No producer was launched.",
+                code="native_mcp_inventory_failed" if operational else "native_mcp_unobservable",
+                outcome=Outcome.HALTED if operational else Outcome.UNPROVEN,
+            )
+
+        def unique_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+            value: dict[str, object] = {}
+            for key, item in pairs:
+                if key in value:
+                    raise ValueError("Duplicate configuration key.")
+                value[key] = item
+            return value
+
+        def parse_names() -> tuple[str, ...] | None:
+            """Discard values and decoder exceptions before any refusal escapes."""
+
+            def reject_constant(value: str) -> None:
+                raise ValueError("Non-JSON numeric constant.")
+
+            try:
+                document = json.loads(
+                    stdout, object_pairs_hook=unique_object, parse_constant=reject_constant
+                )
+            except (ValueError, TypeError, RecursionError):
+                return None
+            if not isinstance(document, dict) or not isinstance(document.get("mcpServers"), dict):
+                return None
+            servers = document["mcpServers"]
+            if len(servers) > 128 or any(
+                not re.fullmatch(r"[A-Za-z0-9_][A-Za-z0-9_.:/@-]{0,255}", name)
+                or not isinstance(value, dict)
+                for name, value in servers.items()
+            ):
+                return None
+            return tuple(sorted(servers))
+
+        request = ProcessRequest(
+            argv=(
+                str(executable),
+                "--no-auto-update",
+                "--no-remote-export",
+                "--log-level",
+                "none",
+                "--no-color",
+                "--no-bash-env",
+                "mcp",
+                "list",
+                "--json",
+            ),
+            cwd=project_root,
+            timeout_seconds=min(10.0, timeout_seconds),
+            env=env,
+        )
+        try:
+            observation = process.supervise_process(request, on_bytes=receive, limits=limits)
+            if (
+                observation.returncode != 0
+                or observation.error
+                or observation.stop_reason
+                or not observation.cleanup_confirmed
+                or observation.signals
+            ):
+                raise refuse(operational=True)
+            if oversized:
+                raise refuse()
+            names = parse_names()
+            if names is None:
+                raise refuse()
+            return names
+        finally:
+            stdout.clear()
 
     def execute_prompt(self, prompt_content: str, **kwargs) -> str:
         """Execute a single prompt and return the response.

--- a/src/apm_cli/runtime/registry.py
+++ b/src/apm_cli/runtime/registry.py
@@ -28,6 +28,7 @@ class RuntimeDescriptor:
     script_builder: str | None = None
     content_argument: str = "positional"
     default_command: str | None = None
+    supports_contracts: bool = False
 
 
 def _build_registry(
@@ -65,6 +66,7 @@ RUNTIME_DESCRIPTORS = _build_registry(
             npm_package="@github/copilot",
             script_builder="_build_copilot_command",
             content_argument="prompt_flag",
+            supports_contracts=True,
             default_command=(
                 "copilot --log-level all --log-dir copilot-logs --allow-all-tools -p {prompt_file}"
             ),

--- a/src/apm_cli/utils/atomic_io.py
+++ b/src/apm_cli/utils/atomic_io.py
@@ -62,6 +62,7 @@ def atomic_write_text(
     normalize_line_endings: bool = True,
     temp_prefix: str = "apm-atomic-",
     temp_suffix: str = "",
+    durable: bool = False,
 ) -> None:
     """Atomically write ``data`` (UTF-8) to ``path``.
 
@@ -85,6 +86,10 @@ def atomic_write_text(
     an established sibling-file naming contract without reimplementing the
     atomic write.
 
+    ``durable=True`` flushes file contents before replacement and syncs the
+    containing directory on POSIX. A directory-sync failure is reported even
+    though replacement has already occurred.
+
     On any failure, the temp file is removed and the original target
     file (if any) remains untouched.
     """
@@ -107,7 +112,16 @@ def atomic_write_text(
         fd_wrapped = True
         with fh:
             fh.write(normalize_crlf_to_lf(data) if normalize_line_endings else data)
+            if durable:
+                fh.flush()
+                os.fsync(fh.fileno())
         _replace_atomic_file(tmp_name, path)
+        if durable and os.name == "posix":
+            directory_fd = os.open(path.parent, os.O_RDONLY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
     except Exception:
         if not fd_wrapped:
             # fdopen never took ownership of the descriptor; close it so

--- a/src/apm_cli/utils/console.py
+++ b/src/apm_cli/utils/console.py
@@ -1,5 +1,8 @@
 """Console utility functions for formatting and output."""
 
+import atexit
+import os
+import sys
 import threading
 from contextlib import contextmanager
 from typing import Any
@@ -25,7 +28,10 @@ except ImportError:
 try:
     from colorama import Fore, Style, init
 
-    init(autoreset=False)
+    # init() registers an unconditional exit-time ANSI reset, even when no
+    # styled output was written. A NO_COLOR terminal must stay escape-free.
+    if "NO_COLOR" not in os.environ:
+        init(autoreset=False)
     COLORAMA_AVAILABLE = True
 except ImportError:
     COLORAMA_AVAILABLE = False
@@ -111,6 +117,9 @@ def _rich_echo(
     style: str = None,  # noqa: RUF013
     bold: bool = False,
     symbol: str = None,  # noqa: RUF013
+    propagate_broken_pipe: bool = False,
+    plain: bool = False,
+    natural_wrap: bool = False,
 ):
     """Echo message with Rich formatting or colorama fallback."""
     # Handle backward compatibility - if style is provided, use it as color
@@ -121,19 +130,32 @@ def _rich_echo(
         symbol_char = STATUS_SYMBOLS[symbol]
         message = f"{symbol_char} {message}"
 
+    if plain:
+        _plain_echo(message)
+        return
+
     console = _get_console()
     if console:
         try:
             style_str = color
             if bold:
                 style_str = f"bold {color}"
-            console.print(message, style=style_str, highlight=False, markup=False)
+            with _broken_pipe_policy(console, propagate_broken_pipe):
+                # Opt-in only: legacy callers retain Rich's usual wrapping.
+                wrap_options = {"soft_wrap": True} if natural_wrap else {}
+                console.print(
+                    message, style=style_str, highlight=False, markup=False, **wrap_options
+                )
             return
+        except BrokenPipeError:
+            # Lifecycle loggers must be able to disable a closed human stream;
+            # a fallback write would only repeat the same broken-pipe failure.
+            raise
         except Exception:
             pass
 
     # Colorama fallback
-    if COLORAMA_AVAILABLE and Fore:
+    if COLORAMA_AVAILABLE and Fore and "NO_COLOR" not in os.environ:
         color_map = {
             "red": Fore.RED,
             "green": Fore.GREEN,
@@ -150,6 +172,46 @@ def _rich_echo(
         click.echo(f"{color_code}{style_code}{message}{Style.RESET_ALL}", err=_console_stderr)
     else:
         click.echo(message, err=_console_stderr)
+
+
+def _plain_echo(message: str) -> None:
+    """Opt-in literal output, including when legacy imports wrapped stdio.
+
+    Do not replace sys.stdout/stderr or change existing converters' autoreset
+    settings: subsequent legacy writes keep their normal behavior. Only this
+    write bypasses Colorama. A plain command must also suppress Colorama's
+    unconditional exit-time reset; a later init() can register it again.
+    """
+    stream = sys.stderr if _console_stderr else sys.stdout
+    if COLORAMA_AVAILABLE:
+        from colorama import initialise
+        from colorama.ansitowin32 import StreamWrapper
+
+        while isinstance(stream, StreamWrapper):
+            # Colorama offers no public unwrap API. This narrow adapter only
+            # unwraps its known proxy, never arbitrary user/capture streams.
+            stream = stream._StreamWrapper__wrapped
+        if initialise.atexit_done:
+            atexit.unregister(initialise.reset_all)
+            initialise.atexit_done = False
+    click.echo(message, file=stream, color=False)
+
+
+@contextmanager
+def _broken_pipe_policy(console: Any, propagate: bool):
+    """Let lifecycle owners finish records instead of Rich exiting the process."""
+    original = getattr(console, "on_broken_pipe", None)
+
+    def raise_broken_pipe() -> None:
+        raise BrokenPipeError("Human output pipe closed.")
+
+    if propagate and original is not None:
+        console.on_broken_pipe = raise_broken_pipe
+    try:
+        yield
+    finally:
+        if propagate and original is not None:
+            console.on_broken_pipe = original
 
 
 def _rich_success(message: str, symbol: str = None):  # noqa: RUF013

--- a/src/apm_cli/utils/yaml_io.py
+++ b/src/apm_cli/utils/yaml_io.py
@@ -14,6 +14,9 @@ Public API::
     yaml_to_str(data)               -- serialize dict -> YAML string
 """
 
+import os
+import stat
+from dataclasses import dataclass
 from io import StringIO
 from pathlib import Path
 from typing import Any, NoReturn
@@ -464,6 +467,167 @@ class _BoundedYAMLHandler(_FrontmatterYAMLHandler):
 
 
 _BOUNDED_FRONTMATTER_HANDLER = _BoundedYAMLHandler()
+
+
+@dataclass(frozen=True)
+class YAMLSourceLocation:
+    """One-based position in a frontmatter source, including its opening fence."""
+
+    line: int
+    column: int
+
+
+@dataclass(frozen=True)
+class FrontmatterDocument:
+    """Exact source bytes, preserved body, and declaration locations."""
+
+    raw: bytes
+    metadata: dict[str, Any]
+    body: str
+    locations: dict[tuple[str | int, ...], YAMLSourceLocation]
+
+
+class FrontmatterSourceError(ValueError):
+    """A strict YAML/frontmatter failure with an original-source position."""
+
+    def __init__(
+        self, message: str, *, line: int = 1, column: int = 1, code: str = "invalid_yaml"
+    ) -> None:
+        super().__init__(message)
+        self.line = line
+        self.column = column
+        self.code = code
+
+
+class _StrictFrontmatterLoader(_BoundedSafeLoader):
+    """Reject amplification and ambiguous declarations before construction."""
+
+    def __init__(self, stream: str) -> None:
+        super().__init__(stream)
+        self._source_depth = 0
+        self._source_nodes = 0
+        self.locations: dict[tuple[str | int, ...], YAMLSourceLocation] = {}
+
+    @staticmethod
+    def _refuse(message: str, mark: Any, code: str = "invalid_yaml") -> NoReturn:
+        raise FrontmatterSourceError(message, line=mark.line + 2, column=mark.column + 1, code=code)
+
+    def compose_node(self, parent: Any, index: Any) -> Any:
+        event = self.peek_event()
+        if isinstance(event, yaml.events.AliasEvent) or getattr(event, "anchor", None):
+            self._refuse("YAML aliases and anchors are not supported.", event.start_mark)
+        if getattr(event, "tag", None) is not None:
+            self._refuse("Explicit YAML tags are not supported.", event.start_mark)
+        self._source_nodes += 1
+        self._source_depth += 1
+        try:
+            if self._source_depth > 24 or self._source_nodes > 4096:
+                self._refuse("YAML nesting or node limit exceeded.", event.start_mark)
+            return super().compose_node(parent, index)
+        finally:
+            self._source_depth -= 1
+
+    def construct_document(self, node: Any) -> Any:
+        def visit(item: Any, path: tuple[str | int, ...]) -> None:
+            self.locations.setdefault(
+                path, YAMLSourceLocation(item.start_mark.line + 2, item.start_mark.column + 1)
+            )
+            if isinstance(item, yaml.nodes.MappingNode):
+                seen: set[str] = set()
+                for key, value in item.value:
+                    if (
+                        not isinstance(key, yaml.nodes.ScalarNode)
+                        or key.tag != "tag:yaml.org,2002:str"
+                    ):
+                        self._refuse(
+                            "Mapping keys must be strings; merges are unsupported.", key.start_mark
+                        )
+                    if key.value == "<<":
+                        self._refuse("YAML merges are not supported.", key.start_mark)
+                    if key.value in seen:
+                        self._refuse(
+                            f"Duplicate YAML key: {key.value}.", key.start_mark, "duplicate_key"
+                        )
+                    seen.add(key.value)
+                    child = (*path, key.value)
+                    self.locations[child] = YAMLSourceLocation(
+                        key.start_mark.line + 2, key.start_mark.column + 1
+                    )
+                    visit(value, child)
+            elif isinstance(item, yaml.nodes.SequenceNode):
+                for index, value in enumerate(item.value):
+                    visit(value, (*path, index))
+
+        visit(node, ())
+        return super().construct_document(node)
+
+
+def loads_frontmatter_document(raw: bytes, *, max_bytes: int = 256 * 1024) -> FrontmatterDocument:
+    """Parse strict fenced YAML once, preserving bytes and source positions.
+
+    This is additive: permissive primitive/frontmatter consumers retain their
+    existing API. Limits are checked before YAML construction or alias expansion.
+    """
+    if len(raw) > max_bytes:
+        raise FrontmatterSourceError(
+            "Frontmatter source exceeds the byte limit.", code="source_limit"
+        )
+    try:
+        text = raw.decode("utf-8-sig")
+    except UnicodeError as exc:
+        raise FrontmatterSourceError("Source must be UTF-8.") from exc
+    lines = text.splitlines(keepends=True)
+    if not lines or lines[0].rstrip("\r\n") != "---":
+        raise FrontmatterSourceError("Source must start with a --- frontmatter delimiter.")
+    closing = next(
+        (index for index in range(1, len(lines)) if lines[index].rstrip("\r\n") == "---"),
+        None,
+    )
+    if closing is None:
+        raise FrontmatterSourceError("Frontmatter is missing its closing --- delimiter.")
+    loader = _StrictFrontmatterLoader("".join(lines[1:closing]))
+    try:
+        metadata = loader.get_single_data()
+        if not isinstance(metadata, dict):
+            raise FrontmatterSourceError("Frontmatter must be a nonempty mapping.", line=2)
+        locations = dict(loader.locations)
+    except FrontmatterSourceError:
+        raise
+    except (yaml.YAMLError, ValueError, RecursionError) as exc:
+        mark = getattr(exc, "problem_mark", None)
+        raise FrontmatterSourceError(
+            "Malformed or over-budget YAML frontmatter.",
+            line=mark.line + 2 if mark else 2,
+            column=mark.column + 1 if mark else 1,
+        ) from exc
+    finally:
+        loader.dispose()
+    locations[("$body",)] = YAMLSourceLocation(closing + 2, 1)
+    return FrontmatterDocument(raw, metadata, "".join(lines[closing + 1 :]), locations)
+
+
+def load_frontmatter_document(path: Path, *, max_bytes: int = 256 * 1024) -> FrontmatterDocument:
+    """Read at most the bounded source size and parse strict frontmatter."""
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_NONBLOCK", 0)
+        | getattr(os, "O_BINARY", 0)
+    )
+    with os.fdopen(os.open(path, flags), "rb") as source:
+        before = os.fstat(source.fileno())
+        if not stat.S_ISREG(before.st_mode):
+            raise FrontmatterSourceError("Source must be a regular file.", code="invalid_file")
+        raw = source.read(max_bytes + 1)
+        after = os.fstat(source.fileno())
+    current = path.stat()
+
+    def identity(info: os.stat_result) -> tuple[int, int, int, int, int]:
+        return info.st_dev, info.st_ino, info.st_size, info.st_mtime_ns, info.st_ctime_ns
+
+    if identity(before) != identity(after) or identity(before) != identity(current):
+        raise FrontmatterSourceError("Source changed while reading.", code="source_changed")
+    return loads_frontmatter_document(raw, max_bytes=max_bytes)
 
 
 def loads_frontmatter(text: str, *, preserve_body: bool = False) -> Any:

--- a/tests/unit/contracts/test_architecture.py
+++ b/tests/unit/contracts/test_architecture.py
@@ -1,0 +1,39 @@
+"""Regression traps for contract ownership and legacy execution bypasses."""
+
+from pathlib import Path
+
+import pytest
+
+from scripts.architecture_linter.checks.contract_leaf_runtime import check_contract_owners
+from scripts.architecture_linter.facts import FactsProvider
+
+pytestmark = pytest.mark.component
+
+
+@pytest.mark.parametrize(
+    ("filename", "source"),
+    [
+        ("frontend.py", "from ..core.script_runner import ScriptRunner\n"),
+        ("engine.py", "subprocess.Popen(command)\n"),
+        ("workspace.py", "digest = compute_file_hash(path)\n"),
+        ("engine.py", "def reduce_outcome():\n    return 0\n"),
+        ("engine.py", "RuntimeFactory.get_best_available_runtime()\n"),
+    ],
+)
+def test_contract_owner_bypasses_are_rejected(tmp_path: Path, filename: str, source: str) -> None:
+    path = f"src/apm_cli/contracts/{filename}"
+    provider = FactsProvider(tmp_path, (path,), None, source_overrides={path: source})
+    findings = check_contract_owners(provider)
+    assert len(findings) == 1
+    assert findings[0].path == path
+    assert findings[0].line >= 1
+
+
+def test_contract_owner_routes_are_accepted(tmp_path: Path) -> None:
+    sources = {
+        "src/apm_cli/contracts/process.py": "subprocess.Popen(request.argv)\n",
+        "src/apm_cli/contracts/records.py": "def reduce_outcome():\n    return result\n",
+        "src/apm_cli/contracts/engine.py": "result = records.reduce_outcome()\n",
+    }
+    provider = FactsProvider(tmp_path, tuple(sources), None, source_overrides=sources)
+    assert check_contract_owners(provider) == ()

--- a/tests/unit/contracts/test_cli_lifecycle.py
+++ b/tests/unit/contracts/test_cli_lifecycle.py
@@ -1,0 +1,113 @@
+"""Real preflight through Click without executing a native model."""
+
+import os
+import shlex
+import shutil
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+from click.testing import CliRunner
+
+from apm_cli.cli import cli
+
+pytestmark = [
+    pytest.mark.component,
+    pytest.mark.skipif(os.name != "posix", reason="Native leaf profile and shell actor are POSIX"),
+]
+
+FIXTURE = Path(__file__).resolve().parents[3] / "examples/contracts/first-contract"
+
+
+def _prepare(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path, Path]:
+    project = tmp_path / "project"
+    shutil.copytree(FIXTURE, project)
+    home = tmp_path / "home"
+    home.mkdir()
+    tools = tmp_path / "tools"
+    tools.mkdir()
+    marker = tmp_path / "native-was-invoked"
+    native = tools / "copilot"
+    native.write_text(
+        f"#!/bin/sh\nprintf invoked > {shlex.quote(str(marker))}\nexit 1\n",
+        encoding="utf-8",
+    )
+    native.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{tools}{os.pathsep}{os.environ.get('PATH', '')}")
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("APM_POLICY_DISABLE", raising=False)
+    monkeypatch.delenv("APM_NO_SCRIPTS", raising=False)
+    monkeypatch.chdir(project)
+    return project, home, marker
+
+
+def _files(root: Path) -> dict[str, bytes]:
+    return {
+        path.relative_to(root).as_posix(): path.read_bytes()
+        for path in root.rglob("*")
+        if path.is_file()
+    }
+
+
+def test_plan_neither_executes_native_nor_mutates_project_or_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project, home, marker = _prepare(tmp_path, monkeypatch)
+    project_before = _files(project)
+    home_before = _files(home)
+    network = Mock(side_effect=AssertionError("planning must not access the network"))
+    monkeypatch.setattr("requests.Session.request", network)
+    result = CliRunner().invoke(
+        cli, ["plan", "handoff.contract.md", "--on", "copilot", "--model", "gpt-6-astra"]
+    )
+    assert result.exit_code == 0, result.output
+    assert not marker.exists()
+    assert _files(project) == project_before
+    assert _files(home) == home_before
+    network.assert_not_called()
+    assert "VERIFIED" not in result.output
+
+
+def test_run_without_consent_refuses_without_native_or_run_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project, _, marker = _prepare(tmp_path, monkeypatch)
+    result = CliRunner().invoke(cli, ["run", "handoff.contract.md", "--on", "copilot"])
+    assert result.exit_code == 21, result.output
+    assert "--allow-advisory" in result.output
+    assert not marker.exists()
+    assert not (project / ".apm" / "runs").exists()
+
+
+@pytest.mark.parametrize("field", ["run: echo no", "budget: {usd: 1}", "sandbox: {network: none}"])
+def test_unsupported_source_cannot_be_waived_with_consent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, field: str
+) -> None:
+    project, _, marker = _prepare(tmp_path, monkeypatch)
+    source = project / "handoff.contract.md"
+    source.write_text(
+        source.read_text(encoding="utf-8").replace("---\n", f"---\n{field}\n", 1),
+        encoding="utf-8",
+    )
+    result = CliRunner().invoke(
+        cli, ["run", "handoff.contract.md", "--on", "copilot", "--allow-advisory"]
+    )
+    assert result.exit_code in {21, 22}, result.output
+    assert not marker.exists()
+    assert not (project / ".apm" / "runs").exists()
+
+
+def test_preflight_cancellation_is_halted_not_legacy_abort(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project, _, marker = _prepare(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        "apm_cli.contracts.frontend.plan_contract",
+        Mock(side_effect=KeyboardInterrupt),
+    )
+    result = CliRunner().invoke(cli, ["plan", "handoff.contract.md", "--on", "copilot"])
+    assert result.exit_code == 22, result.output
+    assert "interrupted" in result.output.lower()
+    assert "terminated" not in result.output.lower()
+    assert not marker.exists()
+    assert not (project / ".apm" / "runs").exists()

--- a/tests/unit/contracts/test_contract_policy.py
+++ b/tests/unit/contracts/test_contract_policy.py
@@ -1,0 +1,127 @@
+"""Read-only no-policy acquisition never mistakes unknown for ungoverned."""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from apm_cli.contracts.frontend import plan_contract
+from apm_cli.contracts.models import ContractError, Outcome
+from apm_cli.policy import contract_prerequisite, discovery
+from apm_cli.policy.discovery import PolicyFetchResult, discover_contract_policy
+
+pytestmark = pytest.mark.component
+
+
+@pytest.fixture(autouse=True)
+def no_policy_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("APM_POLICY_DISABLE", raising=False)
+    monkeypatch.delenv("APM_NO_SCRIPTS", raising=False)
+
+
+def test_no_repository_is_positive_no_remote_without_process_or_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    forbidden = Mock(side_effect=AssertionError("acquisition side effect"))
+    monkeypatch.setattr(discovery, "discover_policy_with_chain", forbidden)
+    monkeypatch.setattr(discovery, "discover_policy", forbidden)
+    monkeypatch.setattr(discovery, "_write_cache", forbidden)
+    monkeypatch.setattr(contract_prerequisite.subprocess, "run", forbidden)
+    result = discover_contract_policy(tmp_path, manifest_data={"name": "fixture"})
+    assert result.outcome == "no_git_remote"
+    forbidden.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("stdout", "returncode", "expected"),
+    [
+        ("", 0, "no_git_remote"),
+        ("origin\n", 0, "cache_miss_fetch_fail"),
+        ("upstream\n", 0, "cache_miss_fetch_fail"),
+        ("", 128, "cache_miss_fetch_fail"),
+    ],
+)
+def test_all_remotes_and_git_errors_stay_distinct(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, stdout: str, returncode: int, expected: str
+) -> None:
+    (tmp_path / ".git").mkdir()
+    runner = Mock(return_value=subprocess.CompletedProcess([], returncode, stdout, ""))
+    monkeypatch.setattr(contract_prerequisite.subprocess, "run", runner)
+    result = discover_contract_policy(tmp_path, manifest_data={"name": "fixture"})
+    assert result.outcome == expected
+    assert runner.call_args.args[0][-1] == "remote"
+    assert runner.call_args.kwargs["timeout"] == 5
+
+
+@pytest.mark.parametrize(
+    ("policy", "expected"),
+    [
+        ({"fetch_failure_default": "block"}, "cache_miss_fetch_fail"),
+        ({}, "cache_miss_fetch_fail"),
+        ({"hash": "sha256:" + "0" * 64}, "hash_mismatch"),
+        ({"hash": "wrong"}, "hash_mismatch"),
+        ("org", "hash_mismatch"),
+    ],
+)
+def test_project_requirement_never_becomes_no_policy(
+    tmp_path: Path, policy: object, expected: str
+) -> None:
+    assert discover_contract_policy(tmp_path, manifest_data={"policy": policy}).outcome == expected
+
+
+def test_disabled_is_not_no_policy(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("APM_POLICY_DISABLE", "1")
+    assert discover_contract_policy(tmp_path, manifest_data={}).outcome == "disabled"
+
+
+def test_bare_repository_is_not_assumed_remote_free(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+    (tmp_path / "objects").mkdir()
+    runner = Mock(return_value=subprocess.CompletedProcess([], 0, "origin\n", ""))
+    monkeypatch.setattr(contract_prerequisite.subprocess, "run", runner)
+    assert discover_contract_policy(tmp_path, manifest_data={}).outcome == "cache_miss_fetch_fail"
+    runner.assert_called_once()
+
+
+def project_source(tmp_path: Path, policy: str = "") -> Path:
+    (tmp_path / "apm.yml").write_text("name: fixture\nversion: 1.0.0\n" + policy, encoding="utf-8")
+    path = tmp_path / "work.contract.md"
+    path.write_text("---\nproduces: out\nverify: {ok: 'true'}\n---\nWork.\n", encoding="utf-8")
+    return path
+
+
+@pytest.mark.parametrize(
+    "outcome", ["absent", "empty", "found", "disabled", "cached_stale", "cache_miss_fetch_fail", ""]
+)
+def test_plan_refuses_every_nonpositive_policy_result(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, outcome: str
+) -> None:
+    monkeypatch.setattr(
+        discovery, "discover_contract_policy", lambda *a, **k: PolicyFetchResult(outcome=outcome)
+    )
+    with pytest.raises(ContractError) as error:
+        plan_contract(project_source(tmp_path), tmp_path, harness="copilot")
+    assert error.value.outcome == Outcome.UNPROVEN
+    assert error.value.code == "policy_unavailable"
+
+
+def test_plan_routes_real_pin_failure_without_legacy_escape(tmp_path: Path) -> None:
+    path = project_source(tmp_path, "policy:\n  hash: wrong\n")
+    with pytest.raises(ContractError) as error:
+        plan_contract(path, tmp_path, harness="copilot")
+    assert error.value.outcome == Outcome.UNPROVEN
+    assert error.value.code == "policy_blocked"
+    assert error.value.__cause__.__class__.__name__ == "PolicyViolationError"
+
+
+def test_no_scripts_blocks_checks_before_runtime(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("APM_NO_SCRIPTS", "anything")
+    with pytest.raises(ContractError) as error:
+        plan_contract(project_source(tmp_path), tmp_path, harness="copilot")
+    assert error.value.code == "scripts_disabled"
+    assert error.value.outcome == Outcome.UNPROVEN

--- a/tests/unit/contracts/test_contract_runtime.py
+++ b/tests/unit/contracts/test_contract_runtime.py
@@ -1,0 +1,271 @@
+"""Native requests use supervised, transient merged MCP inventory."""
+
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from apm_cli.contracts.models import (
+    BaselineSnapshot,
+    CheckSpec,
+    ContractError,
+    ContractLimits,
+    ImportedSkill,
+    LeafContract,
+    LeafPlan,
+    Outcome,
+    ProcessObservation,
+)
+from apm_cli.runtime.copilot_runtime import CopilotRuntime
+from apm_cli.runtime.factory import RuntimeFactory
+from apm_cli.runtime.registry import get_runtime_descriptor
+
+pytestmark = pytest.mark.component
+
+
+def fake_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    raw: bytes = b'{"mcpServers":{}}',
+    observation: ProcessObservation | None = None,
+) -> Mock:
+    def supervise(request, *, on_bytes, limits):
+        on_bytes("stderr", b"never-retain-stderr-secret")
+        for index in range(0, len(raw), 97):
+            on_bytes("stdout", raw[index : index + 97])
+        return observation or ProcessObservation(returncode=0)
+
+    mocked = Mock(side_effect=supervise)
+    monkeypatch.setattr("apm_cli.contracts.process.supervise_process", mocked)
+    return mocked
+
+
+def inventory(tmp_path: Path, *, timeout_seconds: float = 20) -> tuple[str, ...]:
+    return CopilotRuntime.get_contract_mcp_server_names(
+        tmp_path / "native",
+        tmp_path,
+        timeout_seconds=timeout_seconds,
+        env={"ORDINARY": "unchanged"},
+        limits=ContractLimits(),
+    )
+
+
+@pytest.mark.parametrize("model", [None, "gpt-6-astra"])
+def test_native_request_exact_permissions_and_model(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, model: str | None
+) -> None:
+    monkeypatch.setattr(CopilotRuntime, "is_available", staticmethod(lambda: True))
+    for key in (
+        "COPILOT_ALLOW_ALL",
+        "COPILOT_ALLOW_ALL_TOOLS",
+        "COPILOT_ALLOW_ALL_PATHS",
+        "COPILOT_ALLOW_ALL_URLS",
+        "COPILOT_ASSISTED_APPROVAL",
+    ):
+        monkeypatch.setenv(key, "true")
+    monkeypatch.setenv("KEEP_ORDINARY_ENV", "retained")
+    supervised = fake_inventory(
+        monkeypatch,
+        b'{"mcpServers":{"fixture-plugin":{"source":"plugin","env":{"SECRET":"never-retain"}},'
+        b'"fixture-user":{"source":"user"}}}',
+    )
+    clock = Mock(side_effect=[100.0, 102.0])
+    monkeypatch.setattr("apm_cli.runtime.copilot_runtime.time.monotonic", clock)
+    forbidden = Mock(side_effect=AssertionError("unmanaged native or legacy request"))
+    monkeypatch.setattr(CopilotRuntime, "execute_prompt", forbidden)
+    monkeypatch.setattr(CopilotRuntime, "get_runtime_info", forbidden)
+    monkeypatch.setattr(CopilotRuntime, "get_mcp_config_path", forbidden)
+    monkeypatch.setattr("subprocess.Popen", forbidden)
+    monkeypatch.setattr("subprocess.run", forbidden)
+    contract = LeafContract(
+        path=tmp_path / "leaf.contract.md",
+        source_digest="raw",
+        body="Write the handoff.",
+        needs=("notes.md",),
+        produces="handoff.json",
+        checks=(CheckSpec("handoff", "true"),),
+    )
+    context = ImportedSkill(
+        name="handoff-style",
+        source_path=tmp_path / "SKILL.md",
+        content="Always include the special marker.",
+        source_digest="exact-skill",
+        lock_identity="local:../handoff-style",
+    )
+    plan = LeafPlan(
+        contract=contract,
+        project_root=tmp_path,
+        executable=tmp_path / "resolved-copilot",
+        model=model,
+        imported_skills=(context,),
+    )
+    snapshot = BaselineSnapshot(
+        root=tmp_path / "baseline",
+        producer=tmp_path / "producer",
+        files=(),
+        digest="base",
+        original_head=None,
+        synthetic_head="head",
+        resources_digest="resources",
+    )
+    runtime = RuntimeFactory.get_runtime_by_name("copilot", model)
+    request = runtime.build_contract_request(plan, snapshot, tmp_path / "run", timeout_seconds=42)
+    assert request.cwd == snapshot.producer
+    assert request.timeout_seconds == 40
+    assert request.argv[:2] == (str(plan.executable), "-p")
+    prompt = request.argv[2]
+    for selected in (
+        contract.body,
+        context.content,
+        context.source_digest,
+        "notes.md",
+        "handoff.json",
+    ):
+        assert selected in prompt
+    assert "Use view to read and apply_patch to write." in prompt
+    tail = request.argv[3:]
+    assert tail[:4] == ("--output-format", "json", "--stream", "on")
+    assert tail[tail.index("--available-tools") + 1 : tail.index("--available-tools") + 3] == (
+        "view",
+        "apply_patch",
+    )
+    assert tail[tail.index("--allow-tool") + 1] == f"write({snapshot.producer / 'handoff.json'})"
+    assert tail.count("--allow-tool") == 1
+    disabled = [
+        tail[index + 1] for index, flag in enumerate(tail) if flag == "--disable-mcp-server"
+    ]
+    assert disabled == ["fixture-plugin", "fixture-user"]
+    assert request.control_observations["disabled_configured_mcp_servers"] == tuple(disabled)
+    scope = request.control_observations["startup_scope"]
+    assert "User, Workspace, Plugin and Builtin" in scope
+    assert "not isolated" in scope
+    assert "never-retain" not in str(request.control_observations)
+    assert tail.count("--deny-tool") == 2
+    assert "shell" in tail and "url" in tail
+    for flag in (
+        "--no-color",
+        "--no-auto-update",
+        "--no-remote-export",
+        "--no-ask-user",
+        "--no-bash-env",
+        "--disable-builtin-mcps",
+        "--no-custom-instructions",
+        "--disallow-temp-dir",
+    ):
+        assert flag in tail
+    assert tail[tail.index("--log-level") + 1] == "none"
+    assert not any("allow-all" in item or "add-dir" in item for item in tail)
+    assert request.env["KEEP_ORDINARY_ENV"] == "retained"
+    assert not any(name.startswith("COPILOT_ALLOW_") for name in request.env)
+    assert "COPILOT_ASSISTED_APPROVAL" not in request.env
+    if model is None:
+        assert "--model" not in request.argv
+    else:
+        assert request.argv[-2:] == ("--model", model)
+    native = supervised.call_args.args[0]
+    assert native.argv == (
+        str(plan.executable),
+        "--no-auto-update",
+        "--no-remote-export",
+        "--log-level",
+        "none",
+        "--no-color",
+        "--no-bash-env",
+        "mcp",
+        "list",
+        "--json",
+    )
+    assert native.cwd == snapshot.producer
+    assert native.timeout_seconds == 10
+    assert native.env == request.env
+    assert not native.control_observations
+    assert set(supervised.call_args.kwargs) == {"on_bytes", "limits"}
+    forbidden.assert_not_called()
+
+
+def test_runtime_capability_is_owned_by_registry() -> None:
+    assert get_runtime_descriptor("copilot").supports_contracts
+    for name in ("codex", "llm", "gemini"):
+        assert not get_runtime_descriptor(name).supports_contracts
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        b"",
+        b"\xff",
+        b"{malformed-secret-never-display",
+        b'{"mcpServers":{"truncated":',
+        b'{"mcpServers":{}}\ntrailing',
+        b"[]",
+        b"{}",
+        b'{"servers":{}}',
+        b'{"mcpServers":[]}',
+        b'{"mcpServers":{},"mcpServers":{"other":{}}}',
+        b'{"mcpServers":{"same":{},"same":{}}}',
+        b'{"mcpServers":{"--allow-all":{}}}',
+        b'{"mcpServers":{"*":{}}}',
+        b'{"mcpServers":{"empty":null}}',
+        b'{"mcpServers":{"invalid":{"number":NaN}}}',
+        b" " * (256 * 1024 + 1),
+        b'{"mcpServers":' + b"[" * 1000 + b"0" + b"]" * 1000 + b"}",
+        json.dumps({"mcpServers": {f"fixture-{index}": {} for index in range(129)}}).encode(),
+    ],
+)
+def test_unobservable_inventory_refuses_without_retaining_values(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, raw: bytes, capsys
+) -> None:
+    fake_inventory(monkeypatch, raw)
+    with pytest.raises(ContractError) as error:
+        inventory(tmp_path)
+    assert error.value.code == "native_mcp_unobservable"
+    assert error.value.outcome == Outcome.UNPROVEN
+    assert "mcp list --json" in str(error.value)
+    assert "malformed-secret" not in str(error.value)
+    assert error.value.__cause__ is None
+    assert error.value.__context__ is None
+    assert capsys.readouterr() == ("", "")
+
+
+@pytest.mark.parametrize(
+    "observation",
+    [
+        pytest.param(ProcessObservation(returncode=1), id="unsupported-command"),
+        pytest.param(
+            ProcessObservation(returncode=None, error="private-spawn-error"),
+            id="missing-executable",
+        ),
+        ProcessObservation(returncode=0, stop_reason="timeout"),
+        ProcessObservation(returncode=0, stop_reason="cancelled"),
+        ProcessObservation(returncode=0, stop_reason="lingering_children"),
+        ProcessObservation(returncode=0, cleanup_confirmed=False),
+        ProcessObservation(returncode=0, signals=("SIGTERM",)),
+    ],
+)
+def test_inventory_operational_failure_never_launches_producer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, observation: ProcessObservation
+) -> None:
+    supervised = fake_inventory(monkeypatch, observation=observation)
+    with pytest.raises(ContractError) as error:
+        inventory(tmp_path)
+    assert error.value.outcome == Outcome.HALTED
+    assert error.value.code == "native_mcp_inventory_failed"
+    assert "private-spawn-error" not in str(error.value)
+    supervised.assert_called_once()
+
+
+def test_inventory_empty_is_positive_and_timeout_is_clipped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    supervised = fake_inventory(monkeypatch)
+    assert inventory(tmp_path, timeout_seconds=2.5) == ()
+    assert supervised.call_args.args[0].timeout_seconds == 2.5
+
+
+def test_inventory_queries_fresh_merged_names_each_dispatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake_inventory(monkeypatch, b'{"mcpServers":{"before":{}}}')
+    assert inventory(tmp_path) == ("before",)
+    fake_inventory(monkeypatch, b'{"mcpServers":{"after":{}}}')
+    assert inventory(tmp_path) == ("after",)

--- a/tests/unit/contracts/test_dispatch.py
+++ b/tests/unit/contracts/test_dispatch.py
@@ -1,0 +1,101 @@
+"""Contract mode is explicit and cannot inherit legacy success fallbacks."""
+
+from unittest.mock import Mock
+
+import pytest
+from click.testing import CliRunner
+
+from apm_cli.commands import contracts as commands
+from apm_cli.commands.plan import plan
+from apm_cli.commands.run import run
+
+pytestmark = pytest.mark.component
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["--on", "copilot"],
+        ["job.contract.md", "--on", "copilot", "--param", "name=value"],
+        ["script", "--model", "gpt-6-astra"],
+        ["script", "--allow-advisory"],
+    ],
+)
+def test_invalid_mode_options_never_launch(
+    args: list[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    invoke = Mock()
+    monkeypatch.setattr(commands, "invoke_contract", invoke)
+    result = CliRunner().invoke(run, args)
+    assert result.exit_code == 2
+    invoke.assert_not_called()
+
+
+def test_contract_mode_forwards_explicit_selection_without_script_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    invoke = Mock()
+    monkeypatch.setattr(commands, "invoke_contract", invoke)
+    script = Mock(side_effect=AssertionError("legacy runner must not be constructed"))
+    monkeypatch.setattr("apm_cli.core.script_runner.ScriptRunner", script)
+    result = CliRunner().invoke(
+        run,
+        [
+            "job.contract.md",
+            "--on",
+            "copilot",
+            "--model",
+            "gpt-6-astra",
+            "--allow-advisory",
+        ],
+    )
+    assert result.exit_code == 0
+    assert invoke.call_args.args[1] == "job.contract.md"
+    assert invoke.call_args.kwargs == {
+        "harness": "copilot",
+        "model": "gpt-6-astra",
+        "verbose": False,
+        "planning": False,
+        "allow_advisory": True,
+    }
+    script.assert_not_called()
+    assert "Script executed successfully" not in result.output
+
+
+def test_contract_named_script_is_still_a_script_without_on(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    instance = Mock()
+    instance.run_script.return_value = True
+    constructor = Mock(return_value=instance)
+    monkeypatch.setattr("apm_cli.core.script_runner.ScriptRunner", constructor)
+    invoke = Mock()
+    monkeypatch.setattr(commands, "invoke_contract", invoke)
+    result = CliRunner().invoke(run, ["job.contract.md"])
+    assert result.exit_code == 0
+    instance.run_script.assert_called_once_with("job.contract.md", {})
+    invoke.assert_not_called()
+
+
+def test_plan_requires_explicit_harness() -> None:
+    result = CliRunner().invoke(plan, ["job.contract.md"])
+    assert result.exit_code == 2
+    assert "--on" in result.output
+
+
+@pytest.mark.parametrize("command", ["plan", "run"])
+def test_contract_commands_do_not_probe_updates(
+    command: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from apm_cli import cli as cli_module
+    from apm_cli.commands import plan as plan_module
+
+    invoke = Mock()
+    monkeypatch.setattr(commands, "invoke_contract", invoke)
+    monkeypatch.setattr(plan_module, "invoke_contract", invoke)
+    update = Mock(side_effect=AssertionError("contract commands must not check updates"))
+    monkeypatch.setattr(cli_module, "_check_and_notify_updates", update)
+    result = CliRunner().invoke(cli_module.cli, [command, "job.contract.md", "--on", "copilot"])
+    assert result.exit_code == 0, result.output
+    update.assert_not_called()
+    invoke.assert_called_once()

--- a/tests/unit/contracts/test_engine.py
+++ b/tests/unit/contracts/test_engine.py
@@ -1,0 +1,336 @@
+"""Real local child/check processes with a deterministic producer adapter.
+
+These fault-injection tests are not the live Copilot acceptance demonstration.
+"""
+
+import hashlib
+import json
+import shlex
+import sys
+from dataclasses import replace
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from apm_cli.contracts import engine
+from apm_cli.contracts.models import (
+    Artifact,
+    BaselineSnapshot,
+    CheckSpec,
+    ContractError,
+    LeafContract,
+    LeafPlan,
+    Outcome,
+    ProcessRequest,
+)
+from apm_cli.core.contract_logger import ContractLogger
+
+pytestmark = [
+    pytest.mark.component,
+    pytest.mark.skipif(
+        sys.platform == "win32", reason="The native contract execution profile is POSIX-only"
+    ),
+]
+
+
+def _python_check(name: str, code: str) -> CheckSpec:
+    return CheckSpec(name, f"{shlex.quote(sys.executable)} -c {shlex.quote(code)}")
+
+
+def _plan(tmp_path: Path, checks: tuple[CheckSpec, ...]) -> LeafPlan:
+    source = tmp_path / "job.contract.md"
+    source.write_text("---\nproduces: result.txt\n---\nWrite the result.\n", encoding="utf-8")
+    (tmp_path / "input.txt").write_text("hello\n", encoding="utf-8")
+    (tmp_path / "apm.yml").write_text(
+        "name: contract-engine-fixture\nversion: 0.0.0\n", encoding="utf-8"
+    )
+    return LeafPlan(
+        contract=LeafContract(
+            path=source,
+            source_digest=hashlib.sha256(source.read_bytes()).hexdigest(),
+            body="Write the result.",
+            needs=("input.txt",),
+            produces="result.txt",
+            checks=checks,
+        ),
+        project_root=tmp_path,
+        executable=Path(sys.executable),
+        model="gpt-6-astra",
+    )
+
+
+def _fake_adapter(
+    monkeypatch: pytest.MonkeyPatch,
+    plan: LeafPlan,
+    *,
+    produce: bool = True,
+    exit_code: int = 0,
+    reported_exit_code: int | None = None,
+) -> None:
+    event = json.dumps(
+        {
+            "type": "assistant.message",
+            "data": {"messageId": "fake-message", "content": "Done", "model": "gpt-6-astra"},
+        }
+    )
+    completed = json.dumps(
+        {
+            "type": "result",
+            "exitCode": exit_code if reported_exit_code is None else reported_exit_code,
+            "sessionId": "fake-native",
+            "usage": {},
+        }
+    )
+    code = (
+        "from pathlib import Path\n"
+        + ("Path('result.txt').write_bytes(Path('input.txt').read_bytes())\n" if produce else "")
+        + f"print({event!r}, flush=True)\nprint({completed!r}, flush=True)\n"
+        + f"raise SystemExit({exit_code})\n"
+    )
+
+    def build_request(
+        selected: LeafPlan,
+        snapshot: BaselineSnapshot,
+        directory: Path,
+        *,
+        timeout_seconds: float,
+    ) -> ProcessRequest:
+        return ProcessRequest(
+            argv=(sys.executable, "-c", code),
+            cwd=snapshot.producer,
+            timeout_seconds=timeout_seconds,
+        )
+
+    adapter = Mock()
+    adapter.build_contract_request.side_effect = build_request
+    monkeypatch.setattr(engine.frontend, "plan_contract", lambda *args, **kwargs: plan)
+    monkeypatch.setattr(
+        engine.RuntimeFactory, "get_runtime_by_name", lambda *args, **kwargs: adapter
+    )
+
+
+def test_real_child_capture_and_each_check_gets_fresh_baseline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plan = _plan(
+        tmp_path,
+        (
+            _python_check(
+                "first",
+                "from pathlib import Path; assert Path('result.txt').read_bytes() == b'hello\\n'; "
+                "Path('check-local.txt').write_text('private')",
+            ),
+            _python_check(
+                "second",
+                "from pathlib import Path; assert not Path('check-local.txt').exists(); "
+                "assert Path('result.txt').read_bytes() == b'hello\\n'",
+            ),
+        ),
+    )
+    _fake_adapter(monkeypatch, plan)
+    result = engine.run_contract(plan, logger=ContractLogger(), allow_advisory=True)
+    assert result.outcome == Outcome.VERIFIED
+    assert result.artifact is not None
+    assert result.artifact.path.read_bytes() == b"hello\n"
+    assert result.artifact.sha256 == hashlib.sha256(b"hello\n").hexdigest()
+    assert [check.normalized for check in result.checks] == [0, 0]
+    assert result.observed_models == ("gpt-6-astra",)
+    assert not (tmp_path / "result.txt").exists()
+    assert not (tmp_path / "check-local.txt").exists()
+    assert (result.run_directory / "record.json").is_file()
+    record = json.loads((result.run_directory / "record.json").read_text(encoding="utf-8"))
+    transcript = result.run_directory / "transcript.log"
+    assert record["native_reported_exit_code"] == 0
+    assert record["child_pid"] is None
+    assert record["child_pgid"] is None
+    assert record["producer"]["pid"] is not None
+    assert record["checks"][0]["process"]["pid"] is not None
+    assert record["transcript"]["sha256"] == hashlib.sha256(transcript.read_bytes()).hexdigest()
+    assert record["transcript"]["size"] == transcript.stat().st_size
+    assert record["transcript_retention"] == {
+        "omitted_bytes": 0,
+        "omitted_lines": 0,
+        "retention": "bounded-beginning-tail",
+        "redaction": "best-effort",
+    }
+
+
+def test_stale_output_cannot_satisfy_missing_new_output(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plan = _plan(tmp_path, (_python_check("condition", "raise SystemExit(0)"),))
+    (tmp_path / "result.txt").write_bytes(b"old output")
+    _fake_adapter(monkeypatch, plan, produce=False)
+    result = engine.run_contract(plan, logger=ContractLogger(), allow_advisory=True)
+    assert result.outcome == Outcome.UNPROVEN
+    assert result.artifact is None
+    assert result.checks == ()
+    assert (tmp_path / "result.txt").read_bytes() == b"old output"
+
+
+def test_failure_and_incomplete_keep_raw_results(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plan = _plan(
+        tmp_path,
+        (
+            _python_check("failed", "raise SystemExit(1)"),
+            _python_check("unknown", "raise SystemExit(127)"),
+        ),
+    )
+    _fake_adapter(monkeypatch, plan)
+    result = engine.run_contract(plan, logger=ContractLogger(), allow_advisory=True)
+    assert result.outcome == Outcome.REJECTED
+    assert [check.process.returncode for check in result.checks] == [1, 127]
+    assert [check.normalized for check in result.checks] == [1, 2]
+    assert result.artifact is not None
+
+
+def test_failed_producer_keeps_captured_provisional_output_without_assessing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plan = _plan(tmp_path, (_python_check("condition", "raise SystemExit(0)"),))
+    _fake_adapter(monkeypatch, plan, exit_code=7)
+    result = engine.run_contract(plan, logger=ContractLogger(), allow_advisory=True)
+    assert result.outcome == Outcome.HALTED
+    assert result.stop_reason == "producer_failed"
+    assert result.artifact is not None
+    assert result.artifact.path.read_bytes() == b"hello\n"
+    assert result.checks == ()
+
+
+def test_no_consent_allocates_nothing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    plan = _plan(tmp_path, (_python_check("condition", "raise SystemExit(0)"),))
+    create = Mock(side_effect=AssertionError("run must not be admitted"))
+    monkeypatch.setattr(engine.records.AttemptStore, "create", create)
+    with pytest.raises(ContractError) as failure:
+        engine.run_contract(plan, logger=ContractLogger())
+    assert failure.value.outcome == Outcome.UNPROVEN
+    create.assert_not_called()
+    assert not (tmp_path / ".apm").exists()
+
+
+def test_native_reported_failure_cannot_pass_on_os_exit_zero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plan = _plan(tmp_path, (_python_check("condition", "raise SystemExit(0)"),))
+    _fake_adapter(monkeypatch, plan, reported_exit_code=7)
+    result = engine.run_contract(plan, logger=ContractLogger(), allow_advisory=True)
+    assert result.outcome == Outcome.HALTED
+    assert result.checks == ()
+    record = json.loads((result.run_directory / "record.json").read_text(encoding="utf-8"))
+    assert record["producer"]["returncode"] == 0
+    assert record["native_reported_exit_code"] == 7
+
+
+@pytest.mark.parametrize("with_failure", [False, True])
+def test_per_check_timeout_remains_incomplete_without_root_stop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, with_failure: bool
+) -> None:
+    checks = ((_python_check("failed", "raise SystemExit(1)"),) if with_failure else ()) + (
+        _python_check("slow", "import time; time.sleep(30)"),
+    )
+    original = _plan(tmp_path, checks)
+    plan = replace(original, limits=replace(original.limits, check_seconds=0.2))
+    _fake_adapter(monkeypatch, plan)
+    result = engine.run_contract(plan, logger=ContractLogger(), allow_advisory=True)
+    assert result.outcome == (Outcome.REJECTED if with_failure else Outcome.UNPROVEN)
+    assert result.stop_reason is None
+    assert result.checks[-1].normalized == 2
+    assert result.checks[-1].process.stop_reason == "timeout"
+
+
+def test_lingering_check_child_is_an_operational_stop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plan = _plan(
+        tmp_path,
+        (
+            _python_check(
+                "lingers",
+                "import subprocess,sys; subprocess.Popen([sys.executable,'-c',"
+                "'import time; time.sleep(30)'])",
+            ),
+        ),
+    )
+    _fake_adapter(monkeypatch, plan)
+    result = engine.run_contract(plan, logger=ContractLogger(), allow_advisory=True)
+    assert result.outcome == Outcome.HALTED
+    assert result.stop_reason == "lingering_children"
+    assert result.checks[0].normalized == 2
+
+
+def test_changed_plan_refuses_before_admission(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plan = _plan(tmp_path, (_python_check("condition", "raise SystemExit(0)"),))
+    monkeypatch.setattr(
+        engine.frontend,
+        "plan_contract",
+        lambda *args, **kwargs: replace(plan, model="different-model"),
+    )
+    with pytest.raises(ContractError) as failure:
+        engine.run_contract(plan, logger=ContractLogger(), allow_advisory=True)
+    assert failure.value.code == "plan_changed"
+    assert not (tmp_path / ".apm").exists()
+
+
+def test_check_copy_time_cannot_extend_the_attempt_deadline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plan = _plan(tmp_path, (_python_check("condition", "raise SystemExit(0)"),))
+    snapshot = BaselineSnapshot(tmp_path, tmp_path, (), "baseline", None, "head", "resources")
+    artifact = Artifact("result.txt", tmp_path / "result.txt", "subject", 0)
+    store = Mock(directory=tmp_path)
+    events = Mock()
+    monkeypatch.setattr(engine.workspace, "prepare_check_workspace", lambda *args: tmp_path)
+    monkeypatch.setattr(engine.workspace, "verify_check_integrity", lambda *args: True)
+    monkeypatch.setattr(engine.shutil, "which", lambda name: "/bin/sh")
+    monkeypatch.setattr(
+        engine,
+        "_remaining",
+        Mock(side_effect=[5, ContractError("Expired.", code="attempt_deadline")]),
+    )
+    launch = Mock(side_effect=AssertionError("no child may start after the deadline"))
+    monkeypatch.setattr(engine.process, "supervise_process", launch)
+    with pytest.raises(ContractError) as failure:
+        engine._run_checks(plan, snapshot, artifact, store, events, 5, [])
+    assert failure.value.code == "attempt_deadline"
+    launch.assert_not_called()
+
+
+def test_failed_record_finalization_never_announces_verified(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plan = _plan(tmp_path, (_python_check("condition", "raise SystemExit(0)"),))
+    _fake_adapter(monkeypatch, plan)
+    monkeypatch.setattr(
+        engine.records.AttemptStore,
+        "finish",
+        Mock(side_effect=OSError("record write failed")),
+    )
+    logger = Mock(transcript_metadata={})
+    with pytest.raises(OSError, match="record write failed"):
+        engine.run_contract(plan, logger=logger, allow_advisory=True)
+    assert "finished" not in [call.args[0].kind for call in logger.on_event.call_args_list]
+    logger.close.assert_called_once()
+
+
+def test_dispatch_preparation_cannot_extend_the_attempt_deadline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plan = _plan(tmp_path, (_python_check("condition", "raise SystemExit(0)"),))
+    _fake_adapter(monkeypatch, plan)
+    monkeypatch.setattr(
+        engine,
+        "_remaining",
+        Mock(side_effect=[5, ContractError("Expired.", code="attempt_deadline")]),
+    )
+    result = engine.run_contract(plan, logger=ContractLogger(), allow_advisory=True)
+    assert result.outcome == Outcome.HALTED
+    assert result.stop_reason == "attempt_deadline"
+    assert result.artifact is None
+    assert result.checks == ()
+    record = json.loads((result.run_directory / "record.json").read_text(encoding="utf-8"))
+    assert "producer" not in record

--- a/tests/unit/contracts/test_example_checks.py
+++ b/tests/unit/contracts/test_example_checks.py
@@ -1,0 +1,127 @@
+"""Known-good and known-bad cases for the supplied standalone checker."""
+
+import json
+import runpy
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from apm_cli.utils.yaml_io import load_frontmatter
+
+pytestmark = pytest.mark.component
+
+CHECKER = (
+    Path(__file__).resolve().parents[3]
+    / "examples/contracts/first-contract/checks/check_handoff.py"
+)
+
+
+def _check(tmp_path: Path, content: str | None, *arguments: str) -> subprocess.CompletedProcess:
+    notes = tmp_path / "notes.md"
+    notes.write_text("- restore: Restore dependencies.\n", encoding="utf-8")
+    output = tmp_path / "handoff.json"
+    if content is not None:
+        output.write_text(content, encoding="utf-8")
+    return subprocess.run(
+        [sys.executable, str(CHECKER), str(output), str(notes), *arguments],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+
+
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        (None, 2),
+        ("not JSON", 2),
+        ("{}", 1),
+        ("[]", 1),
+        ('[{"source_id":"restore","summary":"","caution":"Read first"}]', 1),
+        ('[{"source_id":"different","summary":"Restore","caution":"Read first"}]', 1),
+        (
+            '[{"source_id":"restore","summary":"Restore","caution":"Read first","extra":true}]',
+            1,
+        ),
+        ('[{"source_id":"restore","summary":"Restore","caution":"Read first"}]', 0),
+    ],
+)
+def test_check_protocol_distinguishes_failed_conditions_from_incomplete(
+    tmp_path: Path, content: str | None, expected: int
+) -> None:
+    result = _check(tmp_path, content)
+    assert result.returncode == expected, result.stderr
+    assert result.stdout.strip()
+    assert result.stderr == ""
+
+
+def test_style_requirement_is_checked_without_corrupting_unicode(tmp_path: Path) -> None:
+    payload = [
+        {
+            "source_id": "restore",
+            "summary": "Caf\u00e9 notes",
+            "caution": "Check first: review sources",
+        }
+    ]
+    result = _check(
+        tmp_path,
+        json.dumps(payload, ensure_ascii=False),
+        "--caution-prefix",
+        "Check first: ",
+    )
+    assert result.returncode == 0, result.stderr
+    assert json.loads((tmp_path / "handoff.json").read_text(encoding="utf-8")) == payload
+
+
+def test_missing_imported_style_is_a_failed_condition(tmp_path: Path) -> None:
+    payload = [{"source_id": "restore", "summary": "Restore", "caution": "Read sources"}]
+    result = _check(tmp_path, json.dumps(payload), "--caution-prefix", "Check first: ")
+    assert result.returncode == 1
+    assert "style criterion" in result.stdout
+
+
+@pytest.mark.skipif(
+    not hasattr(sys, "get_int_max_str_digits"),
+    reason="Interpreter does not implement the JSON integer conversion limit",
+)
+def test_json_integer_parser_limit_is_incomplete(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PYTHONINTMAXSTRDIGITS", "4300")
+    result = _check(tmp_path, "9" * 5000)
+    assert result.returncode == 2, result.stderr
+    assert result.stdout.strip() == ("Could not read the source notes or parse the candidate JSON.")
+    assert result.stderr == ""
+
+
+def test_json_recursion_failure_is_incomplete(tmp_path: Path) -> None:
+    assess = runpy.run_path(str(CHECKER))["assess"]
+    source = tmp_path / "notes.md"
+    source.write_text("- restore: Restore dependencies.\n", encoding="utf-8")
+    output = tmp_path / "handoff.json"
+    output.write_text("[]", encoding="utf-8")
+    with patch("json.loads", side_effect=RecursionError("decoder nesting limit")):
+        status, reason = assess(output, source)
+    assert status == 2
+    assert reason == "Could not read the source notes or parse the candidate JSON."
+
+
+@pytest.mark.parametrize("fixture", ["first-contract", "reuse-contract"])
+def test_example_frontmatter_preserves_the_checker_arguments(fixture: str) -> None:
+    source = CHECKER.parents[2] / fixture / "handoff.contract.md"
+    document = load_frontmatter(source)
+    arguments = shlex.split(document.metadata["verify"]["handoff"])
+    assert arguments[:4] == [
+        "python3",
+        "checks/check_handoff.py",
+        "handoff.json",
+        "notes.md",
+    ]
+    assert arguments[4:] == (
+        ["--caution-prefix", "Check first: "] if fixture == "reuse-contract" else []
+    )

--- a/tests/unit/contracts/test_frontend.py
+++ b/tests/unit/contracts/test_frontend.py
@@ -1,0 +1,234 @@
+"""Strict source diagnostics and read-only planning regression traps."""
+
+import hashlib
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from apm_cli.contracts.frontend import parse_contract, plan_contract
+from apm_cli.contracts.models import ContractError, ContractLimits, Outcome
+
+pytestmark = pytest.mark.component
+
+
+def source(tmp_path: Path, header: str = "produces: out.json\nverify:\n  valid: 'true'") -> Path:
+    path = tmp_path / "work.contract.md"
+    path.write_text("---\n" + header + "\n---\nWrite a result.\n", encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    (tmp_path / "apm.yml").write_text("name: fixture\nversion: 1.0.0\n", encoding="utf-8")
+    binary = tmp_path / "native"
+    binary.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+    binary.chmod(0o755)
+    monkeypatch.delenv("APM_POLICY_DISABLE", raising=False)
+    monkeypatch.delenv("APM_NO_SCRIPTS", raising=False)
+    monkeypatch.setattr("apm_cli.contracts.frontend.sys.platform", "linux")
+    monkeypatch.setattr("apm_cli.runtime.utils.find_runtime_binary", lambda name: str(binary))
+    return tmp_path
+
+
+@pytest.mark.windows_compat
+def test_exact_bom_crlf_body_digest_and_declaration_locations(tmp_path: Path) -> None:
+    path = tmp_path / "work.contract.md"
+    raw = b"\xef\xbb\xbf---\r\nneeds: input.txt\r\nproduces: out.json\r\nverify:\r\n  valid: 'true'\r\n---\r\n  Body\r\n\r\n"
+    path.write_bytes(raw)
+    parsed = parse_contract(path)
+    assert parsed.body == "  Body\r\n\r\n"
+    assert parsed.source_digest == hashlib.sha256(raw).hexdigest()
+    assert parsed.needs == ("input.txt",)
+    assert parsed.locations["produces"].line == 3
+    assert parsed.checks[0].location.line == 5
+    assert parsed.checks[0].location.column == 3
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        "produces: [one, two]\nverify: {ok: true}",
+        "produces: out\nverify: {}",
+        "produces: out\nverify: {ok: {run: check}}",
+        "produces: out\nverify: {ok: ''}",
+        "produces: out\nverify: {true: 'true'}",
+        "produces: out\nverify: {ok: 'true'}\nunknown: 1",
+        "produces: out\nproduces: other\nverify: {ok: 'true'}",
+        "produces: out\nverify:\n  ok: 'true'\n  ok: 'false'",
+        "produces: &out out\nverify: {ok: 'true'}",
+        "produces: *out\nverify: {ok: 'true'}",
+        "produces: !!str out\nverify: {ok: 'true'}",
+        "produces: out\nverify: {<<: {}, ok: 'true'}",
+        "produces: out\nneeds: {from: input}\nverify: {ok: 'true'}",
+        "produces: ../out\nverify: {ok: 'true'}",
+        "produces: /tmp/out\nverify: {ok: 'true'}",
+        "produces: '${capture}.txt'\nverify: {ok: 'true'}",
+        "produces: '*.txt'\nverify: {ok: 'true'}",
+        "produces: 'one|two'\nverify: {ok: 'true'}",
+        "produces: out\nimports: [apm_modules/_local/pkg]\nverify: {ok: 'true'}",
+        "produces: out\nimports: [owner/pkg#v1]\nverify: {ok: 'true'}",
+        "produces: out\nimports: [a, b]\nverify: {ok: 'true'}",
+    ],
+)
+def test_invalid_subset_is_source_located(tmp_path: Path, header: str) -> None:
+    with pytest.raises(ContractError) as error:
+        parse_contract(source(tmp_path, header))
+    assert error.value.outcome == Outcome.HALTED
+    assert error.value.location is not None
+    assert error.value.location.line >= 1
+
+
+def test_duplicate_nested_key_reports_second_declaration(tmp_path: Path) -> None:
+    with pytest.raises(ContractError) as error:
+        parse_contract(source(tmp_path, "produces: out\nverify:\n  ok: 'true'\n  ok: 'false'"))
+    assert error.value.code == "duplicate_key"
+    assert error.value.location.line == 5
+
+
+@pytest.mark.parametrize("field", ["run: echo hi", "budget: {usd: 1}", "sandbox: {network: none}"])
+def test_unsupported_controls_are_unproven(tmp_path: Path, field: str) -> None:
+    with pytest.raises(ContractError) as error:
+        parse_contract(source(tmp_path, f"produces: out\nverify: {{ok: 'true'}}\n{field}"))
+    assert error.value.outcome == Outcome.UNPROVEN
+    assert error.value.location.line == 4
+
+
+def test_parsing_bounds_nesting_and_source_before_construction(tmp_path: Path) -> None:
+    with pytest.raises(ContractError):
+        parse_contract(source(tmp_path), limits=ContractLimits(source_bytes=8))
+    with pytest.raises(ContractError):
+        parse_contract(source(tmp_path, "needs: " + "[" * 1000 + "x" + "]" * 1000))
+    with pytest.raises(ContractError):
+        parse_contract(
+            source(
+                tmp_path,
+                "produces: out\nverify: {ok: 'true'}\nneeds: ["
+                + ", ".join(f"in{i}" for i in range(17))
+                + "]",
+            )
+        )
+    with pytest.raises(ContractError):
+        parse_contract(
+            source(
+                tmp_path,
+                "produces: out\nverify:\n" + "".join(f"  c{i}: 'true'\n" for i in range(9)),
+            )
+        )
+
+
+def test_plan_reads_without_native_probe_install_config_or_writes(
+    project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = source(project)
+    forbidden = Mock(side_effect=AssertionError("side effect during plan"))
+    monkeypatch.setattr("subprocess.run", forbidden)
+    monkeypatch.setattr("subprocess.Popen", forbidden)
+    monkeypatch.setattr(
+        "apm_cli.runtime.copilot_runtime.CopilotRuntime.get_runtime_info", forbidden
+    )
+    monkeypatch.setattr("apm_cli.config.ensure_config_exists", forbidden)
+    monkeypatch.setattr("requests.Session.request", forbidden)
+    monkeypatch.setattr(Path, "mkdir", forbidden)
+    before = {p.relative_to(project): p.read_bytes() for p in project.rglob("*") if p.is_file()}
+    plan = plan_contract(path, project, harness="copilot", model=None)
+    after = {p.relative_to(project): p.read_bytes() for p in project.rglob("*") if p.is_file()}
+    assert before == after
+    assert plan.executable_version is None
+    assert plan.model is None
+    assert plan.manifest_digest == hashlib.sha256((project / "apm.yml").read_bytes()).hexdigest()
+    forbidden.assert_not_called()
+
+
+@pytest.mark.parametrize("name", ["missing.txt", "folder", "alias.txt"])
+def test_needs_must_exist_as_regular_non_symlink_files(project: Path, name: str) -> None:
+    (project / "folder").mkdir()
+    (project / "real.txt").write_text("input", encoding="utf-8")
+    (project / "alias.txt").symlink_to(project / "real.txt")
+    with pytest.raises(ContractError):
+        plan_contract(
+            source(project, f"needs: {name}\nproduces: out\nverify: {{ok: 'true'}}"),
+            project,
+            harness="copilot",
+        )
+
+
+def test_paths_are_project_relative_not_contract_relative(project: Path) -> None:
+    (project / "sub").mkdir()
+    (project / "notes.txt").write_text("notes", encoding="utf-8")
+    path = source(project / "sub", "needs: notes.txt\nproduces: result/out\nverify: {ok: 'true'}")
+    plan = plan_contract(path, project, harness="copilot", model="gpt-6-astra")
+    assert plan.contract.needs == ("notes.txt",)
+    assert plan.project_root == project
+    assert plan.model == "gpt-6-astra"
+
+
+@pytest.mark.parametrize("output", ["notes.txt", "checks/result", "apm.yml", "work.contract.md"])
+def test_output_cannot_overlap_selected_inputs(project: Path, output: str) -> None:
+    (project / "notes.txt").write_text("notes", encoding="utf-8")
+    with pytest.raises(ContractError):
+        plan_contract(
+            source(project, f"needs: notes.txt\nproduces: {output}\nverify: {{ok: 'true'}}"),
+            project,
+            harness="copilot",
+        )
+
+
+def test_source_cannot_escape_project(project: Path, tmp_path: Path) -> None:
+    other = project / "sub"
+    other.mkdir()
+    with pytest.raises(ContractError):
+        plan_contract(source(project), other, harness="copilot")
+
+
+@pytest.mark.parametrize("harness", ["codex", "unknown"])
+def test_explicit_harness_never_falls_back(project: Path, harness: str) -> None:
+    with pytest.raises(ContractError) as error:
+        plan_contract(source(project), project, harness=harness)
+    assert error.value.code == "unsupported_harness"
+
+
+def test_missing_executable_is_halted(project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("apm_cli.runtime.utils.find_runtime_binary", lambda name: None)
+    with pytest.raises(ContractError) as error:
+        plan_contract(source(project), project, harness="copilot")
+    assert error.value.outcome == Outcome.HALTED
+    assert error.value.code == "runtime_missing"
+
+
+@pytest.mark.parametrize("raw", [b"Body only", b"---\nproduces: out", b"---\n{}\n---\n ", b"\xff"])
+def test_malformed_or_empty_source_is_halted(tmp_path: Path, raw: bytes) -> None:
+    path = tmp_path / "bad.contract.md"
+    path.write_bytes(raw)
+    with pytest.raises(ContractError) as error:
+        parse_contract(path)
+    assert error.value.outcome == Outcome.HALTED
+    assert error.value.location.path == path
+
+
+def test_source_and_output_symlink_are_rejected(project: Path) -> None:
+    path = source(project)
+    alias = project / "alias.contract.md"
+    alias.symlink_to(path)
+    with pytest.raises(ContractError):
+        plan_contract(alias, project, harness="copilot")
+    (project / "out.json").symlink_to(project / "missing")
+    with pytest.raises(ContractError):
+        plan_contract(path, project, harness="copilot")
+
+
+def test_source_traversal_is_rejected_even_when_it_lands_inside_root(project: Path) -> None:
+    path = source(project)
+    (project / "sub").mkdir()
+    with pytest.raises(ContractError):
+        plan_contract(project / "sub" / ".." / path.name, project, harness="copilot")
+
+
+def test_windows_execution_refuses_before_native_resolution(
+    project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("apm_cli.contracts.frontend.sys.platform", "win32")
+    with pytest.raises(ContractError) as error:
+        plan_contract(source(project), project, harness="copilot")
+    assert error.value.outcome == Outcome.UNPROVEN
+    assert error.value.code == "unsupported_platform"

--- a/tests/unit/contracts/test_imports.py
+++ b/tests/unit/contracts/test_imports.py
@@ -1,0 +1,242 @@
+"""Installed context identity and exact-byte snapshot regression tests."""
+
+import hashlib
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from apm_cli.contracts.frontend import parse_contract, plan_contract
+from apm_cli.contracts.imports import read_project_manifest, resolve_installed_skills
+from apm_cli.contracts.models import ContractError, ContractLimits
+from apm_cli.deps.lockfile import LockedDependency, LockFile
+from apm_cli.models.dependency.reference import DependencyReference
+from apm_cli.utils.content_hash import compute_package_hash
+
+pytestmark = pytest.mark.component
+
+SKILL = b"---\nname: handoff-style\ndescription: A self-contained style guide.\n---\nInclude a distinctive marker.\n"
+
+
+def fixture(tmp_path: Path, *, local: bool = True) -> tuple[Path, Path, LockFile]:
+    entry = (
+        "    - path: ../handoff-style"
+        if local
+        else "    - git: https://github.com/fixtures/handoff-style.git\n      ref: v1"
+    )
+    (tmp_path / "apm.yml").write_text(
+        "name: fixture\nversion: 1.0.0\ndependencies:\n  apm:\n" + entry + "\n",
+        encoding="utf-8",
+    )
+    dependency = (
+        DependencyReference.parse_from_dict({"path": "../handoff-style"})
+        if local
+        else DependencyReference.parse_from_dict(
+            {"git": "https://github.com/fixtures/handoff-style.git", "ref": "v1"}
+        )
+    )
+    installed = dependency.get_install_path(tmp_path / "apm_modules")
+    installed.mkdir(parents=True)
+    (installed / "apm.yml").write_text("name: handoff-style\nversion: 1.0.0\n", encoding="utf-8")
+    (installed / "SKILL.md").write_bytes(SKILL)
+    locked = LockedDependency(
+        repo_url="_local/handoff-style" if local else dependency.repo_url,
+        host=dependency.host,
+        local_path="../handoff-style" if local else None,
+        source="local" if local else None,
+        resolved_ref=None if local else "v1",
+        resolved_commit=None if local else "a" * 40,
+        content_hash=None if local else compute_package_hash(installed),
+        package_type="skill",
+    )
+    lock = LockFile()
+    lock.add_dependency(locked)
+    (tmp_path / "apm.lock.yaml").write_text(lock.to_yaml(), encoding="utf-8")
+    source = tmp_path / "work.contract.md"
+    source.write_text(
+        "---\nproduces: result\nimports: [handoff-style]\nverify: {ok: 'true'}\n---\nWork.\n",
+        encoding="utf-8",
+    )
+    return source, installed, lock
+
+
+def resolve(source: Path):
+    package, _, _ = read_project_manifest(source.parent, ContractLimits())
+    return resolve_installed_skills(parse_contract(source), source.parent, package)
+
+
+def test_local_identity_and_snapshot_do_not_claim_locked_content_hash(tmp_path: Path) -> None:
+    source, installed, lock = fixture(tmp_path)
+    skills, digest = resolve(source)
+    assert digest == hashlib.sha256((tmp_path / "apm.lock.yaml").read_bytes()).hexdigest()
+    assert len(skills) == 1
+    assert skills[0].name == "handoff-style"
+    assert skills[0].source_path == installed / "SKILL.md"
+    assert skills[0].source_digest == hashlib.sha256(SKILL).hexdigest()
+    assert skills[0].content == SKILL.decode()
+    assert skills[0].lock_identity == next(iter(lock.dependencies))
+    assert skills[0].verified_package_hash is None
+    assert skills[0].assurance == "observed-local-source"
+    (installed / "SKILL.md").write_bytes(SKILL.replace(b"\n", b"\r\n"))
+    assert resolve(source)[0][0] != skills[0]
+
+
+def test_git_import_requires_current_hash_and_ref(tmp_path: Path) -> None:
+    source, installed, lock = fixture(tmp_path, local=False)
+    skills, _ = resolve(source)
+    assert skills[0].verified_package_hash == compute_package_hash(installed)
+    assert skills[0].resolved_commit == "a" * 40
+    (installed / "SKILL.md").write_bytes(SKILL + b"changed")
+    with pytest.raises(ContractError, match="hash"):
+        resolve(source)
+    (installed / "SKILL.md").write_bytes(SKILL)
+    next(iter(lock.dependencies.values())).resolved_ref = "v0"
+    (tmp_path / "apm.lock.yaml").write_text(lock.to_yaml(), encoding="utf-8")
+    with pytest.raises(ContractError, match="reference"):
+        resolve(source)
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        "missing_lock",
+        "malformed_lock",
+        "missing_install",
+        "extra_resource",
+        "nested_symlink",
+        "closure",
+    ],
+)
+def test_import_refusals_never_install(
+    tmp_path: Path, failure: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source, installed, _ = fixture(tmp_path)
+    forbidden = Mock(side_effect=AssertionError("unexpected process/install"))
+    monkeypatch.setattr("subprocess.run", forbidden)
+    if failure == "missing_lock":
+        (tmp_path / "apm.lock.yaml").unlink()
+    elif failure == "malformed_lock":
+        (tmp_path / "apm.lock.yaml").write_text("not: [yaml", encoding="utf-8")
+    elif failure == "missing_install":
+        (installed / "SKILL.md").unlink()
+    elif failure == "extra_resource":
+        (installed / "helper.py").write_text("print('not imported')", encoding="utf-8")
+    elif failure == "nested_symlink":
+        (installed / "helper").symlink_to(installed / "SKILL.md")
+    elif failure == "closure":
+        (installed / "apm.yml").write_text(
+            "name: handoff-style\nversion: 1.0.0\ndependencies:\n  apm: [fixtures/another]\n",
+            encoding="utf-8",
+        )
+    with pytest.raises(ContractError):
+        resolve(source)
+    forbidden.assert_not_called()
+
+
+def test_missing_git_hash_is_not_fabricated(tmp_path: Path) -> None:
+    source, _, lock = fixture(tmp_path, local=False)
+    next(iter(lock.dependencies.values())).content_hash = None
+    (tmp_path / "apm.lock.yaml").write_text(lock.to_yaml(), encoding="utf-8")
+    with pytest.raises(ContractError, match="package hash"):
+        resolve(source)
+
+
+def test_legacy_lock_read_does_not_migrate(tmp_path: Path) -> None:
+    source, _, _ = fixture(tmp_path)
+    (tmp_path / "apm.lock.yaml").rename(tmp_path / "apm.lock")
+    skills, digest = resolve(source)
+    assert skills and digest
+    assert (tmp_path / "apm.lock").is_file()
+    assert not (tmp_path / "apm.lock.yaml").exists()
+
+
+@pytest.mark.windows_compat
+def test_bom_manifest_and_lock_are_parsed_by_yaml_owner(tmp_path: Path) -> None:
+    source, _, _ = fixture(tmp_path)
+    for name in ("apm.yml", "apm.lock.yaml"):
+        path = tmp_path / name
+        path.write_bytes(b"\xef\xbb\xbf" + path.read_bytes())
+    skills, digest = resolve(source)
+    assert skills[0].name == "handoff-style"
+    assert digest == hashlib.sha256((tmp_path / "apm.lock.yaml").read_bytes()).hexdigest()
+
+
+def test_duplicate_skill_name_refuses_ambiguity(tmp_path: Path) -> None:
+    source, _, lock = fixture(tmp_path)
+    (tmp_path / "apm.yml").write_text(
+        "name: fixture\nversion: 1.0.0\ndependencies:\n  apm:\n"
+        "    - path: ../handoff-style\n    - path: ../another\n",
+        encoding="utf-8",
+    )
+    other = DependencyReference.parse_from_dict({"path": "../another"}).get_install_path(
+        tmp_path / "apm_modules"
+    )
+    other.mkdir(parents=True)
+    (other / "SKILL.md").write_bytes(SKILL)
+    lock.add_dependency(
+        LockedDependency(repo_url="_local/another", source="local", local_path="../another")
+    )
+    (tmp_path / "apm.lock.yaml").write_text(lock.to_yaml(), encoding="utf-8")
+    with pytest.raises(ContractError) as error:
+        resolve(source)
+    assert error.value.code == "ambiguous_import"
+
+
+def test_full_dependency_identity_and_virtual_subdirectory_are_supported(tmp_path: Path) -> None:
+    source, installed, lock = fixture(tmp_path, local=False)
+    declaration = {
+        "git": "https://github.com/fixtures/handoff-style.git",
+        "path": "skills/style",
+        "ref": "v1",
+    }
+    dependency = DependencyReference.parse_from_dict(declaration)
+    new_path = dependency.get_install_path(tmp_path / "apm_modules")
+    new_path.mkdir(parents=True, exist_ok=True)
+    for name in ("apm.yml", "SKILL.md"):
+        (installed / name).rename(new_path / name)
+    (tmp_path / "apm.yml").write_text(
+        "name: fixture\nversion: 1.0.0\ndependencies:\n  apm:\n"
+        "    - git: https://github.com/fixtures/handoff-style.git\n"
+        "      path: skills/style\n      ref: v1\n",
+        encoding="utf-8",
+    )
+    old = next(iter(lock.dependencies.values()))
+    old.is_virtual = True
+    old.virtual_path = "skills/style"
+    lock.dependencies.clear()
+    lock.add_dependency(old)
+    (tmp_path / "apm.lock.yaml").write_text(lock.to_yaml(), encoding="utf-8")
+    source.write_text(
+        source.read_text(encoding="utf-8").replace(
+            "imports: [handoff-style]", "imports: [fixtures/handoff-style/skills/style]"
+        ),
+        encoding="utf-8",
+    )
+    skills, _ = resolve(source)
+    assert skills[0].source_path == new_path / "SKILL.md"
+
+
+def test_replanning_changes_on_source_manifest_or_lock_identity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source, installed, _ = fixture(tmp_path)
+    binary = tmp_path / "native"
+    binary.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+    binary.chmod(0o755)
+    monkeypatch.setattr("apm_cli.runtime.utils.find_runtime_binary", lambda name: str(binary))
+    monkeypatch.delenv("APM_POLICY_DISABLE", raising=False)
+    monkeypatch.delenv("APM_NO_SCRIPTS", raising=False)
+    monkeypatch.setattr("apm_cli.contracts.frontend.sys.platform", "linux")
+    first = plan_contract(source, tmp_path, harness="copilot")
+    (installed / "SKILL.md").write_bytes(b"\xef\xbb\xbf" + SKILL)
+    second = plan_contract(source, tmp_path, harness="copilot")
+    assert first != second
+    assert second.imported_skills[0].content.encode("utf-8") == b"\xef\xbb\xbf" + SKILL
+    manifest = tmp_path / "apm.yml"
+    manifest.write_bytes(manifest.read_bytes() + b"# changed\n")
+    third = plan_contract(source, tmp_path, harness="copilot")
+    assert third.manifest_digest != second.manifest_digest
+    lock = tmp_path / "apm.lock.yaml"
+    lock.write_bytes(lock.read_bytes() + b"# changed\n")
+    fourth = plan_contract(source, tmp_path, harness="copilot")
+    assert third.lock_digest != fourth.lock_digest

--- a/tests/unit/contracts/test_logger.py
+++ b/tests/unit/contracts/test_logger.py
@@ -1,0 +1,724 @@
+"""Line output and private transcript tests; no native model invocation."""
+
+import hashlib
+import io
+import json
+import os
+import sys
+from pathlib import Path
+
+import click
+import pytest
+
+from apm_cli.contracts.events import EventEmitter
+from apm_cli.contracts.frontend import parse_contract
+from apm_cli.contracts.models import (
+    Artifact,
+    CheckObservation,
+    CheckSpec,
+    ContractError,
+    FileEntry,
+    ImportedSkill,
+    LeafContract,
+    LeafPlan,
+    Outcome,
+    ProcessObservation,
+    RunResult,
+    SourceLocation,
+)
+from apm_cli.contracts.stream import ContractStreamDecoder
+from apm_cli.core.contract_logger import ContractLogger, _Transcript
+from apm_cli.core.output_mode import OutputMode, configure_output_mode
+from apm_cli.utils import console
+
+pytestmark = pytest.mark.component
+
+
+@pytest.mark.parametrize("verbose", [False, True])
+def test_reuse_plan_shows_resolved_skill_identity_before_consent(
+    tmp_path: Path, capsys: pytest.CaptureFixture, verbose: bool
+) -> None:
+    examples = Path(__file__).resolve().parents[3] / "examples/contracts"
+    source = examples / "handoff-style/SKILL.md"
+    raw = source.read_bytes()
+    digest = hashlib.sha256(raw).hexdigest()
+    plan = LeafPlan(
+        contract=parse_contract(examples / "reuse-contract/handoff.contract.md"),
+        project_root=tmp_path,
+        executable=Path("/native/copilot"),
+        imported_skills=(
+            ImportedSkill("handoff-style", source, raw.decode("utf-8"), digest, "../handoff-style"),
+        ),
+    )
+    ContractLogger(verbose=verbose).render_plan(plan, ())
+    output = capsys.readouterr().out
+    assert "Imported skill: handoff-style" in output
+    assert (
+        "Source identity: ../handoff-style; observed-local-source, not a cryptographic pin"
+        in output
+    )
+    assert (digest in output) is verbose
+    assert not (tmp_path / ".apm").exists()
+
+
+@pytest.fixture(autouse=True)
+def _plain_console(monkeypatch):
+    monkeypatch.setenv("NO_COLOR", "1")
+    monkeypatch.setenv("COLUMNS", "80")
+    console._reset_console()
+    yield
+    console._reset_console()
+
+
+def _check(raw: int | None, normalized: int, name: str = "criterion") -> CheckObservation:
+    return CheckObservation(
+        name=name,
+        command="not printed",
+        process=ProcessObservation(returncode=raw),
+        normalized=normalized,
+        subject_digest="subject",
+        resources_digest="resources",
+        reason=f"Check exited {raw}.",
+    )
+
+
+def _result(tmp_path: Path, outcome: Outcome, **kwargs) -> RunResult:
+    return RunResult(
+        run_id="run-id",
+        run_directory=tmp_path,
+        outcome=outcome,
+        artifact=kwargs.pop("artifact", None),
+        checks=kwargs.pop("checks", ()),
+        **kwargs,
+    )
+
+
+def test_ordered_phases_final_once_and_frozen_transcript(tmp_path: Path, capsys) -> None:
+    logger = ContractLogger()
+    logger.attach_run("run-id", tmp_path)
+    events = EventEmitter("run-id", logger.on_event)
+    events.emit(
+        "selected",
+        contract="hello.contract.md",
+        harness="copilot",
+        model="requested",
+        run_directory=str(tmp_path),
+    )
+    for phase in ("preflight", "execution", "capture", "checks", "record"):
+        events.emit("phase", name=phase)
+    logger.close()
+    path = tmp_path / "transcript.log"
+    digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    result = _result(tmp_path, Outcome.VERIFIED, checks=(_check(0, 0),))
+    events.emit("finished", result=result)
+    events.emit("finished", result=result)
+    logger.close()
+    output = capsys.readouterr().out
+    positions = [
+        output.index(name)
+        for name in ("Preflight", "Execution", "Capture", "Checks", "Record\n", "VERIFIED")
+    ]
+    assert positions == sorted(positions)
+    assert output.count("VERIFIED") == 1
+    assert output.index("Run: run-id") < output.index("Preflight")
+    assert hashlib.sha256(path.read_bytes()).hexdigest() == digest
+    assert b"VERIFIED" not in path.read_bytes()
+    assert "Observed execution model: unknown" in output
+    if os.name == "posix":
+        assert path.stat().st_mode & 0o777 == 0o600
+
+
+@pytest.mark.parametrize(
+    ("outcome", "stop"),
+    [
+        (Outcome.HALTED, "cancelled"),
+        (Outcome.HALTED, "producer_failed"),
+        (Outcome.REJECTED, None),
+        (Outcome.UNPROVEN, None),
+    ],
+)
+def test_final_outcome_is_authoritative_not_inferred(
+    tmp_path: Path, capsys, outcome: Outcome, stop: str | None
+) -> None:
+    logger = ContractLogger()
+    emitter = EventEmitter("run", logger.on_event)
+    # A pass alone cannot override the record owner's outcome.
+    emitter.emit(
+        "finished", result=_result(tmp_path, outcome, stop_reason=stop, checks=(_check(0, 0),))
+    )
+    output = capsys.readouterr().out
+    assert outcome.name in output
+    assert "VERIFIED" not in output
+    assert "[+]" not in output
+
+
+@pytest.mark.parametrize(
+    ("raw", "normalized", "text"),
+    [
+        (0, 0, "passed"),
+        (1, 1, "failed"),
+        (2, 2, "incomplete"),
+        (127, 2, "incomplete"),
+        (-9, 2, "incomplete"),
+        (None, 2, "incomplete"),
+    ],
+)
+def test_empty_stdout_check_status_comes_from_observation(
+    capsys, raw: int | None, normalized: int, text: str
+) -> None:
+    emitter = EventEmitter("run", ContractLogger().on_event)
+    emitter.emit("check_finished", observation=_check(raw, normalized))
+    output = capsys.readouterr().out
+    assert f"criterion: {text}" in output
+    assert ("[+]" in output) is (normalized == 0)
+
+
+@pytest.mark.parametrize("confirmed", [False, True])
+def test_stop_request_precedes_observation_and_preserves_provisional_path(
+    tmp_path: Path, capsys, confirmed: bool
+) -> None:
+    logger = ContractLogger()
+    emitter = EventEmitter("run", logger.on_event)
+    emitter.emit("stop_requested", reason="cancelled")
+    emitter.emit("stop_observed", confirmed=confirmed, reason="cancelled")
+    artifact = Artifact("answer.txt", tmp_path / "answer.txt", "identity", 3)
+    emitter.emit(
+        "finished",
+        result=_result(tmp_path, Outcome.HALTED, stop_reason="cancelled", artifact=artifact),
+    )
+    output = capsys.readouterr().out
+    expected = "Original process-group stop confirmed" if confirmed else "Stop unconfirmed"
+    assert output.index("Stop requested") < output.index(expected) < output.index("HALTED")
+    assert "Provisional artifact:" in output
+    assert "answer.txt" in "".join(line[4:].strip() for line in output.splitlines())
+    assert "cancelled successfully" not in output
+
+
+@pytest.mark.parametrize("width", [30, 40, 80])
+def test_narrow_no_color_controls_and_unicode_identity(
+    tmp_path: Path, capsys, monkeypatch, width: int
+) -> None:
+    monkeypatch.setenv("COLUMNS", str(width))
+    logger = ContractLogger()
+    logger.attach_run("run", tmp_path)
+    emitter = EventEmitter("run", logger.on_event)
+    emitter.emit(
+        "activity",
+        source="harness",
+        stream="stderr",
+        text="Path/" + "long/" * 10 + "\u00e9/\x1b]52;c;evil\x07 \u202e\r[+] FAKE",
+    )
+    logger.close()
+    output = capsys.readouterr().out
+    assert len(output.splitlines()) == 1
+    assert "Path/" + "long/" * 10 in output
+    assert all(character == "\n" or " " <= character <= "~" for character in output)
+    assert "?" not in output
+    transcript = (tmp_path / "transcript.log").read_text()
+    assert "\\xe9" in transcript
+    assert "\\x1b" in transcript
+    assert "\\u202e" in transcript
+    assert "\\r[+] FAKE" in transcript
+    assert "stderr" in transcript
+    assert "untrusted" in transcript
+
+
+def test_terminal_and_transcript_share_split_secret_redaction(tmp_path: Path, capsys) -> None:
+    logger = ContractLogger()
+    logger.attach_run("run", tmp_path)
+    decoder = ContractStreamDecoder(EventEmitter("run", logger.on_event), json_stdout=False)
+    secret = b"ghp_" + b"PRIVATE" * 5
+    for byte in b"Authorization: Bearer " + secret + b"\n":
+        decoder.feed("stderr", bytes([byte]))
+    decoder.finish()
+    logger.close()
+    output = capsys.readouterr().out
+    transcript = (tmp_path / "transcript.log").read_text()
+    for rendered in (output, transcript):
+        assert "PRIVATE" not in rendered
+        assert "***" in rendered
+        assert "stderr" in rendered
+
+
+def test_retention_is_bounded_beginning_tail_and_reports_exact_omission(tmp_path: Path) -> None:
+    transcript = _Transcript(2048)
+    for number in range(200):
+        transcript.append(f"line {number:03d} " + "x" * 80)
+    path = tmp_path / "bounded.log"
+    with path.open("wb") as target:
+        transcript.write(target)
+    data = path.read_bytes()
+    assert len(data) <= 2048
+    assert data.startswith(b"line 000")
+    assert b"line 199" in data
+    assert b"Transcript truncated" in data
+    assert str(transcript.omitted_lines).encode() in data
+    assert str(transcript.omitted_bytes).encode() in data
+    assert len(transcript.head) + len(transcript.tail) + transcript.omitted_lines == 200
+
+
+def test_transcript_saturation_does_not_hide_lifecycle_or_stderr(tmp_path: Path, capsys) -> None:
+    logger = ContractLogger()
+    logger._transcript = _Transcript(1024)
+    logger.attach_run("run", tmp_path)
+    emitter = EventEmitter("run", logger.on_event)
+    for number in range(50):
+        emitter.emit("activity", source="harness", text=f"Activity {number} " + "x" * 80)
+    emitter.emit("activity", source="harness", stream="stderr", text="Useful last error")
+    emitter.emit("phase", name="record")
+    logger.close()
+    emitter.emit(
+        "finished", result=_result(tmp_path, Outcome.HALTED, stop_reason="producer_failed")
+    )
+    output = capsys.readouterr().out
+    assert "Useful last error" in output
+    assert "Record" in output
+    assert "HALTED" in output
+    assert (tmp_path / "transcript.log").stat().st_size <= 1024
+
+
+def test_closed_pipe_disables_human_output_but_not_recording(tmp_path: Path, monkeypatch) -> None:
+    calls = []
+
+    def broken(*args, **kwargs):
+        calls.append(args)
+        raise BrokenPipeError
+
+    monkeypatch.setattr(console, "_rich_echo", broken)
+    logger = ContractLogger()
+    logger.attach_run("run", tmp_path)
+    emitter = EventEmitter("run", logger.on_event)
+    emitter.emit("phase", name="execution")
+    emitter.emit("activity", source="harness", text="Still captured")
+    emitter.emit("stop_requested", reason="cancelled")
+    emitter.emit("stop_observed", confirmed=True, reason="cancelled")
+    logger.close()
+    emitter.emit("finished", result=_result(tmp_path, Outcome.HALTED, stop_reason="cancelled"))
+    logger.close()
+    assert len(calls) == 1
+    assert "Still captured" in (tmp_path / "transcript.log").read_text()
+
+
+def test_unrelated_renderer_errors_are_not_silently_swallowed(monkeypatch) -> None:
+    def failed(*args, **kwargs):
+        raise OSError("unexpected renderer failure")
+
+    monkeypatch.setattr(console, "_rich_echo", failed)
+    with pytest.raises(OSError, match="unexpected renderer failure"):
+        ContractLogger().render_error(ContractError("Cannot proceed"))
+
+
+def test_rich_broken_pipe_does_not_attempt_colorama_fallback(monkeypatch) -> None:
+    class BrokenConsole:
+        def print(self, *args, **kwargs):
+            raise BrokenPipeError
+
+    monkeypatch.setattr(console, "_get_console", lambda: BrokenConsole())
+    monkeypatch.setattr(
+        console.click, "echo", lambda *args, **kwargs: pytest.fail("fallback attempted")
+    )
+    with pytest.raises(BrokenPipeError):
+        console._rich_echo("text")
+
+
+def test_no_color_fallback_honors_stderr_routing(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(console, "_get_console", lambda: None)
+    configure_output_mode(OutputMode(machine_readable=True))
+    ContractLogger().render_error(ContractError("Actionable failure"))
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "Actionable failure" in captured.err
+    assert "\x1b" not in captured.err
+
+
+def test_rich_honors_machine_output_routing(capsys) -> None:
+    configure_output_mode(OutputMode(machine_readable=True))
+    ContractLogger().render_error(ContractError("Inspect source"))
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "Inspect source" in captured.err
+
+
+def test_plan_is_nonexecuting_no_prompt_or_model_claim(capsys, tmp_path: Path) -> None:
+    plan = LeafPlan(
+        contract=LeafContract(
+            tmp_path / "hello.contract.md",
+            "source",
+            "DO NOT DUMP THIS PROMPT",
+            ("input.txt",),
+            "output.txt",
+            (CheckSpec("content", "private check command"),),
+        ),
+        project_root=tmp_path,
+        executable=Path("/native/copilot"),
+        model=None,
+    )
+    ContractLogger().render_plan(plan, (FileEntry("input.txt", "sha", 7, 0o644),))
+    output = capsys.readouterr().out
+    assert "Plan only -- no execution" in output
+    assert "Baseline: 1 files, 7 bytes" in output
+    assert "requested model: native default" in output
+    assert "DO NOT DUMP" not in output
+    assert "private check command" not in output
+    assert "--allow-advisory" in output
+    assert "TTY and pipes" in " ".join(line[4:].strip() for line in output.splitlines())
+    assert not (tmp_path / "transcript.log").exists()
+
+
+def test_pre_admission_error_has_source_location_not_fake_run(capsys, tmp_path: Path) -> None:
+    ContractLogger().render_error(
+        ContractError(
+            "Install the required executable and retry.",
+            code="missing_executable",
+            location=SourceLocation(Path("job.contract.md"), 7, 3),
+        )
+    )
+    output = capsys.readouterr().out
+    assert "HALTED -- missing_executable" in output
+    assert "job.contract.md:7:3" in output
+    assert "copilot login" not in output
+    assert "Run:" not in output
+
+
+def test_heartbeat_is_liveness_not_fake_progress(capsys) -> None:
+    emitter = EventEmitter("run", ContractLogger().on_event)
+    emitter.emit("heartbeat", elapsed_seconds=2)
+    emitter.emit("heartbeat", elapsed_seconds=15)
+    emitter.emit("heartbeat", elapsed_seconds=16)
+    emitter.emit("heartbeat", elapsed_seconds=31)
+    output = capsys.readouterr().out
+    assert output.count("still running") == 2
+    assert "%" not in output
+
+
+def test_transcript_cannot_overwrite_or_follow_existing_path(tmp_path: Path) -> None:
+    path = tmp_path / "transcript.log"
+    path.write_bytes(b"existing")
+    with pytest.raises(FileExistsError):
+        ContractLogger().attach_run("run", tmp_path)
+    assert path.read_bytes() == b"existing"
+
+
+def test_close_failure_propagates_and_cannot_announce_success(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    logger = ContractLogger()
+    logger.attach_run("run", tmp_path)
+
+    def failed_sync(fd):
+        raise OSError("disk failure")
+
+    monkeypatch.setattr(os, "fsync", failed_sync)
+    with pytest.raises(OSError, match="disk failure"):
+        logger.close()
+    logger.close()
+    assert "VERIFIED" not in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("verbose", [False, True])
+def test_native_result_zero_without_artifact_remains_unproven_and_private(
+    tmp_path: Path, capsys, verbose: bool
+) -> None:
+    from apm_cli.contracts.records import reduce_outcome
+
+    logger = ContractLogger(verbose=verbose)
+    logger.attach_run("run", tmp_path)
+    emitter = EventEmitter("run", logger.on_event)
+    decoder = ContractStreamDecoder(emitter)
+    wire = json.dumps(
+        {
+            "type": "result",
+            "exitCode": 0,
+            "sessionId": "harmless-fixture",
+            "timestamp": "2026-09-05T09:42:00Z",
+            "usage": {"reasoning": "PRIVATE_REASONING", "encrypted": "PRIVATE_ENCRYPTED"},
+            "reasoning": "PRIVATE_REASONING",
+            "encryptedContent": "PRIVATE_ENCRYPTED",
+        }
+    ).encode()
+    decoder.feed("stdout", wire)
+    decoder.finish()
+    assert decoder.completion_seen
+    assert decoder.native_exit_code == 0
+    logger.close()
+    result = _result(tmp_path, reduce_outcome(None, (), None))
+    emitter.emit("finished", result=result)
+    output = capsys.readouterr().out
+    transcript = (tmp_path / "transcript.log").read_text()
+    assert "UNPROVEN" in output
+    assert "VERIFIED" not in output
+    assert "[+]" not in output
+    assert "Native completion reported exit code 0" in transcript
+    assert "PRIVATE_" not in output + transcript
+    assert "sessionId" not in output + transcript
+
+
+@pytest.mark.parametrize("verbose", [False, True])
+def test_analysis_phase_never_reaches_terminal_or_transcript(
+    tmp_path: Path, capsys, verbose: bool
+) -> None:
+    logger = ContractLogger(verbose=verbose)
+    logger.attach_run("run", tmp_path)
+    decoder = ContractStreamDecoder(EventEmitter("run", logger.on_event))
+    frames = [
+        ("assistant.message_start", {"messageId": "hidden", "phase": "analysis"}),
+        ("assistant.message_delta", {"messageId": "hidden", "deltaContent": "PRIVATE_ANALYSIS\n"}),
+        ("assistant.message", {"messageId": "hidden", "content": "PRIVATE_ANALYSIS\n"}),
+        ("tool.execution_start", {"toolName": "apply_patch", "arguments": "PRIVATE_TOOL_ARGS"}),
+        ("assistant.message_start", {"messageId": "answer", "phase": "final_answer"}),
+        ("assistant.message_delta", {"messageId": "answer", "deltaContent": "Public answer\n"}),
+        (
+            "assistant.message",
+            {
+                "messageId": "answer",
+                "content": "Public answer\n",
+                "phase": "final_answer",
+                "model": "gpt-6-astra",
+                "reasoning": "PRIVATE_REASONING",
+                "encryptedContent": "PRIVATE_ENCRYPTED",
+            },
+        ),
+    ]
+    for kind, data in frames:
+        wire = (json.dumps({"type": kind, "data": data}) + "\n").encode()
+        for offset in range(0, len(wire), 7):
+            decoder.feed("stdout", wire[offset : offset + 7])
+    decoder.finish()
+    logger.close()
+    output = capsys.readouterr().out
+    transcript = (tmp_path / "transcript.log").read_text()
+    for text in (output, transcript):
+        assert "PRIVATE_" not in text
+        assert text.count("Public answer") == 1
+        assert "Tool started: apply_patch" in text
+
+
+def test_pre_engine_interrupt_reports_halted_without_claiming_child_cleanup(capsys) -> None:
+    logger = ContractLogger()
+    logger.render_error(
+        ContractError(
+            "Offline planning or inventory interrupted before native execution.",
+            code="cancelled",
+        )
+    )
+    logger.close()
+    output = capsys.readouterr().out
+    assert "HALTED" in output
+    assert "cancelled" in output
+    assert "Run:" not in output
+    assert "stop confirmed" not in output
+    assert "terminated" not in output
+    assert "[+]" not in output
+
+
+@pytest.mark.parametrize("verbose", [False, True])
+def test_stop_confirmation_before_capture_does_not_claim_an_artifact(
+    tmp_path: Path, capsys, verbose: bool
+) -> None:
+    logger = ContractLogger(verbose=verbose)
+    logger.attach_run("run", tmp_path)
+    emitter = EventEmitter("run", logger.on_event)
+    emitter.emit("stop_observed", confirmed=True, reason="cancelled")
+    logger.close()
+    output = capsys.readouterr().out
+    transcript = (tmp_path / "transcript.log").read_text()
+    for text in (output, transcript):
+        assert "Original process-group stop confirmed" in text
+        assert "checking for provisional output" in text
+        assert "retained" not in text
+        assert "Artifact:" not in text
+        assert "[+]" not in text
+    assert "Escaped descendants are unobserved." in transcript
+    assert ("Escaped descendants are unobserved." in output) is verbose
+
+
+@pytest.mark.parametrize("stderr", [False, True])
+def test_plain_contract_output_bypasses_nested_autoreset_without_mutating_legacy(
+    monkeypatch, stderr: bool
+) -> None:
+    from colorama import AnsiToWin32, initialise
+
+    target = io.StringIO()
+    inner = AnsiToWin32(target, convert=False, strip=False, autoreset=True)
+    outer = AnsiToWin32(inner.stream, convert=False, strip=False, autoreset=True)
+    unregistered = []
+    monkeypatch.setattr(console.atexit, "unregister", unregistered.append)
+    monkeypatch.setattr(initialise, "atexit_done", True)
+    monkeypatch.setattr(sys, "stderr" if stderr else "stdout", outer.stream)
+    configure_output_mode(OutputMode(machine_readable=stderr))
+
+    ContractLogger().render_error(ContractError("Plain contract refusal"))
+
+    text = target.getvalue()
+    assert "Plain contract refusal" in text
+    assert "\x1b" not in text
+    assert unregistered == [initialise.reset_all]
+    assert not initialise.atexit_done
+    assert inner.autoreset and outer.autoreset
+    assert (sys.stderr if stderr else sys.stdout) is outer.stream
+    outer.stream.write("Legacy write")
+    assert "\x1b[0m" in target.getvalue()
+
+
+def test_colored_contract_mode_preserves_legacy_autoreset_setup(monkeypatch) -> None:
+    from colorama import initialise
+
+    monkeypatch.delenv("NO_COLOR")
+    monkeypatch.setattr(initialise, "atexit_done", True)
+    calls = []
+    monkeypatch.setattr(
+        console.atexit, "unregister", lambda fn: pytest.fail("colored mode changed exit hooks")
+    )
+    monkeypatch.setattr(console, "_rich_echo", lambda *args, **kwargs: calls.append(kwargs))
+    ContractLogger().render_error(ContractError("Colored refusal"))
+    assert calls
+    assert all(not call["plain"] for call in calls)
+    assert initialise.atexit_done
+
+
+def test_transcript_metadata_is_read_only_and_returns_independent_snapshots() -> None:
+    logger = ContractLogger()
+    expected = {
+        "omitted_bytes": 0,
+        "omitted_lines": 0,
+        "retention": "bounded-beginning-tail",
+        "redaction": "best-effort",
+    }
+    assert logger.transcript_metadata == expected
+    snapshot = logger.transcript_metadata
+    snapshot["omitted_bytes"] = 999
+    assert logger.transcript_metadata == expected
+    with pytest.raises(AttributeError):
+        logger.transcript_metadata = {}
+
+
+def test_transcript_metadata_reports_counters_and_stays_frozen_after_close(
+    tmp_path: Path,
+) -> None:
+    logger = ContractLogger()
+    logger._human_enabled = False
+    logger._transcript = _Transcript(512)
+    logger.attach_run("run", tmp_path)
+    lines = [f"entry {number:03d} " + "x" * 64 for number in range(20)]
+    for line in lines:
+        logger._transcript.append(line)
+    expected_bytes = (
+        sum(len(line.encode("ascii")) + 1 for line in lines)
+        - logger._transcript.head_bytes
+        - logger._transcript.tail_bytes
+    )
+    expected_lines = len(lines) - len(logger._transcript.head) - len(logger._transcript.tail)
+    assert expected_bytes > 0 and expected_lines > 0
+    logger.close()
+    snapshot = logger.transcript_metadata
+    assert snapshot["omitted_bytes"] == expected_bytes
+    assert snapshot["omitted_lines"] == expected_lines
+    path = tmp_path / "transcript.log"
+    digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    EventEmitter("run", logger.on_event).emit(
+        "finished", result=_result(tmp_path, Outcome.UNPROVEN)
+    )
+    logger.close()
+    assert logger.transcript_metadata == snapshot
+    assert hashlib.sha256(path.read_bytes()).hexdigest() == digest
+
+
+def test_live_telemetry_names_stay_quiet_without_hiding_stderr_or_native_errors(
+    tmp_path: Path, capsys
+) -> None:
+    """Use event names observed in the retained live attempt, not its payloads."""
+    telemetry = (
+        "session.mcp_server_status_changed",
+        "mcp.tools.list_changed",
+        "session.mcp_servers_loaded",
+        "session.skills_loaded",
+        "session.tools_updated",
+        "session.custom_agents_updated",
+        "session.info",
+        "session.canvas.registry_changed",
+        "user.message",
+        "assistant.turn_start",
+        "assistant.tool_call_delta",
+        "assistant.turn_end",
+        "session.usage_checkpoint",
+    )
+    logger = ContractLogger()
+    logger.attach_run("run", tmp_path)
+    decoder = ContractStreamDecoder(EventEmitter("run", logger.on_event))
+    for kind in telemetry:
+        decoder.feed("stdout", (json.dumps({"type": kind, "data": {}}) + "\n").encode())
+    # Synthetic fault observations: the retained live run had no stderr.
+    decoder.feed("stderr", b"Actionable native stderr\n")
+    decoder.feed(
+        "stdout",
+        (
+            json.dumps(
+                {
+                    "type": "session.error",
+                    "data": {"errorType": "connection_error", "message": "Connection dropped"},
+                }
+            )
+            + "\n"
+        ).encode(),
+    )
+    decoder.finish()
+    logger.close()
+    output = capsys.readouterr().out
+    transcript = (tmp_path / "transcript.log").read_text()
+    assert "Native event not interpreted" not in output
+    assert transcript.count("Native event not interpreted") == len(telemetry)
+    for text in (output, transcript):
+        assert "Actionable native stderr" in text
+        assert "Connection dropped" in text
+        assert "Inspect the native error" in text
+    assert "copilot login" not in output
+
+
+@pytest.mark.parametrize("width", [30, 40, 80])
+@pytest.mark.parametrize("tty", [False, True])
+@pytest.mark.parametrize("no_color", [False, True])
+@pytest.mark.parametrize("stderr", [False, True])
+def test_full_source_artifact_and_log_paths_stay_copyable(
+    tmp_path: Path, monkeypatch, capsys, width: int, tty: bool, no_color: bool, stderr: bool
+) -> None:
+    from rich.console import Console
+
+    monkeypatch.setenv("COLUMNS", str(width))
+    if not no_color:
+        monkeypatch.delenv("NO_COLOR")
+    configure_output_mode(OutputMode(machine_readable=stderr))
+    monkeypatch.setattr(
+        console, "_console_instance", Console(width=width, force_terminal=tty, stderr=stderr)
+    )
+    directory = tmp_path / "deep-source-component" / "session-state" / "contract-run-directory"
+    source = directory / "source-with-a-long-name.contract.md"
+    artifact_path = directory / "artifacts" / "handoff-with-a-long-name.json"
+    logger = ContractLogger()
+    emitter = EventEmitter("run", logger.on_event)
+    emitter.emit(
+        "selected",
+        contract=str(source),
+        harness="copilot",
+        model="gpt-6-astra",
+        run_directory=str(directory),
+    )
+    logger.close()
+    emitter.emit(
+        "finished",
+        result=_result(
+            directory,
+            Outcome.HALTED,
+            stop_reason="cancelled",
+            artifact=Artifact("handoff.json", artifact_path, "identity", 1),
+        ),
+    )
+    captured = capsys.readouterr()
+    assert (captured.out if stderr else captured.err) == ""
+    output = captured.err if stderr else captured.out
+    if no_color:
+        assert "\x1b" not in output
+    lines = click.unstyle(output).splitlines()
+    assert f"[>] Contract: {source}" in lines
+    assert f"[i] Provisional artifact: {artifact_path}" in lines
+    assert lines.count(f"[i] Record and logs: {directory}") == 2
+    assert not any(line.startswith("[i]   ") or line.startswith("[>]   ") for line in lines)

--- a/tests/unit/contracts/test_pty_lifecycle.py
+++ b/tests/unit/contracts/test_pty_lifecycle.py
@@ -1,0 +1,119 @@
+"""A real PTY and installed command boundary, with a deterministic fake harness.
+
+This is cancellation/terminal coverage, not the required live Copilot demo.
+"""
+
+import errno
+import json
+import os
+import select
+import shutil
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+pytestmark = [
+    pytest.mark.component,
+    pytest.mark.skipif(os.name != "posix", reason="PTY and process-group exercise requires POSIX"),
+]
+
+
+def test_pty_interrupt_leaves_halted_record_and_no_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import pty
+    import termios
+
+    source_root = Path(__file__).resolve().parents[3]
+    project = tmp_path / "fixture"
+    shutil.copytree(source_root / "examples/contracts/first-contract", project)
+    tools = tmp_path / "bin"
+    tools.mkdir()
+    actor = tools / "copilot"
+    actor.write_text(
+        f"#!{sys.executable}\n"
+        "import json,sys,time\n"
+        "if 'mcp' in sys.argv:\n"
+        "    print(json.dumps({'mcpServers':{}}),flush=True)\n"
+        "    raise SystemExit(0)\n"
+        "print(json.dumps({'type':'assistant.message','data':"
+        "{'messageId':'pty-ready','content':'PTY actor ready','model':'gpt-6-astra'}}),flush=True)\n"
+        "time.sleep(30)\n",
+        encoding="utf-8",
+    )
+    actor.chmod(0o755)
+    monkeypatch.delenv("APM_NO_SCRIPTS", raising=False)
+    monkeypatch.delenv("APM_POLICY_DISABLE", raising=False)
+    env = {
+        **os.environ,
+        "PATH": str(tools) + os.pathsep + os.environ.get("PATH", ""),
+        "PYTHONPATH": str(source_root / "src"),
+        "NO_COLOR": "1",
+        "COLUMNS": "48",
+    }
+    master, slave = pty.openpty()
+    settings = termios.tcgetattr(slave)
+    child = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            "from apm_cli.cli import cli; cli()",
+            "run",
+            "handoff.contract.md",
+            "--on",
+            "copilot",
+            "--model",
+            "gpt-6-astra",
+            "--allow-advisory",
+        ],
+        cwd=project,
+        env=env,
+        stdin=slave,
+        stdout=slave,
+        stderr=slave,
+        start_new_session=True,
+    )
+    output = bytearray()
+    interrupted = False
+    deadline = time.monotonic() + 15
+    try:
+        while time.monotonic() < deadline:
+            if select.select([master], [], [], 0.1)[0]:
+                try:
+                    chunk = os.read(master, 65536)
+                except OSError as exc:
+                    if exc.errno == errno.EIO:
+                        break
+                    raise
+                if not chunk:
+                    break
+                output.extend(chunk)
+            if not interrupted and b"PTY actor ready" in output:
+                os.kill(child.pid, signal.SIGINT)
+                interrupted = True
+            if child.poll() is not None:
+                break
+        assert interrupted, output.decode("ascii", errors="replace")
+        assert child.wait(timeout=2) == 22, output.decode("ascii", errors="replace")
+        assert termios.tcgetattr(slave) == settings
+    finally:
+        if child.poll() is None:
+            child.kill()
+            child.wait(timeout=2)
+        os.close(master)
+        os.close(slave)
+    records = list((project / ".apm" / "runs").glob("*/record.json"))
+    assert len(records) == 1
+    record = json.loads(records[0].read_text(encoding="utf-8"))
+    assert record["complete"] is True
+    assert record["result"]["outcome"]["name"] == "HALTED"
+    assert record["result"]["stop_reason"] == "cancelled"
+    assert record["producer"]["cleanup_confirmed"] is True
+    assert record["producer"]["returncode"] is not None
+    assert b"VERIFIED" not in output
+    assert b"\x1b" not in output
+    assert all(byte < 128 for byte in output)

--- a/tests/unit/contracts/test_reliability.py
+++ b/tests/unit/contracts/test_reliability.py
@@ -1,0 +1,315 @@
+"""Real local processes and independent exact-byte assessment workspaces."""
+
+import hashlib
+import json
+import os
+import signal
+import stat
+import sys
+import time
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from apm_cli.contracts import process, records, workspace
+from apm_cli.contracts.models import (
+    CheckObservation,
+    ContractError,
+    ContractLimits,
+    LeafContract,
+    LeafPlan,
+    Outcome,
+    ProcessObservation,
+    ProcessRequest,
+    RunResult,
+)
+from apm_cli.utils.atomic_io import atomic_write_text
+
+pytestmark = [
+    pytest.mark.component,
+    pytest.mark.skipif(os.name != "posix", reason="Native contract execution is POSIX-only"),
+]
+
+
+def _plan(root: Path) -> LeafPlan:
+    source = root / "test.contract.md"
+    source.write_bytes(b"---\nproduces: fix.patch\n---\nWrite a patch.\n")
+    (root / "apm.yml").write_text("name: fixture\nversion: 0.0.0\n", encoding="utf-8")
+    (root / "input.txt").write_bytes(b"old\r\n")
+    return LeafPlan(
+        LeafContract(
+            source,
+            hashlib.sha256(source.read_bytes()).hexdigest(),
+            "Patch",
+            ("input.txt",),
+            "fix.patch",
+            (),
+        ),
+        root,
+        Path(sys.executable),
+    )
+
+
+def _capture(tmp_path: Path) -> tuple[LeafPlan, Path]:
+    plan = _plan(tmp_path)
+    run = tmp_path / "run"
+    run.mkdir()
+    return plan, run
+
+
+def test_exact_bytes_and_independent_self_applied_patch(tmp_path: Path) -> None:
+    plan, run = _capture(tmp_path)
+    snapshot = workspace.capture_workspace(plan, run)
+    assert (snapshot.root / "input.txt").read_bytes() == b"old\r\n"
+    assert workspace.local_git(snapshot.root, "show", "HEAD:input.txt") == b"old\r\n"
+    patch = b"diff --git a/input.txt b/input.txt\n--- a/input.txt\n+++ b/input.txt\n@@ -1 +1 @@\n-old\r\n+new\r\n"
+    (snapshot.producer / "fix.patch").write_bytes(patch)
+    artifact = workspace.capture_output(snapshot, "fix.patch", run, plan.limits)
+    assert artifact is not None
+    assert artifact.sha256 == hashlib.sha256(patch).hexdigest()
+    for name in ("one", "two"):
+        check = workspace.prepare_check_workspace(snapshot, artifact, run, name)
+        assert (check / "input.txt").read_bytes() == b"old\r\n"
+        workspace.local_git(check, "apply", "--", "fix.patch")
+        assert (check / "input.txt").read_bytes() == b"new\r\n"
+        assert workspace.verify_check_integrity(snapshot, artifact, check)
+    assert (tmp_path / "input.txt").read_bytes() == b"old\r\n"
+
+
+def test_effective_tracked_edits_deletions_and_selected_untracked(tmp_path: Path) -> None:
+    plan, run = _capture(tmp_path)
+    workspace.local_git(tmp_path, "init", "--quiet")
+    (tmp_path / "deleted.txt").write_text("remove", encoding="utf-8")
+    workspace.local_git(tmp_path, "add", "--", "input.txt", "deleted.txt")
+    workspace.local_git(tmp_path, "commit", "--quiet", "-m", "Original")
+    original = workspace.local_git(tmp_path, "rev-parse", "HEAD").decode().strip()
+    (tmp_path / "input.txt").write_bytes(b"working bytes\n")
+    (tmp_path / "deleted.txt").unlink()
+    (tmp_path / "unselected-secret.txt").write_text("not selected", encoding="utf-8")
+    snapshot = workspace.capture_workspace(plan, run)
+    assert snapshot.original_head == original
+    assert workspace.local_git(snapshot.root, "show", "HEAD:input.txt") == b"working bytes\n"
+    assert not (snapshot.root / "deleted.txt").exists()
+    assert not (snapshot.root / "unselected-secret.txt").exists()
+    assert (snapshot.root / "test.contract.md").exists()
+    assert workspace.local_git(snapshot.root, "remote") == b""
+
+
+def test_inventory_never_executes_configured_fsmonitor(tmp_path: Path) -> None:
+    plan = _plan(tmp_path)
+    workspace.local_git(tmp_path, "init", "--quiet")
+    workspace.local_git(tmp_path, "add", "--", "input.txt")
+    hook = tmp_path / "fsmonitor-hook"
+    marker = tmp_path / "hook-executed"
+    hook.write_text(
+        f"#!{sys.executable}\nfrom pathlib import Path\nPath({str(marker)!r}).touch()\n",
+        encoding="utf-8",
+    )
+    hook.chmod(0o755)
+    workspace.local_git(tmp_path, "config", "core.fsmonitor", str(hook))
+    entries = workspace.inspect_workspace(plan)
+    assert any(entry.relative_path == "input.txt" for entry in entries)
+    assert not marker.exists()
+
+
+def test_missing_empty_oversized_and_symlink_outputs_are_distinct(tmp_path: Path) -> None:
+    plan, run = _capture(tmp_path)
+    snapshot = workspace.capture_workspace(plan, run)
+    assert workspace.capture_output(snapshot, "fix.patch", run, plan.limits) is None
+    output = snapshot.producer / "fix.patch"
+    output.symlink_to(tmp_path / "input.txt")
+    with pytest.raises(ContractError):
+        workspace.capture_output(snapshot, "fix.patch", run, plan.limits)
+    output.unlink()
+    output.write_bytes(b"too large")
+    with pytest.raises(ContractError):
+        workspace.capture_output(snapshot, "fix.patch", run, replace(plan.limits, output_bytes=1))
+    output.write_bytes(b"")
+    artifact = workspace.capture_output(snapshot, "fix.patch", run, plan.limits)
+    assert artifact is not None
+    assert artifact.size == 0
+    assert artifact.sha256 == hashlib.sha256(b"").hexdigest()
+
+
+def test_changed_check_resource_is_incomplete(tmp_path: Path) -> None:
+    plan, run = _capture(tmp_path)
+    (tmp_path / "checks").mkdir()
+    (tmp_path / "checks" / "condition.txt").write_bytes(b"authoritative")
+    snapshot = workspace.capture_workspace(plan, run)
+    (snapshot.producer / "fix.patch").write_bytes(b"candidate")
+    artifact = workspace.capture_output(snapshot, "fix.patch", run, plan.limits)
+    assert artifact is not None
+    root = workspace.prepare_check_workspace(snapshot, artifact, run, "one")
+    assert workspace.verify_check_integrity(snapshot, artifact, root)
+    (root / "checks" / "condition.txt").write_bytes(b"changed")
+    assert not workspace.verify_check_integrity(snapshot, artifact, root)
+    assert records.normalize_check(ProcessObservation(0), integrity_ok=False) == 2
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"), [(0, 0), (1, 1), (2, 2), (127, 2), (-9, 2), (None, 2)]
+)
+def test_raw_check_normalization(raw: int | None, expected: int) -> None:
+    assert records.normalize_check(ProcessObservation(raw)) == expected
+    assert records.normalize_check(ProcessObservation(raw, cleanup_confirmed=False)) == 2
+
+
+def test_empty_checks_and_failure_plus_incomplete_outcomes() -> None:
+    incomplete = CheckObservation("missing", "", ProcessObservation(127), 2, "", "", "missing")
+    failed = replace(incomplete, name="failed", normalized=1, process=ProcessObservation(1))
+    assert records.reduce_outcome(None, (), None) == Outcome.UNPROVEN
+    assert records.reduce_outcome(None, (incomplete, failed), None) == Outcome.REJECTED
+    assert records.reduce_outcome(None, (failed,), "cancelled") == Outcome.HALTED
+
+
+def test_both_streams_are_drained_and_spawn_failure_is_observed(tmp_path: Path) -> None:
+    chunks: dict[str, bytearray] = {"stdout": bytearray(), "stderr": bytearray()}
+    observation = process.supervise_process(
+        ProcessRequest(
+            (sys.executable, "-c", "import os; os.write(1,b'a'*200000); os.write(2,b'b'*200000)"),
+            tmp_path,
+            10,
+        ),
+        on_bytes=lambda stream, data: chunks[stream].extend(data),
+    )
+    assert observation.returncode == 0
+    assert observation.cleanup_confirmed
+    assert chunks == {"stdout": b"a" * 200000, "stderr": b"b" * 200000}
+    missing = process.supervise_process(
+        ProcessRequest((str(tmp_path / "no-executable"),), tmp_path, 1),
+        on_bytes=lambda *args: None,
+    )
+    assert missing.returncode is None
+    assert missing.error
+
+
+def test_watchdog_kills_term_ignoring_child_with_bounded_cleanup(tmp_path: Path) -> None:
+    started = time.monotonic()
+    observation = process.supervise_process(
+        ProcessRequest(
+            (
+                sys.executable,
+                "-c",
+                "import signal,time; signal.signal(signal.SIGTERM,signal.SIG_IGN); print('ready',flush=True); time.sleep(30)",
+            ),
+            tmp_path,
+            0.2,
+        ),
+        on_bytes=lambda *args: None,
+        limits=ContractLimits(cleanup_seconds=0.4),
+    )
+    assert observation.stop_reason == "timeout"
+    assert observation.cleanup_confirmed
+    assert observation.returncode == -signal.SIGKILL
+    assert time.monotonic() - started < 2
+    assert observation.signals == ("SIGTERM", "SIGKILL")
+
+
+def test_natural_child_shutdown_is_not_an_operational_failure(tmp_path: Path) -> None:
+    chunks = bytearray()
+    code = (
+        "import subprocess,sys\n"
+        "subprocess.Popen([sys.executable,'-c',"
+        "'import time; time.sleep(0.15); print(\"closed\",flush=True)'])\n"
+    )
+    observation = process.supervise_process(
+        ProcessRequest((sys.executable, "-c", code), tmp_path, 10),
+        on_bytes=lambda stream, data: chunks.extend(data),
+    )
+    assert observation.returncode == 0
+    assert observation.stop_reason is None
+    assert observation.cleanup_confirmed
+    assert observation.signals == ()
+    assert b"closed" in chunks
+
+
+def test_truly_lingering_child_still_halts_within_cleanup_window(tmp_path: Path) -> None:
+    started = time.monotonic()
+    observation = process.supervise_process(
+        ProcessRequest(
+            (
+                sys.executable,
+                "-c",
+                "import subprocess,sys; subprocess.Popen([sys.executable,'-c',"
+                "'import time; time.sleep(30)'])",
+            ),
+            tmp_path,
+            10,
+        ),
+        on_bytes=lambda *args: None,
+        limits=ContractLimits(cleanup_seconds=0.4),
+    )
+    assert observation.returncode == 0
+    assert observation.stop_reason == "lingering_children"
+    assert "SIGTERM" in observation.signals
+    assert time.monotonic() - started < 2
+    assert records.reduce_outcome(None, (), observation.stop_reason) == Outcome.HALTED
+
+
+def test_callback_failure_still_reaps_the_child(tmp_path: Path) -> None:
+    pids = []
+
+    def fail(stream: str, data: bytes) -> None:
+        raise OSError("transcript storage failed")
+
+    with pytest.raises(OSError, match="transcript storage failed"):
+        process.supervise_process(
+            ProcessRequest(
+                (sys.executable, "-c", "import time; print('ready',flush=True); time.sleep(30)"),
+                tmp_path,
+                10,
+            ),
+            on_bytes=fail,
+            on_started=lambda pid, pgid: pids.append(pid),
+        )
+    with pytest.raises(ProcessLookupError):
+        os.kill(pids[0], 0)
+
+
+def test_record_is_private_atomic_and_observed_not_claimed(tmp_path: Path) -> None:
+    plan = _plan(tmp_path)
+    store = records.AttemptStore.create(plan)
+    store.update("execution", producer=ProcessObservation(7), observed_models=("gpt-6-astra",))
+    data = json.loads(store.record_path.read_text())
+    assert data["complete"] is False
+    assert data["producer"]["returncode"] == 7
+    assert data["observed_models"] == ["gpt-6-astra"]
+    assert store.record_path.stat().st_mode & 0o777 == 0o600
+    assert store.directory.stat().st_mode & 0o777 == 0o700
+    assert "not protected" in data["provenance"]
+
+
+def test_durable_atomic_writer_syncs_file_and_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    synced = []
+    monkeypatch.setattr(os, "fsync", lambda fd: synced.append(os.fstat(fd).st_mode))
+    atomic_write_text(tmp_path / "record.json", "{}\n", durable=True)
+    assert len(synced) == 2
+    assert (tmp_path / "record.json").read_bytes() == b"{}\n"
+
+
+def test_post_replace_directory_sync_failure_cannot_leave_verified_record(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plan = _plan(tmp_path)
+    store = records.AttemptStore.create(plan)
+    (store.directory / "transcript.log").write_text("observed\n", encoding="ascii")
+    original_sync = os.fsync
+
+    def fail_directory_sync(fd: int) -> None:
+        if stat.S_ISDIR(os.fstat(fd).st_mode):
+            raise OSError("directory sync failed after replacement")
+        original_sync(fd)
+
+    monkeypatch.setattr(os, "fsync", fail_directory_sync)
+    result = RunResult(store.run_id, store.directory, Outcome.VERIFIED, None, ())
+    with pytest.raises(ContractError) as failure:
+        store.finish(result)
+    assert failure.value.code == "finalization_failure"
+    visible = json.loads(store.record_path.read_text(encoding="utf-8"))
+    assert visible["complete"] is False
+    assert visible["phase"] == "finalization_failed"
+    assert visible["result"]["outcome"]["name"] == "HALTED"
+    assert visible["result"]["stop_reason"] == "finalization_failure"

--- a/tests/unit/contracts/test_stream.py
+++ b/tests/unit/contracts/test_stream.py
@@ -1,0 +1,588 @@
+"""Deterministic native framing and safety tests; no model execution."""
+
+import json
+from dataclasses import replace
+
+import pytest
+
+from apm_cli.contracts.events import EventEmitter
+from apm_cli.contracts.models import ContractLimits
+from apm_cli.contracts.stream import ContractStreamDecoder, safe_text
+
+pytestmark = pytest.mark.unit
+
+
+def _frame(kind: str, **data: object) -> bytes:
+    return (json.dumps({"type": kind, "data": data}, ensure_ascii=False) + "\n").encode("utf-8")
+
+
+def _result_frame(**changes: object) -> bytes:
+    """Harmless shape supplied from the preliminary native protocol probe."""
+    envelope = {
+        "type": "result",
+        "exitCode": 0,
+        "sessionId": "fixture-session",
+        "timestamp": "2026-09-05T09:42:00Z",
+        "usage": {
+            "codeChanges": {},
+            "premiumRequests": 1,
+            "sessionDurationMs": 1000,
+            "totalApiDurationMs": 800,
+        },
+    }
+    envelope.update(changes)
+    return (json.dumps(envelope) + "\n").encode()
+
+
+def _decoder(**kwargs):
+    observed = []
+    decoder = ContractStreamDecoder(EventEmitter("test-run", observed.append), **kwargs)
+    return decoder, observed
+
+
+def _text(events) -> str:
+    return "\n".join(safe_text(str(event.data.get("text", ""))) for event in events)
+
+
+def test_bytewise_utf8_and_delta_final_correlation() -> None:
+    decoder, events = _decoder()
+    wire = (
+        _frame("assistant.message_start", messageId="a", phase="final_answer")
+        + _frame("assistant.message_delta", messageId="a", deltaContent="Caf\u00e9 ")
+        + _frame("assistant.message_delta", messageId="a", deltaContent="ready\n")
+        + _frame("assistant.message", messageId="a", content="Caf\u00e9 ready\nDone")
+        + _frame("assistant.message", messageId="a", content="Caf\u00e9 ready\nDone")
+        + _frame("assistant.message_delta", messageId="a", deltaContent="duplicate")
+        + _result_frame()
+    )
+    for byte in wire:
+        decoder.feed("stdout", bytes([byte]))
+    decoder.finish()
+    decoder.finish()
+    text = _text(events)
+    assert text.count("Caf\\xe9 ready") == 1
+    assert text.count("Done") == 1
+    assert "duplicate" not in text
+    assert decoder.completion_seen
+    assert decoder.protocol_error is None
+    assert [event.sequence for event in events] == list(range(1, len(events) + 1))
+
+
+def test_separate_streams_and_interleaved_message_ids() -> None:
+    decoder, events = _decoder()
+    decoder.feed("stdout", _frame("assistant.message_delta", messageId="a", deltaContent="one "))
+    decoder.feed("stderr", b"Native connection ")
+    decoder.feed("stdout", _frame("assistant.message", messageId="b", content="two"))
+    decoder.feed("stderr", b"retry\n")
+    decoder.feed("stdout", _frame("assistant.message", messageId="a", content="one done"))
+    decoder.finish()
+    assert [event.data["text"] for event in events] == [
+        "two",
+        "Native connection retry",
+        "one done",
+    ]
+    assert events[1].data["stream"] == "stderr"
+    assert all(event.source == "harness" for event in events)
+
+
+def test_redaction_withheld_across_native_delta_and_byte_boundaries() -> None:
+    decoder, events = _decoder()
+    secret = "ghp_" + "SPLITPRIVATE" * 3
+    decoder.feed("stdout", _frame("assistant.message_start", messageId="a", phase="final_answer"))
+    decoder.feed("stdout", _frame("assistant.message_delta", messageId="a", deltaContent="token: "))
+    decoder.feed(
+        "stdout", _frame("assistant.message_delta", messageId="a", deltaContent=secret[:3])
+    )
+    assert _text(events) == ""
+    for byte in _frame("assistant.message_delta", messageId="a", deltaContent=secret[3:] + "\n"):
+        decoder.feed("stdout", bytes([byte]))
+    decoder.feed("stderr", ("Authorization: Bearer " + secret[:5]).encode())
+    decoder.feed("stderr", (secret[5:] + "\n").encode())
+    decoder.finish()
+    text = _text(events)
+    assert secret not in text
+    assert "SPLITPRIVATE" not in text
+    assert "***" in text
+
+
+def test_no_deltas_and_unterminated_final_frame() -> None:
+    decoder, events = _decoder()
+    decoder.feed("stdout", _frame("assistant.message", messageId="a", content="Done"))
+    assert _text(events) == "Done"
+    decoder.feed("stdout", _result_frame().rstrip(b"\n"))
+    assert not decoder.completion_seen
+    decoder.finish()
+    assert decoder.completion_seen
+
+
+@pytest.mark.parametrize(
+    "wire",
+    [
+        b"not json\n",
+        b'{"type":\xff}\n',
+        b"[]\n",
+        b"{}\n",
+        b'{"type":"session.idle","data":[]}\n',
+        _frame("assistant.message", messageId="a", content=[]),
+        _frame("assistant.message", content="missing ID"),
+        _frame("assistant.message_delta", messageId="a", deltaContent=7),
+        _frame("assistant.intent", intent={}),
+        _frame("session.error", errorType="unknown"),
+        _frame("assistant.message", messageId="a", content="", model={}),
+    ],
+)
+def test_malformed_protocol_is_sticky_but_streams_are_drained(wire: bytes) -> None:
+    decoder, events = _decoder()
+    decoder.feed("stdout", wire)
+    decoder.feed("stdout", _result_frame())
+    decoder.feed("stderr", b"Useful native failure detail\n")
+    decoder.finish()
+    assert decoder.protocol_error is not None
+    assert decoder.completion_seen
+    assert "Useful native failure detail" in _text(events)
+    assert any(event.kind == "diagnostic" for event in events)
+
+
+def test_oversized_frame_discards_prefix_and_recovers_at_newline() -> None:
+    decoder, events = _decoder(limits=replace(ContractLimits(), frame_bytes=128))
+    for _ in range(40):
+        decoder.feed("stdout", b"TOPSECRET" * 7)
+        assert len(decoder._stdout.pending) <= 128
+    decoder.feed("stdout", b"\n" + _frame("assistant.intent", intent="Still draining"))
+    decoder.feed("stdout", _result_frame(timestamp=None, usage={}))
+    decoder.finish()
+    assert decoder.protocol_error is not None
+    assert decoder.completion_seen
+    assert "TOPSECRET" not in _text(events)
+    assert "Still draining" in _text(events)
+    assert sum(event.kind == "diagnostic" for event in events) == 1
+
+
+def test_hard_frame_limit_cannot_be_raised_past_one_mib() -> None:
+    decoder, _ = _decoder(limits=replace(ContractLimits(), frame_bytes=8 * 1024 * 1024))
+    decoder.feed("stdout", b"x" * (1024 * 1024 + 1))
+    assert decoder.protocol_error is not None
+    assert not decoder._stdout.pending
+
+
+def test_checker_plain_text_utf8_stderr_and_no_newline() -> None:
+    decoder, events = _decoder(source="checker", label="criterion", json_stdout=False)
+    wire = "Criterion \u2713".encode()
+    decoder.feed("stdout", wire[:-1])
+    decoder.feed("stderr", b"stderr \xff\n")
+    decoder.feed("stdout", wire[-1:])
+    decoder.finish()
+    assert [event.data["stream"] for event in events] == ["stderr", "stdout"]
+    assert all(event.source == "checker" for event in events)
+    assert all(event.data["label"] == "criterion" for event in events)
+    assert "\\u2713" in _text(events)
+    assert not decoder.completion_seen
+    assert decoder.protocol_error is None
+
+
+def test_long_plain_line_is_withheld_not_partially_redacted() -> None:
+    decoder, events = _decoder(source="checker", json_stdout=False)
+    decoder.feed("stdout", b"token=" + b"A" * 20_000)
+    decoder.feed("stdout", b"private-tail\nNext line\n")
+    decoder.finish()
+    assert _text(events).endswith("Next line")
+    assert "private-tail" not in _text(events)
+    assert any("omitted" in str(event.data) for event in events)
+
+
+def test_unknown_events_are_metadata_only_and_do_not_complete() -> None:
+    decoder, events = _decoder()
+    decoder.feed(
+        "stdout",
+        _frame(
+            "future.event",
+            exitCode=0,
+            toolArguments="PRIVATE",
+            reasoning="SECRET",
+            model="invented",
+        ),
+    )
+    decoder.feed("stdout", _frame("unrecognized", environment={"TOKEN": "private"}))
+    decoder.feed("stdout", _frame("unrecognized", prompt="PRIVATE"))
+    decoder.finish()
+    assert all(event.kind == "metadata" for event in events)
+    assert len(events) == 2
+    assert "PRIVATE" not in str(events)
+    assert "SECRET" not in str(events)
+    assert decoder.observed_models == ()
+    assert not decoder.completion_seen
+    assert decoder.protocol_error is None
+
+
+def test_tool_metadata_never_forwards_arguments_results_or_reasoning() -> None:
+    decoder, events = _decoder()
+    decoder.feed(
+        "stdout",
+        _frame(
+            "tool.execution_start",
+            toolName="read_file",
+            arguments={"path": "PRIVATE"},
+            reasoning="PRIVATE",
+        ),
+    )
+    decoder.feed("stdout", _frame("tool.execution_complete", success=False, result="PRIVATE"))
+    decoder.finish()
+    assert _text(events) == "Tool started: read_file\nTool failed"
+    assert "PRIVATE" not in str(events)
+    assert not decoder.completion_seen
+
+
+def test_only_explicit_execution_and_usage_models_are_observed() -> None:
+    decoder, events = _decoder()
+    decoder.feed("stdout", _frame("session.start", currentModel="not-observed"))
+    decoder.feed("stdout", _frame("assistant.message", messageId="a", content="", model="actual-a"))
+    decoder.feed("stdout", _frame("assistant.usage", model="actual-b"))
+    decoder.feed(
+        "stdout",
+        _frame("assistant.message", messageId="b", content="", usage={"model": "actual-a"}),
+    )
+    decoder.finish()
+    assert decoder.observed_models == ("actual-a", "actual-b")
+    assert "not-observed" not in str(events)
+
+
+@pytest.mark.parametrize(
+    ("error_type", "auth_hint"),
+    [("connection_error", False), ("launch_failed", False), ("authentication_error", True)],
+)
+def test_native_error_action_requires_explicit_auth_signal(
+    error_type: str, auth_hint: bool
+) -> None:
+    decoder, events = _decoder()
+    decoder.feed("stdout", _frame("session.error", errorType=error_type, message="Native failure"))
+    decoder.feed("stdout", _frame("session.idle"))
+    decoder.finish()
+    assert decoder.protocol_error is not None
+    diagnostic = next(event for event in events if event.kind == "diagnostic")
+    assert ("copilot login" in diagnostic.data["action"]) is auth_hint
+
+
+def test_metadata_and_correlation_state_are_bounded() -> None:
+    decoder, events = _decoder()
+    for number in range(100):
+        decoder.feed("stdout", _frame(f"unknown.{number}", private="SECRET"))
+        decoder.feed(
+            "stdout", _frame("assistant.message_delta", messageId=str(number), deltaContent="x")
+        )
+    decoder.finish()
+    assert len(decoder._unknown) == 32
+    assert len(decoder._messages) == 64
+    assert sum(event.kind == "diagnostic" for event in events) == 2
+    assert "SECRET" not in str(events)
+
+
+def test_safe_text_is_ascii_literal_redacted_and_identity_preserving() -> None:
+    value = "path/\u00e9/\U0001f680 \x1b]52;c;clipboard\x07\r\x08\t\x7f\u202e"
+    rendered = safe_text(value)
+    assert all(" " <= character <= "~" for character in rendered)
+    assert "?" not in rendered
+    assert "\\xe9" in rendered
+    assert "\\U0001f680" in rendered
+    assert "\\x1b" in rendered
+    assert "\\x7f" in rendered
+    assert "\\u202e" in rendered
+    assert safe_text("token=SUPERSECRET") == "token=***"
+    assert len(safe_text("x" * 50_000)) == 4096
+
+
+def test_changed_final_is_retained_as_detail_without_repeating_streamed_activity() -> None:
+    decoder, events = _decoder()
+    decoder.feed("stdout", _frame("assistant.message_start", messageId="a", phase="final_answer"))
+    decoder.feed(
+        "stdout", _frame("assistant.message_delta", messageId="a", deltaContent="Earlier\n")
+    )
+    decoder.feed("stdout", _frame("assistant.message", messageId="a", content="Corrected"))
+    decoder.finish()
+    assert [event.data["text"] for event in events if event.kind == "activity"] == ["Earlier"]
+    assert [event.data["text"] for event in events if event.kind == "metadata"] == [
+        "Corrected final response: Corrected"
+    ]
+    assert sum(event.kind == "diagnostic" for event in events) == 1
+
+
+def test_whole_stream_and_arbitrary_chunking_have_identical_observations() -> None:
+    wire = (
+        _frame("assistant.intent", intent="Writing \u00e9")
+        + _frame("assistant.message_delta", messageId="a", deltaContent="token=ghp_")
+        + _frame("assistant.message_delta", messageId="a", deltaContent="PRIVATESECRET\n")
+        + _frame("assistant.message", messageId="a", content="token=ghp_PRIVATESECRET\n")
+        + _result_frame()
+    )
+    whole, expected = _decoder()
+    whole.feed("stdout", wire)
+    whole.finish()
+    for size in (1, 2, 3, 7, 31, 128, 1024):
+        decoder, actual = _decoder()
+        for offset in range(0, len(wire), size):
+            decoder.feed("stdout", wire[offset : offset + size])
+        decoder.finish()
+        assert [(event.kind, event.data) for event in actual] == [
+            (event.kind, event.data) for event in expected
+        ]
+        assert decoder.completion_seen
+        assert "PRIVATESECRET" not in _text(actual)
+
+
+@pytest.mark.parametrize("exit_code", [0, 1, -1, 20, 130])
+def test_observed_native_result_retains_status_and_rejects_failure(exit_code: int) -> None:
+    decoder, events = _decoder()
+    wire = _result_frame(exitCode=exit_code)
+    for byte in wire:
+        decoder.feed("stdout", bytes([byte]))
+    decoder.feed("stdout", wire)
+    decoder.finish()
+    assert decoder.completion_seen
+    assert (decoder.protocol_error is None) is (exit_code == 0)
+    assert decoder.native_exit_code == exit_code
+    assert len(events) == (1 if exit_code == 0 else 2)
+    assert events[0].kind == "metadata"
+    assert events[0].data["native_exit_code"] == exit_code
+    assert "VERIFIED" not in _text(events)
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"exitCode": None},
+        {"exitCode": "0"},
+        {"exitCode": False},
+        {"exitCode": 0.0},
+        {"sessionId": None},
+        {"sessionId": ""},
+        {"sessionId": "x" * 257},
+        {"usage": None},
+        {"usage": []},
+    ],
+)
+def test_malformed_result_cannot_establish_completion(changes: dict) -> None:
+    decoder, events = _decoder()
+    decoder.feed("stdout", _result_frame(**changes))
+    decoder.finish()
+    assert not decoder.completion_seen
+    assert decoder.native_exit_code is None
+    assert decoder.protocol_error is not None
+    assert all(event.kind == "diagnostic" for event in events)
+
+
+def test_result_requires_top_level_metadata_not_a_guessed_data_wrapper() -> None:
+    decoder, _ = _decoder()
+    decoder.feed("stdout", _frame("result", exitCode=0, sessionId="test", usage={}))
+    decoder.finish()
+    assert not decoder.completion_seen
+    assert decoder.protocol_error is not None
+
+
+@pytest.mark.parametrize("kind", ["assistant.idle", "session.idle", "session.shutdown"])
+def test_idle_or_shutdown_cannot_substitute_for_final_result(kind: str) -> None:
+    decoder, events = _decoder()
+    decoder.feed("stdout", _frame(kind))
+    assert not decoder.completion_seen
+    assert _text(events) == f"Native {kind.replace('.', ' ')}"
+    decoder.feed("stdout", _result_frame())
+    decoder.finish()
+    assert decoder.completion_seen
+
+
+def test_probe_shape_observes_actual_model_without_forwarding_sensitive_fields() -> None:
+    decoder, events = _decoder()
+    decoder.feed(
+        "stdout",
+        _frame("model.call_start", model="gpt-6-astra", reasoning="PRIVATE_REASONING"),
+    )
+    decoder.feed(
+        "stdout",
+        _frame(
+            "assistant.message_delta",
+            messageId="a",
+            deltaContent="Useful text",
+            reasoningText="PRIVATE_REASONING",
+            encryptedContent="PRIVATE_ENCRYPTED",
+        ),
+    )
+    decoder.feed(
+        "stdout",
+        _frame(
+            "assistant.message",
+            messageId="a",
+            content="Useful text",
+            model="gpt-6-astra",
+            reasoning="PRIVATE_REASONING",
+            encrypted="PRIVATE_ENCRYPTED",
+        ),
+    )
+    decoder.feed("stdout", _frame("assistant.idle"))
+    decoder.feed(
+        "stdout",
+        _result_frame(
+            reasoning="PRIVATE_REASONING",
+            encryptedContent="PRIVATE_ENCRYPTED",
+            usage={"reasoning": "PRIVATE_REASONING"},
+        ),
+    )
+    decoder.finish()
+    assert decoder.observed_models == ("gpt-6-astra",)
+    assert decoder.native_exit_code == 0
+    assert decoder.completion_seen
+    assert _text(events).count("Useful text") == 1
+    assert "PRIVATE_" not in str(events)
+    assert all(event.kind in {"activity", "metadata"} for event in events)
+
+
+def test_conflicting_results_and_earlier_protocol_error_remain_errors() -> None:
+    decoder, _ = _decoder()
+    decoder.feed("stdout", _result_frame(exitCode=0))
+    decoder.feed("stdout", _result_frame(exitCode=1))
+    decoder.finish()
+    assert decoder.native_exit_code == 0
+    assert decoder.protocol_error is not None
+
+    decoder, _ = _decoder()
+    decoder.feed("stdout", b"malformed\n" + _result_frame())
+    decoder.finish()
+    assert decoder.completion_seen
+    assert decoder.protocol_error is not None
+
+
+@pytest.mark.parametrize("phase", ["analysis", "reasoning", "encrypted", "commentary", None])
+def test_start_phase_suppresses_nonpublic_deltas_and_completion(phase: str | None) -> None:
+    decoder, events = _decoder()
+    decoder.feed(
+        "stdout",
+        _frame(
+            "assistant.message_start",
+            messageId="hidden",
+            phase=phase,
+            reasoning="PRIVATE_START",
+        ),
+    )
+    decoder.feed(
+        "stdout",
+        _frame("assistant.message_delta", messageId="hidden", deltaContent="PRIVATE_DELTA\n"),
+    )
+    # The completion need not repeat the start event's phase.
+    decoder.feed("stdout", _frame("assistant.message", messageId="hidden", content="PRIVATE_FINAL"))
+    decoder.feed(
+        "stdout",
+        _frame("tool.execution_start", toolName="apply_patch", arguments="PRIVATE_ARGUMENTS"),
+    )
+    decoder.finish()
+    assert _text(events) == "Tool started: apply_patch"
+    assert "PRIVATE_" not in str(events)
+    assert decoder.protocol_error is None
+
+
+def test_public_phase_streams_before_completion_and_deduplicates_final() -> None:
+    decoder, events = _decoder()
+    decoder.feed(
+        "stdout", _frame("assistant.message_start", messageId="public", phase="final_answer")
+    )
+    decoder.feed(
+        "stdout",
+        _frame("assistant.message_delta", messageId="public", deltaContent="Writing handoff\n"),
+    )
+    assert _text(events) == "Writing handoff"
+    assert not decoder.completion_seen
+    decoder.feed(
+        "stdout",
+        _frame(
+            "assistant.message",
+            messageId="public",
+            phase="final_answer",
+            content="Writing handoff\n",
+            reasoning="PRIVATE_REASONING",
+            encryptedContent="PRIVATE_ENCRYPTED",
+        ),
+    )
+    decoder.finish()
+    assert _text(events) == "Writing handoff"
+    assert "PRIVATE_" not in str(events)
+
+
+def test_unknown_phase_deltas_are_not_released_before_later_analysis_phase() -> None:
+    decoder, events = _decoder()
+    decoder.feed(
+        "stdout",
+        _frame("assistant.message_delta", messageId="unknown", deltaContent="PRIVATE_UNKNOWN\n"),
+    )
+    assert events == []
+    decoder.feed(
+        "stdout",
+        _frame(
+            "assistant.message",
+            messageId="unknown",
+            phase="analysis",
+            content="PRIVATE_UNKNOWN\n",
+        ),
+    )
+    decoder.finish()
+    assert events == []
+
+
+def test_unclassified_deltas_are_not_flushed_at_process_end() -> None:
+    decoder, events = _decoder()
+    decoder.feed(
+        "stdout",
+        _frame("assistant.message_delta", messageId="unknown", deltaContent="PRIVATE_PENDING"),
+    )
+    decoder.finish()
+    assert events == []
+
+
+def test_late_public_start_waits_for_full_message_without_losing_prefix() -> None:
+    decoder, events = _decoder()
+    decoder.feed(
+        "stdout", _frame("assistant.message_delta", messageId="late", deltaContent="Before ")
+    )
+    decoder.feed(
+        "stdout", _frame("assistant.message_start", messageId="late", phase="final_answer")
+    )
+    decoder.feed(
+        "stdout", _frame("assistant.message_delta", messageId="late", deltaContent="after\n")
+    )
+    assert events == []
+    decoder.feed("stdout", _frame("assistant.message", messageId="late", content="Before after\n"))
+    decoder.finish()
+    assert _text(events) == "Before after"
+
+
+def test_message_phase_is_correlated_per_id_and_not_promoted_after_conflict() -> None:
+    decoder, events = _decoder()
+    for identifier, phase in (("private", "analysis"), ("public", "final_answer")):
+        decoder.feed("stdout", _frame("assistant.message_start", messageId=identifier, phase=phase))
+    decoder.feed(
+        "stdout", _frame("assistant.message_delta", messageId="private", deltaContent="PRIVATE\n")
+    )
+    decoder.feed(
+        "stdout", _frame("assistant.message_delta", messageId="public", deltaContent="Public\n")
+    )
+    decoder.feed(
+        "stdout",
+        _frame(
+            "assistant.message",
+            messageId="private",
+            phase="final_answer",
+            content="PRIVATE_FINAL",
+        ),
+    )
+    decoder.feed("stdout", _frame("assistant.message", messageId="public", content="Public\n"))
+    decoder.finish()
+    assert _text(events).count("Public") == 1
+    assert "PRIVATE" not in str(events)
+    assert any(event.kind == "diagnostic" for event in events)
+
+
+def test_nonzero_result_is_sticky_even_after_idle_and_later_zero() -> None:
+    decoder, events = _decoder()
+    decoder.feed("stdout", _result_frame(exitCode=1))
+    decoder.feed("stdout", _frame("assistant.idle"))
+    decoder.feed("stdout", _result_frame(exitCode=0))
+    decoder.finish()
+    assert decoder.native_exit_code == 1
+    assert decoder.protocol_error is not None
+    assert "exit code 1" in decoder.protocol_error
+    assert sum(event.kind == "diagnostic" for event in events) == 1

--- a/tests/unit/contracts/test_terminal_pty.py
+++ b/tests/unit/contracts/test_terminal_pty.py
@@ -1,0 +1,209 @@
+"""Real POSIX PTY/pipe actors, not real-model or artifact-assessment demos."""
+
+import errno
+import json
+import os
+import select
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+pytestmark = [
+    pytest.mark.component,
+    pytest.mark.skipif(os.name != "posix", reason="The native leaf supervisor requires POSIX."),
+]
+
+_ACTOR = r"""
+import os
+import sys
+from dataclasses import replace
+from pathlib import Path
+from apm_cli.contracts.events import EventEmitter
+from apm_cli.contracts.models import ContractLimits, ProcessRequest, RunResult
+from apm_cli.contracts.process import supervise_process
+from apm_cli.contracts.records import AttemptStore, reduce_outcome
+from apm_cli.contracts.stream import ContractStreamDecoder
+from apm_cli.core.contract_logger import ContractLogger
+
+directory = Path(sys.argv[1])
+pause = float(sys.argv[2])
+logger = ContractLogger()
+logger.attach_run("pty-run", directory)
+events = EventEmitter("pty-run", logger.on_event)
+decoder = ContractStreamDecoder(events)
+events.emit(
+    "selected",
+    contract=str(directory / "long-source-name.contract.md"),
+    harness="copilot",
+    model="gpt-6-astra",
+    run_directory=str(directory),
+)
+events.emit("phase", name="execution")
+native = '''
+import json, time
+def emit(kind, data):
+    print(json.dumps({"type": kind, "data": data}), flush=True)
+emit("assistant.intent", {"intent": "Creating the handoff"})
+emit("assistant.message_start", {"messageId": "first", "phase": "final_answer"})
+emit("assistant.message_delta", {"messageId": "first", "deltaContent": "Useful stream before completion\\n"})
+time.sleep(PAUSE)
+emit("assistant.message", {"messageId": "first", "phase": "final_answer", "content": "Useful stream before completion\\n"})
+emit("assistant.message", {"messageId": "second", "phase": "final_answer", "content": "Native work ended"})
+emit("assistant.idle", {})
+print(json.dumps({"type": "result", "exitCode": 0, "sessionId": "pty-fixture", "usage": {}}), flush=True)
+'''.replace("PAUSE", str(pause))
+observed = supervise_process(
+    ProcessRequest((sys.executable, "-c", native), directory, 8),
+    on_bytes=decoder.feed,
+    events=events,
+    limits=replace(ContractLimits(), cleanup_seconds=1),
+)
+decoder.finish()
+events.emit("phase", name="record")
+result = RunResult(
+    "pty-run", directory, reduce_outcome(None, (), observed.stop_reason),
+    None, (), stop_reason=observed.stop_reason,
+)
+logger.close()
+AttemptStore("pty-run", directory, {"test_actor": True}).finish(result)
+events.emit("finished", result=result)
+logger.close()
+if os.isatty(0):
+    # Keep the terminal session alive for the parent to inspect attributes.
+    # Darwin detaches the slave when its controlling session leader exits.
+    os.read(0, 1)
+"""
+
+
+def _read(fd: int, timeout: float = 0.1) -> bytes:
+    if not select.select([fd], [], [], timeout)[0]:
+        return b""
+    try:
+        return os.read(fd, 65536)
+    except OSError as error:
+        if error.errno != errno.EIO:
+            raise
+        return b""
+
+
+@pytest.mark.parametrize("cancel", [False, True])
+@pytest.mark.parametrize("width", [30, 40, 80])
+def test_real_pty_streams_before_completion_and_restores_terminal(
+    tmp_path: Path, monkeypatch, cancel: bool, width: int
+) -> None:
+    import fcntl
+    import pty
+    import struct
+    import termios
+
+    monkeypatch.setenv("NO_COLOR", "1")
+    monkeypatch.setenv("COLUMNS", str(width))
+    master, slave = pty.openpty()
+    fcntl.ioctl(slave, termios.TIOCSWINSZ, struct.pack("HHHH", 24, width, 0, 0))
+    before = termios.tcgetattr(slave)
+    pid = os.fork()
+    if pid == 0:
+        try:
+            os.close(master)
+            os.setsid()
+            fcntl.ioctl(slave, termios.TIOCSCTTY, 0)
+            for descriptor in (0, 1, 2):
+                os.dup2(slave, descriptor)
+            if slave > 2:
+                os.close(slave)
+            # Fixed local interpreter and test-owned source, never shell input.
+            os.execv(  # noqa: S606
+                sys.executable,
+                [sys.executable, "-c", _ACTOR, str(tmp_path), "5" if cancel else "1"],
+            )
+        finally:
+            os._exit(127)
+    output = bytearray()
+    exited = False
+    streamed = False
+    restored = False
+    deadline = time.monotonic() + 12
+    try:
+        while time.monotonic() < deadline:
+            output.extend(_read(master))
+            # PTYs preserve logical lines; terminal emulators wrap visually.
+            text = output.decode("ascii", errors="strict").replace("\r", "")
+            if not streamed and "Useful stream before completion" in text:
+                assert "UNPROVEN" not in text
+                assert "HALTED" not in text
+                assert os.waitpid(pid, os.WNOHANG) == (0, 0)
+                streamed = True
+                if cancel:
+                    os.write(master, b"\x03")
+            if not restored and ("UNPROVEN" in text or "HALTED" in text):
+                assert termios.tcgetattr(slave) == before
+                restored = True
+                os.write(master, b"\n")
+            found, status = os.waitpid(pid, os.WNOHANG)
+            if found:
+                exited = True
+                output.extend(_read(master))
+                assert os.waitstatus_to_exitcode(status) == 0, output.decode()
+                break
+        assert exited, output.decode()
+        assert streamed, output.decode()
+        assert restored, output.decode()
+        text = output.decode("ascii").replace("\r", "")
+        assert "\x1b" not in text
+        lines = text.splitlines()
+        assert f"[>] Contract: {tmp_path / 'long-source-name.contract.md'}" in lines
+        assert f"[i] Record and logs: {tmp_path}" in lines
+        assert "[i] copilot (untrusted): Useful stream before completion" in lines
+        if cancel:
+            words = " ".join(line[4:].strip() for line in text.splitlines())
+            assert (
+                words.index("Stop requested")
+                < words.index("stop confirmed")
+                < words.index("HALTED")
+            )
+            assert "UNPROVEN" not in text
+        else:
+            assert text.count("UNPROVEN") == 1
+        record = json.loads((tmp_path / "record.json").read_bytes())
+        assert record["complete"]
+        assert (tmp_path / "transcript.log").is_file()
+    finally:
+        if not exited:
+            os.kill(pid, signal.SIGKILL)
+            os.waitpid(pid, 0)
+        os.close(master)
+        os.close(slave)
+
+
+def test_real_closed_stdout_pipe_keeps_draining_and_finishes_record(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("NO_COLOR", "1")
+    child = subprocess.Popen(
+        [sys.executable, "-c", _ACTOR, str(tmp_path), "0.5"],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert child.stdout is not None
+    assert child.stderr is not None
+    try:
+        assert b"Contract:" in child.stdout.readline()
+        child.stdout.close()
+        child.wait(timeout=12)
+        errors = child.stderr.read()
+        assert child.returncode == 0, errors.decode()
+        record = json.loads((tmp_path / "record.json").read_bytes())
+        assert record["complete"]
+        transcript = (tmp_path / "transcript.log").read_text()
+        assert "Native work ended" in transcript
+        assert "Traceback" not in errors.decode()
+    finally:
+        if child.poll() is None:
+            child.kill()
+            child.wait(timeout=3)
+        child.stderr.close()


### PR DESCRIPTION
# add(contracts): execute and assess local Markdown leaves

## TL;DR

Add the first APM Contracts v0.1 slice: inspect a Markdown/frontmatter contract offline, run it through native Copilot, capture one artifact, assess those exact bytes, and retain a local result. Contracts can reuse one installed self-contained skill through existing APM dependency and lock machinery, without turning imports into invocation or authority. Explicit `--on copilot` selects the new path; existing script dispatch remains unchanged.

> [!IMPORTANT]
> This is a bounded, native-advisory capability—not a sandbox, general workflow engine, spending guarantee, or merge approval. “v0.1” names Contracts; APM's release version remains **0.29.1**.

Maintainer-requested feature and documentation; no linked issue or CHANGELOG entry.

## Problem (WHY)

- [!] APM's existing script/prompt path does not own the complete artifact-capture, assessment, and durable-result lifecycle. This adds a separate leaf boundary rather than replacing package/context reuse or script execution: ["you want it to encapsulate a coherent unit of work that composes well with other skills."](https://agentskills.io/skill-creation/best-practices#design-coherent-units)
- [!] A native process can exit zero without creating a file; that occurred during the initial narrow-tool probe. Completion, captured output, and check results therefore remain distinct observations: ["Match the specificity of your instructions to the fragility of the task."](https://agentskills.io/skill-creation/best-practices#calibrating-control)
- [!] Native completion events, available file tools, and ambient MCP startup needed real execution evidence, not a guessed protocol or shell-only demo: ["Run the skill against real tasks, then feed the results — all of them, not just failures — back into the creation process."](https://agentskills.io/skill-creation/best-practices#refine-with-real-execution)

## Approach (WHAT)

- Keep the source small: nonempty Markdown, fixed-file `needs`, one scalar `produces`, 1–8 named command checks, and optionally one installed skill.
- Make planning offline and read-only; require invocation-only `--allow-advisory` for execution in terminals **and** pipes.
- Reuse canonical manifest, lock, source-identity, runtime, policy-discovery, YAML, atomic-I/O, and console owners.
- Capture effective working bytes, then give the producer and every check independent copies. Patch checks apply their own patch; the engine never pre-applies it.
- Centralize phases, native/checker observations, terminal rendering, normalized outcomes, and atomic run completion.
- Refuse unknown or unsupported forms before inference; do not silently weaken required controls.

```sh
apm plan ./handoff.contract.md --on copilot --model gpt-6-astra
apm run ./handoff.contract.md --on copilot --model gpt-6-astra --allow-advisory
```

`--on` selects contract mode even when a script has the same name. Without it, bare `run`, `start`, named scripts, prompt fallback, parameters, and existing harness behavior remain on the legacy path. Contract-only flags cannot silently modify scripts; contract mode rejects `--param`.

## Implementation (HOW)

| Area | Files and intent |
| :--- | :--- |
| CLI boundary | `cli.py`, `commands/{run,plan,contracts}.py`: explicit dispatch, dedicated errors, no contract update probe, and no legacy fallback after contract failure. |
| Source and reuse | `contracts/{__init__,frontend,imports}.py`, `utils/yaml_io.py`: bounded, source-located strict frontmatter; existing installed dependency/lock resolution; observed local bytes distinguished from Git-backed integrity. |
| Lifecycle | `contracts/{models,events,engine}.py`: one per-command conductor, revalidated admission, deadline clipping, native/OS result separation, and capture/check/record sequencing. |
| Exact subject | `contracts/workspace.py`: effective tracked changes/deletions plus explicit untracked resources, raw SHA-256, synthetic Git baseline, independent check copies, and exact retained-artifact/log identity. |
| Processes and records | `contracts/{process,records}.py`, `utils/atomic_io.py`: bounded POSIX supervision, original-group cleanup observations, raw check statuses, atomic completion, and incomplete/HALTED repair after finalization failure. |
| Native adapter | `runtime/{base,registry,copilot_runtime}.py`: additive structured capability; `view`/`apply_patch`, exact-file write grant, shell/URL denials, and supervised run-only merged MCP inventory. |
| Eligibility | `policy/{discovery,contract_prerequisite}.py`: additive offline positive-no-policy prerequisite; configured, unknown, disabled, and unsupported governance cases refuse. |
| Terminal | `core/contract_logger.py`, `contracts/stream.py`, `utils/console.py`: one append-only stream, phase-aware JSONL decoding, stderr, bounded private logs, no reasoning/raw protocol dumps, copyable paths, NO_COLOR, and closed-pipe handling. |
| Ownership | `.apm/architecture/owners/contracts-tooling.json`, `scripts/architecture_linter/{checks/contract_leaf_runtime,groups/contracts_tests}.py`: register and guard new durable decisions. `.gitignore` excludes run state. |
| Examples | `examples/contracts/README.md` and all files under `first-contract/`, `handoff-style/`, `reuse-contract/`: standalone handoff, shared stdlib checker/notes, and explicitly installed skill reuse. |
| Regression coverage | All 14 files under `tests/unit/contracts/`: frontend/imports/policy, dispatch/runtime/engine, exact-byte/process/record, example criteria, architecture, stream/logger, and real-process/PTY cases. |
| User guidance | `docs/src/content/docs/{consumer/run-contracts,reference/cli/plan,reference/cli/run}.md`, `docs/astro.config.mjs`, `.apm/docs-index.yml`, and `packages/apm-guide/.apm/skills/apm-usage/{commands,package-authoring}.md`: first-run, source, outcome, limit, navigation, and agent-guidance updates. Root README is unchanged. |

Review anchors: [dispatch boundary](https://github.com/microsoft/apm/blob/f906a748e1f021218cfe19d43429bdc12046d8c7/src/apm_cli/commands/run.py#L34-L67), [conductor](https://github.com/microsoft/apm/blob/f906a748e1f021218cfe19d43429bdc12046d8c7/src/apm_cli/contracts/engine.py#L126-L266), [outcome reducer](https://github.com/microsoft/apm/blob/f906a748e1f021218cfe19d43429bdc12046d8c7/src/apm_cli/contracts/records.py#L25-L44), and [native inventory](https://github.com/microsoft/apm/blob/f906a748e1f021218cfe19d43429bdc12046d8c7/src/apm_cli/runtime/copilot_runtime.py#L140-L249).

### Outcome and record contract

| Precedence | Outcome / exit | Meaning |
| :---: | :--- | :--- |
| 1 | HALTED / `22` | Operational stop, cancellation, root watchdog, producer failure, lingering children, integrity/capture, cleanup, or finalization failure. |
| 2 | REJECTED / `20` | No operational stop; at least one check returned a failed condition, including failure plus another incomplete check. |
| 3 | UNPROVEN / `21` | No failed condition; missing output or incomplete assessment. Unavailable consent/assurance also refuses without claiming a completed run. |
| 4 | VERIFIED / `0` | Fresh artifact, all required checks pass, and final record completes under accepted native-advisory controls. |

Raw check exits `0/1/2` mean pass/failure/incomplete; unknown exits, missing tools, and signals are incomplete. Per-check timeout stays incomplete unless the root watchdog expires. Missing output is not assessed merely to manufacture rejection; successful forced cleanup never upgrades a lingering-child failure.

Artifacts remain at `.apm/runs/<run-id>/artifacts/`, with `record.json` and bounded `transcript.log`; original output paths are not overwritten. Records preserve source/input/import/output/check identities and raw process observations. Requested and observed models are separate; unavailable usage/version observations are not invented.

## Diagrams

The new dashed stages connect existing APM source selection to exact-artifact assessment; execution requires explicit native-advisory consent, while offline planning stops before baseline creation.

```mermaid
flowchart LR
    subgraph Sources["Source selection"]
        Source["Markdown + frontmatter"]
        Installed["Existing manifest, lock, installed skill"]
        Plan["Strict offline plan"]
        Source --> Plan
        Installed --> Plan
    end
    subgraph Native["Explicit native-advisory run"]
        Baseline["Captured working bytes"]
        Copilot["Copilot through structured adapter"]
        Baseline --> Copilot
    end
    subgraph Assessment["Exact artifact assessment"]
        Artifact["Capture one fresh file"]
        Checks["Independent copy for each check"]
        Artifact --> Checks
    end
    subgraph Outcome["Local observations"]
        Record["Atomic record and outcome"]
    end
    Plan --> Baseline
    Copilot --> Artifact
    Checks --> Record
    classDef new stroke-dasharray: 5 5;
    class Source,Plan,Baseline,Copilot,Artifact,Checks,Record new;
```

## Trade-offs

- **Local leaf, not composition.** Fixed regular files and at most one self-contained direct skill make this executable end to end. Captures/alternatives, transitive resources, child verifiers, command producers, retries/resume/cache, cloud, and delivery are deferred. Presence of `run`, `budget`, or `sandbox` refuses rather than downgrading.
- **Native advisory, not confinement.** Execution initially supports macOS/Linux and positively established no-policy projects. Host identity, ambient credentials/network access, escaped descendants, and same-user mutation are not contained. Consent cannot override policy; do not remove remotes or policy to bypass eligibility.
- **Native-owned inventory, not config crawling.** At run dispatch only, supervised `copilot mcp list --json` supplies merged User/Workspace/Plugin/Builtin names for repeated per-invocation disable flags. No hardcoded user server list, retained config values, global config writes, or additional tool grants. Unobservable/failed inventory stops before production; extensions remain outside isolation guarantees.
- **Local observations, not attestation.** Exact bytes, independent copies, and durable records detect ordinary substitution/failure, not same-identity adversarial change-and-restore. Local skill identity is not a cryptographic pin. VERIFIED assesses declared predicates, not complete prose correctness or merge approval.
- **Bounded evidence, not broad certification.** Live acceptance used one native Copilot version on macOS; other environments need their own exercise. Automated PTY/process cases use deterministic fake harnesses and are not billed-model evidence. No new production dependency, release bump, or OpenAPM specification/conformance claim; existing package formats are unchanged.

## Benefits

1. One explicit command path now produces a captured artifact with a recorded assessment, demonstrated both standalone and with installed context.
2. Offline planning performs no inference, installation, checks, native inventory, or run allocation.
3. Every required check receives the same captured subject in an independent baseline; stale outputs and producer-edited checker resources cannot satisfy the normal flow.
4. The terminal exposes observable phases and one final outcome, with copyable artifact/log paths and bounded retrievable diagnostics in terminals and pipes.

## Validation

### Real native acceptance—not mocks

Both disposable fixtures completed through **Copilot CLI 1.0.83-5** before publication. No native demos were rerun merely to open this PR.

| Fixture | Requested / observed model | Native / OS exit | Actual check exits | Result |
| :--- | :--- | :---: | :---: | :--- |
| `examples/contracts/first-contract` | `gpt-6-astra` / `gpt-6-astra` | `0 / 0` | `0` | VERIFIED / `0` |
| `examples/contracts/reuse-contract` | `gpt-6-astra` / `gpt-6-astra` | `0 / 0` | `0` | VERIFIED / `0` |

Both produced captured JSON artifacts and ended with naturally terminated original process groups, without signals. The reuse output satisfied the extra `Check first: ` criterion supplied by the installed skill. Earlier unsuccessful attempts remained HALTED with provisional artifacts; they were not rewritten as success. Private run records/transcripts are retained locally, not uploaded in this PR.

### Local automated evidence

The publication run used the retained worktree-local environment with existing system-site packages and `--no-sync`. This is **not frozen-lock reproducibility, the full repository test suite, or a claim of remote CI green**.

<details><summary>Exact targeted command and observed result</summary>

```sh
PYTHONPATH="$PWD/src" .venv/bin/python -m pytest -p no:cacheprovider -q \
  tests/unit/contracts \
  tests/unit/test_copilot_runtime.py tests/unit/test_runtime_factory.py \
  tests/unit/commands/test_run_command_surface.py tests/unit/commands/test_run_phase3.py \
  tests/unit/test_yaml_io.py tests/unit/utils/test_atomic_io.py \
  tests/unit/policy/test_discovery.py tests/unit/policy/test_discovery_policy_resolution.py \
  tests/unit/policy/test_chain_discovery_shared.py \
  tests/unit/scripts/test_architecture_registry.py \
  tests/unit/scripts/test_architecture_registry_conflicts.py tests/test_console.py
```

```text
740 passed, 2 subtests passed in 38.26s
```

</details>

<details><summary>Publication quality gates and base integration</summary>

Full Ruff check/format, pylint R0801, auth boundary, architecture registry/boundaries, YAML I/O, portable-path, 2100-line, assertion-quality, exact-test-duplicate, and whitespace gates passed locally.

The same static gates were assessed on a disposable merge tree of `f906a748e` with `origin/main` at `13386d993`; no feature-branch merge or main-checkout changes were made. The archived tree was given private Git/index metadata for the tracked-file ratchets.

`uv run --no-sync --extra dev ruff check src/ tests/ scripts/lint_architecture_boundaries.py scripts/architecture_linter/`:
```text
All checks passed!
```

`uv run --no-sync --extra dev ruff format --check src/ tests/ scripts/lint_architecture_boundaries.py scripts/architecture_linter/` on that merge tree:
```text
1845 files already formatted
```

`uv run --no-sync --extra dev python scripts/check_test_assertions.py --root <merged-tree>` and `scripts/check_exact_test_duplicates.py --root <merged-tree>`:
```text
[+] assertion-quality ratchet clean: AQ001=4, AQ002=12
[+] exact test duplicate ratchet clean: 1199 files, 0 allowed duplicate group(s)
```

The Mermaid block was rendered successfully with `mmdc`.

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
| :---: | :--- | :--- | :--- | :--- |
| 1 | Existing script names—including `.contract.md` names—still run as scripts without `--on`. | Multi-harness support; DevX (pragmatic as npm) | `tests/unit/contracts/test_dispatch.py::test_contract_named_script_is_still_a_script_without_on`; existing `tests/unit/commands/test_run_command_surface.py` | unit |
| 2 | Planning neither runs Copilot nor changes the project/home; execution without consent allocates no run. | DevX (pragmatic as npm) | `tests/unit/contracts/test_cli_lifecycle.py::test_plan_neither_executes_native_nor_mutates_project_or_home`; `test_run_without_consent_refuses_without_native_or_run_directory` | integration |
| 3 | Unsupported controls, unsafe paths, and unresolved policy cannot be waived into execution. | Governed by policy; Secure by default | `tests/unit/contracts/test_frontend.py`; `tests/unit/contracts/test_contract_policy.py`; `tests/unit/contracts/test_cli_lifecycle.py::test_unsupported_source_cannot_be_waived_with_consent` | unit / integration |
| 4 | An installed skill is resolved without installation and disclosed before consent; local bytes are not presented as a locked hash. | Portability by manifest; DevX (pragmatic as npm) | `tests/unit/contracts/test_imports.py::test_local_identity_and_snapshot_do_not_claim_locked_content_hash`; `tests/unit/contracts/test_logger.py::test_reuse_plan_shows_resolved_skill_identity_before_consent` | unit |
| 5 | Dirty inputs are preserved, stale output cannot pass, and each patch check applies exactly once in its own copy. | DevX (pragmatic as npm) | `tests/unit/contracts/test_reliability.py::test_exact_bytes_and_independent_self_applied_patch`; `test_effective_tracked_edits_deletions_and_selected_untracked`; `tests/unit/contracts/test_engine.py::test_stale_output_cannot_satisfy_missing_new_output` | integration |
| 6 | Native success without output, raw rejection, incomplete assessment, and operational failure stay distinguishable. | DevX (pragmatic as npm) | `tests/unit/contracts/test_engine.py`; `tests/unit/contracts/test_example_checks.py`; `tests/unit/contracts/test_stream.py::test_nonzero_result_is_sticky_even_after_idle_and_later_zero` | unit / integration |
| 7 | Native inventory failure stops before production and does not leak configuration values. | Secure by default | `tests/unit/contracts/test_contract_runtime.py::test_unobservable_inventory_refuses_without_retaining_values`; `test_inventory_operational_failure_never_launches_producer` | unit |
| 8 | Ctrl-C restores the terminal and leaves HALTED; paths remain copyable and NO_COLOR stays escape-free. | DevX (pragmatic as npm) | `tests/unit/contracts/test_pty_lifecycle.py::test_pty_interrupt_leaves_halted_record_and_no_success`; `tests/unit/contracts/test_terminal_pty.py`; `tests/unit/contracts/test_logger.py::test_full_source_artifact_and_log_paths_stay_copyable` | integration |
| 9 | Read-only inventory does not execute fsmonitor; a post-replacement durability failure does not leave a successful record. | Secure by default; DevX (pragmatic as npm) | `tests/unit/contracts/test_reliability.py::test_inventory_never_executes_configured_fsmonitor`; `test_post_replace_directory_sync_failure_cannot_leave_verified_record` | integration |

## How to test

Prerequisites: macOS/Linux, Git, Python 3, this APM checkout, and an authenticated native Copilot with the requested model available. The live commands consume model usage; they are separate from automated fake-harness coverage.

- [ ] Set up the checkout with `uv sync --frozen --extra dev`, then retain `export APM_BIN="$PWD/.venv/bin/apm"`. This is reviewer setup, not a claim that the author's environment reproduced the frozen lock.
- [ ] Run `uv run --frozen --extra dev pytest -p no:cacheprovider -q tests/unit/contracts`; expect deterministic contract, process, and PTY coverage without native model inference.
- [ ] Copy the portable fixtures outside another Git repository and inspect the offline plan:
  ```sh
  workspace="$(mktemp -d)"
  cp -R examples/contracts/. "$workspace/"
  cd "$workspace/first-contract"
  "$APM_BIN" plan ./handoff.contract.md --on copilot --model gpt-6-astra
  ```
- [ ] Run `"$APM_BIN" run ./handoff.contract.md --on copilot --model gpt-6-astra --allow-advisory`. Expect observable phases, VERIFIED/0 when the declared check passes, and printed artifact/record/log paths under `.apm/runs/`; inspect the result rather than relying only on chat output.
- [ ] Exercise explicit installed-skill reuse; expect the plan to name `handoff-style`, disclose local-source assurance, and the run to assess both handoff and caution-format criteria:
  ```sh
  cd "$workspace"
  mkdir -p reuse-contract/checks
  cp first-contract/notes.md reuse-contract/notes.md
  cp first-contract/checks/check_handoff.py reuse-contract/checks/check_handoff.py
  cd reuse-contract
  "$APM_BIN" install --only apm --target copilot
  "$APM_BIN" plan ./handoff.contract.md --on copilot --model gpt-6-astra
  "$APM_BIN" run ./handoff.contract.md --on copilot --model gpt-6-astra --allow-advisory
  ```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>