### PR TITLE
fix(ci): recover native Windows workflow contract tests

### DIFF
--- a/tests/unit/install/test_services.py
+++ b/tests/unit/install/test_services.py
@@ -258,6 +258,7 @@ class TestDeployedPathEntry:
         assert result == expected
 
 
+@pytest.mark.windows_compat
 def test_skill_bundle_file_entries_omit_python_compiled_artifacts(tmp_path: Path) -> None:
     project_root = tmp_path / "project"
     skill_dir = project_root / ".agents" / "skills" / "example"
@@ -271,7 +272,7 @@ def test_skill_bundle_file_entries_omit_python_compiled_artifacts(tmp_path: Path
 
     entries = skill_bundle_file_entries(skill_dir, project_root, targets=[])
 
-    assert entries == [
+    assert sorted(entries) == [
         ".agents/skills/example/SKILL.md",
         ".agents/skills/example/scripts/helper.py",
     ]

--- a/tests/unit/integration/test_cleanup_skill_dirs.py
+++ b/tests/unit/integration/test_cleanup_skill_dirs.py
@@ -134,6 +134,7 @@ class TestSkillDirectoryCleanup:
         assert ".agents/skills/my-skill" in result.deleted
         assert not (project_root / ".agents/skills/my-skill").exists()
 
+    @pytest.mark.windows_compat
     def test_skill_dir_removed_when_only_generated_bytecode_remains(
         self,
         project_root,
@@ -162,7 +163,7 @@ class TestSkillDirectoryCleanup:
             recorded_hashes=recorded_hashes,
         )
 
-        assert entries == [
+        assert sorted(entries) == [
             ".agents/skills/my-skill/SKILL.md",
             ".agents/skills/my-skill/scripts/helper.py",
         ]

--- a/tests/unit/test_shared_apm_workflow_contract.py
+++ b/tests/unit/test_shared_apm_workflow_contract.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 import json
 import os
 import re
+import shutil
 import subprocess
+import sys
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 import yaml
@@ -127,6 +130,62 @@ def _package_token_step() -> dict:
     return next(step for step in apm_job["steps"] if step.get("name") == "Select APM package token")
 
 
+def _run_bash(script: str, *, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    """Execute an extracted workflow step with its declared test environment."""
+    # Windows' ambient bash.exe can be the WSL launcher, not Git Bash.
+    search_path = (
+        str(Path(os.environ["PROGRAMFILES"]) / "Git" / "bin") if sys.platform == "win32" else None
+    )
+    executable = shutil.which("bash", path=search_path)
+    if executable is None:
+        raise FileNotFoundError("Workflow contract tests require native Bash (Git for Windows)")
+    return subprocess.run(
+        (executable, "-c", script),
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**os.environ, **env},
+        timeout=30,
+    )
+
+
+@pytest.mark.windows_compat
+@pytest.mark.parametrize("platform", ["win32", "linux", "darwin"])
+def test_workflow_shell_resolves_native_bash(
+    monkeypatch: pytest.MonkeyPatch, platform: str
+) -> None:
+    """Never dispatch a workflow through Windows' ambient WSL launcher."""
+    monkeypatch.setattr(sys, "platform", platform)
+    monkeypatch.setenv("PROGRAMFILES", "C:/Program Files")
+    search_path = str(Path("C:/Program Files") / "Git" / "bin") if platform == "win32" else None
+    executable = str(Path(search_path) / "bash.exe") if search_path else "/bin/bash"
+    with (
+        patch("shutil.which", return_value=executable) as which,
+        patch("subprocess.run") as run,
+    ):
+        result = _run_bash("printf '%s' \"$VALUE\"", env={"VALUE": "workflow value"})
+
+    which.assert_called_once_with("bash", path=search_path)
+    run.assert_called_once_with(
+        (executable, "-c", "printf '%s' \"$VALUE\""),
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**os.environ, "VALUE": "workflow value"},
+        timeout=30,
+    )
+    assert result is run.return_value
+
+
+@pytest.mark.windows_compat
+def test_workflow_shell_does_not_fall_back_when_native_bash_is_missing() -> None:
+    """A missing prerequisite must fail rather than skip or dispatch to WSL."""
+    with patch("shutil.which", return_value=None), patch("subprocess.run") as run:
+        with pytest.raises(FileNotFoundError, match="require native Bash"):
+            _run_bash("exit 0", env={})
+    run.assert_not_called()
+
+
 def _run_compute_step(
     tmp_path: Path,
     *,
@@ -137,15 +196,11 @@ def _run_compute_step(
     legacy_app_id: str = "",
 ) -> tuple[str, dict]:
     assert packages is None or packages_literal is None
-    output = tmp_path / "github-output"
+    output = tmp_path / "github output"
     compute = _compute_step()
-    result = subprocess.run(
-        ("bash", "-c", compute["run"]),
-        capture_output=True,
-        text=True,
-        check=False,
+    result = _run_bash(
+        compute["run"],
         env={
-            **os.environ,
             "AW_APM_PACKAGES": packages_literal
             if packages_literal is not None
             else json.dumps(packages or []),
@@ -154,7 +209,7 @@ def _run_compute_step(
             "AW_APM_LEGACY_OWNER": "",
             "AW_APM_LEGACY_REPOS": "",
             "AW_APM_TOKEN_SOURCE": token_source,
-            "GITHUB_OUTPUT": str(output),
+            "GITHUB_OUTPUT": output.as_posix(),
         },
     )
     assert result.returncode == 0, result.stdout + result.stderr
@@ -303,6 +358,7 @@ def test_shared_apm_fallback_token_has_current_repo_read_only() -> None:
         ("CASCADE", "builtin", "app", "cascade", None, 1),
     ],
 )
+@pytest.mark.windows_compat
 def test_shared_apm_token_selection_has_no_cross_identity_fallback(
     tmp_path: Path,
     token_source: str,
@@ -312,22 +368,18 @@ def test_shared_apm_token_selection_has_no_cross_identity_fallback(
     expected_token: str | None,
     expected_code: int,
 ) -> None:
-    output = tmp_path / "github-output"
+    output = tmp_path / "github output"
     selector = _package_token_step()
-    result = subprocess.run(
-        ("bash", "-c", selector["run"]),
-        capture_output=True,
-        text=True,
-        check=False,
+    result = _run_bash(
+        selector["run"],
         env={
-            **os.environ,
             "ROW_TOKEN_SOURCE": token_source,
             "BUILTIN_TOKEN": builtin_token,
             "APP_TOKEN": app_token,
             "CASCADE_TOKEN": cascade_token,
             "HAS_PLUGINS_TOKEN": "false",
             "HAS_GH_AW_TOKEN": "false",
-            "GITHUB_OUTPUT": str(output),
+            "GITHUB_OUTPUT": output.as_posix(),
         },
     )
 
@@ -353,27 +405,24 @@ def test_shared_apm_token_selection_has_no_cross_identity_fallback(
         ("false", "false", "cascade:GITHUB_TOKEN"),
     ],
 )
+@pytest.mark.windows_compat
 def test_shared_apm_reports_nonsecret_cascade_tier(
     tmp_path: Path,
     has_plugins: str,
     has_gh_aw: str,
     expected_tier: str,
 ) -> None:
-    output = tmp_path / "github-output"
-    result = subprocess.run(
-        ("bash", "-c", _package_token_step()["run"]),
-        capture_output=True,
-        text=True,
-        check=False,
+    output = tmp_path / "github output"
+    result = _run_bash(
+        _package_token_step()["run"],
         env={
-            **os.environ,
             "ROW_TOKEN_SOURCE": "cascade",
             "BUILTIN_TOKEN": "",
             "APP_TOKEN": "",
             "CASCADE_TOKEN": "selected",
             "HAS_PLUGINS_TOKEN": has_plugins,
             "HAS_GH_AW_TOKEN": has_gh_aw,
-            "GITHUB_OUTPUT": str(output),
+            "GITHUB_OUTPUT": output.as_posix(),
         },
     )
 
@@ -403,6 +452,7 @@ def test_job_level_credential_relay_slots_are_frozen() -> None:
 
 
 @pytest.mark.parametrize("token_source", ["cascade", "github-token"])
+@pytest.mark.windows_compat
 def test_shared_apm_routes_no_app_token_source_explicitly(
     tmp_path: Path,
     token_source: str,
@@ -435,6 +485,7 @@ def test_shared_apm_routes_no_app_token_source_explicitly(
     }
 
 
+@pytest.mark.windows_compat
 def test_shared_apm_app_rows_keep_minted_token_precedence(tmp_path: Path) -> None:
     packages = ["DevExpGbb/private-package#abc"]
 
@@ -459,6 +510,7 @@ def test_shared_apm_app_rows_keep_minted_token_precedence(tmp_path: Path) -> Non
     ]
 
 
+@pytest.mark.windows_compat
 def test_shared_apm_app_array_rows_always_mint_regardless_of_selector(
     tmp_path: Path,
 ) -> None:
@@ -482,6 +534,7 @@ def test_shared_apm_app_array_rows_always_mint_regardless_of_selector(
     assert [row["token-source"] for row in matrix["group"]] == ["app"]
 
 
+@pytest.mark.windows_compat
 def test_shared_apm_matrix_rows_carry_no_credential_material(
     tmp_path: Path,
 ) -> None:
@@ -508,6 +561,7 @@ def test_shared_apm_matrix_rows_carry_no_credential_material(
     assert "111" not in raw
 
 
+@pytest.mark.windows_compat
 def test_shared_apm_repairs_go_slice_formatted_packages(tmp_path: Path) -> None:
     _raw, matrix = _run_compute_step(
         tmp_path,
@@ -534,6 +588,7 @@ def test_shared_apm_repairs_go_slice_formatted_packages(tmp_path: Path) -> None:
         ("copilot,ALL", 1, "degrades to auto-detection"),
     ],
 )
+@pytest.mark.windows_compat
 def test_shared_apm_rejects_empty_or_cli_only_target(
     target: str,
     expected_code: int,
@@ -542,12 +597,9 @@ def test_shared_apm_rejects_empty_or_cli_only_target(
     validate = _validate_step()
     assert validate["env"]["AW_APM_TARGET"] == TARGET_EXPRESSION
 
-    result = subprocess.run(
-        ("bash", "-c", validate["run"]),
-        capture_output=True,
-        text=True,
-        check=False,
-        env={**os.environ, "AW_APM_TARGET": target},
+    result = _run_bash(
+        validate["run"],
+        env={"AW_APM_TARGET": target},
     )
 
     assert result.returncode == expected_code
@@ -564,18 +616,16 @@ def test_shared_apm_rejects_empty_or_cli_only_target(
         ("auto", 1, "expected cascade or github-token"),
     ],
 )
+@pytest.mark.windows_compat
 def test_shared_apm_rejects_unknown_token_source(
     token_source: str,
     expected_code: int,
     expected_fragment: str,
 ) -> None:
     validate = _token_source_step()
-    result = subprocess.run(
-        ("bash", "-c", validate["run"]),
-        capture_output=True,
-        text=True,
-        check=False,
-        env={**os.environ, "AW_APM_TOKEN_SOURCE": token_source},
+    result = _run_bash(
+        validate["run"],
+        env={"AW_APM_TOKEN_SOURCE": token_source},
     )
 
     assert result.returncode == expected_code

--- a/tests/unit/test_shared_apm_workflow_contract.py
+++ b/tests/unit/test_shared_apm_workflow_contract.py
@@ -133,12 +133,18 @@ def _package_token_step() -> dict:
 def _run_bash(script: str, *, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
     """Execute an extracted workflow step with its declared test environment."""
     # Windows' ambient bash.exe can be the WSL launcher, not Git Bash.
-    search_path = (
-        str(Path(os.environ["PROGRAMFILES"]) / "Git" / "bin") if sys.platform == "win32" else None
-    )
+    search_path = None
+    if sys.platform == "win32":
+        program_files = os.environ.get("PROGRAMFILES")
+        if not program_files:
+            raise FileNotFoundError(
+                "Workflow contract tests require PROGRAMFILES to locate Git for Windows Bash"
+            )
+        search_path = str(Path(program_files) / "Git" / "bin")
     executable = shutil.which("bash", path=search_path)
     if executable is None:
-        raise FileNotFoundError("Workflow contract tests require native Bash (Git for Windows)")
+        recovery = "install Git for Windows" if sys.platform == "win32" else "install bash on PATH"
+        raise FileNotFoundError(f"Workflow contract tests require native Bash; {recovery}")
     return subprocess.run(
         (executable, "-c", script),
         capture_output=True,
@@ -183,6 +189,59 @@ def test_workflow_shell_does_not_fall_back_when_native_bash_is_missing() -> None
     with patch("shutil.which", return_value=None), patch("subprocess.run") as run:
         with pytest.raises(FileNotFoundError, match="require native Bash"):
             _run_bash("exit 0", env={})
+    run.assert_not_called()
+
+
+@pytest.mark.windows_compat
+@pytest.mark.parametrize(
+    ("platform", "program_files", "message"),
+    [
+        (
+            "win32",
+            None,
+            "Workflow contract tests require PROGRAMFILES to locate Git for Windows Bash",
+        ),
+        (
+            "win32",
+            "",
+            "Workflow contract tests require PROGRAMFILES to locate Git for Windows Bash",
+        ),
+        (
+            "win32",
+            "C:/Program Files",
+            "Workflow contract tests require native Bash; install Git for Windows",
+        ),
+        (
+            "linux",
+            None,
+            "Workflow contract tests require native Bash; install bash on PATH",
+        ),
+        (
+            "darwin",
+            None,
+            "Workflow contract tests require native Bash; install bash on PATH",
+        ),
+    ],
+)
+def test_workflow_shell_reports_missing_native_bash_prerequisites(
+    monkeypatch: pytest.MonkeyPatch,
+    platform: str,
+    program_files: str | None,
+    message: str,
+) -> None:
+    """Missing prerequisites fail explicitly without dispatching another shell."""
+    monkeypatch.setattr(sys, "platform", platform)
+    if program_files is None:
+        monkeypatch.delenv("PROGRAMFILES", raising=False)
+    else:
+        monkeypatch.setenv("PROGRAMFILES", program_files)
+
+    with patch("shutil.which", return_value=None) as which, patch("subprocess.run") as run:
+        with pytest.raises(FileNotFoundError, match=f"^{re.escape(message)}$"):
+            _run_bash("exit 0", env={})
+
+    if platform == "win32" and not program_files:
+        which.assert_not_called()
     run.assert_not_called()
 
 


### PR DESCRIPTION
# fix(ci): recover native Windows workflow contract tests

## TL;DR

Fix the two test-harness portability defects behind 29 failures in current main's Windows release job. Production code and workflow behavior remain unchanged: Windows executes Git Bash rather than the WSL launcher, and inventory assertions compare exact membership without imposing POSIX Path ordering.

> [!IMPORTANT]
> Refs #2866. Its original smoke failures were addressed by #2842 and #2869; this PR addresses the newer Windows failures introduced by #2706 in [run 34133483378](https://github.com/microsoft/apm/actions/runs/34133483378/job/101778914426). The [native Windows Compatibility Gate](https://github.com/microsoft/apm/actions/runs/34138219067/job/101794029283) passed, including all 38 selected cases in the touched modules. All 15 reported PR checks passed at head `0b84190fc14403710dd6527320a15eceb5db1840`. The full post-merge release matrix has not been rerun on this branch.

## Problem (WHY)

- Two inventory assertions expect `SKILL.md` before `scripts/helper.py`, but Windows Path sorting is case-insensitive and returns the reverse order. Both required files are present.
- Five bare `bash` invocation sites resolve the Windows WSL launcher, which reports no installed distributions. The workflow's token and target logic never executes in those failures.
- These cases need native PR-time coverage, not skips or weaker negative assertions. The execute-and-revise approach follows Agent Skills: ["Run the skill against real tasks, then feed the results"](https://agentskills.io/skill-creation/best-practices#refine-with-real-execution); here, actual failed CI cases supply the regression evidence.

## Approach (WHAT)

| Change | Preserved contract |
| :--- | :--- |
| Resolve Bash explicitly from `%PROGRAMFILES%/Git/bin` on Windows; resolve Bash on PATH on POSIX | Execute the original workflow scripts; no WSL fallback or skip |
| Pass forward-slash `GITHUB_OUTPUT` paths containing a space | Real file creation, quoting, token masking and matrix parsing assertions |
| Sort inventory strings at assertion time | Exact membership and cardinality, artifact exclusion and real cleanup |
| Mark the affected cases `windows_compat` | Full normal-suite coverage plus the existing native PR gate |

## Implementation (HOW)

| File | Change |
| :--- | :--- |
| [`tests/unit/test_shared_apm_workflow_contract.py`](https://github.com/microsoft/apm/blob/0b84190fc14403710dd6527320a15eceb5db1840/tests/unit/test_shared_apm_workflow_contract.py#L133-L189) | One local shell runner, resolver regression cases, shell-safe output paths and focused Windows markers |
| `tests/unit/install/test_services.py` | Order-independent exact inventory assertion and Windows marker |
| `tests/unit/integration/test_cleanup_skill_dirs.py` | Same inventory correction; all file/directory removal and unmanaged-file assertions retained |

Architecture impact: **not-applicable** to production authority. `skill_bundle_file_entries` still owns inventory generation and `shared/apm.md` still owns workflow token/target decisions. No source, workflow, README, CHANGELOG or documentation changes.

## Diagrams

Dashed nodes show the changed test-harness selection and output-path boundary; workflow scripts remain unchanged.

```mermaid
flowchart LR
    subgraph Tests["Workflow contract tests"]
        S["Extract unchanged shared/apm.md steps"]
    end
    subgraph Harness["Native shell selection"]
        W{"sys.platform == win32"}
        G["Resolve Git for Windows Bash"]
        P["Resolve POSIX Bash"]
        E["Fail if native Bash is missing"]
    end
    subgraph Execution["Real subprocess"]
        R["Run Bash and jq with inherited PATH"]
        O["Write shell-safe GITHUB_OUTPUT path"]
        A["Assert token, target and matrix contracts"]
    end
    S --> W
    W -->|Yes| G
    W -->|No| P
    G -->|Found| R
    P -->|Found| R
    G -->|Missing| E
    P -->|Missing| E
    R --> O --> A
    classDef new stroke-dasharray: 5 5;
    class W,G,P,E,O new;
```

## Trade-offs

- The Windows harness requires the hosted runner's standard Git for Windows installation rather than probing or falling back to WSL. Missing Bash fails explicitly; jq failures remain observable through existing process/output assertions.
- Production ordering is deliberately unchanged. Sorting strings only for comparison rejects missing, duplicate and unwanted entries without inventing a new lockfile ordering contract.
- Resolver-selection tests mock platform and executable lookup; the existing marked tests still run real Bash/jq and inspect real output files on the native Windows runner.

## Benefits

1. All five workflow-shell call sites use the same bounded, explicit executable selection.
2. Both inventory tests tolerate valid Windows ordering without losing artifact or cleanup checks.
3. The affected execution cases now run in the existing Windows PR gate, without changing the full scheduled matrix.

## Validation

`uv run --extra dev pytest -q --disable-warnings -p no:cacheprovider --basetemp=<session-temp> tests/unit/test_shared_apm_workflow_contract.py tests/unit/install/test_services.py tests/unit/integration/test_cleanup_skill_dirs.py tests/unit/test_windows_compat_gate_workflow.py`:

```text
121 passed in 22.05s
```

All seven canonical local lint gates passed after merging current `origin/main`: Ruff check and format, YAML safety, 2100-line limit, portable paths, pylint R0801 and auth signals. Architecture boundaries and both test-quality ratchets also passed. Mermaid rendered with `mmdc`.

<details><summary>Red/green and mutation evidence</summary>

| Probe | Result |
| :--- | :--- |
| Resolver regression before explicit lookup | 3 failures: executable was never resolved |
| Actual inventory/cleanup tests with Windows Path ordering, before assertion correction | 2 failures: reversed order only |
| Same Windows-order probe after correction | 2 passed |
| Revert explicit subprocess argv to bare `bash` | 3 resolver failures |
| Omit an inventory member | Both inventory assertions fail |
| Duplicate an inventory member | Both inventory assertions fail |
| Disable generated-artifact filtering | Both inventory assertions fail |

All mutations were restored before the final focused run. Native Windows reported `461 passed, 2 skipped, 21900 deselected, 4 warnings in 282.70s`. All 38 selected cases in the three touched modules passed; none was skipped. The two skips belong to other existing tests.

</details>

### Scenario Evidence

| Scenario | Principle | Regression evidence |
| :--- | :--- | :--- |
| Contributors can exercise workflow token/target rules on Windows, including negative inputs | OSS / community-driven; Secure by default | `tests/unit/test_shared_apm_workflow_contract.py`: resolver regression plus existing real-shell token, target and matrix cases |
| Installed skill inventories exclude generated bytecode, and managed cleanup still removes the skill | DevX (pragmatic as npm) | `test_skill_bundle_file_entries_omit_python_compiled_artifacts`; `test_skill_dir_removed_when_only_generated_bytecode_remains` |

## How to test

- [ ] Run the focused pytest command above.
- [ ] Run `uv run --extra dev pytest -m windows_compat tests/unit/test_shared_apm_workflow_contract.py tests/unit/install/test_services.py tests/unit/integration/test_cleanup_skill_dirs.py` on Windows with Git for Windows and jq installed.
- [ ] Inspect the PR's Windows Compatibility Gate for real subprocess and output-file results, not only the mocked resolver tests.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>