### PR TITLE
docs(security): clarify insecure transport policy

### DIFF
--- a/docs/src/content/docs/enterprise/security.md
+++ b/docs/src/content/docs/enterprise/security.md
@@ -565,8 +565,38 @@ For an org standardizing on APM:
 - Publish an `apm-policy.yml` from your `<org>/.github` repo with an allow list and an MCP transport restriction. See [Governance Guide](../governance-guide/).
 - Require signed commits on the source repos APM pulls from -- this is where the trust chain bottoms out.
 - Route dep traffic through an enterprise proxy with audit logging. See [Registry Proxy & Air-gapped](../registry-proxy/).
-- Forbid `allow_insecure: true` via the policy allow list, except where an air-gapped mirror demands it.
+- Treat insecure transport as a separate CI control. `apm-policy.yml` has no
+  dedicated `allow_insecure` field: `dependencies.allow` and
+  `dependencies.deny` match scheme- and host-blind canonical package names, so
+  they restrict which packages may install but cannot distinguish `http://`
+  from `https://` for the same package. Reject committed
+  `allow_insecure: true` entries and prohibit `--allow-insecure` and
+  `--allow-insecure-host` in standard CI; review both explicit gates for any
+  air-gapped exception. `registry_source.allow_non_registry` is a separate
+  source-routing control, not an insecure-transport setting.
 - Scan committed `apm.yml` for literal secrets in `mcp.env` values -- APM assumes env-var indirection (`GITHUB_TOKEN: ${GITHUB_TOKEN}`) but does not enforce it. `apm install` auto-adds `apm_modules/` to `.gitignore`, keeping cached source trees out of commits.
