### PR TITLE
fix(hashing): use explicit SHA-2 policy digests and synthetic fixture IDs

### DIFF
--- a/.apm/architecture/owners/contracts-tooling.json
+++ b/.apm/architecture/owners/contracts-tooling.json
@@ -20,6 +20,13 @@
       "guards": ["contracts-tooling-cached-policy-shape"]
     },
     {
+      "id": "policy-content-hash",
+      "decision": "SHA-2 digest computation for policy pin verification and cache metadata",
+      "owner": "policy/project_config.py (compute_policy_hash)",
+      "selectors": ["src/apm_cli/policy/project_config.py"],
+      "guards": ["contracts-tooling-policy-content-hash"]
+    },
+    {
       "id": "apply-to-hidden-tool-placement",
       "decision": "applyTo normalization and hidden-tool placement",
       "owner": "utils/patterns.py (normalize_apply_to); compilation/context_optimizer.py (ContextOptimizer)",

--- a/docs/src/content/docs/enterprise/policy-reference.md
+++ b/docs/src/content/docs/enterprise/policy-reference.md
@@ -849,7 +849,7 @@ shasum -a 256 .github/apm-policy.yml | awk '{print "sha256:" $1}'
 
 When set, every install / `apm policy status` / `apm audit --ci` verifies the hash of the fetched leaf policy bytes (UTF-8 encoded, **before** YAML parsing -- so re-serialized semantically-equivalent YAML still fails). A mismatch is **always** fail-closed regardless of `policy.fetch_failure` / `policy.fetch_failure_default`. The pin applies only to the leaf policy; parents in an `extends:` chain remain the leaf author's responsibility.
 
-A malformed pin (unsupported algorithm, wrong length, non-hex) is rejected at parse time -- silently ignoring it would defeat the security guarantee. MD5 and SHA-1 are not accepted.
+A malformed pin (unsupported algorithm, wrong length, non-hex) is rejected at parse time -- silently ignoring it would defeat the security guarantee. Only SHA-256, SHA-384, and SHA-512 are supported.
 
 Compute the pin on Linux with `sha256sum .github/apm-policy.yml | awk '{print "sha256:" $1}'`.
 

--- a/scripts/architecture_linter/checks/contracts_test_taxonomy.py
+++ b/scripts/architecture_linter/checks/contracts_test_taxonomy.py
@@ -60,6 +60,9 @@ _GUARD_DEPENDENCY_IDENTITY = "contracts-tooling-dependency-identity"
 _GUARD_CACHED_POLICY = "contracts-tooling-cached-policy-shape"
 
 
+_GUARD_POLICY_HASH = "contracts-tooling-policy-content-hash"
+
+
 _GUARD_APPLY_TO = "contracts-tooling-apply-to-placement"
 
 
@@ -703,6 +706,35 @@ def check_cached_policy_shape(provider: FactsProvider) -> tuple[Violation, ...]:
     )
 
 
+def check_policy_content_hash(provider: FactsProvider) -> tuple[Violation, ...]:
+    """Policy verification and cache digests must use the same SHA-2 owner."""
+    rule_id = _GUARD_POLICY_HASH
+    policy, failures = _facts_for(provider, _POLICY_OWNER, rule_id)
+    if failures:
+        return tuple(failures)
+    findings: list[Violation] = []
+    for name in ("_verify_hash_pin", "_compute_hash_normalized"):
+        function = policy.tree_index.function(name)
+        nodes = policy.tree_index.own_scope(function) if function is not None else ()
+        calls = _named_calls(nodes, "compute_policy_hash")
+        direct_hashes = [
+            node
+            for node in nodes
+            if isinstance(node, ast.Attribute)
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "hashlib"
+        ]
+        if len(calls) != 1 or direct_hashes:
+            findings.append(
+                _summary(
+                    rule_id,
+                    _POLICY_OWNER,
+                    f"{name} must delegate digest computation to compute_policy_hash",
+                )
+            )
+    return tuple(findings)
+
+
 _APPLY_TO_OWNER = "src/apm_cli/utils/patterns.py"
 
 
