### PR TITLE
test: complete clone retry owner mutation coverage

### DIFF
--- a/tests/integration/test_architecture_owner_rule_mutations.py
+++ b/tests/integration/test_architecture_owner_rule_mutations.py
@@ -681,6 +681,14 @@ MUTATIONS: tuple[MutationCase, ...] = (
         intent="Direct Artifactory entry requests regain ambient netrc credentials.",
     ),
     MutationCase(
+        guard_id="transport-platform-clone-connect-retry",
+        rule_id="transport-platform-clone-connect-retry",
+        path="src/apm_cli/deps/clone_engine.py",
+        old="_clone(url, _env_for(attempt, url), target_path)",
+        new="clone_action(url, _env_for(attempt, url), target_path)",
+        intent="A transport attempt invokes the clone action without canonical connection recovery.",
+    ),
+    MutationCase(
         guard_id="transport-platform-git-cache-identity",
         rule_id="transport-platform-git-cache-identity",
         path="src/apm_cli/deps/shared_clone_cache.py",


### PR DESCRIPTION
## TL;DR

Add the missing load-bearing mutation for `transport-platform-clone-connect-retry`, repairing the exact-once owner matrix that failed release run [34015503962](https://github.com/microsoft/apm/actions/runs/34015503962) after #2839. #2840 repaired the unit inventory but missed this independent integration contract.

> [!IMPORTANT]
> Eight added lines in one test file. No production, workflow, specification, version, or changelog changes. No specification waiver. Parent owns merge/tag/release actions.

## Problem (WHY)

Reproduced `test_matrix_covers_every_registry_guard_exactly_once` failing with exactly one missing guard. Adding a name alone would not prove detection: the matrix requires surgical valid Python, a clean baseline, the actual owning rule, and a real attributed `Violation`.

Validation follows ["do the work, run a validator (a script, a reference checklist, or a self-check), fix any issues, and repeat until validation passes."](https://agentskills.io/skill-creation/best-practices#validation-loops)

## Approach (WHAT)

Additive change -- see Implementation.

## Implementation (HOW)

[`tests/integration/test_architecture_owner_rule_mutations.py`](https://github.com/microsoft/apm/blob/752dddb00/tests/integration/test_architecture_owner_rule_mutations.py#L683-L690) gains one sorted row replacing `_clone(url, _env_for(attempt, url), target_path)` with `clone_action(url, _env_for(attempt, url), target_path)` in an in-memory source override. This bypasses canonical connection recovery while preserving the arguments and valid Python. Every existing invariant remains unchanged.

## Diagrams

The new row drives the real selected rule through the existing mutation and baseline proofs (validated with `mmdc`).

```mermaid
flowchart LR
    subgraph Input["Source override"]
        M["NEW: replace _clone with clone_action"]
    end
    subgraph Guard["Selected real rule"]
        R["transport-platform-clone-connect-retry"]
    end
    subgraph Proof["Existing matrix assertions"]
        V["Attributed Violation"]
        B["Unmutated baseline is clean"]
    end
    M --> R --> V
    R --> B
    classDef new stroke-dasharray: 5 5;
    class M new;
```

## Trade-offs

- Keep one integration row per guard; the existing three unit mutations still cover all transport/auth branches. No equality relaxation or duplicate rows.
- No production, docs, CI selection, or release metadata changes: this repairs test coverage, not public behavior.

## Benefits

1. Every registered owner guard again has exactly one mutation matrix row.
2. A direct callback bypass produces the owning rule's `Violation`.
3. Original source stays clean; injected mutations never touch disk.

## Validation

Base: latest main `4b0efe2524319f91434d5fcc04cd1c1e86124d8a`, including `bc9f75704` and #2827. Hosted checks pending at creation; local results below.

<details><summary>Reproduction and full relevant contract suite</summary>

Before patch:

```text
Extra items in the right set:
'transport-platform-clone-connect-retry'
1 failed in 1.33s
```

`uv run --extra dev pytest -q tests/integration/test_architecture_*.py tests/unit/scripts/test_architecture_*.py tests/unit/install/test_architecture_invariants.py tests/unit/deps/test_clone_connect_retry.py tests/integration/test_resolution_staging_mcp_lifecycle.py`

```text
901 passed in 616.27s (0:10:16)
```

Includes the entire affected integration module, every architecture integration mutation/contract module, unit inventory/registry/runner contracts, retry behavior and all three unit bypass cases, and inherited staging MCP lifecycle coverage.

`uv run --frozen --extra dev pytest -q tests/integration/test_architecture_owner_rule_mutations.py -k 'clone_connect_retry or clone-connect-retry or report_nothing or covers_every_registry'`

```text
5 passed, 320 deselected in 5.96s
```

Proves exact-once inventory, owning-rule attribution, surgical valid-source mutation, bypass rejection, and clean unmutated baseline.

</details>

<details><summary>Lint, quality, and inventory audit</summary>

Full canonical lint passed: Ruff, formatting, YAML safety, 2100-line limit, portable relative paths, pylint R0801, auth boundaries, and architecture boundaries.

`uv run --frozen --extra dev pytest -p no:cacheprovider -q tests/quality`

```text
56 passed in 84.89s (0:01:24)
```

`uv run --frozen python scripts/check_test_assertions.py`

```text
[+] assertion-quality ratchet clean: AQ001=4, AQ002=12
```

`uv run --frozen python scripts/check_exact_test_duplicates.py`

```text
[+] exact test duplicate ratchet clean: 1189 files, 0 allowed duplicate group(s)
```

Searched owner registry, registered analyzer, frozen unit runner inventory, integration matrix, unit bypass tests, and other architecture contracts. No additional authoritative inventory discrepancy found. Historical performance parity JSON is not a live guard catalog.

</details>

### Scenario Evidence

| # | Scenario | Principle | Test | Type |
|---|---|---|---|---|
| 1 | Release validation covers every registered guard | DevX | `tests/integration/test_architecture_owner_rule_mutations.py::test_matrix_covers_every_registry_guard_exactly_once` | integration |
| 2 | Clone paths cannot silently bypass recovery | DevX | `tests/integration/test_architecture_owner_rule_mutations.py::test_owner_rule_catches_its_guard_mutation[transport-platform-clone-connect-retry]` | integration |
| 3 | Recovery stays bounded inside original attempt | DevX | `tests/unit/deps/test_clone_connect_retry.py` | component |
| 4 | MCP paths survive staging cleanup | Portability | `tests/integration/test_resolution_staging_mcp_lifecycle.py` | integration |

## How to test

- [ ] Run the comprehensive command above: all 901 selected cases pass.
- [ ] Run the focused command: bypass rejection and clean baseline pass.
- [ ] Inspect diff: exactly one new row, no invariant relaxation.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>