### PR TITLE
fix(hooks): anchor POSIX user-scope hook commands to $HOME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING:** after consumers re-vendor the shared gh-aw `apm.md`, its import requires an explicit `target` instead of deprecated `all`; `apm-action` otherwise writes `all` into the isolated `apm.yml`, where it degrades to auto-detection without harness markers. Set the workflow engine's target and recompile; see the [gh-aw migration recipe](https://microsoft.github.io/apm/integrations/gh-aw/#shared-apmmd-import-recommended). (#2706)
 - Re-vendored shared gh-aw workflows now default to APM 0.28.0 for both pack and restore, the version used for the recorded `microsoft/apm-action@v1.10.0` compatibility proof, not the latest CLI release; an explicit `apm-version` still overrides it. (#2706)
 
+### Fixed
+
+- User-scope hook commands now anchor to `$HOME` on POSIX hosts instead of the installing host's home prefix, so a `~/.claude/settings.json` kept in a dotfiles repo stops churning between machines; Windows targets and dynamic config roots outside the home directory keep absolute paths. (closes #2821)
+
 ### Security
 
 - The shared gh-aw APM pack job now declares `contents: read` (previously `permissions: {}`), the minimum the explicit built-in-token path needs. No write scope is added, and the token is not forwarded to restore or agent jobs. (#2706)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- User-scope hook commands now anchor to `$HOME` on POSIX hosts instead of the installing host's home prefix, so a `~/.claude/settings.json` kept in a dotfiles repo stops churning between machines; Windows targets and dynamic config roots outside the home directory keep absolute paths. (closes #2821)
+- User-scope hook commands now anchor to `$HOME` on POSIX hosts instead of the installing host's home prefix, so a `~/.claude/settings.json` kept in a dotfiles repo stops churning between machines; Windows targets, single-quoted references, and dynamic config roots outside the home directory keep absolute paths. (closes #2821) (#2944)
 
 ### Security
 

--- a/docs/src/content/docs/producer/author-primitives/hooks-and-commands.md
+++ b/docs/src/content/docs/producer/author-primitives/hooks-and-commands.md
@@ -294,8 +294,9 @@ agent a procedure" fits a skill -- and reaches every harness.
   anchor resolves late, the hook runs the script under whatever `HOME` the
   launching shell provides -- keep `HOME` pointing at the installing user's
   home when a wrapper script, service, or CI job invokes the harness.
-  Windows keeps the absolute form, and a dynamic target root outside the
-  home directory (for example `CLAUDE_CONFIG_DIR`) stays absolute too.
+  Windows keeps the absolute form, and so do single-quoted references (a
+  shell does not expand `$HOME` inside single quotes) and a dynamic target
+  root outside the home directory (for example `CLAUDE_CONFIG_DIR`).
   Project-scope `apm install` (no `-g`) keeps
   non-Claude command paths repo-relative. Claude project hooks use
   `CLAUDE_PROJECT_DIR` (or `$env:CLAUDE_PROJECT_DIR` for PowerShell) so

--- a/docs/src/content/docs/producer/author-primitives/hooks-and-commands.md
+++ b/docs/src/content/docs/producer/author-primitives/hooks-and-commands.md
@@ -285,9 +285,18 @@ agent a procedure" fits a skill -- and reaches every harness.
   alias) for scripts that ship inside the package, using the quoting forms
   described above. Plain absolute paths break on consumers' machines.
 - **Hook script path resolution.** `apm install -g` (user-scope)
-  rewrites `${PLUGIN_ROOT}` and relative `./` references to absolute
-  paths so Claude Code and Copilot CLI can execute scripts regardless
-  of the working directory. Project-scope `apm install` (no `-g`) keeps
+  rewrites `${PLUGIN_ROOT}` and relative `./` references so Claude Code
+  and Copilot CLI can execute scripts regardless of the working
+  directory. On POSIX hosts the rewritten path is anchored to `$HOME`
+  (for example `$HOME/.claude/hooks/<pkg>/run.sh`), which the shell
+  expands at invocation time, so a user-scope config kept in a dotfiles
+  repo stays valid on a host with a different home directory. Because the
+  anchor resolves late, the hook runs the script under whatever `HOME` the
+  launching shell provides -- keep `HOME` pointing at the installing user's
+  home when a wrapper script, service, or CI job invokes the harness.
+  Windows keeps the absolute form, and a dynamic target root outside the
+  home directory (for example `CLAUDE_CONFIG_DIR`) stays absolute too.
+  Project-scope `apm install` (no `-g`) keeps
   non-Claude command paths repo-relative. Claude project hooks use
   `CLAUDE_PROJECT_DIR` (or `$env:CLAUDE_PROJECT_DIR` for PowerShell) so
   checked-in settings remain portable while hooks can run from outside the

--- a/docs/src/content/docs/reference/targets-matrix.md
+++ b/docs/src/content/docs/reference/targets-matrix.md
@@ -127,8 +127,8 @@ GitHub Copilot (CLI and IDE).
   `~/.copilot/copilot-instructions.md` (Copilot CLI reads only that single file
   at user scope). User-scope deploys land under `~/.copilot/`, not
   `~/.github/`; hook script commands are anchored so Copilot CLI can invoke
-  them from any working directory -- `$HOME`-relative on POSIX hosts,
-  absolute on Windows.
+  them from any working directory -- `$HOME`-relative on POSIX hosts, absolute
+  on Windows and for single-quoted references.
 - **Global compile.** `apm compile -g` can also render global instructions to
   `~/.copilot/AGENTS.md` for root-context readers that honor `AGENTS.md`.
 

--- a/docs/src/content/docs/reference/targets-matrix.md
+++ b/docs/src/content/docs/reference/targets-matrix.md
@@ -126,8 +126,9 @@ GitHub Copilot (CLI and IDE).
   `instructions` from all packages are concatenated into
   `~/.copilot/copilot-instructions.md` (Copilot CLI reads only that single file
   at user scope). User-scope deploys land under `~/.copilot/`, not
-  `~/.github/`; hook script commands are written as absolute paths so Copilot
-  CLI can invoke them from any working directory.
+  `~/.github/`; hook script commands are anchored so Copilot CLI can invoke
+  them from any working directory -- `$HOME`-relative on POSIX hosts,
+  absolute on Windows.
 - **Global compile.** `apm compile -g` can also render global instructions to
   `~/.copilot/AGENTS.md` for root-context readers that honor `AGENTS.md`.
 

--- a/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
@@ -219,8 +219,13 @@ merged target keeps APM reconciliation ownership in a sibling `apm-hooks.json`
 sidecar, so clones, contributors, and CI runners do not see the installer's
 machine-local absolute prefix. `apm install -g` (user-scope, e.g.
 `~/.claude/settings.json`) rewrites `${PLUGIN_ROOT}` and relative `./`
-references to absolute paths because the user-scope config is read
-without a fixed cwd. If a manifest in `hooks/` or `.apm/hooks/` uses
+references so the user-scope config resolves without a fixed cwd: on POSIX
+hosts the rewritten path is anchored to `$HOME` (for example
+`$HOME/.claude/hooks/<pkg>/run.sh`), which the invoking shell expands, so the
+merged file stays identical across machines. Windows keeps the absolute form,
+and so do single-quoted references (a shell does not expand `$HOME` inside
+single quotes) and dynamic target roots outside the home directory such as
+`CLAUDE_CONFIG_DIR`. If a manifest in `hooks/` or `.apm/hooks/` uses
 `./hooks/<script>`, APM first resolves it from the hook file directory,
 then falls back to the package root to avoid deploying a doubled
 `hooks/hooks/` path. If a referenced hook script is missing at install

--- a/src/apm_cli/install/services.py
+++ b/src/apm_cli/install/services.py
@@ -492,8 +492,9 @@ def integrate_package_primitives(  # noqa: PLR0913
             }
             # Hook integrator alone needs the scope signal: project-scope
             # deploys keep ``command`` paths repo-relative (#1394), user-scope
-            # deploys absolutize them (#1310 / #1354).  Sibling integrators
-            # don't accept this kwarg, so include it only for hooks.
+            # deploys make them cwd-independent (#1310 / #1354), anchored to
+            # ``$HOME`` on POSIX hosts. Sibling integrators don't accept this
+            # kwarg, so include it only for hooks.
             if _prim_name == "hooks":
                 _call_kwargs["user_scope"] = scope is InstallScope.USER
                 _call_kwargs["dep_targets_active"] = dep_targets_active

--- a/src/apm_cli/integration/hook_integrator.py
+++ b/src/apm_cli/integration/hook_integrator.py
@@ -120,6 +120,15 @@ _POSIX_USER_HOOK_PATHS = os.name != "nt"
 _filter_hook_files_for_target = filter_hook_files_for_target
 
 
+def _wrapping_quote(command: str, match: re.Match[str]) -> str:
+    """Return the quote character wrapping a reference, or "" when it has none."""
+    if match.start() > 0 and match.end() < len(command):
+        quote = command[match.start() - 1]
+        if quote in "\"'" and command[match.end()] == quote:
+            return quote
+    return ""
+
+
 # DEPRECATED -- use IntegrationResult directly for new code.
 # Backward-compatible shim: accepts hooks_integrated= kwarg and
 # exposes a hooks_integrated property for consumers of the old API.
@@ -591,12 +600,15 @@ class HookIntegrator(BaseIntegrator):
         target_rel: str,
         deploy_root: Path | None,
         source_key: str | None = None,
-        path_is_quoted: bool = False,
+        path_quote: str = "",
     ) -> str:
         """Return a target-native script reference without sacrificing portability."""
         if deploy_root is not None:
             target_path = (deploy_root / target_rel).resolve()
