### PR TITLE
chore: release v0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,23 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.0] - 2026-09-07
+
 ### Security
 
-- Unix binary installs now verify original publisher SHA-256 sidecars before
-  extraction or execution, refuse historical or mirrored archives without
-  sidecars, and never fall back to pip after integrity failures. (#2842)
-### Fixed
+- **BREAKING:** Unix binary installs now require matching original publisher SHA-256 sidecars before extraction or execution, with no pip fallback after integrity failures. For historical releases or mirrors, select a release with sidecars or update the mirrored installer and publish the original publisher sidecars alongside its archives. (#2842)
 
-- Unix installation defaults to user-local directories without profile edits or implicit `sudo`. Existing destinations are preserved, but ordinary users cannot replace root-owned or package-managed installs; ask the original administrator or package manager to update or uninstall before migrating. See [Unix install ownership and migration](https://microsoft.github.io/apm/getting-started/installation/#unix-install-ownership-and-migration). (#2844)
 ### Changed
 
+- **BREAKING:** Fresh Unix native installs default to `~/.local`, add `install.sh --prefix PATH`, and configure eligible bash/zsh/fish profiles without implicit `sudo`; set `APM_NO_MODIFY_PATH=1` to opt out of shell setup. Existing destinations are preserved, and root-owned or package-managed installs require their original administrator or package manager to update or uninstall before [migration](https://microsoft.github.io/apm/getting-started/installation/#unix-install-ownership-and-migration). (#2844)
 - macOS onboarding now recommends Homebrew core (`brew install apm`, no tap) for existing Homebrew users, with `brew upgrade apm` for updates and visible standalone alternatives. (#2846)
 
 ### Fixed
 
 - Public CLI release discovery can recover from a rejected environment token: one anonymous retry after a selected token's 401/non-rate-limit 403 only for canonical public APM metadata; metadata redirects require `APM_RELEASE_METADATA_URL` at the final JSON endpoint or a `VERSION` pin. (#2843)
+- `apm cache prune` now counts only successfully deleted SHA groups, continues after removal errors, and exits `1` with failed paths and causes when pruning is incomplete. Fix permissions or release file locks, then rerun the command. (#2865)
+- `apm prune` now exits `1` when orphan deletion fails, continues processing remaining packages, and retains failed packages' lockfile entries. Resolve the reported deletion errors and rerun `apm prune`. (#2863)
+- `apm cache prune --days` now rejects negative ages before touching the cache, preventing accidental eviction from invalid input. (#2862)
+- `apm cache prune` now retains recently reused Git checkouts by refreshing shared SHA-group recency when either a full or sparse variant is reused. (#2861)
 - `apm uninstall` now preserves declarations and deployed ownership after package deletion failures, keeping retry and reinstall recovery available after partial removal. (#2860)
 - Successful HTTP cache hits now refresh LRU recency without extending response freshness, retaining frequently used MCP registry responses. (#2859)
+- `apm cache clean` now continues removing other entries after deletion errors, reports affected paths, and exits non-zero instead of claiming complete cleanup. Resolve permissions or file locks and retry; `--force` only skips confirmation. (#2864)
+
+### Performance
+
+- Dependency policy checks now reuse canonical dependency names across required-package and executable checks, avoiding repeated name computation without changing policy results. (by @aryansk, #2588)
+- `apm compile` now reuses the resolved project base path during instruction matching and placement, avoiding repeated filesystem path resolution. (by @aryansk, #2587)
 
 ## [0.29.1] - 2026-09-06
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apm-cli"
-version = "0.29.1"
+version = "0.30.0"
 description = "MCP configuration tool"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -203,7 +203,7 @@ wheels = [
 
 [[package]]
 name = "apm-cli"
-version = "0.29.1"
+version = "0.30.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
# ship(release): prepare v0.30.0

## TL;DR

Cut release **0.30.0**: bump package metadata and finalize the **2026-09-07** changelog with 13 user-facing entries from 18 PRs merged since v0.29.1.
The minor bump covers new Unix installer configuration and automatic native shell setup, with explicit compatibility notes for installer ownership and mandatory publisher checksums.
This PR changes no runtime code and does not tag or publish a release.

> [!IMPORTANT]
> Post-merge, a maintainer must tag `v0.30.0` on the merged release commit and push that tag to trigger the release workflow.

## Problem (WHY)

- [x] Package metadata still identified the cycle as 0.29.1 while 18 additional PRs had merged; six existing Unreleased entries omitted several fixes and both contributor optimizations.
- [x] The #2844 draft said Unix installation made no profile edits, but its merged implementation and installation documentation configure eligible native bash/zsh/fish profiles.

Release notes were grounded in actual PR metadata and merged patches, following Agent Skills' guidance to use ["Version control history, especially patches and fixes (reveals patterns through what actually changed)"](https://agentskills.io/skill-creation/best-practices#synthesize-from-existing-project-artifacts), rather than inferring behavior from titles alone.

## Why minor (0.30.0), not patch (0.29.2)

#2844 adds `install.sh --prefix PATH`, `APM_NO_MODIFY_PATH`, and automatic native shell setup: new user-facing configuration triggers the release rubric's minor-bump signal.
#2842 intentionally refuses archives without original publisher sidecars, and #2844 changes Unix installation defaults and ownership rules.
These compatibility changes are marked **BREAKING** with migration guidance; the project remains pre-1.0, so this does not imply a 1.0 stability commitment.
The remaining entries cover fixes, existing-path optimizations, and Homebrew-first guidance.
The maintainer approved both 0.30.0 and the complete changelog diff.

### Compatibility and migration

| Surface | Release behavior and migration |
| :--- | :--- |
| Unix archive verification (#2842) | Missing or mismatching publisher checksums stop installation without pip fallback. Select a release with sidecars, or update the mirrored installer and publish the original publisher sidecars beside its archives. |
| Unix ownership and shell setup (#2844) | Fresh native installs default to `~/.local`; eligible bash/zsh/fish profiles are configured. Set `APM_NO_MODIFY_PATH=1` to opt out. Existing destinations remain unchanged; root-owned/package-managed installs must be updated or uninstalled by their original owner before migration. |
| Homebrew guidance (#2846) | Existing Homebrew users are directed to core `brew install apm` and `brew upgrade apm`; standalone alternatives remain documented. |

## Approach (WHAT)

- Retain an empty `[Unreleased]` placeholder and preserve all published history from `[0.29.1]` onward.
- Consolidate the release into 13 entries, mark compatibility changes, and retain @aryansk attribution for #2587 and #2588.
- Exclude test-only #2858 and #2869, historical changelog reconciliation #2847, Actions dependency maintenance #2785, and internal CI support #2870 from new release notes.
- Change only the project version and matching local-package lock entry; keep every dependency pin, hash, and public registry URL unchanged.

## Implementation (HOW)

| File | Intent and scope |
| :--- | :--- |
| [`CHANGELOG.md`](https://github.com/microsoft/apm/blob/15692dcdec08caef6fe9328b0227976c19f277ba/CHANGELOG.md#L8-L37) | Date 0.30.0, add missing fixes and optimizations, and correct the Unix shell-setup statement. |
| [`pyproject.toml`](https://github.com/microsoft/apm/blob/15692dcdec08caef6fe9328b0227976c19f277ba/pyproject.toml#L5-L7) | Set the project version to 0.30.0; no dependency or build configuration changes. |
| [`uv.lock`](https://github.com/microsoft/apm/blob/15692dcdec08caef6fe9328b0227976c19f277ba/uv.lock#L204-L207) | Update only the editable `apm-cli` package version to match project metadata. |

## Diagrams

Dashed nodes are the three artifacts changed here; tagging remains a separate human action after merge.

```mermaid
flowchart LR
    subgraph Prep["This PR"]
        C["CHANGELOG.md: 0.30.0 dated 2026-09-07"]
        P["pyproject.toml: 0.30.0"]
        L["uv.lock: apm-cli 0.30.0"]
    end
    C --> R["Release PR"]
    P --> R
    L --> R
    R --> M["Merge to main"]
    M --> H["Human: create and push v0.30.0 tag"]
    H --> W["build-release.yml"]
    classDef changed stroke-dasharray: 5 5;
    class C,P,L changed;
```

## Trade-offs

- **Release metadata only.** Runtime scenarios belong to the already-merged PRs; this is the asset/version-bump-only exception to Scenario Evidence. No test suite or binary build was run by this release-preparation task.
- **Preserve dependency provenance.** The initial `uv lock` picked up this machine's package mirror and rewrote unrelated URLs. That generated churn was discarded; the version-only lockfile passes the offline public-index consistency check.

## Benefits

1. Both version-bearing package files identify 0.30.0.
2. Thirteen release entries cover user-facing work, including two credited external-contributor optimizations.
3. Two explicitly marked compatibility entries include migration instructions.

## Validation

Refreshed against main `d592b7b8afb44dec22682b3e32d5f9760ce7a097` at release head `20f2f21646c957dcc9fe0a910d8b91b7bb3389c9`. The approved changelog and both version files are unchanged by the merge.

The [main CI/CD Pipeline run 34097665598](https://github.com/microsoft/apm/actions/runs/34097665598) completed successfully, including Windows, both Linux architectures, and macOS x86_64. It includes the Windows fixture fixes in #2869 and CodeQL merge-queue support in #2870; tag-only publishing jobs were skipped.

The canonical local lint mirror and all three source guards passed again on the refreshed release head. New PR checks must complete on that head; the successful main run is not a substitute for them.

`uv lock --check --offline --default-index https://pypi.org/simple`:

```text
Resolved 107 packages in 20ms
```

<details><summary>Local CI-mirror evidence</summary>

`uv run --frozen --extra dev ruff check src/ tests/ scripts/lint_architecture_boundaries.py scripts/architecture_linter/`:

```text
All checks passed!
```

`uv run --frozen --extra dev ruff format --check src/ tests/ scripts/lint_architecture_boundaries.py scripts/architecture_linter/`:

```text
1836 files already formatted
```

`uv run --frozen --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/ scripts/lint_architecture_boundaries.py scripts/architecture_linter/`:

```text
--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)
```

`bash scripts/lint-auth-signals.sh`:

```text
[*] Rule A: get_bearer_provider boundary (any reference)
[*] Rule B: git ls-remote auth-delegated annotation
[+] auth-signal lint clean
```

The YAML I/O and portable-relative-path checks used the CI regexes with GNU `ggrep` on macOS; the 2100-line guard and `bash scripts/lint-architecture-boundaries.sh` also passed.
The bundled release mirror passed during initial preparation; the expanded/frozen canonical commands above were rerun after merging current main.
`git diff --check` and Mermaid CLI rendering exited 0.

</details>

## How to test

- [ ] Compare `origin/main...HEAD`: only `CHANGELOG.md`, `pyproject.toml`, and `uv.lock` should differ.
- [ ] Confirm both package version fields are `0.30.0`; `uv.lock` should have exactly one changed line.
- [ ] Read the dated release block: 13 entries, two BREAKING markers, both @aryansk credits, empty Unreleased, and unchanged older history.
- [ ] Run `uv lock --check --offline --default-index https://pypi.org/simple` with the existing cache; expect a consistent 107-package lock.
- [ ] Run the canonical lint contract in `.apm/instructions/linting.instructions.md` and review remote PR CI separately.

## Post-merge

From the merged release commit on `main`, tag `v0.30.0` to trigger the release workflow:

```bash
git tag v0.30.0
git push origin v0.30.0
```

No tag was created or pushed by this task.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>