### PR TITLE
docs: reconcile published v0.29.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- `apm install` now keeps transitive plugin MCP launchers usable after
-  publication and cached replay by resolving plugin-root placeholders from the
-  published package directory. Lockfile writes and self-defined MCP
-  configuration construction reject remaining resolution-staging references
-  without echoing configuration values. (by @lkshrk, #2827)
-- Git dependency downloads retry one narrowly classified HTTPS connection failure without changing credentials or transport; lifecycle timeout tests now wait for descendant readiness before exercising process-tree termination.
-
-## [0.29.1] - 2026-09-05
+## [0.29.1] - 2026-09-06
 
 ### Security
 
@@ -38,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `apm install` now keeps transitive plugin MCP launchers usable after publication and cached replay by resolving plugin-root placeholders from the published package directory. Lockfiles and MCP configurations reject remaining resolution-staging paths without echoing configuration values. (by @lkshrk, #2827)
+- Git dependency downloads retry one narrowly classified HTTPS connection failure without changing credentials or transport. (#2839)
 - `apm install` now preserves SSH transport for semver discovery, keeps
   inactive hooks when targets are not declared in the manifest, and honors
   explicitly configured HTTP registries during MCP integration. (#2814)


### PR DESCRIPTION
# document(release): reconcile the published v0.29.1 changelog

## TL;DR

Move the already-shipped user-facing fixes from #2827 and #2839 into the existing 0.29.1 changelog section. Replace the historical planned date, 2026-09-05, with the actual publication date, 2026-09-06.

> [!IMPORTANT]
> This is a post-publication, `CHANGELOG.md`-only correction, not release preparation. The published tag `v0.29.1` remains at `1b3d80ad2bfcb7ab3ce24bdac0538855aaddf3bc`; no version bump, runtime change, tag movement, release edit, PyPI action, or new publication is included.

## Problem (WHY)

- [x] The published source still listed #2827 and the connection-retry fix from #2839 under Unreleased, even though both merge commits are ancestors of the published tag.
- [x] The existing September 5 heading recorded the planned release date. The [official release](https://github.com/microsoft/apm/releases/tag/v0.29.1) was actually published at `2026-09-06T07:47:16Z`.
- [x] The connection-retry entry lacked its PR reference and mixed user-facing recovery with test-harness implementation details.

This correction uses release metadata, PR records, and Git ancestry rather than inferred release contents, consistent with Agent Skills' guidance: ["Effective skills are grounded in real expertise."](https://agentskills.io/skill-creation/best-practices)

## Approach (WHAT)

- Move only the two confirmed shipped entries into 0.29.1's existing Fixed section.
- Keep the plugin portability attribution to @lkshrk and add the missing #2839 reference.
- Remove test-only timeout wording; do not add #2830, #2840, #2841, or #2845.
- Preserve every unrelated entry and leave an empty Unreleased placeholder.

## Implementation (HOW)

[`CHANGELOG.md`](https://github.com/microsoft/apm/blob/2f08153c2/CHANGELOG.md#L8-L34) is the only changed file. The existing release block now records published MCP launcher portability and bounded Git HTTPS connection recovery under the actual publication date. Latest `main` matched the published tag when this branch was prepared; there were no post-tag entries to relocate.

## Trade-offs

- Correct the repository history after publication instead of rewriting the immutable release or regenerating packages. The original planned date is retained here as historical context, not as the release date.
- This is documentation-only: no runtime scenario evidence or new tests are needed. Existing release entries remain otherwise untouched; internal-only PRs are excluded under the release sanitizer.

## Benefits

1. Both shipped fixes appear in the version users can install.
2. The changelog date matches the official publication timestamp.
3. Both moved entries have PR references, with external contributor credit preserved.

## Validation

Both ancestry commands exited 0:

```bash
git merge-base --is-ancestor 4b0efe2524319f91434d5fcc04cd1c1e86124d8a v0.29.1
git merge-base --is-ancestor 6cbac86ad82e491bb73bf4b76bee73b44f1bc500 v0.29.1
```

<details><summary>Local lint and scope evidence</summary>

Dependency restoration was blocked by package-host connection failures. The canonical checks ran against this worktree using an existing release-worktree environment with `uv run --no-sync`; that environment was not modified. `PYTHONPATH` selected this worktree's `src/` and `scripts/`, and `apm_cli.__file__` was confirmed to resolve here.

Ruff check:
```text
All checks passed!
```

Ruff format check:
```text
1813 files already formatted
```

Pylint R0801:
```text
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)
```

Auth-signal lint passed; the architecture boundary checker, YAML I/O guard, 2100-line guard, portable-path guard, and `git diff --check` passed. Hosted PR checks are separate and are not claimed green by this local evidence.

`git diff --stat origin/main...HEAD`:
```text
 CHANGELOG.md | 13 +++----------
 1 file changed, 3 insertions(+), 10 deletions(-)
```

</details>

## How to test

- [ ] Compare the 0.29.1 heading with the official release's `published_at`; expect September 6, 2026.
- [ ] Run the ancestry commands above; both should exit 0.
- [ ] Inspect the diff: only `CHANGELOG.md` changes, the two entries move out of Unreleased, and all unrelated entries remain unchanged.
- [ ] Review hosted checks before merging. Do not retag or republish v0.29.1.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>