### PR TITLE
fix(tests): preserve literal plugin-root suffixes on Windows

### DIFF
--- a/tests/integration/test_resolution_staging_mcp_lifecycle.py
+++ b/tests/integration/test_resolution_staging_mcp_lifecycle.py
@@ -79,7 +79,7 @@ def _publish_plugin(tmp_path: Path) -> tuple[Path, DependencyReference, APMPacka
 def _assert_published_server(package: APMPackage, live_path: Path) -> dict[str, object]:
     server = package.get_all_mcp_dependencies()[0]
     assert server.args == [
-        str(live_path / "start.mjs"),
+        f"{live_path}/start.mjs",
         f"--root={live_path}/data",
     ]
     assert server.env == {"TOOL_HOME": str(live_path)}
@@ -160,7 +160,7 @@ def test_replayed_plugin_writes_lock_claude_and_codex_configs(tmp_path: Path) ->
     claude_config = json.loads((project / ".mcp.json").read_text(encoding="utf-8"))
     codex_config = tomlkit.parse((project / ".codex" / "config.toml").read_text(encoding="utf-8"))
     lock_data = load_yaml(lock_path)
-    expected_script = str(live_path / "start.mjs")
+    expected_script = f"{live_path}/start.mjs"
     expected_home = str(live_path)
 
     lock_server = lock_data["mcp_configs"]["toolsrv"]["_raw_stdio"]

--- a/tests/unit/deps/test_apm_resolver_staging_paths.py
+++ b/tests/unit/deps/test_apm_resolver_staging_paths.py
@@ -7,14 +7,22 @@ recorded at its published ``apm_modules/<owner>/<repo>`` location, never at the
 
 from __future__ import annotations
 
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
+from unittest.mock import Mock
 
+import pytest
 import yaml
 
 from apm_cli.deps.apm_resolver import APMDependencyResolver
+from apm_cli.deps.plugin_parser import (
+    rebase_plugin_root_paths,
+    resolve_plugin_root_placeholders,
+)
 from apm_cli.install.resolution_staging import ResolutionStagingSession
 from apm_cli.models.dependency.reference import DependencyReference
 from apm_cli.utils.staging_guard import STAGING_DIR_NAME
+
+pytestmark = pytest.mark.windows_compat
 
 _ROOT = "${CLAUDE_PLUGIN_ROOT}"
 _MANIFEST = {
@@ -76,7 +84,7 @@ def test_staged_download_records_published_mcp_args(tmp_path: Path) -> None:
     servers = package.get_all_mcp_dependencies()
     assert [server.name for server in servers] == ["toolsrv"]
     server = servers[0]
-    assert server.args[0] == str(live_path / "start.mjs")
+    assert server.args[0] == f"{live_path}/start.mjs"
     assert Path(server.args[0]).exists()
     assert server.env["TOOL_HOME"] == str(live_path)
 
@@ -96,3 +104,29 @@ def test_staged_download_leaves_no_staging_reference(tmp_path: Path) -> None:
     server = package.get_all_mcp_dependencies()[0]
     rendered = [*server.args, *server.env.values(), str(package.package_path)]
     assert not [value for value in rendered if STAGING_DIR_NAME in value]
+
+
+def test_windows_root_substitution_preserves_literal_argument_suffixes() -> None:
+    staged = PureWindowsPath(r"C:\cache\.apm-resolution-staging\tool")
+    published = PureWindowsPath(r"C:\project\apm_modules\acme\tool")
+    root = Mock(spec=Path)
+    root.resolve.return_value = staged
+    manifest = {
+        "command": f"{_ROOT}/server",
+        "args": [f"{_ROOT}/start.mjs", f"--search={_ROOT}/a:{_ROOT}/b", r"--literal=a/b\c"],
+    }
+
+    resolved = resolve_plugin_root_placeholders(manifest, root)
+    rebased = rebase_plugin_root_paths(resolved, staged, published)
+
+    assert resolved["command"] == f"{staged}/server"
+    assert rebased == {
+        "command": f"{published}/server",
+        "args": [
+            f"{published}/start.mjs",
+            f"--search={published}/a:{published}/b",
+            r"--literal=a/b\c",
+        ],
+    }
+    assert PureWindowsPath(rebased["args"][0]) == published / "start.mjs"
+    assert manifest["command"] == f"{_ROOT}/server"

--- a/tests/unit/install/test_legacy_plugin_compat.py
+++ b/tests/unit/install/test_legacy_plugin_compat.py
@@ -319,6 +319,7 @@ def test_failed_normalization_does_not_partially_mutate_cache(tmp_path: Path) ->
     assert_unchanged(before_external, ArtifactSnapshot.capture(external_prompts))
 
 
+@pytest.mark.windows_compat
 def test_normalization_persists_portable_plugin_root_paths(tmp_path: Path) -> None:
     package = _legacy_cache(tmp_path)
     (package / "plugin.json").write_text(
@@ -343,7 +344,7 @@ def test_normalization_persists_portable_plugin_root_paths(tmp_path: Path) -> No
     assert ".apm-resolution-staging" not in manifest
     assert "${CLAUDE_PLUGIN_ROOT}/server" in manifest
     server = result.get_all_mcp_dependencies()[0]
-    assert server.command == str(package.resolve() / "server")
+    assert server.command == f"{package.resolve()}/server"
 
 
 def test_fresh_hash_accepts_only_the_parser_receipt_delta(tmp_path: Path) -> None:

--- a/tests/unit/test_windows_compat_gate_workflow.py
+++ b/tests/unit/test_windows_compat_gate_workflow.py
@@ -57,7 +57,8 @@ FULL_SUITE_ROOTS = ("tests/unit", "tests/test_console.py", "tests/red_team")
 # past this, that is a signal to re-examine scope. The current ceiling
 # includes the Git environment matrix plus 19 release regressions:
 # eight failures, two unmocked credential lookups, and nine Azure CLI contracts.
-MAX_BOUNDED_FAMILY_SIZE = 344
+# Six staged plugin-root contracts preserve literal suffixes on Windows.
+MAX_BOUNDED_FAMILY_SIZE = 350
 
 
 def _ci_workflow() -> dict:


### PR DESCRIPTION
## TL;DR

Correct the Windows-specific expected strings introduced in #2827 without changing production behavior. Add six focused plugin-root contracts to the native Windows PR gate, including deterministic Windows-path coverage on every host.

> [!IMPORTANT]
> Test-only release unblocker. No command normalization, integrity changes, version bump, or release actions.

## Problem (WHY)

[Windows release job 101443611556](https://github.com/microsoft/apm/actions/runs/34017435921/job/101443611556) failed exactly two unit tests: `test_normalization_persists_portable_plugin_root_paths` and `test_staged_download_records_published_mcp_args`. Actual strings end in `cached-plugin/server` and `tool/start.mjs`; the expectations used `str(root / leaf)`, converting suffixes to backslashes on Windows. Two analogous integration expectations had the same assumption.

The canonical resolver and rebasing helper replace only root substrings. Literal suffixes and embedded arguments are intentionally preserved, not interpreted as whole filesystem paths. The deterministic reproduction follows Agent Skills guidance: ["Run the skill against real tasks, then feed the results — all of them, not just failures — back into the creation process."](https://agentskills.io/skill-creation/best-practices)

## Approach (WHAT)

- Assert exact published-root-plus-literal-suffix strings.
- Retain filesystem existence, portable placeholders, published hashes, and no-staging-reference assertions.
- Select five dedicated staging tests and one legacy normalization test with `windows_compat`.
- Account for six additional cases: bounded ceiling 344 to 350, retaining previous single-case headroom.

## Implementation (HOW)

| File | Change |
| :--- | :--- |
| `tests/unit/deps/test_apm_resolver_staging_paths.py` | Correct script expectation, mark dedicated module, exercise actual substitution/rebasing owners with a Windows root. |
| `tests/unit/install/test_legacy_plugin_compat.py` | Correct command expectation; narrowly mark portable normalization test. |
| `tests/integration/test_resolution_staging_mcp_lifecycle.py` | Correct fresh/replayed server and serialized lock/Claude/Codex expectations. |
| `tests/unit/test_windows_compat_gate_workflow.py` | Increase bounded ceiling by exactly six; no workflow enumeration. |

[Deterministic owner contract](https://github.com/microsoft/apm/blob/c735c6efd/tests/unit/deps/test_apm_resolver_staging_paths.py#L109-L132).

## Diagrams

The production pipeline remains unchanged; corrected assertions and native Windows selection protect literal suffix preservation.

```mermaid
flowchart LR
    P["Stored plugin-root placeholder"] --> R["resolve_plugin_root_placeholders"]
    R --> B["rebase_plugin_root_paths"]
    B --> A["Published root plus unchanged literal suffix"]
    A --> T["Exact string and filesystem assertions"]
    T --> W["windows_compat PR gate"]
    classDef new stroke-dasharray: 5 5;
    class T,W new;
```

## Trade-offs

- Preserve exact strings rather than weaken assertions to path equivalence. Additional `PureWindowsPath` equality proves mixed separators identify the intended Windows file.
- Production, CHANGELOG, and user docs remain unchanged; #2827 already describes the runtime fix. Integration tests remain in the normal suite rather than adding workflow file enumeration.

## Benefits

1. Both observed Windows failures get corrected expectations and native PR-time coverage.
2. Both analogous integration assertions are corrected before another release attempt.
3. Six focused additional cases cover published roots, repeated/embedded roots, literal arguments, and portable placeholders.

## Validation

Before: hosted Windows release reported `2 failed, 21315 passed, 89 skipped, 21 xfailed`.

Deterministic reproduction with the real substitution owner:

```text
server: old expectation FAIL; corrected expectation PASS; Windows path identity PASS
start.mjs: old expectation FAIL; corrected expectation PASS; Windows path identity PASS
```

`uv run --extra dev pytest -q tests/unit/deps/test_apm_resolver_staging_paths.py tests/unit/install/test_legacy_plugin_compat.py tests/unit/install/test_staging_path_guard.py tests/integration/test_resolution_staging_mcp_lifecycle.py tests/unit/test_windows_compat_gate_workflow.py tests/quality`

```text
107 passed in 56.91s
```

<details><summary>Local lint and quality evidence</summary>

Canonical Ruff, format, pylint duplication, auth and architecture boundary commands passed on latest main (`2551ff037`). YAML, portable-relative-path, and file-length guards passed too.

```text
All checks passed!
1813 files already formatted
[+] auth-signal lint clean
YAML, portable-relative-path and 2100-line guards passed
[+] assertion-quality ratchet clean: AQ001=4, AQ002=12
[+] exact test duplicate ratchet clean: 1189 files, 0 allowed duplicate group(s)
```

Diagram rendered successfully with `mmdc`.

</details>

Hosted PR checks, including native Windows, are pending at creation; this is not a claim that hosted CI is green.

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
| --- | :--- | :--- | :--- | :--- |
| 1 | A staged plugin launches from its published Windows file. | Portability by manifest | `tests/unit/deps/test_apm_resolver_staging_paths.py::test_staged_download_records_published_mcp_args` (regression trap for #2827) | unit |
| 2 | A legacy cache stores portable placeholders but uses the live root. | Portability by manifest | `tests/unit/install/test_legacy_plugin_compat.py::test_normalization_persists_portable_plugin_root_paths` | unit |
| 3 | Replay preserves hash and writes lock, Claude, and Codex configs. | Secure by default; Multi-harness support | `tests/integration/test_resolution_staging_mcp_lifecycle.py` | integration |
| 4 | Embedded arguments retain punctuation and separators. | Portability by manifest | `tests/unit/deps/test_apm_resolver_staging_paths.py::test_windows_root_substitution_preserves_literal_argument_suffixes` | unit |

## How to test

- [ ] Run the affected-files pytest command above; expect no failures.
- [ ] Run `uv run --frozen --extra dev pytest -m windows_compat tests/unit tests/integration/test_lifecycle_workspace_lock.py --collect-only -q`; confirm six new cases within the bounded family.
- [ ] Wait for Windows Compatibility Gate and all other hosted checks before merging.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>