### PR TITLE
fix(tests): restore Windows cache recency CI coverage

### DIFF
--- a/tests/integration/test_isolated_apm_environment_contract.py
+++ b/tests/integration/test_isolated_apm_environment_contract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import _socket
 import inspect
 import os
 import subprocess
@@ -747,7 +748,12 @@ def test_python_child_network_is_denied(tmp_path: Path) -> None:
         )
 
         assert result.returncode != 0
-        assert result.stderr.count("IP network disabled by test environment") == 1
+        if ".sendmsg(" in script and not hasattr(_socket.socket, "sendmsg"):
+            assert "AttributeError:" in result.stderr
+            assert "has no attribute 'sendmsg'" in result.stderr
+            assert "IP network disabled by test environment" not in result.stderr
+        else:
+            assert result.stderr.count("IP network disabled by test environment") == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/cache/test_git_cache_recency.py
+++ b/tests/unit/cache/test_git_cache_recency.py
@@ -25,6 +25,12 @@ _FRESH_NS = 4102444800000000000
 _REMOTE = "https://gitlab.example.invalid/cache/recency.git"
 
 
+@pytest.fixture
+def recency_root(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Reproduce main's worker-depth fixture paths in the Windows PR gate."""
+    return tmp_path_factory.mktemp("test_checkout_recency_error_co") / "popen-gw0"
+
+
 def _populated_cache(
     tmp_path: Path, sparse_paths: list[str] | None
 ) -> tuple[GitCache, dict[str, str], tuple[Path, Path, Path]]:
@@ -67,10 +73,13 @@ def _populated_cache(
     ],
 )
 def test_successful_checkout_reuse_survives_prune(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sparse_paths: list[str] | None, refresh: bool
+    recency_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    sparse_paths: list[str] | None,
+    refresh: bool,
 ) -> None:
     """Access refreshes the shared SHA root, not merely its variant directory."""
-    cache, environment, (used, stale, fresh) = _populated_cache(tmp_path, sparse_paths)
+    cache, environment, (used, stale, fresh) = _populated_cache(recency_root, sparse_paths)
     original_inode = used.stat().st_ino
     lock_path = Path(shard_lock(used).lock_file)
     lock_path.touch()