@@ -1306,6 +1338,11 @@ RULES: tuple[Rule, ...] = (
         _GUARD_CACHED_POLICY,
         "Cached policy shape and ADO coordinate stay owned by policy/discovery.py.",
         check_cached_policy_shape,
+    ),
+    _owner_rule(
+        _GUARD_POLICY_HASH,
+        "Policy pin verification and cache digests use project_config.compute_policy_hash.",
+        check_policy_content_hash,
     ),
     _owner_rule(
         _GUARD_APPLY_TO,

--- a/src/apm_cli/policy/discovery.py
+++ b/src/apm_cli/policy/discovery.py
@@ -160,9 +160,7 @@ def _verify_hash_pin(
             expected_hash=expected_hash,
         )
 
-    digest = hashlib.new(algo)
-    digest.update(raw_bytes)
-    actual_hex = digest.hexdigest().lower()
+    actual_hex = compute_policy_hash(raw_bytes, algo)
     if actual_hex == expected_hex:
         return None
 

--- a/src/apm_cli/policy/project_config.py
+++ b/src/apm_cli/policy/project_config.py
@@ -204,9 +204,10 @@ def read_project_policy_hash_pin(
     return parse_project_policy_hash_pin(policy_block)
 
 
-def compute_policy_hash(content: str, algorithm: str = _DEFAULT_HASH_ALGORITHM) -> str:
+def compute_policy_hash(content: str | bytes, algorithm: str = _DEFAULT_HASH_ALGORITHM) -> str:
     """Compute the digest of fetched policy content under *algorithm*.
 
+    Text is encoded as UTF-8; bytes are hashed without decoding or normalization.
     The hash is computed on the **UTF-8 bytes of the raw policy text** --
     the same bytes that ``yaml.safe_load`` consumes -- so a malicious
     mirror cannot return semantically equivalent YAML with different bytes
@@ -218,6 +219,13 @@ def compute_policy_hash(content: str, algorithm: str = _DEFAULT_HASH_ALGORITHM) 
         raise ProjectPolicyConfigError(
             f"Refusing to compute policy hash with unsupported algorithm '{algorithm}'"
         )
-    digest = hashlib.new(algorithm)
-    digest.update(content.encode("utf-8"))
-    return digest.hexdigest()
+    raw_bytes = content.encode("utf-8") if isinstance(content, str) else content
+    if algorithm == "sha256":
+        return hashlib.sha256(raw_bytes).hexdigest()
+    if algorithm == "sha384":
+        return hashlib.sha384(raw_bytes).hexdigest()
+    if algorithm == "sha512":
+        return hashlib.sha512(raw_bytes).hexdigest()
+    raise ProjectPolicyConfigError(
+        f"Refusing to compute policy hash with unsupported algorithm '{algorithm}'"
+    )

--- a/tests/benchmarks/test_git_and_compiler_benchmarks.py
+++ b/tests/benchmarks/test_git_and_compiler_benchmarks.py
@@ -9,7 +9,6 @@ Covers three CPU-bound code-paths:
 Run with: uv run pytest tests/benchmarks/test_git_and_compiler_benchmarks.py -v -m benchmark
 """
 
-import hashlib
 import time
 from dataclasses import dataclass, field  # noqa: F401
 from pathlib import Path
@@ -33,8 +32,17 @@ from apm_cli.primitives.models import Instruction
 
 
 def _make_sha(index: int) -> str:
-    """Generate a deterministic 40-hex-char SHA for a given index."""
-    return hashlib.sha1(f"ref-{index}".encode()).hexdigest()  # noqa: S324
+    """Generate a synthetic 40-hex-character object ID, not a Git object hash."""
+    return f"{index + 1:040x}"
+
+
+def test_synthetic_object_ids_preserve_format_and_uniqueness() -> None:
+    """Fixture IDs stay deterministic and distinct across all benchmark ranges."""
+    ids = [_make_sha(index) for index in range(10500)]
+    assert len(set(ids)) == len(ids)
+    assert all(len(value) == 40 and set(value) <= set("0123456789abcdef") for value in ids)
+    assert "0" * 40 not in ids
+    assert ids == [_make_sha(index) for index in range(10500)]
 
 
 def _generate_ls_remote_output(ref_count: int) -> str:
@@ -188,6 +196,13 @@ class TestParseLsRemoteThroughput:
         tag_refs = [r for r in refs if r.ref_type == GitReferenceType.TAG]
         branch_refs = [r for r in refs if r.ref_type == GitReferenceType.BRANCH]
         assert len(tag_refs) + len(branch_refs) == len(refs)
+        assert len(refs) == ref_count
+        assert {ref.commit_sha for ref in tag_refs} == {
+            _make_sha(index) for index in range(int(ref_count * 0.6))
+        }
+        assert {ref.commit_sha for ref in branch_refs} == {
+            _make_sha(index + 5000) for index in range(ref_count - int(ref_count * 0.6))
+        }
         # Generous ceiling (5x expected) -- catches catastrophic regressions only.
         # Scaling guards in the default test suite handle O(n^2) detection.
         assert elapsed < ceiling, (

--- a/tests/integration/test_architecture_owner_rule_mutations.py
+++ b/tests/integration/test_architecture_owner_rule_mutations.py
@@ -174,6 +174,14 @@ MUTATIONS: tuple[MutationCase, ...] = (
         intent="An Agent Plugin consumer reimplements the reproducible timestamp fallback.",
     ),
     MutationCase(
+        guard_id="contracts-tooling-policy-content-hash",
+        rule_id="contracts-tooling-policy-content-hash",
+        path="src/apm_cli/policy/discovery.py",
+        old="actual_hex = compute_policy_hash(raw_bytes, algo)",
+        new="actual_hex = _local_policy_hash(raw_bytes, algo)",
+        intent="Policy verification bypasses the canonical SHA-2 digest owner.",
+    ),
+    MutationCase(
         guard_id="contracts-tooling-project-yaml-write-delegation",
         rule_id="contracts-tooling-project-yaml-write-delegation",
         path="src/apm_cli/utils/yaml_io.py",

--- a/tests/unit/policy/test_policy_hash_pin.py
+++ b/tests/unit/policy/test_policy_hash_pin.py
@@ -24,14 +24,19 @@ import pytest
 from apm_cli.install.phases.policy_gate import PolicyViolationError, run
 from apm_cli.policy.discovery import (
     PolicyFetchResult,
+    _compute_hash_normalized,
+    _fetch_from_repo,
     _verify_hash_pin,
+    _write_cache,
     discover_policy_with_chain,
 )
 from apm_cli.policy.project_config import (
     ProjectPolicyConfigError,
+    compute_policy_hash,
     parse_project_policy_hash_pin,
     read_project_policy_hash_pin,
 )
+from apm_cli.policy.schema import ApmPolicy
 
 _VALID_POLICY_YAML = "name: org-policy\nversion: '1.0'\nenforcement: warn\n"
 
@@ -50,6 +55,43 @@ def _sha384(content: str) -> str:
 
 
 class TestVerifyHashPin:
+    def test_default_and_bare_pin_remain_sha256(self) -> None:
+        """Default hashing and case-insensitive bare pins retain SHA-256 semantics."""
+        digest = _sha256(_VALID_POLICY_YAML)
+        assert compute_policy_hash(_VALID_POLICY_YAML) == digest
+        assert _compute_hash_normalized(_VALID_POLICY_YAML, None) == f"sha256:{digest}"
+        assert _verify_hash_pin(_VALID_POLICY_YAML, digest.upper(), "file:x") is None
+
+    @pytest.mark.parametrize("algorithm", ["sha256", "sha384", "sha512"])
+    @pytest.mark.parametrize("content", ["name: caf\u00e9\r\n", b"\xffraw\r\nbytes"])
+    def test_explicit_sha2_preserves_raw_bytes(self, algorithm: str, content: str | bytes) -> None:
+        """All approved algorithms retain their exact byte-level digest."""
+        raw_bytes = content.encode("utf-8") if isinstance(content, str) else content
+        constructors = {
+            "sha256": hashlib.sha256,
+            "sha384": hashlib.sha384,
+            "sha512": hashlib.sha512,
+        }
+        expected = constructors[algorithm](raw_bytes).hexdigest()
+        with patch("hashlib.new", side_effect=AssertionError("dynamic digest selection")):
+            assert compute_policy_hash(content, algorithm) == expected
+            assert _verify_hash_pin(content, f"{algorithm}:{expected}", "file:x") is None
+            mismatch = _verify_hash_pin(content, f"{algorithm}:{'0' * len(expected)}", "file:x")
+        assert mismatch is not None
+        assert mismatch.outcome == "hash_mismatch"
+        assert mismatch.policy is None
+        assert mismatch.raw_bytes_hash == f"{algorithm}:{expected}"
+
+    @pytest.mark.parametrize("algorithm", ["md5", "sha1", "blake2b", "unknown"])
+    def test_unsupported_algorithms_still_fail_closed(self, algorithm: str) -> None:
+        """Neither direct hashing nor discovery accepts an unapproved digest."""
+        with pytest.raises(ProjectPolicyConfigError, match="unsupported algorithm"):
+            compute_policy_hash("payload", algorithm)
+        result = _verify_hash_pin("payload", f"{algorithm}:{'0' * 64}", "file:x")
+        assert result is not None
+        assert result.outcome == "hash_mismatch"
+        assert result.policy is None
+
     def test_no_pin_returns_none(self):
         assert _verify_hash_pin("anything", None, "file:x") is None
 
@@ -92,6 +134,36 @@ class TestVerifyHashPin:
         mismatch = _verify_hash_pin(b, f"sha256:{digest_a}", "x")
         assert mismatch is not None
         assert mismatch.outcome == "hash_mismatch"
+
+
+@pytest.mark.parametrize("algorithm", ["sha256", "sha384", "sha512"])
+def test_existing_sha2_cache_digest_remains_compatible(tmp_path: Path, algorithm: str) -> None:
+    """Existing digest sidecars remain usable; changed pins still fail closed."""
+    constructors = {
+        "sha256": hashlib.sha256,
+        "sha384": hashlib.sha384,
+        "sha512": hashlib.sha512,
+    }
+    digest = constructors[algorithm](_VALID_POLICY_YAML.encode("utf-8")).hexdigest()
+    pin = f"{algorithm}:{digest}"
+    policy = ApmPolicy(name="cached-policy", enforcement="block")
+    _write_cache("org/.github", policy, tmp_path, raw_bytes_hash=pin)
+    with patch("hashlib.new", side_effect=AssertionError("dynamic digest selection")):
+        assert _compute_hash_normalized(_VALID_POLICY_YAML, pin.upper()) == pin
+        cached = _fetch_from_repo(
+            "org/.github", tmp_path, expected_hash=pin.upper(), cache_only=True
+        )
+        mismatch = _fetch_from_repo(
+            "org/.github",
+            tmp_path,
+            expected_hash=f"{algorithm}:{'0' * len(digest)}",
+            cache_only=True,
+        )
+    assert cached.cached is True
+    assert cached.policy == policy
+    assert cached.raw_bytes_hash == pin
+    assert mismatch.outcome == "hash_mismatch"
+    assert mismatch.policy is None
 
 
 # =====================================================================

--- a/tests/unit/scripts/test_architecture_runner.py
+++ b/tests/unit/scripts/test_architecture_runner.py
@@ -611,6 +611,7 @@ contracts-tooling-lockfile-read
 contracts-tooling-lockfile-timestamp
 contracts-tooling-lockfile-timestamp-constructor
 contracts-tooling-lockfile-timestamp-fallback
+contracts-tooling-policy-content-hash
 contracts-tooling-project-yaml-write-delegation
 install-deployment-approval-outcome-routing
 install-deployment-audit-policy-discovery


### PR DESCRIPTION
# fix(hashing): use explicit SHA-2 policy digests and synthetic fixture IDs

## TL;DR

Remove benchmark-only SHA-1 and replace dynamic policy digest construction with explicit SHA-256/384/512 APIs in the existing hash owner. This addresses surviving source patterns associated with `SM02167` / `py/weak-hashes` without changing accepted policy algorithms, pins, cache identities, or real Git object hashing.

> [!IMPORTANT]
> Policy hashing already rejected weak algorithms. This is not evidence of an exploitable weak-policy hash, and the private Microsoft CodeQL query pack was **not rerun**.

## Problem (WHY)

- [x] [`_make_sha` on current main](https://github.com/microsoft/apm/blob/d8a9bd0d279314b91ba445926d72ecc07af41d22/tests/benchmarks/test_git_and_compiler_benchmarks.py#L35-L37) still used SHA-1 only to manufacture synthetic reference/lockfile IDs.
- [!] Policy verification and `compute_policy_hash` still called `hashlib.new(variable)`, despite restricting that variable to SHA-256/384/512. Explicit constructors remove this dynamic-API ambiguity without broadening the allowlist.
- [!] The two reported `discovery.py` locations (lines 35/89) do not identify hashing calls even at the report's recorded commit, `0ae9a78c6129e41caf87cb75130f9006b31ed98d`. The current dynamic sites are `discovery._verify_hash_pin` and `project_config.compute_policy_hash`; exact attribution of those two old findings cannot be established from their locations alone.

Source inspection and executable regressions, rather than alert-record state, are the evidence here: ["do the work, run a validator (a script, a reference checklist, or a self-check), fix any issues, and repeat until validation passes."](https://agentskills.io/skill-creation/best-practices#validation-loops)

## Approach (WHAT)

| # | Fix |
| :---: | --- |
| 1 | Use the existing `compute_policy_hash` owner for both verification and cache-metadata digests, with explicit SHA-2 constructors. |
| 2 | Generate positive, zero-padded 40-character hexadecimal fixture IDs without hashing. |
| 3 | Preserve the byte-level contract with regressions and register the required single-owner architecture guard. |

## Implementation (HOW)

| File | Intent |
| --- | --- |
| `src/apm_cli/policy/project_config.py` | Accept text or raw bytes; retain the allowlist and error wording; dispatch through explicit SHA-2 constructors. |
| `src/apm_cli/policy/discovery.py` | Delegate pin verification to the same helper already used for cache-metadata digests. |
| `tests/benchmarks/test_git_and_compiler_benchmarks.py` | Remove SHA-1 and its suppression; check fixture uniqueness, nonzero 40-hex shape, determinism, and parsed tag/branch IDs. |
| `tests/unit/policy/test_policy_hash_pin.py` | Cover SHA-256/384/512, UTF-8/CRLF and arbitrary bytes, unsupported names, default/bare/normalized pins, cache compatibility, and fail-closed mismatch. |
| `.apm/architecture/owners/contracts-tooling.json` | Register the existing policy-content hash owner. |
| `scripts/architecture_linter/checks/contracts_test_taxonomy.py` | Require both discovery digest paths to delegate, rather than introduce local hashing. |
| `tests/integration/test_architecture_owner_rule_mutations.py` | Prove the new owner guard rejects bypassing that delegation. |
| `tests/unit/scripts/test_architecture_runner.py` | Keep the registered rule catalog expectation synchronized. |
| `docs/src/content/docs/enterprise/policy-reference.md` | Clarify the existing exhaustive SHA-2 allowlist in one sentence. |

## Diagrams

Both discovery digest paths now share the same explicit SHA-2 implementation; dashed nodes identify the changed implementation.

```mermaid
flowchart LR
    subgraph Discovery
        V["_verify_hash_pin"]
        C["_compute_hash_normalized"]
    end
    subgraph Owner["project_config.py"]
        H["compute_policy_hash"]
        S["Explicit SHA-256 / SHA-384 / SHA-512"]
    end
    V --> H
    C --> H
    H --> S
    classDef changed stroke-dasharray: 5 5;
    class H,S changed;
```

## Trade-offs

- Use literal SHA-2 constructor calls rather than suppressing the scanner or accepting dynamic algorithm names. The allowlist, default, normalization, mismatch errors, and digests remain unchanged; no cache invalidation or migration is needed.
- Counter IDs replace hashing only in synthetic fixtures. They are not real Git object IDs or integrity values. No README/changelog entry, manifest/schema change, CodeQL configuration change, alert dismissal, or protection-rule change is included.

## Benefits

1. No SHA-1 or dynamic `hashlib.new` calls remain in the three affected source/test files.
2. All three supported policy algorithms retain their existing raw-byte digests and cached-pin compatibility.
3. A registered, mutation-tested boundary prevents policy verification from bypassing the digest owner.

## Validation

Local validation on `d8a9bd0d2` plus this commit; this is not a claim about remote CI or the private query pack.

<details><summary>Focused regression and lint evidence</summary>

`uv run --frozen --extra dev pytest -q -m 'not live'` with the selectors below explicitly includes benchmarks:

```text
tests/unit/policy/test_policy_hash_pin.py
tests/unit/policy/test_cache_merged_effective.py
tests/unit/policy/test_discovery_policy_resolution.py
tests/unit/policy/test_discovery_phase3w4.py
tests/benchmarks/test_git_and_compiler_benchmarks.py
tests/unit/scripts/test_architecture_runner.py
tests/integration/test_architecture_owner_rule_mutations.py
```

```text
743 passed in 162.71s (0:02:42)
```

Full canonical lint mirror after merging latest main: Ruff check/format over `src/`, `tests/`, and architecture-linter sources; pylint R0801; YAML I/O, 2100-line, portable-relative-path guards; auth signals; architecture boundaries. All exited 0. The three grep-style guards used equivalent Python regex/line scans on macOS, not an unavailable `rg` executable.

`uv run --frozen python scripts/check_test_assertions.py`:

```text
[+] assertion-quality ratchet clean: AQ001=4, AQ002=12
```

`uv run --frozen python scripts/check_exact_test_duplicates.py`:

```text
[+] exact test duplicate ratchet clean: 1208 files, 0 allowed duplicate group(s)
```

AST inspection confirmed no `hashlib.new`, `hashlib.sha1`, or `hashlib.md5` calls in the three affected files. Mermaid validated with `mmdc` 11.15.0. `uv.lock` is unchanged.

</details>

### Scenario Evidence

| # | Scenario (preserved user promise) | Principle | Test proving it | Type |
| :---: | --- | --- | --- | --- |
| 1 | Existing SHA-2 pins still verify exactly the same bytes; altered bytes fail closed. | Governed by policy | `tests/unit/policy/test_policy_hash_pin.py::TestVerifyHashPin::test_explicit_sha2_preserves_raw_bytes` | unit |
| 2 | Cached policy remains usable with the matching pin; a different pin is rejected offline. | Secure by default | `tests/unit/policy/test_policy_hash_pin.py::test_existing_sha2_cache_digest_remains_compatible` | integration (in-process cache/discovery) |
| 3 | Unsupported digest names remain rejected rather than silently changing policy enforcement. | Governed by policy | `tests/unit/policy/test_policy_hash_pin.py::TestVerifyHashPin::test_unsupported_algorithms_still_fail_closed` | unit |

## How to test

- [ ] Run `uv run --frozen --extra dev pytest -q tests/unit/policy/test_policy_hash_pin.py tests/unit/policy/test_cache_merged_effective.py`; matching pins/cache entries should pass and mismatches should fail closed.
- [ ] Run `uv run --frozen --extra dev pytest -q -m 'not live' tests/benchmarks/test_git_and_compiler_benchmarks.py`; all fixture and benchmark cases should pass.
- [ ] Run `bash scripts/lint-architecture-boundaries.sh` and `uv run --frozen --extra dev pytest -q tests/integration/test_architecture_owner_rule_mutations.py -k policy-content-hash`; the current source should pass and the in-memory delegation mutation should be detected.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>