### PR TITLE
fix(tests): repair release inventory and teardown diagnostic race

### DIFF
--- a/tests/unit/scripts/test_architecture_runner.py
+++ b/tests/unit/scripts/test_architecture_runner.py
@@ -710,6 +710,7 @@ registry_delegation.runtime_descriptors
 registry_delegation.target_vocabulary
 transport-platform-artifactory-full-commit-sha
 transport-platform-artifactory-netrc-isolation
+transport-platform-clone-connect-retry
 transport-platform-git-cache-identity
 transport-platform-git-child-environment
 transport-platform-git-semver-preflight

--- a/tests/unit/test_windows_unit_diagnostics.py
+++ b/tests/unit/test_windows_unit_diagnostics.py
@@ -136,6 +136,7 @@ def test_xdist_reports_names_while_blocked_without_capture_or_locals(
                 if (
                     (tmp_path / "entered").exists()
                     and "test_probe.py::test_diagnostic_probe" in output
+                    and (phase != "teardown" or "FAILED" in output)
                 ) or process.poll() is not None:
                     break
                 time.sleep(0.05)
@@ -158,3 +159,29 @@ def test_xdist_reports_names_while_blocked_without_capture_or_locals(
     assert "1 failed, 1 passed" in output
     assert "DO_NOT_DUMP_PROBE_LOCAL" not in output
     assert "DO_NOT_DUMP_PROBE_CAPTURE" not in output
+
+
+@pytest.mark.windows_compat
+def test_xdist_waits_for_failed_report_after_teardown_entry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A worker can enter teardown before the controller renders its call report."""
+    read_text = Path.read_text
+    delayed = False
+
+    def delayed_report(path: Path, encoding: str | None = None, errors: str | None = None) -> str:
+        nonlocal delayed
+        output = read_text(path, encoding=encoding, errors=errors)
+        if (
+            path == tmp_path / "pytest.log"
+            and (tmp_path / "entered").exists()
+            and "test_probe.py::test_diagnostic_probe" in output
+            and not delayed
+        ):
+            delayed = True
+            return output.replace("FAILED", "")
+        return output
+
+    monkeypatch.setattr(Path, "read_text", delayed_report)
+    test_xdist_reports_names_while_blocked_without_capture_or_locals(tmp_path, "teardown")
+    assert delayed


### PR DESCRIPTION
## TL;DR

Correct both confirmed unit failures in the v0.29.1 release run after #2839: the missing frozen inventory entry and a Windows teardown diagnostic observation race. Both changes are test-only; production behavior remains unchanged.

> [!IMPORTANT]
> No guard removal, dynamic expected-set derivation, production changes, skipped assertions, timeout increases, or release/tag actions.

## Problem (WHY)

- On main `6cbac86ad`, the inventory assertion fails with `Extra items in the left set: 'transport-platform-clone-connect-retry'` after #2839 registered the guard without updating the explicit expected inventory.
- The completed Windows job in [release run 34014311098](https://github.com/microsoft/apm/actions/runs/34014311098/job/101435347949) also failed because its nested xdist worker entered teardown before the controller printed `FAILED`. The polling loop stopped on entry/name alone, then asserted the not-yet-rendered result.

## Approach (WHAT)

Preserve exact inventory equality and all diagnostic assertions. Wait for the complete teardown readiness condition within the existing 20-second deadline, rather than increasing sleeps or timeouts.

## Implementation (HOW)

| File | Change |
| :--- | :--- |
| [`tests/unit/scripts/test_architecture_runner.py`](https://github.com/microsoft/apm/blob/bdfc8e200/tests/unit/scripts/test_architecture_runner.py#L713) | Include the existing rule in the frozen semantic contract. Exact set equality is unchanged. Existing retry-bypass mutation tests cover all three call sites and need no edits. |
| [`tests/unit/test_windows_unit_diagnostics.py`](https://github.com/microsoft/apm/blob/bdfc8e200/tests/unit/test_windows_unit_diagnostics.py#L134-L187) | Require `FAILED` in the teardown polling predicate before releasing the blocked fixture. Add a deterministic regression that withholds the result from one log snapshot; it reproduces the old assertion failure and is selected by the native Windows compatibility gate. |

## Trade-offs

- Keep the explicit frozen inventory rather than deriving it from the registry, preserving detection of missing and unexpected rules.
- Model delayed log observation while still running real nested xdist; do not fake subprocess success, skip phases, or remove assertions. No runtime behavior, documentation claims, or changelog entries change.

## Benefits

1. The previously failing inventory assertion passes.
2. Exact inventory equality and all three retry-bypass mutations remain enforced.
3. Teardown diagnostics tolerate delayed controller output while still requiring a live blocked process and visible failed-call output.

## Validation

Before inventory correction:

```text
FAILED tests/unit/scripts/test_architecture_runner.py::test_registered_rule_inventory_matches_frozen_semantic_contract
1 failed in 3.31s
```

Deterministic stale-log regression before synchronization correction:

```text
FAILED tests/unit/test_windows_unit_diagnostics.py::test_xdist_waits_for_failed_report_after_teardown_entry
1 failed in 2.54s
```

After: `uv run --frozen --extra dev pytest -q tests/unit/scripts/test_architecture_runner.py tests/unit/deps/test_clone_connect_retry.py tests/unit/test_windows_unit_diagnostics.py`

```text
111 passed in 22.71s
```

Windows selector: `uv run --frozen --extra dev pytest -q -m windows_compat tests/unit/test_windows_unit_diagnostics.py`

```text
4 passed, 5 deselected in 12.91s
```

Merged main `88ee17b9` (#2830) before final validation. Full latest-main local lint passed: Ruff check and format, pylint R0801, auth-signal boundaries, architecture boundaries, YAML safety, 2100-line guard, and portable relative paths. Assertion and duplicate-test ratchets also passed. Hosted checks for the new head are pending; earlier-head green checks are not final proof.

### Scenario Evidence

| Scenario | Evidence | Type |
| :--- | :--- | :--- |
| Release validation recognizes the existing clone-retry guard without weakening the inventory | `tests/unit/scripts/test_architecture_runner.py::test_registered_rule_inventory_matches_frozen_semantic_contract` | Unit |
| Retry bypasses remain rejected on every existing transport/auth branch | `tests/unit/deps/test_clone_connect_retry.py::test_registered_guard_rejects_retry_bypass` (three mutations) | Component |
| A failed call is visibly reported while teardown is still blocked, even if its report arrives later | `tests/unit/test_windows_unit_diagnostics.py::test_xdist_waits_for_failed_report_after_teardown_entry` | Component / windows_compat |

## How to test

- [ ] Run the combined command above; expect 111 passing tests.
- [ ] Run the Windows selector; expect four passing cases, including the deterministic stale-log regression.
- [ ] Confirm exact inventory equality, all diagnostic assertions, and original timeouts remain unchanged.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>