### PR TITLE
fix(compile): resolve context links when folding instructions into CL…

### DIFF
--- a/src/apm_cli/compilation/claude_formatter.py
+++ b/src/apm_cli/compilation/claude_formatter.py
@@ -107,6 +107,10 @@ class ClaudeFormatter:
             source_attribution = config.get("source_attribution", True)
             skip_instructions = config.get("skip_instructions", False)
 
+            # Reset any previous state so contexts from earlier compile passes
+            # can't leak into later calls and rewrite links incorrectly.
+            self.link_resolver.context_registry.clear()
+
             # Register context/memory fragments so embedded links to them
             # (e.g. ".context.md") resolve to their actual on-disk location,
             # mirroring the AGENTS.md distributed compiler.

--- a/src/apm_cli/compilation/claude_formatter.py
+++ b/src/apm_cli/compilation/claude_formatter.py
@@ -15,6 +15,7 @@ from ..version import get_version
 from .constants import BUILD_ID_PLACEHOLDER
 from .constitution import read_constitution
 from .footer import build_generation_footer
+from .link_resolver import UnifiedLinkResolver
 from .template_builder import build_attributed_instructions
 
 # CRITICAL: Shadow Click commands to prevent namespace collision
@@ -80,6 +81,7 @@ class ClaudeFormatter:
 
         self.warnings: builtins.list[str] = []
         self.errors: builtins.list[str] = []