-            if _POSIX_USER_HOOK_PATHS:
+            # A shell expands $HOME outside single quotes only, so a
+            # single-quoted reference keeps the previous absolute form instead
+            # of becoming a literal path the target would never expand.
+            if _POSIX_USER_HOOK_PATHS and path_quote != "'":
                 try:
                     relative_path = target_path.relative_to(deploy_root.resolve())
                 except ValueError:
@@ -624,7 +636,7 @@ class HookIntegrator(BaseIntegrator):
         ):
             return f"$env:{project_dir}/{target_rel}"
         path = f"${{{project_dir}}}/{target_rel}"
-        return path if path_is_quoted else f'"{path}"'
+        return path if path_quote else f'"{path}"'
 
     def _rewrite_command_for_target(
         self,
@@ -682,10 +694,7 @@ class HookIntegrator(BaseIntegrator):
                     target_rel,
                     deploy_root,
                     source_key,
-                    match.start() > 0
-                    and match.end() < len(command)
-                    and command[match.start() - 1] in "\"'"
-                    and command[match.end()] == command[match.start() - 1],
+                    _wrapping_quote(command, match),
                 )
                 new_command = new_command.replace(full_var, resolved_cmd)
             else:
@@ -735,10 +744,7 @@ class HookIntegrator(BaseIntegrator):
                     target_rel,
                     deploy_root,
                     source_key,
