### PR TITLE
fix: recover transient Git connections and synchronize timeout smoke setup

### DIFF
--- a/.apm/architecture/owners/transport-auth-platform.json
+++ b/.apm/architecture/owners/transport-auth-platform.json
@@ -89,6 +89,13 @@
       "guards": ["transport-platform-self-update-resolution"]
     },
     {
+      "id": "git-clone-connect-retry",
+      "decision": "Bounded same-action HTTPS connection retry below auth and protocol selection",
+      "owner": "deps/clone_engine.py (CloneEngine)",
+      "selectors": ["src/apm_cli/deps/clone_engine.py"],
+      "guards": ["transport-platform-clone-connect-retry"]
+    },
+    {
       "id": "github-api-throttle-classification",
       "decision": "GitHub API throttle classification",
       "owner": "deps/github_rate_limit.py",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Git dependency downloads retry one narrowly classified HTTPS connection failure without changing credentials or transport; lifecycle timeout tests now wait for descendant readiness before exercising process-tree termination.
+
 ## [0.29.1] - 2026-09-05
 
 ### Security

--- a/docs/src/content/docs/consumer/manage-dependencies.md
+++ b/docs/src/content/docs/consumer/manage-dependencies.md
@@ -232,6 +232,12 @@ preference with `apm config set prefer-ssh true`, or save the retry escape hatch
 with `apm config set allow-protocol-fallback true`. See the
 [`apm config` reference](../../reference/cli/config/).
 
+If Git reports an HTTPS `Failed to connect...` / `Couldn't connect to server`
+error for the requested remote, APM retries that Git action once after 1 second
+with the same URL, credentials, and transport. A persistent connection failure
+still fails the command. This adds no retries for auth, TLS, policy, timeout,
+or content errors; existing auth and protocol fallback rules are unchanged.
+
 ## Pin a version
 
 Append `#<ref>` to a shorthand entry. `<ref>` can be a tag, branch, or

--- a/scripts/architecture_linter/checks/transport_network_and_runtime.py
+++ b/scripts/architecture_linter/checks/transport_network_and_runtime.py
@@ -43,6 +43,41 @@ from scripts.architecture_linter.models import Rule, Violation
 
 _RID_THROTTLE = "transport-platform-github-throttle"
 
+_RID_CONNECT_RETRY = "transport-platform-clone-connect-retry"
+_CONNECT_RETRY_OWNER = "src/apm_cli/deps/clone_engine.py"
+
+
+def _check_clone_connect_retry(provider: FactsProvider) -> tuple[Violation, ...]:
+    inv = frozenset(provider.inventory)
+    findings = list(
+        _require_subs(
+            provider,
+            inv,
+            _RID_CONNECT_RETRY,
+            _CONNECT_RETRY_OWNER,
+            (
+                "def _is_connect_failure(",
+                "if not _is_connect_failure(exc, url):",
+                "_clone(winning_url, git_env, target_path)",
+                "_clone(attempt_url, attempt_env, target_path)",
+                "_clone(url, _env_for(attempt, url), target_path)",
+            ),
+            "CloneEngine must own connection retries below every auth attempt",
+        )
+    )
+    findings.extend(
+        _forbid_scan(
+            provider,
+            inv,
+            _RID_CONNECT_RETRY,
+            _src_python(provider, exclude={_CONNECT_RETRY_OWNER}),
+            re.compile(r"def _is_connect_failure\(|Couldn't connect to server"),
+            "Git connection retry classification belongs only to CloneEngine",
+            exempt=False,
+        )
+    )
+    return tuple(findings)
+
 
 _THROTTLE_OWNER = "src/apm_cli/deps/github_rate_limit.py"
 
@@ -479,6 +514,13 @@ def _check_runtime_deadline_safety(provider: FactsProvider) -> tuple[Violation, 
 
 
 RULES: tuple[Rule, ...] = (
+    Rule(
+        id=_RID_CONNECT_RETRY,
+        group=GROUP,
+        guard_ids=(_RID_CONNECT_RETRY,),
+        description="CloneEngine owns bounded same-action HTTPS connection retries.",
+        check=_check_clone_connect_retry,
+    ),
     Rule(
         id=_RID_THROTTLE,
         group=GROUP,

--- a/src/apm_cli/deps/clone_engine.py
+++ b/src/apm_cli/deps/clone_engine.py
@@ -21,10 +21,13 @@ unit-testable in isolation and mirrors the existing
 from __future__ import annotations
 
 import os
+import re
 import subprocess
+import time
 from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol
+from urllib.parse import urlsplit
 
 from git.exc import GitCommandError
 
@@ -44,6 +47,34 @@ if TYPE_CHECKING:
 _PROTOCOL_FALLBACK_DOCS_URL = (
     "https://microsoft.github.io/apm/guides/dependencies/#restoring-the-legacy-permissive-chain"
 )
+
+
+def _is_connect_failure(error: GitCommandError | subprocess.CalledProcessError, url: str) -> bool:
+    """Recognize only Git's pre-connection HTTPS failure for this exact remote."""
+    remote = urlsplit(url)
+    if remote.scheme != "https" or not remote.hostname:
+        return False
+    stderr = error.stderr
+    if isinstance(stderr, bytes):
+        stderr = stderr.decode("utf-8", errors="replace")
+    if not isinstance(stderr, str):
+        return False
+    if isinstance(error, GitCommandError):
+        if error.status != 128:
+            return False
+        stderr = stderr.removeprefix("\n  stderr: '").removesuffix("'")
+    elif error.returncode != 128:
+        return False
+    return (
+        re.fullmatch(
+            r"(?:Cloning into [^\r\n]+\r?\n)?"
+            rf"fatal: unable to access '{re.escape(url.rstrip('/'))}/?': "
+            rf"Failed to connect to {re.escape(remote.hostname)} port {remote.port or 443}"
+            r" after [0-9]+ ms: Couldn't connect to server",
+            stderr.strip(),
+        )
+        is not None
+    )
 
 
 def _debug(msg: str) -> None:
@@ -149,6 +180,19 @@ class CloneEngine:
         host = self._host
         last_error: Exception | None = None
         is_ado = bool(dep_ref and dep_ref.is_azure_devops())
+
+        def _clone(url: str, env: dict[str, str], target: Path) -> None:
+            """Retry one failed connection without changing transport or credentials."""
+            try:
+                clone_action(url, env, target)
+            except (GitCommandError, subprocess.CalledProcessError) as exc:
+                if not _is_connect_failure(exc, url):
+                    raise
+                _debug("HTTPS connection failed; retrying the same Git action once in 1s")
+                # Clone callbacks own partial-target cleanup; fetch callbacks
+                # retain the existing bare repository. Never delete here.
+                time.sleep(1)
+                clone_action(url, env, target)
 
         dep_host = dep_ref.host if dep_ref else None
         is_github = is_github_hostname(dep_host) if dep_host else True
@@ -332,7 +376,7 @@ class CloneEngine:
                     token="",
                     auth_scheme="basic",
                 )
-                clone_action(winning_url, git_env, target_path)
+                _clone(winning_url, git_env, target_path)
 
             org = repository_owner(repo_url_base)
             host.auth_resolver.try_with_fallback(
@@ -403,7 +447,7 @@ class CloneEngine:
                         attempt_env: dict[str, str],
                     ) -> tuple[str, str | Exception]:
                         try:
-                            clone_action(attempt_url, attempt_env, target_path)
+                            _clone(attempt_url, attempt_env, target_path)
                             return "ok", attempt_url
                         except (
                             GitCommandError,
@@ -453,7 +497,7 @@ class CloneEngine:
                     url = str(outcome[1])
                     authenticated_fallback_used = fallback.bearer_attempted
                 else:
-                    clone_action(url, _env_for(attempt, url), target_path)
+                    _clone(url, _env_for(attempt, url), target_path)
                 if verbose_callback:
                     display = (
                         host._sanitize_git_error(url)

--- a/tests/integration/test_apm_lifecycle_runner_contract.py
+++ b/tests/integration/test_apm_lifecycle_runner_contract.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import inspect
 import os
+import select
+import signal
 import subprocess
 import sys
 import time
+from contextlib import suppress
 from dataclasses import FrozenInstanceError
 from pathlib import Path
 
@@ -156,11 +159,19 @@ def test_expired_scenario_deadline_reports_context_before_spawn(
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX process-group assertion")
-def test_timeout_terminates_descendant_process_tree(tmp_path: Path) -> None:
+@pytest.mark.parametrize("startup_delay", [0.0, 0.6], ids=["normal-start", "slow-start"])
+def test_timeout_terminates_descendant_process_tree(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    startup_delay: float,
+) -> None:
     script = (
-        "import pathlib, subprocess, sys, time; "
-        "child = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(60)']); "
-        "pathlib.Path('descendant.pid').write_text(str(child.pid)); "
+        "import subprocess, sys, time; "
+        f"time.sleep({startup_delay!r}); "
+        "child = subprocess.Popen("
+        "[sys.executable, '-c', 'import time; time.sleep(60)'], "
+        "stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL); "
+        "print(child.pid, flush=True); "
         "time.sleep(60)"
     )
     runner = ApmLifecycleRunner(
@@ -168,19 +179,50 @@ def test_timeout_terminates_descendant_process_tree(tmp_path: Path) -> None:
         timeout_seconds=0.3,
     )
 
-    with pytest.raises(subprocess.TimeoutExpired):
-        runner.run((), cwd=tmp_path, env=os.environ)
+    communicate = subprocess.Popen.communicate
+    descendant_pid: int | None = None
+    process: subprocess.Popen[str] | None = None
 
-    descendant_pid = int((tmp_path / "descendant.pid").read_text())
-    deadline = time.monotonic() + 2.0
-    while time.monotonic() < deadline:
-        try:
+    def communicate_after_ready(
+        child: subprocess.Popen[str],
+        input: str | None = None,
+        timeout: float | None = None,
+    ) -> tuple[str, str]:
+        nonlocal descendant_pid, process
+        process = child
+        if timeout is not None:
+            # Startup is setup, not the timeout under test. Exercise the real
+            # communicate deadline only after a live descendant exists.
+            assert child.stdout is not None
+            ready, _, _ = select.select([child.stdout], [], [], 10.0)
+            assert ready, "process tree did not become ready within 10 seconds"
+            readiness = os.read(child.stdout.fileno(), 64)
+            assert readiness.endswith(b"\n"), "child exited or sent an incomplete readiness PID"
+            descendant_pid = int(readiness)
             os.kill(descendant_pid, 0)
-        except ProcessLookupError:
-            break
-        time.sleep(0.05)
-    else:
-        pytest.fail(f"descendant process {descendant_pid} survived timeout")
+        return communicate(child, input=input, timeout=timeout)
+
+    monkeypatch.setattr(subprocess.Popen, "communicate", communicate_after_ready)
+    try:
+        with pytest.raises(subprocess.TimeoutExpired) as exc_info:
+            runner.run((), cwd=tmp_path, env=os.environ)
+
+        assert exc_info.value.timeout == 0.3
+        assert descendant_pid is not None
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            try:
+                os.kill(descendant_pid, 0)
+            except ProcessLookupError:
+                break
+            time.sleep(0.05)
+        else:
+            pytest.fail(f"descendant process {descendant_pid} survived timeout")
+    finally:
+        if process is not None:
+            with suppress(ProcessLookupError):
+                os.killpg(process.pid, signal.SIGKILL)
+            communicate(process)
 
 
 def test_run_sequence_preserves_order_and_results(tmp_path: Path) -> None:

--- a/tests/unit/deps/test_clone_connect_retry.py
+++ b/tests/unit/deps/test_clone_connect_retry.py
@@ -1,0 +1,267 @@
+"""Bounded HTTPS connection recovery below auth and protocol selection."""
+
+from __future__ import annotations
+
+import subprocess
+from contextlib import nullcontext
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+from git.exc import GitCommandError
+
+from apm_cli.core.auth import AuthResolver
+from apm_cli.deps.bare_cache import bare_clone_with_fallback, clone_with_fallback
+from apm_cli.deps.clone_engine import CloneEngine
+from apm_cli.deps.transport_selection import ProtocolPreference, TransportAttempt, TransportPlan
+from apm_cli.models.dependency.reference import DependencyReference
+
+pytestmark = pytest.mark.component
+
+URL = "https://github.com/microsoft/apm-sample-package.git"
+CONNECT = (
+    f"fatal: unable to access '{URL}/': "
+    "Failed to connect to github.com port 443 after 8126 ms: Couldn't connect to server"
+)
+
+
+@pytest.fixture
+def host() -> MagicMock:
+    """Provide one strict HTTPS attempt, without credential discovery or network."""
+    context = MagicMock()
+    context._protocol_pref = ProtocolPreference.HTTPS
+    context._allow_fallback = False
+    context._transport_selector.select.return_value = TransportPlan(
+        attempts=[TransportAttempt(scheme="https", label="HTTPS", use_token=False)],
+        strict=True,
+    )
+    context._resolve_dep_token.return_value = None
+    context._resolve_dep_auth_ctx.return_value = None
+    context.auth_resolver.uses_public_github_anonymous_first.return_value = False
+    context.auth_resolver.build_error_context.return_value = ""
+    context._build_repo_url.return_value = URL
+    context._build_noninteractive_git_env.return_value = {"LC_ALL": "C"}
+    context._sanitize_git_error.side_effect = lambda text: text
+    context.has_ado_token = False
+    return context
+
+
+def _execute(host: MagicMock, target: Path, action: MagicMock) -> None:
+    CloneEngine(host).execute(
+        "microsoft/apm-sample-package",
+        target,
+        dep_ref=DependencyReference.parse("microsoft/apm-sample-package"),
+        clone_action=action,
+    )
+
+
+@pytest.mark.parametrize(
+    "stream", [CONNECT, CONNECT.encode(), f"Cloning into 'tmp'...\n{CONNECT}\n"]
+)
+@pytest.mark.parametrize("error_type", [subprocess.CalledProcessError, GitCommandError])
+def test_connect_retry_preserves_action_arguments(
+    host: MagicMock, tmp_path: Path, stream: str | bytes, error_type: type[Exception]
+) -> None:
+    """The observed diagnostic earns exactly one retry on the same URL/env/target."""
+    error = (
+        GitCommandError(["git", "clone"], 128, stderr=stream)
+        if error_type is GitCommandError
+        else subprocess.CalledProcessError(128, ["git", "clone"], stderr=stream)
+    )
+    action = MagicMock(side_effect=[error, None])
+    with patch("apm_cli.deps.clone_engine.time.sleep") as sleep:
+        _execute(host, tmp_path, action)
+    assert action.call_count == 2
+    first, second = action.call_args_list
+    assert first == second
+    assert first.args[0] == URL
+    assert first.args[1] is second.args[1]
+    sleep.assert_called_once_with(1)
+    host._resolve_dep_token.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        subprocess.CalledProcessError(128, ["git"], stderr="fatal: Authentication failed"),
+        subprocess.CalledProcessError(128, ["git"], stderr="fatal: HTTP 403"),
+        subprocess.CalledProcessError(128, ["git"], stderr="fatal: SSL certificate problem"),
+        subprocess.CalledProcessError(128, ["git"], stderr="fatal: repository not found"),
+        subprocess.CalledProcessError(128, ["git"], stderr="fatal: invalid reference"),
+        subprocess.CalledProcessError(128, ["git"], stderr=f"remote: {CONNECT}"),
+        subprocess.CalledProcessError(
+            128, ["git"], stderr=f"{CONNECT}\nfatal: Authentication failed"
+        ),
+        subprocess.CalledProcessError(128, ["git"], stderr=CONNECT.replace("8126", "invalid")),
+        subprocess.CalledProcessError(
+            128, ["git"], stderr=CONNECT.replace("github.com", "other.test")
+        ),
+        subprocess.CalledProcessError(128, ["git"], output=CONNECT),
+        subprocess.CalledProcessError(1, ["git"], stderr=CONNECT),
+        subprocess.TimeoutExpired(["git"], 10, stderr=CONNECT),
+        ValueError("policy rejected"),
+        AssertionError("invalid downloaded content"),
+    ],
+)
+def test_non_connect_failure_is_not_retried(
+    host: MagicMock, tmp_path: Path, error: Exception
+) -> None:
+    action = MagicMock(side_effect=error)
+    with patch("apm_cli.deps.clone_engine.time.sleep") as sleep:
+        with pytest.raises((RuntimeError, ValueError, AssertionError)):
+            _execute(host, tmp_path, action)
+    action.assert_called_once()
+    sleep.assert_not_called()
+
+
+def test_persistent_connection_failure_preserves_final_diagnostic(
+    host: MagicMock, tmp_path: Path
+) -> None:
+    final = CONNECT.replace("8126", "9127")
+    action = MagicMock(
+        side_effect=[
+            subprocess.CalledProcessError(128, ["git"], stderr=CONNECT),
+            subprocess.CalledProcessError(128, ["git"], stderr=final),
+        ]
+    )
+    with patch("apm_cli.deps.clone_engine.time.sleep") as sleep:
+        with pytest.raises(RuntimeError, match="after 9127 ms"):
+            _execute(host, tmp_path, action)
+    assert action.call_count == 2
+    sleep.assert_called_once_with(1)
+
+
+@pytest.mark.parametrize("persistent", [False, True])
+def test_public_anonymous_retry_stays_inside_auth_callback(
+    host: MagicMock, tmp_path: Path, persistent: bool
+) -> None:
+    host.auth_resolver.uses_public_github_anonymous_first.return_value = True
+    env = {"LC_ALL": "C", "GIT_TERMINAL_PROMPT": "0"}
+    resolver = AuthResolver()
+    host.auth_resolver.try_with_fallback.side_effect = resolver.try_with_fallback
+    error = subprocess.CalledProcessError(128, ["git"], stderr=CONNECT)
+    action = MagicMock(side_effect=[error, error if persistent else None])
+    with (
+        patch("apm_cli.deps.clone_engine.time.sleep"),
+        patch.object(resolver, "uses_public_github_anonymous_first", return_value=True),
+        patch.object(resolver, "build_public_github_anonymous_git_env", return_value=env),
+        patch.object(resolver, "resolve") as resolve,
+        pytest.raises(RuntimeError) if persistent else nullcontext(),
+    ):
+        _execute(host, tmp_path, action)
+    assert action.call_args_list == [call(URL, env, tmp_path), call(URL, env, tmp_path)]
+    host.auth_resolver.try_with_fallback.assert_called_once()
+    host._resolve_dep_token.assert_not_called()
+    host._resolve_dep_auth_ctx.assert_not_called()
+    resolve.assert_not_called()
+
+
+@pytest.mark.parametrize("persistent", [False, True])
+def test_ado_retry_stays_inside_primary_auth_attempt(
+    host: MagicMock, tmp_path: Path, persistent: bool
+) -> None:
+    url = "https://dev.azure.com/org/proj/_git/repo"
+    host._build_repo_url.return_value = url
+    host._resolve_dep_token.return_value = "test-pat"
+    host._resolve_dep_auth_ctx.return_value = SimpleNamespace(auth_scheme="basic")
+    host._transport_selector.select.return_value = TransportPlan(
+        attempts=[TransportAttempt(scheme="https", label="HTTPS token", use_token=True)],
+        strict=True,
+    )
+    host.auth_resolver.execute_with_bearer_fallback.side_effect = (
+        AuthResolver().execute_with_bearer_fallback
+    )
+    stderr = (
+        f"fatal: unable to access '{url}/': Failed to connect to dev.azure.com port 443 "
+        "after 8126 ms: Couldn't connect to server"
+    )
+    error = subprocess.CalledProcessError(128, ["git"], stderr=stderr)
+    action = MagicMock(side_effect=[error, error if persistent else None])
+    with (
+        patch("apm_cli.deps.clone_engine.time.sleep"),
+        patch("apm_cli.core.azure_cli.get_bearer_provider") as bearer_provider,
+        pytest.raises(RuntimeError) if persistent else nullcontext(),
+    ):
+        CloneEngine(host).execute(
+            "org/proj/_git/repo",
+            tmp_path,
+            dep_ref=DependencyReference.parse("dev.azure.com/org/proj/_git/repo"),
+            clone_action=action,
+        )
+    assert action.call_count == 2
+    assert action.call_args_list[0] == action.call_args_list[1]
+    host.auth_resolver.execute_with_bearer_fallback.assert_called_once()
+    host.auth_resolver.build_ado_bearer_git_env.assert_not_called()
+    bearer_provider.assert_not_called()
+
+
+@pytest.mark.parametrize("bare", [False, True])
+def test_clone_callbacks_clean_partial_target_before_retry(
+    host: MagicMock, tmp_path: Path, bare: bool
+) -> None:
+    """Exercise real cleanup callbacks, not a mock which pretends cleanup happened."""
+    target = tmp_path / "clone"
+    attempts = 0
+
+    def fail_then_succeed(*_args: object, **_kwargs: object) -> MagicMock:
+        nonlocal attempts
+        assert not target.exists()
+        target.mkdir()
+        (target / "partial").write_text("partial", encoding="ascii")
+        attempts += 1
+        # Bare clone already has a shallow-to-full fallback. Fail both tiers.
+        if attempts <= (2 if bare else 1):
+            raise subprocess.CalledProcessError(128, ["git", "clone"], stderr=CONNECT)
+        return MagicMock()
+
+    engine = CloneEngine(host)
+    dep = DependencyReference.parse("microsoft/apm-sample-package")
+    with patch("apm_cli.deps.clone_engine.time.sleep") as sleep:
+        if bare:
+            with (
+                patch("apm_cli.deps.bare_cache.subprocess.run", side_effect=fail_then_succeed),
+                patch(
+                    "apm_cli.utils.git_env.git_clone_env",
+                    side_effect=lambda _u, env, *_a, **_k: env,
+                ),
+                patch("apm_cli.deps.bare_cache._scrub_bare_remote_url"),
+            ):
+                bare_clone_with_fallback(
+                    engine.execute, dep.repo_url, target, dep_ref=dep, ref=None, is_commit_sha=False
+                )
+        else:
+            with (
+                patch("apm_cli.utils.git_env.clone_git_worktree", side_effect=fail_then_succeed),
+                patch("apm_cli.deps.bare_cache.Repo"),
+            ):
+                clone_with_fallback(engine.execute, dep.repo_url, target, dep_ref=dep)
+    assert attempts == (3 if bare else 2)
+    sleep.assert_called_once_with(1)
+
+
+@pytest.mark.parametrize(
+    "bypass",
+    [
+        "_clone(winning_url, git_env, target_path)",
+        "_clone(attempt_url, attempt_env, target_path)",
+        "_clone(url, _env_for(attempt, url), target_path)",
+    ],
+)
+def test_registered_guard_rejects_retry_bypass(bypass: str) -> None:
+    """Every transport/auth branch remains behind the single recovery owner."""
+    from scripts.architecture_linter.runner import run_selected_rules
+
+    root = Path(__file__).resolve().parents[3]
+    owner = "src/apm_cli/deps/clone_engine.py"
+    source = (root / owner).read_text(encoding="utf-8")
+    rule = "transport-platform-clone-connect-retry"
+    report = run_selected_rules(
+        root,
+        (rule,),
+        source_overrides={
+            owner: source.replace(bypass, bypass.replace("_clone(", "clone_action("))
+        },
+    )
+    assert not report.failures
+    assert any(item.rule_id == rule for item in report.violations)


### PR DESCRIPTION
# fix(reliability): bound Git connection recovery and synchronize timeout smoke setup

## TL;DR

Repair two independent failures seen on the v0.29.1 source: a real GitHub connection failure in release binary smoke, and a process-startup race in scheduled-main integration tests. Git dependency downloads now retry one precisely classified HTTPS connection failure using the same URL, environment, and transport. The process-tree test establishes bounded descendant readiness before exercising its unchanged 0.3-second timeout.

> [!IMPORTANT]
> This is a production download behavior change plus a separate test-harness repair. It does not move the v0.29.1 tag, publish a release, or rerun any release workflow.

## Problem (WHY)

- [x] [Release run 33989174647, macOS x86_64](https://github.com/microsoft/apm/actions/runs/33989174647/job/101368180691) failed `apm deps update apm-sample-package` at `2026-09-05T20:28:42Z`: Git could not connect to `github.com:443` after 8126 ms. Five of six smoke groups passed; release publishing was skipped. The terminal diagnostic was network failure, not authentication or a README assertion.
- [x] [Scheduled-main run 34010736178, macOS ARM](https://github.com/microsoft/apm/actions/runs/34010736178/job/101425984267) failed `test_timeout_terminates_descendant_process_tree`: the 0.3-second timeout could kill the parent before it wrote `descendant.pid`. The subsequent read raised `FileNotFoundError`; the test had not established its process-tree precondition.
- [!] [Earlier non-publishing run 33986838530](https://github.com/microsoft/apm/actions/runs/33986838530) succeeded. Its SHA `13386d993` differs from failing SHA `8758587f7` only by five CHANGELOG lines. The release-merge CI push also succeeded. These are two distinct incidents, not evidence that a changelog edit broke binaries.

The repair is grounded in captured diagnostics and deterministic regression tests rather than blanket reruns. The validation approach follows Agent Skills: ["do the work, run a validator (a script, a reference checklist, or a self-check), fix any issues, and repeat until validation passes."](https://agentskills.io/skill-creation/best-practices#validation-loops)

## Approach (WHAT)

- Match the complete captured Git error for the exact requested HTTPS remote, including exit status, hostname, port, and the observed libcurl connection diagnostic.
- Wait one second and repeat the selected Git action once, beneath the existing authentication and transport owners.
- Propagate every other error unchanged; preserve the final diagnostic if the retry fails.
- Establish descendant readiness through a bounded pipe read, then run the real `communicate(timeout=0.3)` and retain the no-orphan assertion.

## Implementation (HOW)

| File | Change |
| :--- | :--- |
| `src/apm_cli/deps/clone_engine.py` | Owns exact connection classification and the bounded wrapper used by public anonymous, ADO, and ordinary clone/fetch callbacks. |
| `tests/unit/deps/test_clone_connect_retry.py` | Covers byte/GitPython stderr, unchanged arguments, persistent failures, rejected non-connect errors, real auth-owner boundaries, partial-target cleanup, and guard mutations. |
| `tests/integration/test_apm_lifecycle_runner_contract.py` | Replaces PID-file timing assumptions with a 10-second readiness bound and explicit EOF/incomplete-read failure; exercises normal and deliberately delayed startup; cleans up on every exit path. |
| `.apm/architecture/owners/transport-auth-platform.json` | Registers CloneEngine as the single owner of the new recovery decision. |
| `scripts/architecture_linter/checks/transport_network_and_runtime.py` | Guards all three callback routes and prevents a second connection classifier. |
| `docs/src/content/docs/consumer/manage-dependencies.md` | Explains the narrow retry and persistent-failure behavior alongside transport selection. |
| `CHANGELOG.md` | Records both repairs under Unreleased. |

The [production retry](https://github.com/microsoft/apm/blob/d69f9e8fd/src/apm_cli/deps/clone_engine.py#L52-L78) leaves auth selection, protocol plans, and clone cleanup ownership unchanged.

## Diagram

The highlighted region adds one connection retry inside the already-selected authentication and transport attempt.

```mermaid
sequenceDiagram
    participant Auth as Auth and transport owners
    participant Engine as CloneEngine
    participant Git as Git action
    Auth->>Engine: Selected URL and environment
    Engine->>Git: Clone or fetch
    Git-->>Engine: Captured failure
    rect rgb(255, 247, 200)
        alt Exact HTTPS connection failure
            Engine->>Engine: Wait 1 second
            Engine->>Git: Repeat action once
            Note over Engine,Git: Same URL, credentials, transport, and target
            Git-->>Engine: Success or final failure
        else Any other failure
            Engine-->>Auth: Propagate without connection retry
        end
    end
    Engine-->>Auth: Existing result and fallback rules
```

## Trade-offs

- **One bounded retry, not guaranteed outage recovery.** Only the observed HTTPS connect failure qualifies. DNS, TLS, HTTP authentication, policy, content, and subprocess-timeout failures gain no retry.
- **Production boundary, not whole-test reruns.** Repeating the entire CLI or smoke group could hide an assertion failure or repeat unrelated side effects. Clone callbacks retain responsibility for partial-target cleanup; fetch callbacks retain their existing bare repository.
- **Existing fallbacks remain.** A bare-clone action can already try shallow and full clones. The new bound is one additional action invocation, not a global two-process limit. Existing explicitly enabled protocol/auth fallback behavior is unchanged.
- **Readiness belongs to test setup.** The test-only handshake excludes process startup from the teardown scenario, while the separate runner deadline tests still check ordinary timeout behavior. No production lifecycle timeout was enlarged.
- **Local evidence is deterministic, not a recreated GitHub outage.** Captured diagnostics are injected into real recovery/auth/cleanup boundaries. Native macOS process tests ran; a fresh PyInstaller binary matrix was not built locally.

## Benefits

1. One transient matching connection failure can recover without credential discovery or protocol switching.
2. Persistent failures still fail closed and report the last Git diagnostic.
3. Slow process startup no longer prevents the teardown test from establishing a live descendant.
4. The real process-tree termination assertion still rejects surviving descendants.

## Validation

<details><summary>Focused execution and quality evidence</summary>

`uv run --frozen --extra dev pytest -q tests/integration/test_apm_lifecycle_runner_contract.py tests/unit/deps/test_clone_connect_retry.py tests/unit/deps/test_clone_engine_bearer_env.py tests/unit/deps/test_bare_cache_clone_failure.py tests/unit/core/test_public_github_anonymous_first.py tests/unit/test_transport_selection.py`

```text
159 passed in 7.72s
```

After replacing the readiness `readline` with a bounded-size read:

`uv run --frozen --extra dev pytest -q tests/integration/test_apm_lifecycle_runner_contract.py`

```text
12 passed in 5.63s
```

`uv run --frozen python scripts/check_test_assertions.py`

```text
[+] assertion-quality ratchet clean: AQ001=4, AQ002=12
```

`uv run --frozen python scripts/check_exact_test_duplicates.py`

```text
[+] exact test duplicate ratchet clean: 1185 files, 0 allowed duplicate group(s)
```

The canonical local Ruff, formatter, pylint R0801, YAML I/O, file-length, portable-path, auth-signal, and architecture guards passed against latest main. The PR diagram also passed `mmdc`. Hosted PR checks are separate and are not claimed green here.

</details>

The six connection-recovery cases fail when `_is_connect_failure` is temporarily disabled in the test process, proving that the new recovery is load-bearing. The delayed-start lifecycle case reproduces the old race; a parent-only-kill mutation is rejected by the retained descendant-survival assertion.

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
| :--- | :--- | :--- | :--- | :--- |
| 1 | A dependency download can recover from one matching HTTPS connection failure. | DevX (pragmatic as npm) | `tests/unit/deps/test_clone_connect_retry.py::test_connect_retry_preserves_action_arguments` (regression trap for release run 33989174647) | integration |
| 2 | A continued outage still fails and reports the final connection error. | DevX (pragmatic as npm) | `tests/unit/deps/test_clone_connect_retry.py::test_persistent_connection_failure_preserves_final_diagnostic` | integration |
| 3 | Connection recovery never discovers extra credentials or changes auth identity. | Secure by default | `tests/unit/deps/test_clone_connect_retry.py::test_public_anonymous_retry_stays_inside_auth_callback`, `test_ado_retry_stays_inside_primary_auth_attempt` | integration |
| 4 | Auth, TLS, policy, invalid content, and subprocess timeout errors are not retried by this recovery path. | Secure by default; Governed by policy | `tests/unit/deps/test_clone_connect_retry.py::test_non_connect_failure_is_not_retried` | integration |
| 5 | A retry cannot inherit a partial clone destination. | DevX (pragmatic as npm) | `tests/unit/deps/test_clone_connect_retry.py::test_clone_callbacks_clean_partial_target_before_retry` | integration |
| 6 | A timeout terminates a live descendant even after slow startup. | OSS / community-driven | `tests/integration/test_apm_lifecycle_runner_contract.py::test_timeout_terminates_descendant_process_tree` (regression trap for scheduled run 34010736178) | integration |

Here, integration rows cross in-process module boundaries with mocked external Git I/O; the lifecycle row uses real native processes. They do not claim a live-network or packaged-binary end-to-end run.

## How to test

- [ ] Run the focused pytest command above; expect both the normal and delayed-start cases to pass.
- [ ] Run `bash scripts/lint-architecture-boundaries.sh`; expect the connection retry owner and callback routes to pass.
- [ ] Inject the observed connection diagnostic followed by success; expect exactly one identical action retry. Inject it twice; expect failure with the final diagnostic.
- [ ] Review hosted PR checks before merging. Release tagging and publishing remain a separate maintainer action.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>