### PR TITLE
fix(tests): prove global uninstall recovery after partial removal

### DIFF
--- a/tests/integration/test_global_scope_e2e.py
+++ b/tests/integration/test_global_scope_e2e.py
@@ -779,17 +779,33 @@ class TestGlobalUninstallLifecycle:
         assert not (apm_dir / "apm_modules" / "_local" / "removed-target-cleanup").exists()
         assert (apm_dir / "apm_modules" / "_local" / "survivor-target-cleanup").exists()
 
+    @pytest.mark.parametrize("resolution", ["restore", "remove"])
     def test_uninstall_global_preserves_state_for_user_edited_removed_target_file(
         self,
         apm_binary_path,
         fake_home,
         tmp_path,
+        resolution: str,
     ):
-        """A retained edited file leaves all removal state available for retry."""
+        """Retained ownership permits retry after package content was removed."""
         removed, survivor_file, removed_file = self._install_survivor_and_removed_target_packages(
             apm_binary_path, fake_home, tmp_path
         )
-        removed_file.write_text("# user edit\n", encoding="utf-8")
+        apm_dir = fake_home / ".apm"
+        manifest_path = apm_dir / "apm.yml"
+        lockfile_path = apm_dir / "apm.lock.yaml"
+        removed_materialized = apm_dir / "apm_modules" / "_local" / "removed-target-cleanup"
+        survivor_materialized = apm_dir / "apm_modules" / "_local" / "survivor-target-cleanup"
+        assert removed_materialized.is_dir()
+        assert survivor_materialized.is_dir()
+        manifest_before = manifest_path.read_bytes()
+        lockfile_before = lockfile_path.read_bytes()
+        survivor_before = survivor_file.read_bytes()
+        survivor_source = survivor_materialized / ".apm" / "skills" / "survivor" / "SKILL.md"
+        survivor_source_before = survivor_source.read_bytes()
+        managed_bytes = removed_file.read_bytes()
+        edited_bytes = b"# user edit\n"
+        removed_file.write_bytes(edited_bytes)
 
         result = _run_apm(
             apm_binary_path,
@@ -799,15 +815,44 @@ class TestGlobalUninstallLifecycle:
         )
 
         combined = result.stdout + result.stderr
-        apm_dir = fake_home / ".apm"
         assert result.returncode != 0, combined
+        assert "Uninstall complete" not in combined
         assert ".config/opencode/agents/orphan.md" in combined
         assert "retry uninstall" in combined
-        assert removed_file.exists()
-        assert survivor_file.exists()
-        assert "removed-target-cleanup" in (apm_dir / "apm.yml").read_text(encoding="utf-8")
-        assert "removed-target-cleanup" in (apm_dir / "apm.lock.yaml").read_text(encoding="utf-8")
-        assert (apm_dir / "apm_modules" / "_local" / "removed-target-cleanup").exists()
+        assert removed_file.read_bytes() == edited_bytes
+        assert survivor_file.read_bytes() == survivor_before
+        assert manifest_path.read_bytes() == manifest_before
+        assert lockfile_path.read_bytes() == lockfile_before
+        assert survivor_materialized.is_dir()
+        assert survivor_source.read_bytes() == survivor_source_before
+        # Package deletion precedes target cleanup; ownership, not content, survives.
+        assert not removed_materialized.exists()
+
+        if resolution == "restore":
+            removed_file.write_bytes(managed_bytes)
+        else:
+            removed_file.unlink()
+        retry = _run_apm(
+            apm_binary_path,
+            ["uninstall", "--global", str(removed)],
+            fake_home,
+            fake_home,
+        )
+        assert retry.returncode == 0, retry.stdout + retry.stderr
+        assert "Uninstall complete" in retry.stdout
+        assert not removed_file.exists()
+        assert not removed_materialized.exists()
+        assert survivor_file.read_bytes() == survivor_before
+        assert survivor_materialized.is_dir()
+        assert survivor_source.read_bytes() == survivor_source_before
+        manifest_after = manifest_path.read_text(encoding="utf-8")
+        lockfile_after = lockfile_path.read_text(encoding="utf-8")
+        assert "removed-target-cleanup" not in manifest_after
+        assert "removed-target-cleanup" not in lockfile_after
+        assert ".config/opencode/agents/orphan.md" not in lockfile_after
+        assert "survivor-target-cleanup" in manifest_after
+        assert "survivor-target-cleanup" in lockfile_after
+        assert ".agents/skills/survivor/SKILL.md" in lockfile_after
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## TL;DR

Correct the stale global-uninstall integration contract that blocked the unpublished v0.30.0 release. Package directories are intentionally deleted before target cleanup; manifest and lockfile ownership, not package-directory rollback, make retries recoverable. Strengthen the test to prove both supported recovery paths against the exact tagged macOS ARM binary.

> [!IMPORTANT]
> Test-only change. No runtime, dependency, lockfile, version, changelog, or packaging changes. Merge/tag/release recovery remains with the release maintainer.

## Problem (WHY)