+        self.link_resolver = UnifiedLinkResolver(self.source_dir)
 
     def format_distributed(
         self,
@@ -104,6 +106,11 @@ class ClaudeFormatter:
             config = config or {}
             source_attribution = config.get("source_attribution", True)
             skip_instructions = config.get("skip_instructions", False)
+
+            # Register context/memory fragments so embedded links to them
+            # (e.g. ".context.md") resolve to their actual on-disk location,
+            # mirroring the AGENTS.md distributed compiler.
+            self.link_resolver.register_contexts(primitives)
 
             # Generate Claude placements from the placement map
             placements = self._generate_placements(
@@ -340,7 +347,21 @@ class ClaudeFormatter:
         if source_attribution:
             sections.extend(build_generation_footer())
 
-        return "\n".join(sections)
+        content = "\n".join(sections)
+
+        # Resolve context/memory links (".context.md", ".memory.md") to their
+        # actual on-disk location, mirroring the AGENTS.md distributed
+        # compiler (distributed_compiler.py). Without this, embedded
+        # relative links are emitted verbatim -- correct only when CLAUDE.md
+        # happens to live in the same directory as their source file, and
+        # broken for any dependency-sourced or non-root placement.
+        content = self.link_resolver.resolve_links_for_compilation(
+            content=content,
+            source_file=placement.claude_path.parent,
+            compiled_output=placement.claude_path,
+        )
+
+        return content
 
     def _compile_stats(
         self, placements: builtins.list[ClaudePlacement], primitives: PrimitiveCollection

--- a/tests/unit/compilation/test_claude_formatter.py
+++ b/tests/unit/compilation/test_claude_formatter.py
@@ -16,7 +16,7 @@ from apm_cli.compilation.claude_formatter import (
     format_claude_md,
 )
 from apm_cli.compilation.constants import BUILD_ID_PLACEHOLDER
-from apm_cli.primitives.models import Chatmode, Instruction, PrimitiveCollection
+from apm_cli.primitives.models import Chatmode, Context, Instruction, PrimitiveCollection
 from apm_cli.version import get_version
 
 
@@ -705,3 +705,117 @@ class TestSkipInstructions:
         content = next(iter(result.content_map.values()))
         assert "## Dependencies" in content.splitlines()
         assert "Project Standards" not in content
+
+
+class TestContextLinkResolution:
+    """Regression tests: CLAUDE.md must resolve ``.context.md``/``.memory.md``
+    links the same way AGENTS.md already does (distributed_compiler.py).
+
+    Before this fix, ``_generate_claude_content`` returned
+    ``"\\n".join(sections)`` directly with no call into
+    ``UnifiedLinkResolver`` at all, so any relative link embedded in an
+    instruction body was emitted byte-for-byte from the source file --
+    correct only when CLAUDE.md happens to land in the same directory as the
+    instruction that referenced it, and silently broken otherwise (e.g. a
+    global/no-``applyTo`` instruction whose body links to a sibling
+    ``.apm/context/*.context.md`` fragment).
+    """
+
+    @pytest.fixture
+    def temp_project(self):
+        temp_dir = tempfile.mkdtemp()
+        resolved = Path(temp_dir).resolve()
+        yield resolved
+        shutil.rmtree(resolved, ignore_errors=True)
+
+    def test_context_link_rewritten_relative_to_claude_md(self, temp_project):
+        """A link to a `.context.md` fragment must resolve from CLAUDE.md's
+        own directory, not from the source instruction's directory."""
+        primitives = PrimitiveCollection()
+
+        context_file = temp_project / ".apm" / "context" / "conventions.context.md"
+        context_file.parent.mkdir(parents=True)
+        context_file.write_text("Real content lives here.")
+        primitives.add_primitive(
+            Context(
+                name="conventions",
+                file_path=context_file,
+                content="Real content lives here.",
+                source="local",
+            )
+        )
+
+        instruction_file = temp_project / ".apm" / "instructions" / "signpost.instructions.md"
+        instruction_file.parent.mkdir(parents=True)
+        instruction = Instruction(
+            name="signpost",
+            file_path=instruction_file,
+            description="Signpost",
+            apply_to="",
+            content="See [conventions](../context/conventions.context.md) for details.",
+            author="test",
+            source="local",
+        )
+        primitives.add_primitive(instruction)
+
+        formatter = ClaudeFormatter(str(temp_project))
+        placement_map = {temp_project: list(primitives.instructions)}
+        result = formatter.format_distributed(primitives, placement_map)
+
+        assert result.success
+        content = result.content_map[temp_project / "CLAUDE.md"]
+
+        # The link must now be anchored to CLAUDE.md's own directory
+        # (temp_project), matching what AGENTS.md already produces for the
+        # same source instruction -- not the original "../context/..."
+        # written relative to the instruction file's own directory.
+        assert "(.apm/context/conventions.context.md)" in content
+        assert "../context/conventions.context.md" not in content
+
+        # And the rewritten link must actually resolve on disk.
+        rewritten_target = temp_project / ".apm" / "context" / "conventions.context.md"
+        assert rewritten_target.exists()
+
+    def test_context_link_rewritten_for_dependency_sourced_instruction(self, temp_project):
+        """Same as above, but the instruction+context pair are sourced from a
+        dependency materialized under apm_modules/, matching how a real
+        component-repo dependency is discovered."""
+        primitives = PrimitiveCollection()
+
+        dep_root = temp_project / "apm_modules" / "_local" / "some-repo"
+        context_file = dep_root / ".apm" / "context" / "conventions.context.md"
+        context_file.parent.mkdir(parents=True)
+        context_file.write_text("Real content lives here.")
+        primitives.add_primitive(
+            Context(
+                name="conventions",
+                file_path=context_file,
+                content="Real content lives here.",
+                source="dependency:some-repo",
+            )
+        )
+
+        instruction_file = dep_root / ".apm" / "instructions" / "signpost.instructions.md"
+        instruction_file.parent.mkdir(parents=True)
+        instruction = Instruction(
+            name="signpost",
+            file_path=instruction_file,
+            description="Signpost",
+            apply_to="",
+            content="See [conventions](../context/conventions.context.md) for details.",
+            author="test",
+            source="dependency:some-repo",
+        )
+        primitives.add_primitive(instruction)
+
+        formatter = ClaudeFormatter(str(temp_project))
+        placement_map = {temp_project: [instruction]}
+        result = formatter.format_distributed(primitives, placement_map)
+
+        assert result.success
+        content = result.content_map[temp_project / "CLAUDE.md"]
+
+        expected_relative = "apm_modules/_local/some-repo/.apm/context/conventions.context.md"
+        assert f"({expected_relative})" in content
+        assert "../context/conventions.context.md" not in content
+        assert (temp_project / expected_relative).exists()


### PR DESCRIPTION
## Description

`ClaudeFormatter` (the `CLAUDE.md` generator) never ran its assembled instruction content through
the markdown-link resolver, so any relative link embedded in an instruction body -- most notably a
link to a `.apm/context/*.context.md` fragment -- was emitted byte-for-byte from the source file.
That is correct only when `CLAUDE.md` happens to land in the same directory as the instruction that
referenced it, and silently broken otherwise: a global (no-`applyTo`) instruction sourced from a
dependency, or placed anywhere but the project root, produces a link that no longer resolves from
`CLAUDE.md`'s own location.

The equivalent `AGENTS.md` pipeline (`distributed_compiler.py` / `agents_compiler.py`) does not have
this problem -- it explicitly calls `UnifiedLinkResolver.resolve_links_for_compilation()` /
`resolve_markdown_links()` before returning the generated content. `claude_formatter.py` had no
equivalent call anywhere in the file.

This PR mirrors that call in `ClaudeFormatter`:
- construct a `UnifiedLinkResolver` once in `__init__`
- call `register_contexts()` at the start of `format_distributed()`
- call `resolve_links_for_compilation()` on the assembled content before returning it from
  `_generate_claude_content()`

I found this while designing a monorepo/workspace layout where a root package depends on several
component-repo packages purely to pull in one "signpost" instruction each (an unconditional
instruction whose body links out to `.apm/context/*.context.md` fragments in the same package).
`AGENTS.md` resolved those links correctly out of the box; `CLAUDE.md` did not.

Fixes #2881

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [x] Added tests for new functionality (if applicable)

Added `TestContextLinkResolution` to `tests/unit/compilation/test_claude_formatter.py`:
- `test_context_link_rewritten_relative_to_claude_md` -- local context fragment, link must resolve
  from `CLAUDE.md`'s own directory rather than the instruction's source directory.
- `test_context_link_rewritten_for_dependency_sourced_instruction` -- same, but the instruction and
  its linked context fragment are sourced from a dependency materialized under `apm_modules/`, since
  that's the scenario where the bug actually bites (root instruction is never in the same directory
  as a dependency-sourced context file).

Confirmed both regression tests fail on the pre-fix code (reverting just
`src/apm_cli/compilation/claude_formatter.py` while keeping the tests) and pass after the fix.

Ran the full `tests/unit/compilation/` suite (1402 tests) before and after: no regressions, all
green. Ran `tests/unit/compilation/test_claude_formatter.py` specifically (35 tests, up from 33):
all pass.

Minimal manual repro (also embedded as the reproduction steps in the test fixtures):
```yaml
# apm.yml
name: my-pkg
version: 0.0.1
targets: [claude]
dependencies:
  apm: []
```
```markdown
<!-- .apm/instructions/signpost.instructions.md -->
---
description: Signpost
---

See [conventions](../context/conventions.context.md) for details.
```
```markdown
<!-- .apm/context/conventions.context.md -->
Real content lives here.
```
```bash
apm install --target claude
apm compile --target claude --force-instructions
cat CLAUDE.md
```
Before: `[conventions](../context/conventions.context.md)` (broken from `CLAUDE.md`'s own
directory). After: `[conventions](.apm/context/conventions.context.md)` (correct, matches what
`apm compile --target opencode` already produces for the same source instruction).

## Spec conformance (OpenAPM v0.1)

- [x] N/A -- this PR does not change OpenAPM-observable behaviour.

This is an internal implementation bug fix (a missing function call) that brings `CLAUDE.md`'s
link-resolution behaviour in line with what `AGENTS.md` already does and what the spec/docs already
describe as the intended behaviour; it does not introduce, change, or remove any normative
`req-XXX` requirement.