@@ -139,7 +148,7 @@ def test_failed_sparse_validation_does_not_refresh_access(
     ],
 )
 def test_checkout_recency_error_contract(
-    tmp_path: Path,
+    recency_root: Path,
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
     refresh: bool,
@@ -149,7 +158,7 @@ def test_checkout_recency_error_contract(
     message: str,
 ) -> None:
     """Only denied recency metadata is non-fatal, with a visible recovery hint."""
-    cache, environment, (used, _stale, _fresh) = _populated_cache(tmp_path, sparse_paths)
+    cache, environment, (used, _stale, _fresh) = _populated_cache(recency_root, sparse_paths)
     error = error_type(error_number, message)
     original_inode = used.stat().st_ino
     original_utime = os.utime
@@ -191,9 +200,9 @@ def test_checkout_recency_error_contract(
 
 
 @pytest.mark.windows_compat
-def test_recency_permission_warning_reaches_default_cli_stderr(tmp_path: Path) -> None:
+def test_recency_permission_warning_reaches_default_cli_stderr(recency_root: Path) -> None:
     """The real CLI logging configuration exposes the backend warning by default."""
-    cache, environment, (used, _stale, _fresh) = _populated_cache(tmp_path, None)
+    cache, environment, (used, _stale, _fresh) = _populated_cache(recency_root, None)
     environment.pop("APM_LOG_LEVEL", None)
     result = subprocess.run(
         [

--- a/tests/unit/cache/test_git_cache_recency.py
+++ b/tests/unit/cache/test_git_cache_recency.py
@@ -27,8 +27,10 @@ _REMOTE = "https://gitlab.example.invalid/cache/recency.git"
 
 @pytest.fixture
 def recency_root(tmp_path_factory: pytest.TempPathFactory) -> Path:
-    """Reproduce main's worker-depth fixture paths in the Windows PR gate."""
-    return tmp_path_factory.mktemp("test_checkout_recency_error_co") / "popen-gw0"
+    """Keep Git metadata below MAX_PATH, including main's worker-depth layout."""
+    # Per-test names exhaust Git's config.worktree path budget. Retain an extra
+    # worker component so the unsharded Windows gate also exercises main's depth.
+    return tmp_path_factory.mktemp("r") / "popen-gw0"
 
 
 def _populated_cache(

--- a/tests/unit/cache/test_git_cache_recency.py
+++ b/tests/unit/cache/test_git_cache_recency.py
@@ -42,19 +42,25 @@ def _populated_cache(
         commits.append(repositories.commit(repository, message=name))
     environment = repositories.url_rewrite_subprocess_env(repository, _REMOTE)
     cache = GitCache(isolated.cache_root)
-    used, stale, fresh = (
-        cache.get_checkout(
-            _REMOTE, None, locked_sha=commit.sha, env=environment, sparse_paths=sparse_paths
+    try:
+        used, stale, fresh = (
+            cache.get_checkout(
+                _REMOTE, None, locked_sha=commit.sha, env=environment, sparse_paths=sparse_paths
+            )
+            for commit in commits
         )
-        for commit in commits
-    )
+    except RuntimeError as exc:
+        if isinstance(exc.__cause__, subprocess.CalledProcessError):
+            pytest.fail(f"Local Git fixture failed: {exc.__cause__.stderr}")
+        raise
     return cache, environment, (used, stale, fresh)
 
 
+@pytest.mark.windows_compat
 @pytest.mark.parametrize(
     ("refresh", "sparse_paths"),
     [
-        pytest.param(False, None, id="hit-full", marks=pytest.mark.windows_compat),
+        pytest.param(False, None, id="hit-full"),
         pytest.param(False, ["skills"], id="hit-sparse"),
         pytest.param(True, None, id="write-dedup-full"),
         pytest.param(True, ["skills"], id="write-dedup-sparse"),
@@ -121,6 +127,7 @@ def test_failed_sparse_validation_does_not_refresh_access(
     record_access.assert_not_called()
 
 
+@pytest.mark.windows_compat
 @pytest.mark.parametrize("refresh", [False, True], ids=["hit", "write-dedup"])
 @pytest.mark.parametrize("sparse_paths", [None, ["skills"]], ids=["full", "sparse"])
 @pytest.mark.parametrize(
@@ -183,6 +190,7 @@ def test_checkout_recency_error_contract(
             assert not caplog.records
 
 
+@pytest.mark.windows_compat
 def test_recency_permission_warning_reaches_default_cli_stderr(tmp_path: Path) -> None:
     """The real CLI logging configuration exposes the backend warning by default."""
     cache, environment, (used, _stale, _fresh) = _populated_cache(tmp_path, None)

--- a/tests/unit/test_isolated_network_guard.py
+++ b/tests/unit/test_isolated_network_guard.py
@@ -1,0 +1,162 @@
+"""Cross-platform capability contracts for the generated subprocess guard."""
+
+from __future__ import annotations
+
+import _socket
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.utils.isolated_apm_environment import _NETWORK_GUARD, IsolatedApmEnvironment
+
+pytestmark = [pytest.mark.component, pytest.mark.windows_compat]
+
+
+def _run_guarded_child(
+    tmp_path: Path, script: str, *, prelude: str = ""
+) -> subprocess.CompletedProcess[str]:
+    """Run a fresh interpreter with the real generated sitecustomize guard."""
+    isolated = IsolatedApmEnvironment.create(tmp_path / "scenario", base_env=os.environ)
+    if prelude:
+        (isolated.root / "network_guard" / "sitecustomize.py").write_text(
+            prelude + _NETWORK_GUARD, encoding="utf-8"
+        )
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=isolated.work_root,
+        env=isolated.subprocess_env(),
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+
+
+def test_guard_preserves_native_sendmsg_capability(tmp_path: Path) -> None:
+    """Both public constructors retain their native platform capabilities."""
+    result = _run_guarded_child(
+        tmp_path,
+        """
+import _socket, json, sitecustomize, socket
+capabilities = {}
+for module, native in (
+    (socket, sitecustomize._REAL_SOCKET),
+    (_socket, sitecustomize._REAL_RAW_SOCKET),
+):
+    expected = hasattr(native, "sendmsg")
+    for name in ("socket", "SocketType"):
+        constructor = getattr(module, name)
+        instance = constructor()
+        try:
+            assert hasattr(constructor, "sendmsg") == expected
+            assert hasattr(instance, "sendmsg") == expected
+            capabilities[module.__name__ + "." + name] = expected
+        finally:
+            instance.close()
+print(json.dumps(capabilities))
+""",
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stderr == ""
+    assert json.loads(result.stdout) == {
+        f"{module}.{constructor}": hasattr(_socket.socket, "sendmsg")
+        for module in ("socket", "_socket")
+        for constructor in ("socket", "SocketType")
+    }
+
+
+@pytest.mark.parametrize("module", ["asyncio", "unittest.mock"])
+def test_guard_allows_real_async_imports(tmp_path: Path, module: str) -> None:
+    """Fresh imports must not take a nonexistent Windows os.sysconf branch."""
+    result = _run_guarded_child(
+        tmp_path,
+        f"import importlib; print(importlib.import_module({module!r}).__name__)",
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stderr == ""
+    assert result.stdout.strip() == module
+
+
+def test_guard_without_native_sendmsg_or_sysconf(tmp_path: Path) -> None:
+    """Exercise Windows' absent capabilities deterministically on every OS."""
+    result = _run_guarded_child(
+        tmp_path,
+        """
+import asyncio, unittest.mock
+import _socket, socket
+for module in (socket, _socket):
+    for name in ("socket", "SocketType"):
+        constructor = getattr(module, name)
+        assert not hasattr(constructor, "sendmsg")
+        assert not hasattr(constructor(), "sendmsg")
+print("imports and absent capabilities preserved")
+""",
+        prelude="""
+import _socket, os, socket
+
+class _SocketWithoutSendmsg:
+    pass
+
+class _HighLevelSocketWithoutSendmsg(_SocketWithoutSendmsg):
+    pass
+
+_socket.socket = _SocketWithoutSendmsg
+socket.socket = _HighLevelSocketWithoutSendmsg
+if hasattr(os, "sysconf"):
+    del os.sysconf
+""",
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stderr == ""
+    assert result.stdout.strip() == "imports and absent capabilities preserved"
+
+
+@pytest.mark.parametrize("module", ["socket", "_socket"])
+@pytest.mark.parametrize("constructor", ["socket", "SocketType"])
+@pytest.mark.parametrize("family", ["AF_INET", "AF_INET6"])
+@pytest.mark.parametrize("operation", ["connect", "sendmsg"])
+def test_guard_denies_network_with_native_capabilities(
+    tmp_path: Path, module: str, constructor: str, family: str, operation: str
+) -> None:
+    """Deny IP traffic without manufacturing unsupported socket operations."""
+    result = _run_guarded_child(
+        tmp_path,
+        f"""
+import {module} as module
+constructor = module.{constructor}
+sock = constructor(module.{family}, module.SOCK_DGRAM)
+try:
+    operation = {operation!r}
+    supported = {operation != "sendmsg" or hasattr(_socket.socket, "sendmsg")!r}
+    assert hasattr(constructor, operation) == supported
+    address = ("203.0.113.1", 9) if {family!r} == "AF_INET" else ("2001:db8::1", 9)
+    try:
+        if operation == "sendmsg":
+            sock.sendmsg([b"x"], [], 0, address)
+        else:
+            sock.connect(address)
+    except OSError as error:
+        assert supported
+        assert str(error) == "IP network disabled by test environment"
+        print("denied")
+    except AttributeError:
+        assert not supported
+        print("unsupported")
+    else:
+        raise AssertionError("Network operation escaped guard")
+finally:
+    sock.close()
+""",
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stderr == ""
+    expected = (
+        "unsupported"
+        if operation == "sendmsg" and not hasattr(_socket.socket, "sendmsg")
+        else "denied"
+    )
+    assert result.stdout.strip() == expected

--- a/tests/utils/isolated_apm_environment.py
+++ b/tests/utils/isolated_apm_environment.py
@@ -75,10 +75,11 @@ class _GuardedSocketOperations:
             raise OSError(_MESSAGE)
         return super().sendto(*args, **kwargs)
 
-    def sendmsg(self, *args, **kwargs):
-        if self.family in (socket.AF_INET, socket.AF_INET6):
-            raise OSError(_MESSAGE)
-        return super().sendmsg(*args, **kwargs)
+    if hasattr(_REAL_RAW_SOCKET, "sendmsg"):
+        def sendmsg(self, *args, **kwargs):
+            if self.family in (socket.AF_INET, socket.AF_INET6):
+                raise OSError(_MESSAGE)
+            return super().sendmsg(*args, **kwargs)
 
 
 class _GuardedSocket(_GuardedSocketOperations, _REAL_SOCKET):


### PR DESCRIPTION
# fix(tests): restore Windows cache recency CI coverage

## TL;DR

Fix both test-harness defects behind the nine Windows main failures from #2861: overly long sparse-Git fixture paths and a socket guard that invented an unsupported Windows capability. Keep real-Git recency assertions and the no-network boundary intact, and select the regressions in the Windows PR gate.

> [!NOTE]
> Test-only: no production cache, authentication, release, dependency, or publishing changes. Release PR #2868 is untouched.

## Problem (WHY)

- [x] Main [Windows job](https://github.com/microsoft/apm/actions/runs/34091280816/job/101645083270) failed eight sparse fixture setups before reaching recency assertions.
- [x] A [worker-depth diagnostic run](https://github.com/microsoft/apm/actions/runs/34094048879/job/101653554709) exposed the exact Git error: `fatal: unable to access '.git/config.worktree': Filename too long`. Git's sparse config probe fails despite `core.longpaths=true`.
- [x] The ninth failure imported `unittest.mock` through `asyncio`, which saw a guard-provided `sendmsg` and called Windows' nonexistent `os.sysconf`.
- [!] The initial shallow PR gate passed all eight sparse cases. Main adds an xdist worker directory, so marker coverage alone was not a sufficient trap.

This fix follows observed execution rather than a guessed path diagnosis: ["Run the skill against real tasks, then feed the results — all of them, not just failures — back into the creation process."](https://agentskills.io/skill-creation/best-practices#refine-with-real-execution)

## Approach (WHAT)

- Allocate a short unique pytest root, retaining an explicit worker-depth directory even in the unsharded Windows gate.
- Define guarded `sendmsg` only if the native raw socket supports it.
- Exercise native parity, real imports, simulated missing capabilities, and IPv4/IPv6 denial without Windows skips.
- Include all nine previously failing cases in the existing marker-based gate.

## Implementation (HOW)

| File | Change |
| --- | --- |
| [`tests/unit/cache/test_git_cache_recency.py`](https://github.com/microsoft/apm/blob/04aebbfa0548815efc14e931187518b2392bed33/tests/unit/cache/test_git_cache_recency.py#L27-L87) | Short unique fixture roots retain `/popen-gw0` depth; real recency cases gain Windows selection; chained local Git failures surface captured stderr. |
| [`tests/utils/isolated_apm_environment.py`](https://github.com/microsoft/apm/blob/04aebbfa0548815efc14e931187518b2392bed33/tests/utils/isolated_apm_environment.py#L78-L83) | Guard optional `sendmsg` definition by the native capability; supported operations still deny IP traffic. |
| [`tests/unit/test_isolated_network_guard.py`](https://github.com/microsoft/apm/blob/04aebbfa0548815efc14e931187518b2392bed33/tests/unit/test_isolated_network_guard.py#L1-L166) | Twenty marker-selected cases cover constructor/instance capability parity, fresh asyncio/mock imports, simulated Windows absence, and denial through both socket modules. |
| [`tests/integration/test_isolated_apm_environment_contract.py`](https://github.com/microsoft/apm/blob/04aebbfa0548815efc14e931187518b2392bed33/tests/integration/test_isolated_apm_environment_contract.py#L749-L757) | Existing denial contracts require native `AttributeError` for unsupported `sendmsg`; supported operations still require the guard's denial. |

## Diagrams

Dashed nodes highlight the fixture-path correction, capability-preserving guard, and expanded Windows gate coverage.

```mermaid
flowchart LR
    subgraph Fixtures
        A["Short unique pytest root plus worker depth"] --> B["Real sparse and full Git checkouts"]
        B --> C["Pruning and warning assertions"]
    end
    subgraph Guard
        D["Native socket capability"] --> E["Define sendmsg only when supported"]
        E --> F["Real asyncio imports and IP denial"]
    end
    C --> G["Windows compatibility gate"]
    F --> G
    classDef new stroke-dasharray: 5 5;
    class A,E,G new;
```

## Trade-offs

- Shorten fixture paths, not production cache layout. This addresses the proven harness failure without claiming to fix arbitrary long cache roots.
- Preserve worker-equivalent depth in the unsharded gate instead of adding workflow-specific file enumeration. Under xdist it adds extra depth.
- Unsupported methods remain absent, not artificial no-op or denial methods; supported methods still enforce the no-network contract.
- Keep Git stderr diagnostics in the hermetic local-file-only fixture, not production error rendering. No inherited credentials enter that environment.

## Benefits

1. All nine original failing cases are selected before merge.
2. Twenty new cross-platform cases protect native capability parity and denial.
3. The sparse fixture trap retains the depth that reproduced main's failures.

## Validation

Final [Windows Compatibility Gate](https://github.com/microsoft/apm/actions/runs/34094792720/job/101655853019) at `04aebbfa0548815efc14e931187518b2392bed33`:

```text
== 423 passed, 2 skipped, 21759 deselected, 4 warnings in 234.21s (0:03:54) ===
```

The log explicitly passes all nine original failures at retained worker depth and all twenty new socket cases. All current PR checks pass (CodeQL summary is neutral; both analysis jobs succeeded). The full post-merge Windows build and 21k-test suite were not rerun; this is actual focused Windows evidence.

`uv run --frozen --extra dev pytest -q -n 2 tests/unit/cache/test_git_cache_recency.py tests/unit/test_isolated_network_guard.py tests/integration/test_isolated_apm_environment_contract.py -p no:cacheprovider`:

```text
53 passed in 13.36s
```

`uv run --frozen --extra dev pytest -q tests/quality -p no:cacheprovider`:

```text
63 passed in 41.98s
```

<details><summary>Regression proof and additional evidence</summary>

Before correction, the worker-depth Windows diagnostic revision reproduced all nine original failures:

```text
9 failed, 394 passed, 2 skipped, 21759 deselected, 4 warnings in 235.72s (0:03:55)
```

The new simulated-Windows socket regression failed against the original guard with the same missing `os.sysconf` traceback: 1 failed, 19 passed.

Neighboring cache and hermetic/lifecycle tests: `279 passed, 2 skipped in 27.08s`.

After merging current main, the canonical lint chain passed: Ruff check and format including architecture scripts, pylint R0801, YAML I/O, file length, portable paths, auth signals, and architecture boundaries. Assertion/duplicate ratchets and the Mermaid renderer also passed.

The pytest processes emitted cleanup warnings for pre-existing temporary directories outside this worktree, unrelated to the passing cases. Dependency bootstrap used exact frozen exported versions through the configured index after direct files.pythonhosted.org downloads failed. `uv.lock` is unchanged.

Docs-sync: schema-validated L0 `no_change`, high confidence; all four changed files match the corpus index's test-only no-impact rule. Two bounded reviews found no meaningful correctness or coverage issues.

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
| :---: | --- | --- | --- | --- |
| 1 | Recently used cached content survives pruning | DevX (pragmatic as npm) | `tests/unit/cache/test_git_cache_recency.py::test_successful_checkout_reuse_survives_prune` | integration |
| 2 | Timestamp denial warns without losing usable content; other failures propagate | DevX (pragmatic as npm) | `tests/unit/cache/test_git_cache_recency.py::test_checkout_recency_error_contract` | integration |
| 3 | Default CLI stderr exposes the recovery hint on Windows | DevX (pragmatic as npm) | `tests/unit/cache/test_git_cache_recency.py::test_recency_permission_warning_reaches_default_cli_stderr` (regression trap) | integration |
| 4 | Contributors can run isolated Python imports without enabling IP traffic | OSS / community-driven, Secure by default | `tests/unit/test_isolated_network_guard.py`, including `test_guard_without_native_sendmsg_or_sysconf` (regression trap), and `tests/integration/test_isolated_apm_environment_contract.py::test_python_child_network_is_denied` | integration |

## How to test

- [ ] Run `uv sync --frozen --extra dev`.
- [ ] Run the 53-case targeted command above; all cases should pass with two actual xdist workers.
- [ ] Run `uv run --frozen --extra dev pytest -m windows_compat -q tests/unit/cache/test_git_cache_recency.py tests/unit/test_isolated_network_guard.py`; all 37 selected cases should pass.
- [ ] Inspect the final Windows Compatibility Gate, including the eight sparse cases at retained worker-equivalent depth and the CLI stderr case.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>