-                    match.start() > 0
-                    and match.end() < len(command)
-                    and command[match.start() - 1] in "\"'"
-                    and command[match.end()] == command[match.start() - 1],
+                    _wrapping_quote(command, match),
                 )
                 new_command = new_command.replace(rel_ref, resolved_cmd)
             else:

--- a/src/apm_cli/integration/hook_integrator.py
+++ b/src/apm_cli/integration/hook_integrator.py
@@ -44,6 +44,7 @@ Script path handling:
 
 import json
 import logging
+import os
 import re
 from collections.abc import Iterable
 from dataclasses import dataclass, field
@@ -111,6 +112,8 @@ if TYPE_CHECKING:
     from apm_cli.deps.lockfile import LockFile
 
 _log = logging.getLogger(__name__)
+
+_POSIX_USER_HOOK_PATHS = os.name != "nt"
 
 # Testability seam: tests can patch deprecated filename routing without
 # replacing the imported helper for every call site.
@@ -592,7 +595,23 @@ class HookIntegrator(BaseIntegrator):
     ) -> str:
         """Return a target-native script reference without sacrificing portability."""
         if deploy_root is not None:
-            return str((deploy_root / target_rel).resolve())
+            target_path = (deploy_root / target_rel).resolve()
+            if _POSIX_USER_HOOK_PATHS:
+                try:
+                    relative_path = target_path.relative_to(deploy_root.resolve())
+                except ValueError:
+                    # A dynamic target root such as CLAUDE_CONFIG_DIR may live
+                    # outside the deploy root. Keep that explicit absolute path
+                    # rather than emitting a misleading $HOME-relative command.
+                    pass
+                else:
+                    # User-scope configs live in files people track in dotfiles
+                    # repos, so anchor the path to $HOME instead of embedding
+                    # the installing host's home prefix. Hooks run through a
+                    # shell, which expands $HOME at invocation time and keeps
+                    # the #1310 / #1354 cwd-independence intact.
+                    return f"$HOME/{relative_path.as_posix()}"
+            return str(target_path)
         if target != "claude":
             return target_rel
 
@@ -757,7 +776,7 @@ class HookIntegrator(BaseIntegrator):
             hook_file_dir: Directory containing the hook JSON file (for ./path resolution)
             root_dir: Override root directory (e.g. ".copilot" for user scope)
             deploy_root: Absolute root of the deployment directory.  When provided,
-                all rewritten script paths are resolved to absolute paths so the
+                all rewritten script paths are pinned to the deploy root so the
                 target can locate scripts regardless of the working directory.
                 When *None*, paths remain relative (backward-compatible behaviour).
 
@@ -1026,8 +1045,8 @@ class HookIntegrator(BaseIntegrator):
             force: If True, overwrite user-authored files on collision
             managed_files: Set of relative paths known to be APM-managed
             target: Optional TargetProfile for scope-resolved root_dir
-            user_scope: If True, rewrite hook script commands to absolute paths
-                so global hooks resolve from any working directory
+            user_scope: If True, rewrite hook script commands so global hooks
+                resolve from any working directory
 
         Returns:
             HookIntegrationResult: Results of the integration operation
@@ -1675,7 +1694,7 @@ class HookIntegrator(BaseIntegrator):
         ``_MERGE_HOOK_TARGETS`` registry.
 
         ``user_scope`` controls whether merged-hook ``command`` paths are