- [x] [Tagged release run 34099752136](https://github.com/microsoft/apm/actions/runs/34099752136) failed the same final directory-existence assertion on Linux ARM and macOS ARM. The edited file, nonzero exit, manifest, and lockfile assertions all passed.
- [x] #2860 intentionally moved package deletion before target cleanup. The [documented contract](https://github.com/microsoft/apm/blob/d8a9bd0d279314b91ba445926d72ecc07af41d22/docs/src/content/docs/reference/cli/uninstall.md#L143-L147) says directories may already be gone while declarations and deployed ownership remain.
- [!] The old test stopped at refusal and never proved the advertised retry could finish.

The correction follows the Agent Skills validation pattern: ["do the work, run a validator (a script, a reference checklist, or a self-check), fix any issues, and repeat until validation passes."](https://agentskills.io/skill-creation/best-practices#validation-loops) Here the evidence is a failing original test and passing strengthened tests against the same release executable.

## Approach (WHAT)

- Replace the obsolete package-directory rollback expectation with an explicit assertion that deletion occurred.
- Require byte-identical manifest, lockfile, edited target, and surviving deployed/materialized skill content during refusal.
- Parameterize restoring the managed target bytes or removing the edited target; retry the identical uninstall command and assert only the removed package's state disappears.

## Implementation (HOW)

[`tests/integration/test_global_scope_e2e.py`](https://github.com/microsoft/apm/blob/924a0e3bd6ba6eaa95a4ff076f8bbd3d2b80644d/tests/integration/test_global_scope_e2e.py#L782-L855) extends the existing global-uninstall test through recovery. Precondition assertions establish that both packages were materialized, so the new absence assertion cannot pass vacuously. Final assertions cover removed manifest/lock entries and the removed OpenCode deployment path, while preserving the survivor's declaration, deployment record, source bytes, and deployed bytes.

## Diagrams

The lifecycle below shows existing production behavior and the two newly proven recovery paths; runtime ordering is unchanged.

```mermaid
stateDiagram-v2
    [*] --> Installed
    Installed --> Edited: overwrite managed OpenCode agent
    Edited --> OwnershipRetained: uninstall exits nonzero after package deletion
    note right of OwnershipRetained
        Exact manifest, lockfile and edited bytes remain.
        Survivor source and deployment remain unchanged.
    end note
    OwnershipRetained --> Restored: restore managed agent bytes
    OwnershipRetained --> Removed: remove edited agent file
    Restored --> Recovered: retry same uninstall command
    Removed --> Recovered: retry same uninstall command
    note right of Recovered
        NEW proof for both recovery paths.
        Removed ownership gone; survivor still installed.
    end note
    Recovered --> [*]
```

## Trade-offs

- Preserve #2860's documented partial-removal semantics rather than reorder production cleanup to satisfy an obsolete test. No skipped cases or weakened user-data assertions.
- Exact-artifact execution was local macOS ARM, not a substitute for the entire tag-only cross-platform suite. Linux ARM evidence comes from the original release failure; the restarted release pipeline must establish full-platform success. Existing docs already describe this contract, so there is no documentation or release-note change.

## Benefits

1. The original release-blocking case passes against the same executable that exposed the stale expectation.
2. Two recovery paths now reach a successful second uninstall.
3. Byte-level assertions detect metadata, edited-file, and survivor corruption that existence-only checks would miss.

## Validation

The binary was downloaded from the failed release run's `apm-darwin-arm64` artifact and selected with `APM_BINARY_PATH`. It was not rebuilt or modified.

Original class against that binary:

```text
FAILED tests/integration/test_global_scope_e2e.py::TestGlobalUninstallLifecycle::test_uninstall_global_preserves_state_for_user_edited_removed_target_file
1 failed, 3 passed in 17.22s
```

Final tree, same binary:

```bash
APM_BINARY_PATH=/path/to/artifact/dist/apm-darwin-arm64/apm \
uv run --no-sync --frozen --extra dev pytest --no-cov -q \
  tests/integration/test_global_scope_e2e.py \
  tests/integration/test_uninstall_deletion_failure_lifecycle.py --tb=short
```

```text
42 passed in 66.03s (0:01:06)
```

The global-scope module uses the selected frozen binary. The neighboring deletion-failure module uses its existing source subprocess fault-injection harness.

<details><summary>Local lint and quality evidence</summary>

Canonical Ruff check/format, pylint R0801, auth boundary, YAML I/O, 2100-line, portable-relative-path, and architecture-boundary guards passed. Environment-only `--no-sync --frozen` prevented machine-index lockfile churn; installed versions were restored from `uv export --frozen --extra dev`.

```text
All checks passed!
1836 files already formatted
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)
[+] auth-signal lint clean
[+] assertion-quality ratchet clean: AQ001=4, AQ002=12
[+] exact test duplicate ratchet clean: 1208 files, 0 allowed duplicate group(s)
```

`git diff --check` passed. Mermaid CLI rendered the lifecycle diagram successfully. Remote PR CI status is reported by GitHub checks, not implied by these local results.

</details>

### Scenario Evidence

Both cases are in `tests/integration/test_global_scope_e2e.py::TestGlobalUninstallLifecycle::test_uninstall_global_preserves_state_for_user_edited_removed_target_file`.

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|---|---|---|---|
| 1 | My edited file and ownership survive a refused global uninstall, even after the package directory is removed. | Secure by default; DevX (pragmatic as npm) | Both `[restore]` and `[remove]` cases; regression correction for the v0.30.0 release failure | e2e |
| 2 | Restoring the original managed file lets the same uninstall command finish. | DevX (pragmatic as npm) | `[restore]` | e2e |
| 3 | Removing the conflicting file lets the same uninstall command finish. | DevX (pragmatic as npm) | `[remove]` | e2e |
| 4 | My unrelated global skill remains installed and unchanged through refusal and retry. | Multi-harness support | Both `[restore]` and `[remove]` cases | e2e |

## How to test

- [ ] Install the development dependencies with `uv sync --frozen --extra dev`.
- [ ] Download the failed run's `apm-darwin-arm64` artifact on macOS ARM, make its `apm` executable, and set `APM_BINARY_PATH` to that absolute executable path.
- [ ] Run the two-module command above; expect all 42 cases to pass with no skips.
- [ ] Inspect the diff: only the global-scope integration test changes; runtime, version, released notes, and lockfile remain untouched.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>