### PR TITLE
fix(compile): include ADO three-level CLAUDE.md dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `apm compile --target claude` now includes `CLAUDE.md` imports for Azure DevOps three-level dependency paths (`apm_modules/org/project/repo`), matching GitHub two-level packages. (#2951)
+
 ### Added
 
 - gh-aw's shared APM import now supports `token-source: github-token`; after consumers re-vendor the workflow, its read-only current-repository identity can fetch same-repository private packages, while `cascade` remains the default and cross-repository packages still require a dedicated token or GitHub App. (#2706)

--- a/src/apm_cli/compilation/claude_formatter.py
+++ b/src/apm_cli/compilation/claude_formatter.py
@@ -9,6 +9,7 @@ import builtins
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from ..primitives.discovery import get_dependency_declaration_order
 from ..primitives.models import Chatmode, Instruction, PrimitiveCollection
 from ..utils.paths import resolve_base_and_source_dirs
 from ..version import get_version
@@ -232,32 +233,58 @@ class ClaudeFormatter:
     def _collect_dependencies(self) -> builtins.list[str]:
         """Collect @import paths for apm_modules dependencies.
 
+        Prefers installed package roots from ``apm.yml`` / lockfile declaration
+        order (GitHub ``owner/repo``, Azure DevOps ``org/project/repo``, and
+        virtual paths). Falls back to a shallow filesystem scan that understands
+        both two-level and three-level layouts when no declarations are present
+        (e.g. unit fixtures).
+
         Returns:
             List[str]: List of @import paths for dependencies.
         """
-        dependencies = []
-        apm_modules_dir = self.base_dir / "apm_modules"
+        dependencies: builtins.list[str] = []
 
-        if not apm_modules_dir.is_dir():
+        # Modules live with sources; honor --root by preferring source_dir.
+        modules_root = self.source_dir / "apm_modules"
+        if not modules_root.is_dir() and self.base_dir.resolve() != self.source_dir.resolve():
+            modules_root = self.base_dir / "apm_modules"
+        if not modules_root.is_dir():
             return dependencies
 
-        # Scan for CLAUDE.md files in apm_modules
-        # Structure: apm_modules/{owner}/{package}/CLAUDE.md
-        for owner_dir in apm_modules_dir.iterdir():
+        declared = get_dependency_declaration_order(str(self.source_dir))
+        if not declared and self.base_dir.resolve() != self.source_dir.resolve():
+            declared = get_dependency_declaration_order(str(self.base_dir))
+
+        if declared:
+            for rel in declared:
+                if (modules_root / rel / "CLAUDE.md").is_file():
+                    dependencies.append(f"@apm_modules/{rel}/CLAUDE.md")
+            return sorted(dependencies)
+
+        # Fallback FS scan: GitHub owner/repo and ADO org/project/repo.
+        # Only treat a third level as a package when the mid directory has no
+        # package-root CLAUDE.md (avoids picking nested docs under GitHub pkgs).
+        for owner_dir in modules_root.iterdir():
             if not owner_dir.is_dir() or owner_dir.name.startswith("."):
                 continue
 
-            for package_dir in owner_dir.iterdir():
-                if not package_dir.is_dir() or package_dir.name.startswith("."):
+            for mid_dir in owner_dir.iterdir():
+                if not mid_dir.is_dir() or mid_dir.name.startswith("."):
                     continue
 
-                claude_md_path = package_dir / "CLAUDE.md"
-                if not claude_md_path.is_file():
+                package_claude = mid_dir / "CLAUDE.md"
+                if package_claude.is_file():
+                    dependencies.append(f"@apm_modules/{owner_dir.name}/{mid_dir.name}/CLAUDE.md")
                     continue
 
-                # Build the @import path
-                import_path = f"@apm_modules/{owner_dir.name}/{package_dir.name}/CLAUDE.md"
-                dependencies.append(import_path)
+                for repo_dir in mid_dir.iterdir():
+                    if not repo_dir.is_dir() or repo_dir.name.startswith("."):
+                        continue
+                    ado_claude = repo_dir / "CLAUDE.md"
+                    if ado_claude.is_file():
+                        dependencies.append(
+                            f"@apm_modules/{owner_dir.name}/{mid_dir.name}/{repo_dir.name}/CLAUDE.md"
+                        )
 
         return sorted(dependencies)
 

--- a/tests/unit/compilation/test_claude_formatter.py
+++ b/tests/unit/compilation/test_claude_formatter.py
@@ -336,6 +336,77 @@ class TestDependenciesImportSyntax:
         assert "@apm_modules/owner1/no-claude/CLAUDE.md" not in deps
         assert "@apm_modules/owner3/skills-only/CLAUDE.md" not in deps
 
+    def test_ado_three_level_dependencies_included(self, tmp_path):
+        """Azure DevOps packages live at apm_modules/org/project/repo (issue #2951)."""
+        ado_pkg = tmp_path / "apm_modules" / "contoso" / "platform" / "standards"
+        ado_pkg.mkdir(parents=True)
+        (ado_pkg / "CLAUDE.md").write_text("# ADO package", encoding="utf-8")
+        # Depth-3 tree without CLAUDE.md must stay omitted.
+        empty = tmp_path / "apm_modules" / "contoso" / "platform" / "empty-repo"
+        empty.mkdir(parents=True)
+        (empty / "README.md").write_text("no claude", encoding="utf-8")
+
+        formatter = ClaudeFormatter(str(tmp_path))
+        deps = formatter._collect_dependencies()
+
+        assert "@apm_modules/contoso/platform/standards/CLAUDE.md" in deps
+        assert "@apm_modules/contoso/platform/empty-repo/CLAUDE.md" not in deps
+
+    def test_nested_claude_md_under_github_package_not_imported(self, tmp_path):
+        """Do not treat nested docs/CLAUDE.md as a package root when mid has CLAUDE.md."""
+        pkg = tmp_path / "apm_modules" / "owner" / "repo"
+        pkg.mkdir(parents=True)
+        (pkg / "CLAUDE.md").write_text("# Package root", encoding="utf-8")
+        nested = pkg / "docs"
+        nested.mkdir()
+        (nested / "CLAUDE.md").write_text("# Nested docs", encoding="utf-8")
+
+        formatter = ClaudeFormatter(str(tmp_path))
+        deps = formatter._collect_dependencies()
+
+        assert deps == ["@apm_modules/owner/repo/CLAUDE.md"]
+
+    def test_mixed_github_and_ado_dependencies_sorted(self, tmp_path):
+        """Two-level and three-level roots can coexist and stay sorted."""
+        gh = tmp_path / "apm_modules" / "zeta" / "pkg"
+        gh.mkdir(parents=True)
+        (gh / "CLAUDE.md").write_text("# gh", encoding="utf-8")
+        ado = tmp_path / "apm_modules" / "alpha" / "proj" / "repo"
+        ado.mkdir(parents=True)
+        (ado / "CLAUDE.md").write_text("# ado", encoding="utf-8")
+
+        formatter = ClaudeFormatter(str(tmp_path))
+        deps = formatter._collect_dependencies()
+
+        assert deps == [
+            "@apm_modules/alpha/proj/repo/CLAUDE.md",
+            "@apm_modules/zeta/pkg/CLAUDE.md",
+        ]
+
+    def test_ado_dependency_appears_in_distributed_output(self, tmp_path):
+        """format_distributed Dependencies section includes ADO three-level imports."""
+        ado_pkg = tmp_path / "apm_modules" / "org" / "project" / "repo"
+        ado_pkg.mkdir(parents=True)
+        (ado_pkg / "CLAUDE.md").write_text("# ADO", encoding="utf-8")
+
+        formatter = ClaudeFormatter(str(tmp_path))
+        primitives = PrimitiveCollection()
+        instruction = Instruction(
+            name="test",
+            file_path=tmp_path / "test.instructions.md",
+            description="Test",
+            apply_to="**/*.py",
+            content="Test content",
+            author="test",
+        )
+        primitives.add_primitive(instruction)
+        placement_map = {formatter.base_dir: [instruction]}
+        result = formatter.format_distributed(primitives, placement_map)
+        content = result.content_map[formatter.base_dir / "CLAUDE.md"]
+
+        assert "## Dependencies" in content
+        assert "@apm_modules/org/project/repo/CLAUDE.md" in content
+
 
 class TestAgentsExcludedFromClaudeMd:
     """Tests verifying agents/workflows are NOT included in CLAUDE.md.


### PR DESCRIPTION
## Description

`apm compile --target claude` only walked `apm_modules/{owner}/{package}/CLAUDE.md`, so Azure DevOps packages materialized at `apm_modules/{org}/{project}/{repo}` never appeared in the Dependencies `@import` list (silent miss).

This change prefers declared install roots from `apm.yml` / lockfile declaration order (already aware of GitHub vs ADO vs virtual paths), and falls back to a shallow two- and three-level filesystem scan for fixture layouts without declarations. Nested `CLAUDE.md` under a GitHub package that already has a package-root file is not imported.

Fixes #2951

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [x] Added tests for new functionality (if applicable)

`uv run --extra dev pytest tests/unit/compilation/test_claude_formatter.py`

## Spec conformance (OpenAPM v0.1)

- [ ] Spec edit: `docs/src/content/docs/specs/openapm-v0.1.md` updated
      (new/changed `<a id="req-XXX"></a>` anchor + prose + Appendix C
      row).
- [ ] Manifest edit: `docs/src/content/docs/specs/manifests/openapm-v0.1.requirements.yml`
      updated.
- [ ] Test edit: a `@pytest.mark.req("req-XXX")` test under
      `tests/spec_conformance/` added or extended.
- [ ] `CONFORMANCE.{md,json}` regenerated via
      `uv run --extra dev python -m tests.spec_conformance.gen_statement`
      and committed.
- [x] N/A -- this PR does not change OpenAPM-observable behaviour.