### PR TITLE
fix(registry): exact version selectors must match published build metadata

### DIFF
--- a/src/apm_cli/deps/registry/resolver.py
+++ b/src/apm_cli/deps/registry/resolver.py
@@ -233,6 +233,18 @@ class RegistryPackageResolver:
                 f"constraint (version selector required)"
             )
         version_strings = [v.version for v in versions]
+
+        # Exact-string match always wins, before range matching runs. This
+        # matters for semver-shaped selectors too: range matching (below)
+        # ignores build metadata per the semver spec, so a selector like
+        # '1.0.2+fa163e16' would otherwise tie with, and could resolve to,
+        # a *different* published build such as '1.0.2+863e11af'. No real
+        # range operator ('^', '~', '>=', a wildcard, ...) can ever equal a
+        # published version string, so this can't shadow genuine ranges.
+        exact = next((v for v in versions if v.version == spec), None)
+        if exact is not None:
+            return exact
+
         if not is_semver_range(spec):
             from apm_cli.models.dependency.identity import _looks_like_invalid_semver_range
 
@@ -244,15 +256,13 @@ class RegistryPackageResolver:
                     f"use a complete range like '^1.0.0' or a published version"
                 )
             # Non-semver selector: exact match per the registry HTTP API spec
-            # (section 1.3 -- "Non-semver selectors are matched exactly").
-            chosen = next((v for v in versions if v.version == spec), None)
-            if chosen is None:
-                raise RegistryResolutionError(
-                    f"version {spec!r} not found for {dep_ref.repo_url!r} "
-                    f"in registry {dep_ref.registry_name!r} "
-                    f"(available: {', '.join(version_strings) or '<none>'})"
-                )
-            return chosen
+            # (section 1.3 -- "Non-semver selectors are matched exactly") --
+            # already tried above and failed.
+            raise RegistryResolutionError(
+                f"version {spec!r} not found for {dep_ref.repo_url!r} "
+                f"in registry {dep_ref.registry_name!r} "
+                f"(available: {', '.join(version_strings) or '<none>'})"
+            )
         best = pick_best(spec, version_strings)
         if best is None:
             raise RegistryResolutionError(

--- a/tests/unit/registry/test_resolver.py
+++ b/tests/unit/registry/test_resolver.py
@@ -200,22 +200,29 @@ class TestHappyPath:
         # by build metadata (e.g. a branch-build git hash). Range matching
         # ignores build metadata entirely, so without an exact-match check
         # first, this selector could resolve to the *other* build depending on
-        # version-list order (microsoft/apm#2877).
-        raw, digest = _make_apm_tarball(version="1.0.2")
+        # version-list order (microsoft/apm#2877). Each build gets its own
+        # tarball (apm.yml version matches its VersionEntry) so a wrong pick
+        # would surface as a hash/content mismatch, not just a mock-call check.
+        raw_863e, digest_863e = _make_apm_tarball(version="1.0.2+863e11af")
+        raw_fa16, digest_fa16 = _make_apm_tarball(version="1.0.2+fa163e16")
         fake = MagicMock(spec=RegistryClient)
         fake.list_versions.return_value = [
             VersionEntry(
                 version="1.0.2+863e11af",
-                digest=f"sha256:{digest}",
+                digest=f"sha256:{digest_863e}",
                 published_at="2026-01-01T00:00:00Z",
             ),
             VersionEntry(
                 version="1.0.2+fa163e16",
-                digest=f"sha256:{digest}",
+                digest=f"sha256:{digest_fa16}",
                 published_at="2026-01-02T00:00:00Z",
             ),
         ]
-        fake.download_archive.return_value = (raw, "application/gzip")
+        archives = {
+            "1.0.2+863e11af": (raw_863e, "application/gzip"),
+            "1.0.2+fa163e16": (raw_fa16, "application/gzip"),
+        }
+        fake.download_archive.side_effect = lambda owner, repo, version: archives[version]
         fake.archive_url.return_value = "https://x/download"
 
         resolver = _make_resolver(fake)
@@ -227,7 +234,7 @@ class TestHappyPath:
         # A selector with no build metadata still resolves via range matching
         # when no published version literally equals the selector string --
         # the exact-match fast path must not change this existing behavior.
-        raw, digest = _make_apm_tarball(version="1.0.2")
+        raw, digest = _make_apm_tarball(version="1.0.2+aaa")
         fake = MagicMock(spec=RegistryClient)
         fake.list_versions.return_value = [
             VersionEntry(

--- a/tests/unit/registry/test_resolver.py
+++ b/tests/unit/registry/test_resolver.py
@@ -195,6 +195,53 @@ class TestHappyPath:
         # Confirm download_archive was asked for the highest matching version.
         fake.download_archive.assert_called_once_with("acme", "web-skills", "1.5.3")
 
+    def test_build_metadata_selector_matches_exact_build(self, tmp_path):
+        # Two published builds share the same major.minor.patch and differ only
+        # by build metadata (e.g. a branch-build git hash). Range matching
+        # ignores build metadata entirely, so without an exact-match check
+        # first, this selector could resolve to the *other* build depending on
+        # version-list order (microsoft/apm#2877).
+        raw, digest = _make_apm_tarball(version="1.0.2")
+        fake = MagicMock(spec=RegistryClient)
+        fake.list_versions.return_value = [
+            VersionEntry(
+                version="1.0.2+863e11af",
+                digest=f"sha256:{digest}",
+                published_at="2026-01-01T00:00:00Z",
+            ),
+            VersionEntry(
+                version="1.0.2+fa163e16",
+                digest=f"sha256:{digest}",
+                published_at="2026-01-02T00:00:00Z",
+            ),
+        ]
+        fake.download_archive.return_value = (raw, "application/gzip")
+        fake.archive_url.return_value = "https://x/download"
+
+        resolver = _make_resolver(fake)
+        resolver.download_package(_make_dep("1.0.2+fa163e16"), tmp_path / "p")
+
+        fake.download_archive.assert_called_once_with("acme", "web-skills", "1.0.2+fa163e16")
+
+    def test_bare_version_selector_unaffected_by_exact_match(self, tmp_path):
+        # A selector with no build metadata still resolves via range matching
+        # when no published version literally equals the selector string --
+        # the exact-match fast path must not change this existing behavior.
+        raw, digest = _make_apm_tarball(version="1.0.2")
+        fake = MagicMock(spec=RegistryClient)
+        fake.list_versions.return_value = [
+            VersionEntry(
+                version="1.0.2+aaa", digest=f"sha256:{digest}", published_at="2026-01-01T00:00:00Z"
+            ),
+        ]
+        fake.download_archive.return_value = (raw, "application/gzip")
+        fake.archive_url.return_value = "https://x/download"
+
+        resolver = _make_resolver(fake)
+        resolver.download_package(_make_dep("1.0.2"), tmp_path / "p")
+
+        fake.download_archive.assert_called_once_with("acme", "web-skills", "1.0.2+aaa")
+
 
 class TestFailurePaths:
     def test_hash_mismatch_fails_closed(self, tmp_path):


### PR DESCRIPTION
## Summary

Fixes #2877: a version selector with no range operator (e.g. `1.0.2+fa163e16`) was routed through semver range matching, which ignores build metadata in every comparison. Two published builds sharing the same `major.minor.patch` (e.g. `1.0.2+fa163e16` and `1.0.2+863e11af`) tied under that comparison, so the resolver could silently return a different build than the one requested — non-deterministically, based on the order the registry listed versions in.

**Fix:** check for an exact string match against the published version list before falling into range matching (`RegistryPackageResolver._pick_version`). This is a minimal, scoped change — it doesn't touch `is_semver_range`/`pick_best`/`satisfies_range` or any of their other callers (marketplace plugin resolution, `apm outdated`, git-tag resolution, drift checks). Real ranges (`^`, `~`, `>=`, wildcards) are unaffected, since none of them can ever equal a published version string literally, so the new exact-match check never shadows genuine range matching. An unqualified selector like `1.0.0` keeps resolving exactly as it does today when no published version literally equals `1.0.0`.

## Test plan

- [x] Added `test_build_metadata_selector_matches_exact_build`: two builds of `1.0.2` differing only by build metadata; selecting one by its full exact string now reliably returns that build.
- [x] Added `test_bare_version_selector_unaffected_by_exact_match`: confirms a bare selector (`1.0.2`) still resolves via range matching when no version literally equals it, unchanged from current behavior.
- [x] `.venv/bin/python -m pytest tests/unit/registry/ -q` — 282 passed, 2 xfailed (no regressions).
- [x] `.venv/bin/python -m pytest tests/unit/ -k "resolver or semver or registry" -q` — 2215 passed, 20 xfailed (no regressions).
- [x] `ruff check` / `ruff format --check` on changed files — clean.