-        rewritten to absolute paths (required when deploying to
+        rewritten so they resolve from any cwd (required when deploying to
         ``~/.claude/settings.json`` -- see #1310 / #1354) or left
         repo-relative so checked-in project-scope configs stay portable
         across clones, contributors, and CI runners (#1394).

--- a/tests/integration/test_hook_integrator_copilot_casing_e2e.py
+++ b/tests/integration/test_hook_integrator_copilot_casing_e2e.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any
 
@@ -192,8 +193,13 @@ def test_copilot_install_scope_controls_script_paths(
     ).resolve()
     monkeypatch.chdir(package_info.install_path)
     if user_scope:
-        assert Path(command).is_absolute()
-        assert Path(command).resolve() == installed_script
+        # User-scope commands must resolve from any cwd. On POSIX they anchor
+        # to $HOME so a settings file kept in a dotfiles repo stays valid on a
+        # host with a different home directory; Windows keeps absolute paths.
+        relative = f"{target.root_dir}/hooks/scripts/{package_info.package.name}/run.sh"
+        assert command == (f"$HOME/{relative}" if os.name != "nt" else str(installed_script))
+        expanded = command.replace("$HOME", str(Path.home()))
+        assert Path(expanded).resolve() == installed_script
     else:
         assert not Path(command).is_absolute()
         assert command == f"{target.root_dir}/hooks/scripts/{package_info.package.name}/run.sh"
@@ -236,8 +242,12 @@ def test_kiro_install_scope_controls_script_paths(
     ).resolve()
     monkeypatch.chdir(package_info.install_path)
     if user_scope:
-        assert Path(command).is_absolute()
-        assert Path(command).resolve() == installed_script
+        # Same POSIX $HOME anchor as Copilot: Kiro consumes the shared hook
+        # scope rewrite decision.
+        relative = f"{target.root_dir}/hooks/{package_info.package.name}/run.sh"
+        assert command == (f"$HOME/{relative}" if os.name != "nt" else str(installed_script))
+        expanded = command.replace("$HOME", str(Path.home()))
+        assert Path(expanded).resolve() == installed_script
     else:
         assert not Path(command).is_absolute()
         assert command == f"{target.root_dir}/hooks/{package_info.package.name}/run.sh"

--- a/tests/integration/test_hook_js_sidecar_lifecycle_contract.py
+++ b/tests/integration/test_hook_js_sidecar_lifecycle_contract.py
@@ -725,13 +725,17 @@ def test_required_global_copilot_sidecar_lifecycle(
     descriptor = copilot_root.joinpath(*_GLOBAL_DESCRIPTOR.parts)
     payload = json.loads(descriptor.read_text(encoding="utf-8"))
     command = tuple(shlex.split(payload["hooks"]["preToolUse"][0]["bash"]))
-    assert Path(command[1]).is_absolute()
+    # POSIX user-scope commands anchor to $HOME so `~/.copilot` config stays
+    # portable across hosts. The real harness runs hooks through a shell, which
+    # expands it; mirror that here because the runner executes directly.
+    hook_argv = [arg.replace("$HOME", str(scenario.isolated.home)) for arg in command[1:]]
+    assert Path(hook_argv[0]).is_absolute()
     hook_result = ApmLifecycleRunner(
         (command[0],),
         timeout_seconds=30,
         scenario_timeout_seconds=30,
     ).run(
-        command[1:],
+        hook_argv,
         scenario_id="global-copilot-execute",
         cwd=cwd,
         env=published.environment,

--- a/tests/unit/integration/test_hook_integrator.py
+++ b/tests/unit/integration/test_hook_integrator.py
@@ -850,16 +850,17 @@ class TestClaudeIntegration:
             f"Project-scope command must not embed the installer's absolute prefix; got {cmd!r}"
         )
 
-    def test_user_scope_still_writes_absolute_hook_paths(self, temp_project):
-        """User-scope deploys must still absolutize hook commands --
-        ``~/.claude/settings.json`` runs without a fixed cwd, so relative
-        paths cannot resolve (#1310 / #1354).
+    def test_user_scope_writes_portable_home_hook_paths(self, temp_project, monkeypatch):
+        """POSIX user-scope commands anchor to HOME instead of the installer home.
 
         ``user_scope=True`` is the explicit signal the production dispatch
         (``services.integrate_package_primitives``) computes from the
         ``InstallScope`` enum, kept independent of deploy-root layout in
         ``core/scope.py``.
         """
+        from apm_cli.integration import hook_integrator as hi_mod
+
+        monkeypatch.setattr(hi_mod, "_POSIX_USER_HOOK_PATHS", True)
         pkg_dir = temp_project / "scope-pkg"
         hooks_dir = pkg_dir / "hooks"
         hooks_dir.mkdir(parents=True, exist_ok=True)
@@ -889,10 +890,7 @@ class TestClaudeIntegration:
 
         settings = json.loads((temp_project / ".claude" / "settings.json").read_text())
         cmd = settings["hooks"]["Stop"][0]["hooks"][0]["command"]
-        assert Path(cmd).is_absolute(), f"User-scope command must be absolute; got {cmd!r}"
-        assert cmd == str(
-            (temp_project / ".claude" / "hooks" / "scope-pkg" / "hooks" / "stop.sh").resolve()
-        )
+        assert cmd == "$HOME/.claude/hooks/scope-pkg/hooks/stop.sh"
 
     def test_no_hooks_returns_empty_result(self, temp_project):
         """Test Claude integration with no hook files returns empty result."""
@@ -3338,8 +3336,11 @@ class TestScopeResolvedHookDeployment:
         monkeypatch.chdir(self.root)
         assert Path(cmd).resolve() == (scripts_dir / "run.sh").resolve()
 
-    def test_copilot_user_scope_writes_absolute_hook_paths(self, monkeypatch):
-        """Copilot user-scope hook commands must resolve from any cwd."""
+    def test_copilot_user_scope_writes_portable_home_hook_paths(self, monkeypatch):
+        """POSIX Copilot user hooks anchor to HOME instead of the installer home."""
+        from apm_cli.integration import hook_integrator as hi_mod
+
+        monkeypatch.setattr(hi_mod, "_POSIX_USER_HOOK_PATHS", True)
         hooks_dir = self.pkg_dir / ".apm" / "hooks"
         script = hooks_dir / "run.sh"
         script.write_text("#!/bin/bash\necho test", encoding="utf-8")
@@ -3363,11 +3364,7 @@ class TestScopeResolvedHookDeployment:
             (self.root / ".copilot" / "hooks" / "scope-pkg-hooks.json").read_text(encoding="utf-8")
         )
         cmd = hooks_config["hooks"]["sessionStart"][0]["bash"]
-        assert Path(cmd).is_absolute(), f"User-scope Copilot command must be absolute; got {cmd!r}"
-        expected = (self.root / ".copilot" / "hooks" / "scripts" / "scope-pkg" / "run.sh").resolve()
-        assert cmd == str(expected)
-        monkeypatch.chdir(self.pkg_dir)
-        assert Path(cmd).resolve() == expected
+        assert cmd == "$HOME/.copilot/hooks/scripts/scope-pkg/run.sh"
 
     def test_sync_with_copilot_scope_prefix(self):
         """sync_integration removes .copilot/hooks/ files when target is present."""
@@ -3886,8 +3883,13 @@ class TestIssue1007Fixes:
         assert cmd == original, "Unknown variable must not be modified"
         assert scripts == [], "No scripts should be scheduled for copy"
 
-    def test_rewrite_command_deploy_root_produces_absolute_path(self, tmp_path: Path) -> None:
-        """deploy_root parameter makes _rewrite_command_for_target produce absolute paths."""
+    def test_rewrite_command_deploy_root_uses_portable_home_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """POSIX user hooks keep paths portable across home directories."""
+        from apm_cli.integration import hook_integrator as hi_mod
+
+        monkeypatch.setattr(hi_mod, "_POSIX_USER_HOOK_PATHS", True)
         pkg_dir = tmp_path / "pkg"
         script = pkg_dir / "hooks" / "run.sh"
         script.parent.mkdir(parents=True, exist_ok=True)
@@ -3905,12 +3907,57 @@ class TestIssue1007Fixes:
 
         assert "${CLAUDE_PLUGIN_ROOT}" not in cmd, "Variable must be replaced"
         assert len(scripts) == 1, "Script copy entry must be produced"
-        assert cmd.startswith(str(deploy_root.resolve())), (
-            f"Command must be absolute path under deploy_root; got {cmd}"
+        assert cmd == "$HOME/.claude/hooks/my-pkg/hooks/run.sh"
+
+    def test_rewrite_command_deploy_root_keeps_windows_absolute_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Windows user hooks keep their existing absolute path representation."""
+        from apm_cli.integration import hook_integrator as hi_mod
+
+        monkeypatch.setattr(hi_mod, "_POSIX_USER_HOOK_PATHS", False)
+        pkg_dir = tmp_path / "pkg"
+        script = pkg_dir / "hooks" / "run.sh"
+        script.parent.mkdir(parents=True, exist_ok=True)
+        script.write_text("#!/bin/bash\necho run", encoding="utf-8")
+        deploy_root = tmp_path / "home"
+
+        cmd, scripts = HookIntegrator()._rewrite_command_for_target(
+            "${CLAUDE_PLUGIN_ROOT}/hooks/run.sh",
+            pkg_dir,
+            "my-pkg",
+            "claude",
+            deploy_root=deploy_root,
         )
-        assert cmd.replace("\\", "/").endswith(".claude/hooks/my-pkg/hooks/run.sh"), (
-            f"Command must end with .claude/hooks/my-pkg/hooks/run.sh; got {cmd}"
+
+        assert cmd == str((deploy_root / ".claude/hooks/my-pkg/hooks/run.sh").resolve())
+        assert len(scripts) == 1
+
+    def test_rewrite_command_dynamic_root_outside_home_stays_absolute(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An absolute target root outside HOME is never mislabeled as portable."""
+        from apm_cli.integration import hook_integrator as hi_mod
+
+        monkeypatch.setattr(hi_mod, "_POSIX_USER_HOOK_PATHS", True)
+        pkg_dir = tmp_path / "pkg"
+        script = pkg_dir / "hooks" / "run.sh"
+        script.parent.mkdir(parents=True, exist_ok=True)
+        script.write_text("#!/bin/bash\necho run", encoding="utf-8")
+        deploy_root = tmp_path / "home"
+        dynamic_root = tmp_path / "claude-config"
+
+        cmd, scripts = HookIntegrator()._rewrite_command_for_target(
+            "${CLAUDE_PLUGIN_ROOT}/hooks/run.sh",
+            pkg_dir,
+            "my-pkg",
+            "claude",
+            root_dir=str(dynamic_root),
+            deploy_root=deploy_root,
         )
+
+        assert cmd == str(dynamic_root / "hooks" / "my-pkg" / "hooks" / "run.sh")
+        assert len(scripts) == 1
 
     def test_rewrite_command_deploy_root_absent_script_resolves_to_source(
         self, tmp_path: Path
@@ -3957,8 +4004,13 @@ class TestIssue1007Fixes:
         assert cmd == '"${CLAUDE_PROJECT_DIR}/.claude/hooks/my-pkg/hooks/run.sh"'
         assert not cmd.startswith("/"), "Command must not be absolute without deploy_root"
 
-    def test_rewrite_command_deploy_root_relative_path_handler(self, tmp_path: Path) -> None:
-        """deploy_root makes ./path references produce absolute paths too."""
+    def test_rewrite_command_deploy_root_relative_path_handler(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """User-scope ./path references use the portable home prefix on POSIX."""
+        from apm_cli.integration import hook_integrator as hi_mod
+
+        monkeypatch.setattr(hi_mod, "_POSIX_USER_HOOK_PATHS", True)
         pkg_dir = tmp_path / "pkg"
         script = pkg_dir / "hooks" / "run.sh"
         script.parent.mkdir(parents=True, exist_ok=True)
@@ -3977,9 +4029,7 @@ class TestIssue1007Fixes:
 
         assert "./" not in cmd, "Relative ./ reference must be replaced"
         assert len(scripts) == 1, "Script copy entry must be produced"
-        assert cmd.startswith(str(deploy_root.resolve())), (
-            f"Command must be absolute path under deploy_root; got {cmd}"
-        )
+        assert cmd == "$HOME/.claude/hooks/my-pkg/hooks/run.sh"
         assert not cmd.startswith("./"), "Command must not be relative"
 
     def test_rewrite_command_nonexistent_script_with_deploy_root(self, tmp_path: Path) -> None:

--- a/tests/unit/integration/test_hook_integrator.py
+++ b/tests/unit/integration/test_hook_integrator.py
@@ -3933,6 +3933,36 @@ class TestIssue1007Fixes:
         assert cmd == str((deploy_root / ".claude/hooks/my-pkg/hooks/run.sh").resolve())
         assert len(scripts) == 1
 
+    def test_rewrite_command_single_quoted_reference_stays_absolute(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A single-quoted reference keeps its absolute form.
+
+        A shell expands $HOME outside single quotes only, so anchoring here
+        would hand the target a literal '$HOME/...' path that never resolves.
+        """
+        from apm_cli.integration import hook_integrator as hi_mod
+
+        monkeypatch.setattr(hi_mod, "_POSIX_USER_HOOK_PATHS", True)
+        pkg_dir = tmp_path / "pkg"
+        script = pkg_dir / "hooks" / "run.sh"
+        script.parent.mkdir(parents=True, exist_ok=True)
+        script.write_text("#!/bin/bash\necho run", encoding="utf-8")
+        deploy_root = tmp_path / "home"
+
+        cmd, scripts = HookIntegrator()._rewrite_command_for_target(
+            "bash '${CLAUDE_PLUGIN_ROOT}/hooks/run.sh'",
+            pkg_dir,
+            "my-pkg",
+            "claude",
+            deploy_root=deploy_root,
+        )
+
+        assert "$HOME" not in cmd, f"$HOME stays literal inside single quotes; got {cmd!r}"
+        expected = str((deploy_root / ".claude/hooks/my-pkg/hooks/run.sh").resolve())
+        assert cmd == f"bash '{expected}'"
+        assert len(scripts) == 1
+
     def test_rewrite_command_dynamic_root_outside_home_stays_absolute(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
# fix(hooks): anchor POSIX user-scope hook commands to $HOME

## TL;DR

User-scope installs (`apm install -g`) expanded the installing machine's home
directory into merged hook commands, so a `~/.claude/settings.json` kept in a
dotfiles repo differed on every host and hand-normalizing it was undone by the
next install. On POSIX hosts the rewritten path is now anchored to `$HOME`,
which the invoking shell expands, so cwd-independence is unchanged. Windows
keeps absolute paths, and so do single-quoted references and a dynamic target
root outside the home directory.

> [!NOTE]
> Fixes #2821. Only the *form* of the user-scope path changes; the merge,
> ownership, and cleanup behavior is untouched.

## Problem (WHY)

- [x] `apm install -g` embedded the installing host's home prefix in merged hook commands: `"command": "node \"/Users/alice/.claude/hooks/context-mode/hooks/pretooluse.mjs\""`.
- [x] `~/.claude/settings.json` is commonly tracked in a dotfiles repo, so the same hooks produced a host-specific diff on every machine — the install is reproducible, the tracked file is not.
- [x] Hand-normalizing the merged file does not stick: the next install rewrites absolute entries next to the normalized ones, reported as 14 → 28 entries in #2821.
- [!] Only the user-scope form was affected; project-scope configs stay repo-relative on purpose (#1394), so the two scopes disagreed about what "portable" means.

Why these matter: the absolute rewrite itself is required — hook commands
resolve against the working directory, not against the settings file:

> "The absolute rewrite itself is right (#1310 / #1354: hook commands resolve
> against the cwd, not the settings file) ... The ask is only about *how*
> user-scope paths are anchored on POSIX targets."
> — [#2821](https://github.com/microsoft/apm/issues/2821)

The repo's own authoring guidance says the same thing about tracked files:

> "Script paths. Use `${PLUGIN_ROOT}` ... Plain absolute paths break on
> consumers' machines."
> — [hooks-and-commands.md](https://github.com/microsoft/apm/blob/6331f22b0e9a1ff4fee6b6ffd06de12b1a3133c3/docs/src/content/docs/producer/author-primitives/hooks-and-commands.md?plain=1#L284-L286)

## Approach (WHAT)

| # | Fix (and why, if non-obvious) |
|---|-------------------------------|
| 1 | In the `deploy_root` branch (populated for user scope only), emit `$HOME/<path-relative-to-deploy-root>` instead of `str((deploy_root / target_rel).resolve())`. The deploy root *is* `Path.home()` for user scope, so the substitution is exact rather than heuristic. |
| 2 | Substitute only when `relative_to(deploy_root)` succeeds. A target root that resolves outside the deploy root — `CLAUDE_CONFIG_DIR` pointing elsewhere — keeps the previous absolute path instead of gaining a `$HOME` prefix that would point at the wrong location. |
| 3 | Gate the behavior on one module constant (`_POSIX_USER_HOOK_PATHS = os.name != "nt"`) so Windows keeps the current form and tests can drive both branches deterministically. |
| 4 | Keep quoting exactly as it was. The deploy root branch never consulted `path_is_quoted` before, and it still does not, so no command string changes shape beyond its prefix. |
| 5 | Update the three test layers that encoded the old contract, rather than adding a parallel expectation set: the unit hook suite, the in-process install-dispatch suite, and the real-CLI lifecycle contract. |
| 6 | Anchor only when the reference is unquoted or double-quoted. A shell expands `$HOME` outside single quotes only, so a single-quoted reference keeps the previous absolute form instead of handing the target a literal `'$HOME/…'` path. The existing quote detection now reports the quote character rather than a boolean (`_wrapping_quote`), which is the whole cost of this guard. |

## Implementation (HOW)

Diff for line-level evidence:
<https://github.com/microsoft/apm/pull/2944/files>

- **`src/apm_cli/integration/hook_integrator.py`** — the anchoring itself, in `_project_scoped_command_path` ([L606-L625](https://github.com/microsoft/apm/blob/6331f22b0e9a1ff4fee6b6ffd06de12b1a3133c3/src/apm_cli/integration/hook_integrator.py#L606-L625)), the quote-character helper `_wrapping_quote` ([L123](https://github.com/microsoft/apm/blob/6331f22b0e9a1ff4fee6b6ffd06de12b1a3133c3/src/apm_cli/integration/hook_integrator.py#L123-L130)) that replaced the inline boolean, plus two docstring lines that described the old absolute contract. Nothing else in the module changed: the missing-script warning path, the ownership markers, and the script-copy plan are deliberately untouched.
- **`src/apm_cli/install/services.py`** — comment only. Records that the user-scope signal now produces cwd-independent, `$HOME`-anchored paths.
- **`src/apm_cli/integration/…` tests** — `tests/unit/integration/test_hook_integrator.py` re-expresses the user-scope expectations as the `$HOME` form and adds two boundary cases (Windows keeps absolute, dynamic root outside home stays absolute).
- **`tests/integration/test_hook_integrator_copilot_casing_e2e.py`** — Copilot and Kiro user-scope branches, since both consume the same rewrite decision.
- **`tests/integration/test_hook_js_sidecar_lifecycle_contract.py`** — the global Copilot lifecycle contract asserted an absolute path and executed it directly. The real harness launches hooks through a shell, so the test now expands `$HOME` from the isolated home before asserting and executing.
- **`docs/.../hooks-and-commands.md`, `docs/.../targets-matrix.md`** — describe the anchoring instead of "absolute paths", including the late-resolution caveat.
- **`CHANGELOG.md`** — entry under `Fixed`, matching how #1310 / #1354 and #1394 were recorded.

## Trade-offs

- **Chose** `$HOME` over leaving the absolute path and documenting a dotfiles workaround. **Rejected**: telling users to post-process a file APM owns — the rewrite would still lose on the next install, as #2821 reports.
- **Chose** to keep Windows absolute. **Rejected**: a Windows variable form (`%USERPROFILE%`) in this PR, because its cmd/PowerShell semantics differ and #2408 shows cwd handling is already special there.
- **Chose** absolute for a dynamic root outside the home directory. **Rejected**: writing `$HOME/...` there, which would resolve to a path that does not contain the deployed script.
- **Chose** absolute for a single-quoted reference. **Rejected**: rewriting the surrounding single quotes into double quotes, which would widen this PR into a quote-normalization change for a shape the repo's own examples do not use — and the failure mode of getting it wrong is a hook that silently never runs.
- **Chose** target-agnostic anchoring on POSIX, because `_project_scoped_command_path` is shared by every merge-based target. **Rejected**: restricting to `claude`/`codex` without maintainer input — it is a one-line condition if you prefer that.
- **Chose** no mermaid diagram. **Rejected**: a decorative flowchart for a one-line prefix substitution; the repo requires every block to be validated with `mmdc`, which is not available in this environment, so an unvalidated diagram would be worse than none.

## Benefits

1. A user-scope settings file tracked in a dotfiles repo now holds the same hook entries on macOS and Linux, whatever the username or home path.
2. Re-running `apm install -g` on such a repo produces no diff instead of rewriting every hook entry.
3. Renaming a user or moving a home directory no longer invalidates user-scope hook commands.
4. Containment is stricter, not looser: a path resolving outside the deploy root can no longer be rewritten at all.
5. Windows users observe no change in generated commands.

## Validation

`pytest tests/unit/integration/test_hook_integrator.py -q -n0`

```text
188 passed in 2.82s
```

`pytest tests/integration/test_hook_js_sidecar_lifecycle_contract.py -q -n0` — real CLI, locally built `apm` binary, isolated `HOME`:

```text
5 passed in 71.30s
```

`ruff check src/ tests/` and `ruff format --check src/ tests/` (both must be silent in CI):

```text
All checks passed!
1768 files already formatted
```

Baseline comparison, because this machine cannot run the full CI matrix:

<details>
<summary>Full unit suite and lifecycle-smoke selection, branch vs. an untouched baseline checkout using the same binary</summary>

```text
tests/unit + tests/test_console.py
  branch:   118 failed, 22183 passed
  baseline: 118 failed, 22181 passed
  -> candidate-only failures: none; failure sets identical. The branch collects
     exactly the 2 tests added here.

pytest -m 'lifecycle_smoke and not lifecycle_merge_group' tests/integration
  branch:   166 passed, 14 failed
  baseline: 165 passed, 15 failed
  -> candidate-only failures: none. The single baseline-only failure is the
     global hook lifecycle contract, which fails on that checkout because it
     still expects an absolute path while the shared binary already writes
     $HOME -- the control that shows this diff is what changes the behavior.
```

Every failure on both sides is a pre-existing environment limitation here:
no `gh` CLI, no `pwsh`, sandboxed `pty` allocation, and network-dependent
contracts.

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|-------------------------|--------------|--------------------|------|
| 1 | Install a hook package with `apm install -g` on a POSIX host — the tracked settings file holds a `$HOME`-anchored command instead of the installing host's prefix (regression trap for #2821) | Portability by manifest | `tests/unit/integration/test_hook_integrator.py::TestClaudeIntegration::test_user_scope_writes_portable_home_hook_paths` | unit |
| 2 | Install globally, then run the hook from an unrelated working directory — it still executes | DevX (pragmatic as npm), Multi-harness support | `tests/integration/test_hook_js_sidecar_lifecycle_contract.py::test_required_global_copilot_sidecar_lifecycle` | e2e |
| 3 | Reinstall the same package globally — hook entries converge instead of duplicating, and `apm uninstall --global` removes exactly the package-owned files | DevX (pragmatic as npm) | `tests/integration/test_hook_js_sidecar_lifecycle_contract.py::test_required_global_copilot_sidecar_lifecycle` | e2e |
| 4 | Install the same package at user scope for Copilot and Kiro — both targets get the anchored command | Multi-harness support, Portability by manifest | `tests/integration/test_hook_integrator_copilot_casing_e2e.py::test_copilot_install_scope_controls_script_paths[True]`, `::test_kiro_install_scope_controls_script_paths[True]` | integration |
| 5 | Install globally on Windows — the generated command keeps its previous absolute form | Multi-harness support | `tests/unit/integration/test_hook_integrator.py::TestIssue1007Fixes::test_rewrite_command_deploy_root_keeps_windows_absolute_path` | unit |
| 6 | Point `CLAUDE_CONFIG_DIR` outside the home directory — the command is never rewritten into a wrong `$HOME` path | Secure by default, Portability by manifest | `tests/unit/integration/test_hook_integrator.py::TestIssue1007Fixes::test_rewrite_command_dynamic_root_outside_home_stays_absolute` | unit |
| 7 | Write a hook command with a single-quoted plugin-root reference — the emitted command stays executable instead of containing a literal `$HOME` | DevX (pragmatic as npm), Multi-harness support | `tests/unit/integration/test_hook_integrator.py::TestIssue1007Fixes::test_rewrite_command_single_quoted_reference_stays_absolute` | unit |

## How to test

- [ ] `uv run --extra dev pytest tests/unit/integration/test_hook_integrator.py -q -n0` → `188 passed`, including the three boundary cases (Windows, single-quoted reference, root outside home).
- [ ] `uv run --extra dev pytest tests/integration/test_hook_integrator_copilot_casing_e2e.py -q -n0` → passes for both `user_scope` parametrizations of Copilot and Kiro.
- [ ] Build the CLI (`scripts/build-binary.sh`) and run `APM_BINARY_PATH=… APM_E2E_TESTS=1 uv run --extra dev pytest tests/integration/test_hook_js_sidecar_lifecycle_contract.py -q -n0` → `5 passed`.
- [ ] `uv run --extra dev ruff check src/ tests/ && uv run --extra dev ruff format --check src/ tests/` → both silent.
- [ ] Spot-check the artifact: `HOME=/tmp/scratch apm install --global --target claude <pkg>` then `grep -o '\$HOME[^"]*' /tmp/scratch/.claude/settings.json` → prints `$HOME/.claude/hooks/…` and never `/tmp/scratch/...`.

---

## Review feedback addressed

Responding to the Copilot review on `6331f22`:

- **[critical] Single-quoted references** (`hook_integrator.py:613`) — correct, and this was a regression I introduced, not a pre-existing one: the previous absolute form worked inside any quoting. `node '${CLAUDE_PLUGIN_ROOT}/hooks/run.mjs'` produced `node '$HOME/.claude/hooks/…'`, where the shell expands nothing. Anchoring now requires an unquoted or double-quoted reference; the quote character is threaded through instead of a boolean, and a regression test asserts the single-quoted form stays absolute and executable.
- **[nit] CHANGELOG entry missing the PR reference** — fixed: the entry now ends with `(#2944)`.
- **[nit] `packages/apm-guide/.apm/skills/apm-usage/package-authoring.md` still documents absolute paths** — fixed: that resource now describes the `$HOME` anchor and its three exceptions.
- **[suppressed] Absolute root outside home + bundle copying** (`hook_integrator.py:605`) — verified as pre-existing rather than introduced here. On an untouched `main` checkout, the same input produces the same absolute command *and* the same absolute copy target from this branch, so the `ensure_path_within` rejection in `copy_deployed_hook_bundle` is independent of this diff. This PR neither touches `hook_bundle.py` nor changes that path's behavior; happy to file or take a follow-up that supports an absolute root end to end.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [x] Added tests for new functionality (if applicable)

## Spec conformance (OpenAPM v0.1)

- [x] N/A — this PR does not change OpenAPM-observable behaviour.

The Mode B detector counts substantive added lines under `src/apm_cli/integration/`;
this diff is at 22, above the 20-line threshold, so it carries the documented
waiver rather than a spec citation. No existing `req-XXX` covers *user-scope*
hook anchoring, and inventing one for a path-spelling change would put
implementation detail into the spec:

apm-spec-waiver: user-scope hook anchoring changes path spelling only, adding no new OpenAPM requirement

If you would rather make user-scope anchoring normative, I am happy to add the
anchor + manifest row + conformance test instead and drop the waiver.