+
+A restrictive dependency policy is still valuable, but it is identity-based,
+not transport-aware:
+
+```yaml
+# apm-policy.yml
+name: contoso-security
+version: "1.0"
+enforcement: block
+
+dependencies:
+  allow:
+    - "contoso/approved-agent-config"
+    - "microsoft/*"
+```
+
+This example blocks every unlisted package identity regardless of transport; it
+does **not** enforce HTTPS for the two allowed patterns. See the
+[HTTP dependency two-gate model](#http-insecure-dependencies),
+[dependency pattern matching](../policy-reference/#pattern-matching), and the
+[`registry_source` policy](../../reference/policy-schema/#registry_source) for
+the three distinct controls.
 
 ## Frequently asked questions
 

--- a/docs/src/content/docs/enterprise/security.md
+++ b/docs/src/content/docs/enterprise/security.md
@@ -567,9 +567,10 @@ For an org standardizing on APM:
 - Route dep traffic through an enterprise proxy with audit logging. See [Registry Proxy & Air-gapped](../registry-proxy/).
 - Treat insecure transport as a separate CI control. `apm-policy.yml` has no
   dedicated `allow_insecure` field: `dependencies.allow` and
-  `dependencies.deny` match scheme- and host-blind canonical package names, so
-  they restrict which packages may install but cannot distinguish `http://`
-  from `https://` for the same package. Reject committed
+  `dependencies.deny` match scheme-blind canonical package identities. The
+  default `github.com` host is omitted while non-default hosts are retained, so
+  rules can restrict package and host identity but cannot distinguish
+  `http://` from `https://` for the same canonical host and path. Reject committed
   `allow_insecure: true` entries and prohibit `--allow-insecure` and
   `--allow-insecure-host` in standard CI; review both explicit gates for any
   air-gapped exception. `registry_source.allow_non_registry` is a separate

--- a/tests/unit/test_tls_docs_scope.py
+++ b/tests/unit/test_tls_docs_scope.py
@@ -121,7 +121,9 @@ def test_enterprise_security_docs_do_not_claim_transport_aware_policy():
     normalized = " ".join(security.replace("**", "").split())
 
     assert "no dedicated `allow_insecure` field" in normalized
-    assert "scheme- and host-blind canonical package names" in normalized
+    assert "scheme-blind canonical package identities" in normalized
+    assert "non-default hosts are retained" in normalized
+    assert "host-blind" not in normalized
     assert "does not enforce HTTPS" in normalized
     assert "`registry_source.allow_non_registry`" in normalized
     assert "Forbid `allow_insecure: true` via the policy allow list" not in normalized

--- a/tests/unit/test_tls_docs_scope.py
+++ b/tests/unit/test_tls_docs_scope.py
@@ -117,12 +117,14 @@ def test_enterprise_security_docs_do_not_claim_transport_aware_policy():
     security = (
         _repo_root() / "docs" / "src" / "content" / "docs" / "enterprise" / "security.md"
     ).read_text(encoding="utf-8")
-    normalized = " ".join(security.split())
+    # Keep this contract about the guidance rather than Markdown presentation.
+    normalized = " ".join(security.replace("**", "").split())
 
     assert "no dedicated `allow_insecure` field" in normalized
     assert "scheme- and host-blind canonical package names" in normalized
-    assert "does **not** enforce HTTPS" in normalized
+    assert "does not enforce HTTPS" in normalized
     assert "`registry_source.allow_non_registry`" in normalized
+    assert "Forbid `allow_insecure: true` via the policy allow list" not in normalized
 
 
 def test_ssl_docs_verify_apm_path_and_mark_planned_scope():

--- a/tests/unit/test_tls_docs_scope.py
+++ b/tests/unit/test_tls_docs_scope.py
@@ -113,6 +113,18 @@ def test_enterprise_security_docs_transport_trust_model():
     assert "Rust" in security
 
 
+def test_enterprise_security_docs_do_not_claim_transport_aware_policy():
+    security = (
+        _repo_root() / "docs" / "src" / "content" / "docs" / "enterprise" / "security.md"
+    ).read_text(encoding="utf-8")
+    normalized = " ".join(security.split())
+
+    assert "no dedicated `allow_insecure` field" in normalized
+    assert "scheme- and host-blind canonical package names" in normalized
+    assert "does **not** enforce HTTPS" in normalized
+    assert "`registry_source.allow_non_registry`" in normalized
+
+
 def test_ssl_docs_verify_apm_path_and_mark_planned_scope():
     docs = (
         _repo_root() / "docs" / "src" / "content" / "docs" / "troubleshooting" / "ssl-issues.md"


### PR DESCRIPTION
## Description

Corrects the Recommended hardening guidance so it matches APM's current transport and policy behavior.

The previous sentence said organizations could forbid `allow_insecure: true` “via the policy allow list.” That is not a control the policy engine provides: dependency allow/deny patterns match scheme-blind canonical package identities. The default `github.com` host is omitted while non-default hosts are retained, so policy can restrict package and host identity but cannot distinguish an HTTP source from an HTTPS source for the same canonical host and path.

This update:

- states that `apm-policy.yml` has no dedicated `allow_insecure` field
- documents the manifest plus CLI two-gate model for direct HTTP dependencies and the separate transitive-host flag
- recommends rejecting `allow_insecure: true` and insecure CLI flags in standard CI when an organization wants an HTTPS-only rule
- explains the scheme-blind, host-preserving canonical identity used by dependency policy
- explains that `registry_source.allow_non_registry` controls source routing, not transport security
- adds a restrictive allow-list example while explicitly warning that it is identity-based, not HTTPS enforcement
- adds a docs contract test to prevent the misleading transport-aware policy claim from returning

Fixes #2346

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Maintenance / refactor

## Testing

- [x] Tested locally
- [x] Added tests for the corrected documentation contract
- [x] `pytest -q tests/unit/test_tls_docs_scope.py` (9 passed)
- [x] Ruff lint and format checks for the changed test
- [x] Astro production build (124 pages)
- [x] Internal link check (1,032 relative links, no broken links)
- [x] `git diff --check`

## Spec conformance (OpenAPM v0.1)

- [x] N/A -- this corrects implementation-specific hardening guidance and does not change an OpenAPM v0.1 normative requirement.
