### PR TITLE
chore: finalize v0.29.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `apm install` now preserves SSH transport for semver discovery, keeps
+  inactive hooks when targets are not declared in the manifest, and honors
+  explicitly configured HTTP registries during MCP integration. (#2814)
+- Abandoned install transactions now release their state-update lock without
+  releasing locks still owned by other operations. (#2817)
 - `apm install` now fails before state writes when a host-qualified package
   path uses an unknown platform host, and routes all host/reference coordinate
   parsing through one canonical parser. (#2800)


### PR DESCRIPTION
# document(release): finalize v0.29.1 changelog

## TL;DR

Add the two maintainer-approved release notes for merged #2814 and #2817 to the existing v0.29.1 Fixed section. This completes the changelog follow-up to release preparation #2811 without changing the version, date, or runtime.

> [!IMPORTANT]
> CHANGELOG.md only. Version remains 0.29.1, dated 2026-09-05. Merging and post-merge tagging are separate maintainer actions.

## Problem (WHY)

The existing release section omits the user-facing fixes in two merged follow-ups:

- #2814: "SSH semver discovery now preserves the selected transport, absent manifest targets no longer delete inactive hooks".
- #2817: "Release an abandoned `InstallTransaction`'s lifecycle-lock acquisition even when another reference keeps the shared `FileLock` alive."

These source-PR statements ground the approved entries; this PR adds no new behavior.

## Approach (WHAT)

Additive change -- see Implementation.

## Implementation (HOW)

Add two bullets (five lines) under the existing `## [0.29.1] - 2026-09-05` / `### Fixed` heading in [CHANGELOG.md](https://github.com/microsoft/apm/blob/f0c4564f35e2aaa121adeb40226624339046039b/CHANGELOG.md#L29-L36). Preserve all existing release notes and the empty Unreleased placeholder.

## Trade-offs

- Keep the explicitly approved user-facing scope: omit #2812, #2819, #2822, and #2828 as test/CI/internal follow-ups.
- Docs-only skip case: no runtime scenario-test mapping or diagram is needed. No version bump, `pyproject.toml`, `uv.lock`, documentation-corpus, or production edits.

## Benefits

1. Two merged fixes are represented in the release notes.
2. Exactly one repository file changes.
3. Version 0.29.1 and date 2026-09-05 remain unchanged.

## Validation

Canonical lint ran on latest main `13386d9937f92aa0105c59fc3c4b7bbff4a7c6d2` plus the changelog addition.

`uv run --extra dev ruff check src/ tests/ scripts/lint_architecture_boundaries.py scripts/architecture_linter/`:

```text
All checks passed!
```

`uv run --extra dev ruff format --check src/ tests/ scripts/lint_architecture_boundaries.py scripts/architecture_linter/`:

```text
1808 files already formatted
```

Pylint R0801, auth-signal lint, YAML I/O safety, file-length, raw-relative-path, and architecture-boundary guards exited 0. Hosted PR checks are tracked separately; this local evidence does not claim they have completed.

`git diff --name-status origin/main...HEAD`:

```text
M	CHANGELOG.md
```

## How to test

- [ ] Run `git diff origin/main...HEAD -- CHANGELOG.md`; expect only the two approved entries under v0.29.1 Fixed.
- [ ] Run `git diff --name-only origin/main...HEAD`; expect only `CHANGELOG.md`.
- [ ] Confirm no version/date changes and no entries for #2812, #2819, #2822, or #2828 were added.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>