### PR TITLE
docs: establish issue-first contribution and governance policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,14 @@ assignees: ''
 
 ---
 
+Reporting and investigating a bug need no permission. Before implementing a
+substantive fix for inclusion in APM, obtain human scope approval and a review
+contact on this issue. Trivial documentation corrections have standing
+preapproval. See [Contributing](https://github.com/microsoft/apm/blob/main/CONTRIBUTING.md).
+
+For vulnerabilities, use [SECURITY.md](https://github.com/microsoft/apm/blob/main/SECURITY.md)
+instead of a public issue. Remove credentials and other sensitive data from logs.
+
 **Describe the bug**
 A clear and concise description of what the bug is.
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,14 +7,22 @@ assignees: ''
 
 ---
 
+Proposals are welcome before implementation. For substantive changes, wait
+for a responsible human maintainer to approve the scope and identify a review
+contact. An automated recommendation, label alone, or silence is not approval.
+See [Contributing](https://github.com/microsoft/apm/blob/main/CONTRIBUTING.md).
+
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+Describe the user problem and who encounters it. Include examples or evidence
+of the need where possible.
 
 **Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+Describe the intended outcome, how you would know it works, and important
+boundaries. You do not need to implement it or write a full design first.
 
 **Describe alternatives you've considered**
 A clear and concise description of any alternative solutions or features you've considered.
 
 **Additional context**
-Add any other context or screenshots about the feature request here.
+Link related issues. If you would like to help with design, implementation,
+or testing, say so; offering help does not commit you or the maintainers.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,21 @@
 
 Brief description of changes and motivation.
 
-Fixes # (issue)
+## Issue and approved scope
+
+Issue: # (required; use the canonical issue or a bounded child issue)
+
+Human scope-approval comment: (link, state the trivial-documentation
+standing-preapproval case, or indicate private security coordination without
+disclosing report details)
+
+Does this PR complete the issue, or what remains?
+
+<!-- Use "Fixes #N" only for an issue this PR completes. A related issue,
+     automated recommendation, or label alone is not scope approval.
+     Routine automated maintenance needs a bounded, human-approved issue.
+     Security changes may use private tracking: do not disclose report details.
+     Existing PRs follow the transition guidance in CONTRIBUTING.md. -->
 
 ## Type of change
 
@@ -20,8 +34,8 @@ Fixes # (issue)
 ## Spec conformance (OpenAPM v0.1)
 
 If this PR changes behaviour that an OpenAPM v0.1 `req-XXX` covers,
-confirm the three-step ritual (see CONTRIBUTING.md "Adding or
-changing a normative requirement"):
+confirm the three-step ritual in the
+[development guide](https://github.com/microsoft/apm/blob/main/docs/src/content/docs/contributing/development-guide.md#adding-or-changing-a-normative-requirement-openapm-v01):
 
 - [ ] Spec edit: `docs/src/content/docs/specs/openapm-v0.1.md` updated
       (new/changed `<a id="req-XXX"></a>` anchor + prose + Appendix C

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,495 +1,144 @@
 # Contributing to APM
 
-Thank you for considering contributing to APM! This document outlines the process for contributing to the project.
+Thank you for helping improve APM. Bug reports, reproductions, documentation,
+reviews, and code are all valuable contributions. Please follow our
+[Code of Conduct](CODE_OF_CONDUCT.md).
 
-## Code of Conduct
+**Start with an issue, not an implementation.** For substantive changes, wait
+for a responsible human maintainer to approve the scope before coding for
+inclusion in APM. This avoids work the project cannot support or accept.
+[GOVERNANCE.md](GOVERNANCE.md) names the maintainers and their decision areas.
 
-By participating in this project, you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md). Please read it before contributing.
+## Find work or propose an idea
 
-## How to Contribute
+- **Find work:** look for [issues marked `help wanted`](https://github.com/microsoft/apm/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22).
+  Read the issue's human approval and check that nobody is already working
+  on it. `good first issue` identifies supported newcomer tasks when available.
+- **Report a bug:** check existing issues and the current release, then use
+  the [bug report template](https://github.com/microsoft/apm/issues/new?template=bug_report.md).
+  Include a reproduction, expected behavior, version, and relevant logs.
+- **Propose a change:** open an [issue](https://github.com/microsoft/apm/issues/new/choose)
+  explaining the user problem, evidence, alternatives, and expected benefit.
+  Proposals, investigations, and design discussion need no prior permission.
 
-### Reporting Bugs
+Do not report vulnerabilities or publish credentials in public issues or
+PRs. Use the private reporting route in [SECURITY.md](SECURITY.md).
 
-Before submitting a bug report:
+## Before you start implementation
 
-1. Check the [GitHub Issues](https://github.com/microsoft/apm/issues) to see if the bug has already been reported.
-2. Update your copy of the code to the latest version to ensure the issue hasn't been fixed.
+A [responsible maintainer](GOVERNANCE.md#maintainers-and-scope) records approval
+on the issue with:
 
-When submitting a bug report:
+- **Scope:** the bounded change the project welcomes.
+- **Done when:** the acceptance criteria.
+- **Out of scope:** important exclusions, if any.
+- **Review contact:** a maintainer willing to support review.
 
-1. Use our bug report template.
-2. Include detailed steps to reproduce the bug.
-3. Describe the expected behavior and what actually happened.
-4. Include any relevant logs or error messages.
+`status/accepted` communicates this decision; the **human approval record is
+authoritative**. A label, automated recommendation, milestone, or silence is
+not approval. `needs-design` work needs an agreed design before implementation.
+If no reviewer has capacity, maintainers may defer the proposal rather than
+invite work they cannot support.
 
-### Suggesting Enhancements
+For accepted, unclaimed work, comment that you intend to work on it; you do
+not need a second permission request. Check existing comments and linked PRs
+to avoid duplicate work. Assignment records coordination, not permanent
+ownership. If you need to pause, say so on the issue so someone else can help.
+If the scope changes, discuss it before expanding the implementation.
 
-Enhancement suggestions are welcome! Please:
+Approval welcomes work within the agreed scope. It does **not** guarantee
+merge, a particular implementation, or a release date. You may experiment in
+your own fork without approval, but an unsolicited PR does not oblige
+maintainers to review or adopt it.
 
-1. Use our feature request template.
-2. Clearly describe the enhancement and its benefits.
-3. Provide examples of how the enhancement would work.
+### Small corrections
 
-### Author your PR with the agent skills shipped in this repo (APM dogfoods APM)
+Typo fixes and broken documentation links have standing preapproval. Create
+a short issue alongside the PR and link it; no separate approval wait is
+needed. This exception does not cover code fixes, behavior changes, or
+substantive documentation changes. If uncertain, ask on the issue.
 
-This repo *uses* APM to ship its own author and review skills. The
-canonical sources live under [`.apm/skills/`](.apm/skills/) and
-[`.apm/agents/`](.apm/agents/) -- the same primitive layout any APM
-package uses. They are not magically loaded by your editor; you have
-to install them like any other APM dependency.
+Maintainer-authored changes and automated PRs also need issue traceability.
+Routine automation may use a bounded maintenance or release issue with
+recorded human approval; it is not a blanket exception for unrelated work.
+Security fixes may use private tracking and human coordination through the
+security-reporting process; do not publish confidential approval links or
+report details to satisfy the PR template.
 
-After cloning, run APM against this repo the way you would against any
-other APM project:
+## Submit a reviewable PR
 
-```bash
-# 1. Install APM itself if you haven't already.
-#    See https://github.com/microsoft/apm#install for all install options.
-curl -sSL https://aka.ms/apm-unix | sh        # macOS / Linux
-# irm https://aka.ms/apm-windows | iex        # Windows PowerShell
+1. Fork and create a branch for the approved issue.
+2. Keep the PR focused on one concern. Include relevant tests and update
+   documentation for changed behavior.
+3. Follow the [development guide](docs/src/content/docs/contributing/development-guide.md)
+   for setup, local checks, and any surface-specific requirements.
+4. In the PR template, link the canonical issue and human approval comment,
+   or state the standing-preapproval case. Explain the change, evidence,
+   and any remaining limitations.
+5. Use `Fixes #N` only when the PR completes that issue. For partial work,
+   reference the issue without closing it and describe what remains.
 
-# 2. From the root of this repo:
-apm install
-```
+Maintain the same issue reference on stacked PRs, or link a bounded child
+issue for each layer. Scope approval and PR review are separate decisions.
+Required checks and maintainer review still apply before merge.
 
-`apm install` reads this repo's [`apm.yml`](apm.yml) (`includes: auto`),
-picks up everything under `.apm/`, and deploys it into `.github/` and
-`.agents/skills/` -- the tree this repo commits. `apm.yml` pins the
-`copilot` target, so every contributor gets that same tree regardless of
-which harness their own machine signals.
+Maintainers check eligibility before detailed implementation review. Work
+outside the agreed scope may be redirected or closed with a reason without
+a full code review. A relevant issue link is not permission for unrelated
+changes. Authors remain responsible for their submissions, including
+agent-generated work.
 
-To deploy to a different harness for one install, first exclude that
-harness's generated root locally, then override the pinned target:
+### Agent tools are optional
 
-```bash
-# Claude Code example:
-printf '.claude/\n' >> "$(git rev-parse --git-path info/exclude)"
-apm install --target claude
-```
+You do not need an AI tool, a particular harness, or the repository's skills
+to contribute. The [development guide](docs/src/content/docs/contributing/development-guide.md#optional-agent-tools)
+explains the available tooling. Automated reviews are advisory: they do not
+approve scope or replace human review. Relevant tests and a clear explanation
+matter more than the tool used to produce them.
 
-The local exclusion keeps generated files out of `git status` without hiding
-harness configuration from every contributor. The explicit-target install
-still adds its deploy paths to `apm.lock.yaml`; leave that change uncommitted.
-Your harness (Claude Code, GitHub Copilot CLI, Cursor, OpenCode, Codex,
-Gemini, ...) can then discover and invoke the skills by name. For another
-target, check its output directory in the
-[target catalogue](docs/src/content/docs/concepts/primitives-and-targets.md#target-catalogue);
-some targets write to more than one root.
+## What to expect from maintainers
 
-For most PRs, two of those skills carry most of the weight:
+Maintainers consider user need, project direction, maintenance cost, risk,
+and review capacity. They may accept, request design or information, defer,
+or decline with a reason. A milestone is a release target, not a prerequisite
+for acceptance or a delivery guarantee.
 
-| Skill | When to use it |
-|---|---|
-| [`pr-description-skill`](.apm/skills/pr-description-skill/SKILL.md) | **Every PR.** Drafts a self-sufficient PR body (TL;DR, Problem / Approach / Implementation, mermaid diagrams, validation evidence, How-to-test) that anchors every WHY-claim to PROSE / Agent Skills. Avoids the "what does this PR even do?" round-trip with reviewers. |
-| [`apm-review-panel`](.apm/skills/apm-review-panel/SKILL.md) | **Non-trivial PRs** (new behaviour, security-relevant code, CLI UX changes, manifest/schema changes). Runs the same multi-persona panel CI runs in `pr-review-panel.yml` -- locally, on your working tree, before you push. Surfaces the `required` findings while the cost of fixing is still cheap. |
+Keep discussion on the issue or PR so others can follow the decision.
+Maintainer availability varies; there is no guaranteed turnaround. If you
+are waiting, a concise follow-up on the original thread is welcome. Waiting
+on a maintainer is not contributor abandonment.
 
-Typical local flow (after `apm install`):
+**Existing contributions:** older labels and automated comments may describe
+a different process. Check for explicit human approval rather than treating
+those signals as permission to start new work. Existing PRs will be considered
+on their merits and may have wanted scope ratified now; they will not be
+automatically rejected for lacking approval under a rule introduced later.
 
-1. Implement your change against `main`.
-2. Ask your agent: *"Run the apm-review-panel skill on my working tree."*
-   The panel fans out to the architectural, CLI-logging, DevX,
-   supply-chain, growth, and (if relevant) auth personas, and returns
-   a single verdict with `required` findings split from `nits`.
-   Address the `required` items in-place.
-3. Ask your agent: *"Use the pr-description-skill to draft the PR body
-   for this branch."* Review the draft, paste it into
-   `gh pr create --body-file`.
-4. Push and open the PR. The same panel runs in CI on label, but most
-   `required` findings will already be addressed -- the comment thread
-   stays focused on substance instead of correctness debt.
+For responsibilities, progression, and how disagreements are resolved, see
+[GOVERNANCE.md](GOVERNANCE.md).
 
-You don't have to use these skills, but the panel verdict in CI applies
-the same rubric either way, and PRs that have already been through it
-locally tend to merge faster.
+## Development reference
 
-The full persona roster lives in [`.apm/agents/`](.apm/agents/) -- you
-can also summon any single persona (e.g. `python-architect`,
-`supply-chain-security-expert`) for a focused review of a specific file
-or design question without running the full panel.
-
-#### When to summon which persona during design and implementation
-
-Don't wait for the panel verdict to discover you should have talked to
-a specialist. The same personas the panel runs are the ones to consult
-*while* you are designing and building. Recommended pairings:
-
-| Situation | Persona to summon | Why |
-|---|---|---|
-| Any new feature or feature change | [`devx-ux-expert`](.apm/agents/devx-ux-expert.agent.md) **first** | Validate the user-facing approach (flags, defaults, error messages, manifest shape) *before* you write code. Cheaper than re-doing the implementation after the panel rejects it. |
-| Anything that prints to the terminal | [`cli-logging-expert`](.apm/agents/cli-logging-expert.agent.md) | Always include this. Keeps log levels, colours, prefixes, and progress indicators consistent across the CLI. |
-| Refactor, new module, or non-trivial architecture decision | [`python-architect`](.apm/agents/python-architect.agent.md) | Get the boundaries / interfaces / dependency direction right up front. |
-| Anything that fetches packages, evaluates manifests, scans content, signs / verifies / locks, or touches `apm install` | [`supply-chain-security-expert`](.apm/agents/supply-chain-security-expert.agent.md) **mandatory** | A core promise of APM is that `apm install` blocks compromised packages before agents read them. This persona is **non-optional** for any PR that touches the supply chain -- the panel will reject it otherwise. |
-| Any change touching authentication, tokens, credential resolution, or remote host auth (GitHub, GHE, ADO, EMU, GitHub Apps) | [`auth-expert`](.apm/agents/auth-expert.agent.md) | Auth bugs are silent and expensive. Run this persona on the design and again on the diff. |
-| New primitive type, manifest schema change, or cross-target deployment behaviour | [`apm-primitives-architect`](.apm/agents/apm-primitives-architect.agent.md) | Keeps the primitive model coherent across Copilot, Claude, Cursor, OpenCode, Codex, Gemini. |
-| Public-facing copy, README, docs site, or release notes | [`doc-writer`](.apm/agents/doc-writer.agent.md) and/or [`oss-growth-hacker`](.apm/agents/oss-growth-hacker.agent.md) | Voice consistency and positioning for new-user moments. |
-
-Rule of thumb: ask the matching persona to **critique your plan before
-you implement**, then ask it again to **review the diff before you
-push**. Two cheap, focused passes per persona beat one expensive panel
-rejection. The `apm-review-panel` skill at the end is then a sanity
-check, not a redesign.
-
-
-
-1. Fork the repository.
-2. Create a new branch for your feature/fix: `git checkout -b feature/your-feature-name` or `git checkout -b fix/issue-description`.
-3. Make your changes.
-4. Run tests: `uv run pytest tests/unit tests/test_console.py -x`
-5. Mirror the CI `Lint` job locally before pushing -- both commands must be silent:
-   ```bash
-   uv run --extra dev ruff check src/ tests/
-   uv run --extra dev ruff format --check src/ tests/
-   ```
-   Auto-fix with `ruff check --fix` and `ruff format` (without `--check`). The full contract -- including common surprises like `RUF043`, `UP006`, `I001` -- lives in [`.apm/instructions/linting.instructions.md`](.apm/instructions/linting.instructions.md), the canonical source of truth that CI, the `pr-description-skill`, and the dogfood `apm compile -t copilot` all mirror.
-6. Commit your changes with a descriptive message.
-7. Push to your fork.
-8. Submit a pull request.
-
-### Pull Request Process
-
-1. Fill out the PR template - describe what changed, why, and link the issue.
-2. Ensure your PR addresses only one concern (one feature, one bug fix).
-3. Include tests for new functionality.
-4. Update documentation if needed.
-5. PRs must pass all CI checks before they can be merged.
-
-### How merging works
-
-This repo uses GitHub's native **merge queue**. Once your PR is approved, a
-maintainer adds it to the queue. The queue then:
-
-1. Builds a tentative merge of your PR against the latest `main` - no manual
-   "Update branch" needed.
-2. Runs the integration suite against that tentative merge.
-3. Auto-merges if checks pass; ejects from the queue if they fail.
-
-What this means for contributors:
-
-- You don't need to keep your branch up to date with `main` manually.
-- The fast unit + build checks (Tier 1) run on every push to your PR.
-- A hermetic ~65-70s Lifecycle Smoke check also runs on every push, validating
-  core install/lock-convergence/policy-enforcement contracts via a declarative
-  `lifecycle_smoke` pytest marker -- no network, credentials, or built binary
-  required, so you get real regression feedback before the queue instead of
-  only after.
-- The full integration suite (Tier 2) only runs once your PR is in the queue,
-  not on every WIP push.
-
-If your PR is ejected from the queue because of a real failure, push a fix and
-ask a maintainer to re-queue.
-
-### Issue Triage
-
-Every new issue is automatically labeled `needs-triage`. Maintainers review incoming issues and:
-
-1. **Accept** - remove `needs-triage`, add `accepted`, and assign a milestone.
-2. **Prioritize** - optionally add `priority/high` or `priority/low`.
-3. **Close** - if it's a duplicate (`duplicate`) or out of scope, close with a comment explaining why.
-
-Labels used for triage: `needs-triage`, `accepted`, `needs-design`, `priority/high`, `priority/low`.
-
-## Development Environment
-
-This project uses uv to manage Python environments and dependencies:
-
-```bash
-# Clone the repository
-git clone <this-repo-url>
-cd apm
-
-# Install all dependencies (creates .venv automatically)
-uv sync --extra dev
-```
-
-## Testing
-
-We use pytest for testing with `pytest-xdist` for parallel execution. After completing the setup above:
-
-```bash
-# Run the unit test suite (recommended - matches CI, fast)
-uv run pytest tests/unit tests/test_console.py -x
-
-# Run a specific test file (fastest, use during development)
-uv run pytest tests/unit/path/to/relevant_test.py -x
-
-# Run the full test suite (includes integration & acceptance tests)
-uv run pytest
-
-# Run with verbose output
-uv run pytest tests/unit -x -v
-```
-
-Tests run in parallel automatically (`-n auto` is configured in `pyproject.toml`). To force serial execution, add `-n0`.
+The [development guide](docs/src/content/docs/contributing/development-guide.md)
+contains environment setup, testing, linting, optional agent tooling, and
+merge-queue guidance. Required technical checks are unchanged by this policy.
 
 ### Running the bounded mutation pilot
 
-The advisory mutation pilot checks five stable owners: dependency subset
-selection, update-plan construction, cached-policy serialization, canonical
-in-package link projection, and lockfile field normalization (the fail-closed
-`host_type`/`exec_status` normalizers, not the `@dataclass` reconstruction
-methods `to_dict`/`from_dict`/`to_dependency_ref` -- mutmut cannot mutate
-`@dataclass` methods; those are defended by PR #2246's manual mutation-break
-twins instead). It is intentionally separate from
-required PR CI and runs nightly or by manual workflow dispatch with a
-20-minute job budget.
-
-Run the same exact-function allowlist locally:
-
-```bash
-uv run --frozen --extra dev python scripts/run_mutation_pilot.py \
-  --output mutation-pilot-report.json
-```
-
-The command exits nonzero for a new survivor, timeout, suspicious result,
-unchecked mutant, or any other incomplete outcome. It writes a sorted,
-timestamp-free JSON report even when the survivor comparison fails. Reuse the
-`mutants/` cache only when the source, test seams, configuration, runner, and
-lockfile are unchanged:
-
-```bash
-uv run --frozen --extra dev python scripts/run_mutation_pilot.py \
-  --reuse-cache --output mutation-pilot-report.json
-```
-
-To inspect existing mutmut metadata without executing mutants:
-
-```bash
-uv run --frozen --extra dev python scripts/run_mutation_pilot.py \
-  --report-only --output mutation-pilot-report.json
-```
-
-The accepted survivor allowlist is
-[`tests/mutation/baseline.json`](tests/mutation/baseline.json). Do not update it
-to make a run green. Review every surviving diff with `mutmut show`, add a
-behavioral test for real contract gaps, and use `--update-baseline` only for a
-reviewed baseline change.
-
-```bash
-uv run --frozen --extra dev python scripts/run_mutation_pilot.py \
-  --update-baseline --output mutation-pilot-report.json
-```
-
-If you don't have `uv` available, you can use a standard Python venv and pip:
-
-```bash
-# create and activate a venv (POSIX / WSL)
-python -m venv .venv
-source .venv/bin/activate
-
-# install this package in editable mode and test deps
-pip install -U pip
-pip install -e .[dev]
-
-# run unit tests
-pytest tests/unit tests/test_console.py -x
-```
-
-### Running integration tests
-
-Integration tests under `tests/integration/` use a marker-driven
-discovery system: each test declares the precondition it needs
-(token, runtime, opt-in flag, ...) as a `pytest.mark.requires_*`
-marker, and `tests/integration/conftest.py` auto-skips at collection
-time when the precondition is missing. Without any setup,
-`uv run pytest tests/integration` is silent rather than red -- every
-test reports as `SKIPPED` with a one-line reason, so you can see
-exactly what is missing.
-
-The full marker reference (one row per `_MARKER_CHECKS` entry, with
-the env-var or `apm runtime setup` command that satisfies it) lives
-in
-[Integration Testing](docs/src/content/docs/contributing/integration-testing.md#the-marker-registry).
-For install, compile, pack, or audit lifecycle changes, reuse the
-[hermetic lifecycle fixtures](docs/src/content/docs/contributing/integration-testing.md#hermetic-lifecycle-fixtures)
-to exercise the real CLI with a sanitized child environment and reviewed local
-Git sources.
-A typical local run looks like:
-
-```bash
-# Run only what your current env satisfies
-uv run pytest tests/integration -v
-
-# Run only one marker family (e.g. tests that need a GitHub token)
-uv run pytest tests/integration -m requires_github_token -v
-```
-
-When adding a new precondition, add an entry to `_MARKER_CHECKS` and
-declare the marker in `pyproject.toml`; that is the only place the
-precondition needs to live.
-
-### Coverage policy
-
-Both suites enforce a hard coverage gate in CI. A PR that drops
-coverage below the gate cannot merge.
-
-| Suite       | Gate | Enforced in |
-|-------------|------|-------------|
-| Unit        | 80%  | `pyproject.toml` (`fail_under`) |
-| Integration | 70%  | `.github/workflows/ci-integration.yml` (`--fail-under`) |
-
-**Ratchet rule.** Gates only move upward. When actual coverage
-exceeds the gate by 5 or more percentage points, raise the gate to
-`actual - 3` in the next release PR.
-
-**Finding low-coverage files.** Every CI run publishes a
-"Lowest-coverage files" collapsible section in the job summary
-(rendered by `scripts/coverage-summary.py`). Check there to see
-which files would benefit most from new tests.
-
-## Coding Style
-
-This project follows:
-- [PEP 8](https://pep8.org/) for Python style guidelines
-- We use [Ruff](https://docs.astral.sh/ruff/) for linting and formatting
-
-CI enforces all lint and formatting rules automatically. The CI `Lint` job runs the following two commands -- both must be silent before you open a PR:
-
-```bash
-uv run --extra dev ruff check src/ tests/         # lint (CI-mirror)
-uv run --extra dev ruff format --check src/ tests/ # format check (CI-mirror)
-```
-
-Auto-fix locally with:
-
-```bash
-uv run --extra dev ruff check src/ tests/ --fix   # lint with auto-fix
-uv run --extra dev ruff format src/ tests/        # apply formatter
-```
-
-The canonical lint contract (with common diagnostics and lifecycle binding for skills that claim green CI) lives in [`.apm/instructions/linting.instructions.md`](.apm/instructions/linting.instructions.md). Do not redefine these commands elsewhere -- honor that instruction.
-
-### Optional: local pre-commit hooks
-
-For instant feedback before pushing, install the pre-commit hooks:
-
-```bash
-uv run pre-commit install
-```
-
-This is optional -- CI is the authoritative gate. The pre-commit hook rev may lag behind the CI version; check `.pre-commit-config.yaml` against `uv.lock` if you see discrepancies.
-
-## Documentation
-
-If your changes affect how users interact with the project, update the documentation accordingly.
-
-## Extending APM
-
-### Adding or modifying an MCP client adapter
-
-The MCP client adapters (`src/apm_cli/adapters/client/`) inherit shared
-utilities from `MCPClientAdapter` in `base.py`.  When adding a new adapter
-or modifying an existing one:
-
-- Inherit from `MCPClientAdapter` and reuse the shared helpers
-  (`_apply_pypi_homebrew_generic_config`, `_apply_auth_and_headers_impl`,
-  `_resolve_env_vars_with_prompting`).
-- Do **not** copy-paste logic from sibling adapters -- the pylint R0801
-  similarity threshold is 10 lines and CI will fail on duplicated blocks.
-- For marketplace tag-parsing, use `marketplace._shared.iter_semver_tags`
-  rather than re-implementing the refs-iteration loop.
+See the [mutation pilot instructions](docs/src/content/docs/contributing/development-guide.md#running-the-bounded-mutation-pilot),
+including how to review survivor-baseline changes.
 
 ### How to add an experimental feature flag
 
-Use an experimental flag to de-risk rollout of a user-visible behavioural change that may need early adopter feedback. Do not add a flag for a bug fix, internal refactor, or any change that should simply ship as the default behaviour.
+See the [experimental flag recipe](docs/src/content/docs/contributing/development-guide.md#how-to-add-an-experimental-feature-flag).
 
-Experimental flags MUST NOT gate security-critical behaviour (content scanning, path validation, lockfile integrity, token handling, MCP trust, collision detection). Flags are ergonomic/UX toggles only.
+## Spec amendment workflow
 
-When adding a new experimental flag:
+### Adding or changing a normative requirement (OpenAPM v0.1)
 
-1. Register it in `src/apm_cli/core/experimental.py` in the `FLAGS` dict with a frozen `ExperimentalFlag(name=..., description=..., default=False, hint=...)`.
-2. Gate the code path with a function-scope import (avoids import cycles):
-   ```python
-   def my_function():
-       from apm_cli.core.experimental import is_enabled
-       if is_enabled("my_flag"):
-           ...
-   ```
-3. Add tests that cover both the enabled and disabled code paths.
-4. Update the experimental command reference page at `docs/src/content/docs/reference/experimental.md`.
-
-Naming rules:
-
-- Use `snake_case` in the registry and config.
-- Use `kebab-case` for display and other user-facing strings.
-- The CLI accepts both forms on input.
-
-Graduation and retirement:
-
-1. When a flag becomes the default, remove the gate and remove the matching `FLAGS` entry in the same PR.
-2. Add a `CHANGELOG.md` entry under `Changed` with a migration note if the previous default differed.
-
-Avoid these anti-patterns:
-
-- Do not gate security-critical behaviour behind an experimental flag.
-- Do not read `is_enabled()` at module import time.
-- Do not persist flag state anywhere other than `~/.apm/config.json` via `update_config`.
-
-## Adding or changing a normative requirement (OpenAPM v0.1)
-
-The OpenAPM v0.1 spec (`docs/src/content/docs/specs/openapm-v0.1.md`)
-and APM the implementation are co-evolved in this repo. APM is the
-sole implementation of the spec. To prevent the spec from rotting
-into a document of lies, every normative change MUST land as three
-coupled edits in the same PR. There is NO automated CI detector for
-"APM behaviour drifted from the spec" beyond the 4-way orphan_check
-gate -- the ritual below is the only safeguard.
-
-Three-step ritual:
-
-1. **Spec edit.** Add or change a `<a id="req-XXX"></a>` anchor with
-   prose in the spec body. Add or change the matching Appendix C row.
-2. **Manifest edit.** Add or change the entry in
-   `docs/src/content/docs/specs/manifests/openapm-v0.1.requirements.yml`
-   so it stays a byte-equivalent projection of the canonical anchors.
-3. **Test edit.** Add or extend a `@pytest.mark.req("req-XXX")` test
-   under `tests/spec_conformance/`. If a real assertion is not yet
-   possible, call `waive("...")` from `_helpers.py` with a one-line
-   rationale; the waiver will surface in `CONFORMANCE.md` as honest
-   debt, not invisible coverage.
-
-After the three edits, regenerate the conformance statement:
-
-```
-uv run --extra dev python -m tests.spec_conformance.gen_statement
-```
-
-and commit the resulting `CONFORMANCE.{md,json}` at repo root. CI
-gates a clean diff.
-
-Common modes the ritual catches:
-
-- **Mode A (silent regression)** -- a code change in `src/apm_cli/**`
-  breaks an assertion bound to a `req-XXX`. The spec-conformance
-  pytest job fails; fix the code, do not touch the spec.
-- **Mode B (silent extension)** -- a new APM behaviour lands under a
-  normative critical path (`primitives/`, `deps/`, `policy/`,
-  `registry/`, `runtime/`, `install/`, `integration/`) with no spec
-  citation. Two gates catch this: (a) `orphan_check` fails if you
-  added a `@pytest.mark.req` marker but forgot the anchor, manifest
-  row, or Appendix C row; (b) the **Mode B detector** fails if you
-  added substantive code under a critical path and added NO spec
-  artifacts at all (no anchor, no manifest row, no marker). The fix
-  is to add the anchor + manifest row + marker, or -- for a true
-  refactor / perf rewrite / internal cleanup with no observable
-  behaviour delta -- add a single line `apm-spec-waiver: <one-line
-  rationale, >= 16 chars>` to the PR body or a commit message. The
-  waiver is echoed verbatim to the CI log and is reviewer-auditable.
-  The critical-path allowlist itself lives at
-  `tests/spec_conformance/critical_paths.txt`; edits to it are
-  themselves critical-path edits.
-- **Mode C (stale spec)** -- the spec prose is wrong about APM's
-  intended behaviour. Amend the anchor + Appendix C row + manifest
-  entry. The same PR carries both the spec edit and the test that
-  proves it.
-
-Choosing between modes is a human call. The harness exposes the
-choice; it does not pick.
+See the [normative requirement workflow](docs/src/content/docs/contributing/development-guide.md#adding-or-changing-a-normative-requirement-openapm-v01)
+for the coupled specification, manifest, test, and conformance-statement edits.
 
 ## License
 
-By contributing to this project, you agree that your contributions will be licensed under the project's [MIT License](LICENSE).
-
-## Questions?
-
-If you have any questions, feel free to open an issue or reach out to the maintainers.
-
-Thank you for your contributions!
+Contributions are licensed under the project's [MIT License](LICENSE).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,105 @@
+# APM project governance
+
+APM is maintainer-led. Anyone may propose improvements and participate in
+discussion; maintainers decide which work the project can support. This
+document covers project responsibilities, not APM's enterprise policy engine.
+The contribution process lives in [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Maintainers and scope
+
+| Maintainer | Role | Responsibility |
+| --- | --- | --- |
+| [Daniel Meppiel](https://github.com/danielmeppiel) | Lead and core maintainer | Project-wide scope approval, roadmap coordination, and resolution of unresolved direction disagreements. |
+| [Sergio](https://github.com/sergio-sisternes-epam) | Core maintainer | Project-wide scope approval and technical maintenance, without requiring the lead to approve routine work again. |
+| [Nadav](https://github.com/nadav-y) | Registry public API maintainer | Primary scope and technical owner for the APM registry public API. Core maintainers provide backup. |
+
+Core maintainers have overlapping project-wide responsibility; the project
+does not require an artificial split of every file into exclusive domains.
+For registry public API work, involve Nadav first. His area does not
+automatically include unrelated registry internals, broader CLI behavior,
+or project-wide authentication policy.
+
+For cross-area work, name one coordinating maintainer and consult affected
+owners. When an owner is unavailable, a core maintainer may arrange qualified
+backup and record the handoff on the issue. Ownership routes decisions; it
+does not create a veto through absence or waive relevant expertise and review.
+
+These are individual project responsibilities, not employer seats. Affiliation
+or sponsorship does not buy roadmap priority or approval rights.
+[CODEOWNERS](.github/CODEOWNERS) routes code review; it is not the scope-approval
+roster. GitHub access is managed separately under repository and organization
+controls. This document does not itself grant access.
+
+## Decisions and accountability
+
+Routine work within the project's direction may be approved by the
+responsible maintainer, with bounded scope, acceptance criteria, and a
+review contact recorded on the issue. The lead is not an extra approval
+gate for every contribution.
+
+New product directions, significant compatibility changes, and governance
+changes need discussion among the affected maintainers. Seek agreement;
+if a direction disagreement remains unresolved, the lead records a decision
+and rationale. Contributors may request reconsideration with new evidence.
+A disagreement with an area decision can be raised with a core maintainer.
+
+Keep proposals and decisions public on issues or PRs. Summarize decisions
+made in private meetings on the relevant issue, except confidential security,
+conduct, or organizational matters. Follow [SECURITY.md](SECURITY.md) and the
+[Code of Conduct](CODE_OF_CONDUCT.md) for those reports.
+
+Human scope approval, code-review approval, and release targeting are
+separate decisions. Automated recommendations, labels alone, and silence
+do not authorize implementation or commit a release. An accepted issue
+does not need a release milestone. The same contribution rules apply to
+maintainers and automated submissions.
+
+## Contributor progression
+
+| Role | How to contribute | Additional responsibility |
+| --- | --- | --- |
+| Contributor | Report or reproduce problems; improve docs or code; review and help others. | No appointment is needed to participate. |
+| Triager / reviewer | Consistently classify issues, give useful reviews, and help contributors navigate the process. | A trusted triager may manage issue metadata under the agreed policy, without merge access or automatic scope-approval authority. |
+| Maintainer | Demonstrate sound judgment, collaboration, follow-through, and stewardship of an area or the whole project. | Approve scope within the recorded remit, support review, and maintain accepted changes. Merge authority depends on separately granted access. |
+
+These are paths to responsibility, not a compulsory sequence or a contest
+for the most commits. Documentation, review, triage, and contributor support
+count alongside code. A contributor can remain in any role without pressure
+to take on more work.
+
+To seek a role, open an issue or ask a maintainer to sponsor a nomination.
+Describe the proposed scope, relevant contributions, and realistic
+availability. An existing maintainer sponsors and mentors the transition;
+the core maintainers discuss it and the lead records the appointment and
+rationale. Obtain the nominee's agreement and update this roster for
+maintainer appointments. Access changes follow organization policy separately.
+
+## Capacity, continuity, and stepping down
+
+Maintainers should only invite implementation when a reviewing maintainer
+can support it. Defer openly when capacity is missing rather than leaving
+contributors with an indefinite promise. Review assistance and onboarding
+new maintainers are part of maintenance, not work reserved for the lead.
+
+Maintainers may reduce their scope or step down by notifying the others.
+Arrange a handoff for active issues and update the roster. Review inactive
+access with the individual where possible and remove permissions no longer
+needed through the organization's process; stepping down is not a punishment.
+
+Before a planned lead absence, agree who will coordinate roadmap and release
+decisions and record that delegation. Routine decisions remain with the
+responsible maintainers. If the lead cannot arrange a handoff, the remaining
+core maintainer or maintainers choose an interim coordinator; a permanent
+successor is discussed with the maintainer group and recorded publicly.
+
+Release and infrastructure continuity also require verified backup access
+under Microsoft organization controls. Naming a coordinator does not prove
+that access exists; verify it before relying on the handoff.
+
+## Changing this policy
+
+Propose governance changes in an issue before a PR. Describe the problem,
+the affected responsibilities, and the transition for existing contributors.
+Record the human decision publicly and update this file and the contribution
+guide together where necessary. Agent personas may advise; they do not hold
+project offices or ratify governance decisions.

--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -1,9 +1,9 @@
 # APM Principles
 
-The hard contract APM is held to. Every PR, every release, every
-roadmap call cites these principles. The triage panel, the review
-panel, and the batch-bug-shepherd Phase 1.5 strategic-alignment
-gate cite them by number when accepting or rejecting work.
+The product principles APM is held to. Maintainers use them to explain
+scope and roadmap decisions. Automated triage and review may cite them
+in recommendations; human authority is defined in
+[GOVERNANCE.md](GOVERNANCE.md).
 
 MANIFESTO = values. PRD = product pitch (currently framed at native
 platform owners). **This file = the rejection contract.** When a
@@ -84,13 +84,16 @@ changelog.
 
 ## P7 -- Community over feature count
 
-External-contributor PRs and issues triage before internal
-nice-to-haves. A contributor lost is worse than a feature delayed.
-Surface every external interaction at the top of the queue.
+Prioritize timely, respectful decisions on external contributions over
+internal nice-to-haves. Give contributors clear scope and a review contact
+before inviting implementation. Community priority does not require
+accepting every proposal or promising review capacity the project lacks.
+An honest deferral or decline is better than an indefinite promise.
 
 ## How this file is used
 
-- `apm-ceo` cites by number in arbitration prose.
+- Maintainers cite relevant principles when explaining scope decisions.
+- `apm-ceo` cites by number in advisory prose.
 - `batch-bug-shepherd` Phase 1.5 spawns one ceo subagent per
   triaged-LEGIT row, which returns a verdict + cited principle.
 - `apm-triage-panel` CEO arbiter cites a principle on every
@@ -98,8 +101,8 @@ Surface every external interaction at the top of the queue.
 - `apm-review-panel` CEO synthesizer cites a principle when
   surfacing strategic implications in arbitration.
 
-Any addition to this file requires the apm-ceo persona to ratify
-and ships in a PR that updates MANIFESTO.md cross-refs in the same
-commit. Removal of a principle is a breaking strategic change --
-requires CHANGELOG entry, migration line, and explicit `BREAKING:`
-prefix.
+Changes to these principles require a public issue and a human decision
+under [GOVERNANCE.md](GOVERNANCE.md#decisions-and-accountability).
+Update affected documentation in the same PR. If a change alters a public
+product contract, document the compatibility impact and migration in the
+changelog. Agent recommendations do not ratify policy.

--- a/docs/src/content/docs/contributing/development-guide.md
+++ b/docs/src/content/docs/contributing/development-guide.md
@@ -349,7 +349,7 @@ the previous default differed.
 
 ## Adding or changing a normative requirement (OpenAPM v0.1)
 
-The [OpenAPM v0.1 specification](../../specs/openapm-v0.1/) and APM's
+The [OpenAPM v0.1 specification](../../specs/openapm-v01/) and APM's
 implementation evolve together. Every normative change MUST include three
 coupled edits in the same PR:
 

--- a/docs/src/content/docs/contributing/development-guide.md
+++ b/docs/src/content/docs/contributing/development-guide.md
@@ -1,96 +1,17 @@
 ---
 title: "Development Guide"
-description: "How to contribute to APM — setup, coding style, testing, and pull request process."
+description: "APM development setup, testing, coding guardrails, and extension recipes."
 sidebar:
   order: 1
 ---
 
-Thank you for considering contributing to APM! This document outlines the process for contributing to the project.
-
-## Code of Conduct
-
-By participating in this project, you agree to abide by our [Code of Conduct](https://github.com/microsoft/apm/blob/main/CODE_OF_CONDUCT.md). Please read it before contributing.
-
-## How to Contribute
-
-### Reporting Bugs
-
-Before submitting a bug report:
-
-1. Check the [GitHub Issues](https://github.com/microsoft/apm/issues) to see if the bug has already been reported.
-2. Update your copy of the code to the latest version to ensure the issue hasn't been fixed.
-
-When submitting a bug report:
-
-1. Use our bug report template.
-2. Include detailed steps to reproduce the bug.
-3. Describe the expected behavior and what actually happened.
-4. Include any relevant logs or error messages.
-
-### Suggesting Enhancements
-
-Enhancement suggestions are welcome! Please:
-
-1. Use our feature request template.
-2. Clearly describe the enhancement and its benefits.
-3. Provide examples of how the enhancement would work.
-
-### Development Process
-
-1. Fork the repository.
-2. Create a new branch for your feature/fix: `git checkout -b feature/your-feature-name` or `git checkout -b fix/issue-description`.
-3. Make your changes.
-4. Run tests: `uv run pytest`
-5. Ensure your code passes linting: `uv run --extra dev ruff check src/ tests/`
-6. Commit your changes with a descriptive message.
-7. Push to your fork.
-8. Submit a pull request.
-
-### Pull Request Process
-
-1. Fill out the PR template — describe what changed, why, and link the issue.
-2. Ensure your PR addresses only one concern (one feature, one bug fix).
-3. Include tests for new functionality.
-4. Update documentation if needed.
-5. PRs must pass all CI checks before they can be merged.
-
-### Workflow dependency updates
-
-When updating actions in generated `.github/workflows/*.lock.yml` files,
-keep their `gh-aw-manifest` headers, human-readable action lists, and
-`.github/aw/actions-lock.json` entries aligned with the runtime `uses:` pins.
-Dependabot does not update those metadata records. Preserve the compiler
-version and source hashes for dependency-only edits; recompile with
-`gh aw compile` when changing workflow source.
-
-Run `uv run --frozen --extra dev pytest tests/unit/test_triage_panel_lock.py`
-to check setup and app-token action pin consistency across the manifest-bearing
-workflows.
-
-### Issue Triage
-
-Every new issue is automatically labeled `needs-triage`. Maintainers review incoming issues and:
-
-1. **Accept** — remove `needs-triage`, add `accepted`, and assign a milestone.
-2. **Prioritize** — optionally add `priority/high` or `priority/low`.
-3. **Close** — if it's a duplicate (`duplicate`) or out of scope, close with a comment explaining why.
-
-Labels used for triage: `needs-triage`, `accepted`, `needs-design`, `priority/high`, `priority/low`.
-
-### Code scanning on pull requests and merge queues
-
-The CodeQL workflow runs Python and GitHub Actions analysis on pull requests,
-pushes to `main`, merge-queue `checks_requested` events, and the weekly schedule.
-Keep the workflow path, `analyze` job ID, and language matrix stable: they
-identify the analysis configurations GitHub compares against the base branch.
-PR results do not replace results for the merge queue's separate commit.
-
-If both analysis jobs succeed but Code scanning still reports a missing
-configuration, inspect the CodeQL check summary. An additional `API upload`
-configuration on the base branch belongs to a separate upload producer;
-rerunning this workflow cannot supply that producer's results. Coordinate
-matching PR and queue uploads with its owner rather than deleting findings,
-renaming categories, or weakening the code-scanning ruleset.
+Start with [CONTRIBUTING.md](https://github.com/microsoft/apm/blob/main/CONTRIBUTING.md)
+for issue-first scope approval, PR eligibility, small corrections, private
+security reporting, and the transition for existing contributions.
+[GOVERNANCE.md](https://github.com/microsoft/apm/blob/main/GOVERNANCE.md) names
+the responsible human maintainers and explains decisions and responsibilities.
+Those root documents own contribution policy; this guide covers technical work
+within the approved scope. Reporting and investigation need no prior permission.
 
 ## Development Environment
 
@@ -105,15 +26,65 @@ cd apm
 uv sync --extra dev
 ```
 
-## Testing
+## Optional agent tools
 
-We use pytest for testing. After completing the setup above, run the test suite with:
+No AI tool, harness, or repository skill is required to contribute. APM
+dogfoods its own primitives from
+[`.apm/skills/`](https://github.com/microsoft/apm/tree/main/.apm/skills) and
+[`.apm/agents/`](https://github.com/microsoft/apm/tree/main/.apm/agents), with
+local package dependencies declared in
+[`apm.yml`](https://github.com/microsoft/apm/blob/main/apm.yml).
+Automated recommendations are advisory, not scope approval or a substitute
+for human review.
+
+To use these tools, [install APM](../../getting-started/installation/) if needed,
+then run from the repository root:
 
 ```bash
-uv run pytest -q
+apm install
 ```
 
-If you don't have `uv` available, you can use a standard Python venv and pip:
+The manifest's `includes: auto` picks up `.apm/`. Its pinned `copilot` target
+deploys to the committed `.github/` and `.agents/skills/` tree, regardless of
+which harness your machine detects. Your harness can then discover and invoke
+the installed skills by name.
+
+For a different harness, exclude its generated roots locally before overriding
+the pinned target. For example, with Claude Code:
+
+```bash
+printf '.claude/\n' >> "$(git rev-parse --git-path info/exclude)"
+apm install --target claude
+```
+
+The local exclusion avoids changing repository-wide ignore rules. This install
+also adds deploy paths to `apm.lock.yaml`; leave that local override uncommitted.
+Check the [target catalogue](../../concepts/primitives-and-targets/#target-catalogue)
+for other targets; some write to more than one root.
+
+## Testing
+
+After setup, use pytest for focused feedback:
+
+```bash
+# Unit suite
+uv run pytest tests/unit tests/test_console.py -x
+
+# Focused file; replace with the test relevant to your change
+uv run pytest tests/test_console.py -x
+
+# Full suite, including integration and acceptance tests
+uv run pytest
+
+# Verbose unit results
+uv run pytest tests/unit -x -v
+```
+
+`pytest-xdist` is available: add `-n auto` for parallel execution or `-n0`
+to force serial execution. The default selection in `pyproject.toml` excludes
+`benchmark` and `live` tests.
+
+Without `uv`, use a standard Python venv and pip:
 
 ```bash
 # create and activate a venv (POSIX / WSL)
@@ -122,11 +93,48 @@ source .venv/bin/activate
 
 # install this package in editable mode and test deps
 pip install -U pip
-pip install -e .[dev]
+pip install -e '.[dev]'
 
-# run tests
-pytest -q
+# run unit tests
+pytest tests/unit tests/test_console.py -x
 ```
+
+### Running integration tests
+
+Tests under `tests/integration/` declare preconditions with `requires_*`
+markers. The `_MARKER_CHECKS` registry in `tests/integration/conftest.py`
+skips tests with missing prerequisites at collection time and reports why.
+Use the [marker registry](../integration-testing/#the-marker-registry) to
+find the token, runtime setup command, or opt-in flag each family needs.
+
+```bash
+# Run tests whose prerequisites your environment satisfies
+uv run pytest tests/integration -v
+
+# Select a prerequisite family
+uv run pytest tests/integration -m requires_github_token -v
+```
+
+When adding a precondition, add its check to `_MARKER_CHECKS` and declare the
+marker in `pyproject.toml`; do not duplicate the check in each test. For install,
+compile, pack, or audit lifecycle changes, reuse the
+[hermetic lifecycle fixtures](../integration-testing/#hermetic-lifecycle-fixtures)
+to exercise the real CLI with a sanitized child environment and reviewed local
+Git sources.
+
+### Coverage policy
+
+Both suites have hard CI coverage gates that must pass before merge:
+
+| Suite | Gate | Enforced in |
+| --- | --- | --- |
+| Unit | 80% | `pyproject.toml` (`fail_under`) and combined coverage in `.github/workflows/ci.yml` |
+| Integration | 70% | Combined coverage in `.github/workflows/ci-integration.yml` (`--fail-under`) |
+
+Gates only move upward. When actual coverage exceeds the gate by at least
+5 percentage points, raise the gate to `actual - 3` in the next release PR.
+CI's coverage summaries include a "Lowest-coverage files" section, rendered by
+`scripts/coverage-summary.py`, to identify where new tests would help.
 
 ### Running the bounded mutation pilot
 
@@ -147,9 +155,10 @@ uv run --frozen --extra dev python scripts/run_mutation_pilot.py \
 ```
 
 The command fails on new survivors, timeouts, suspicious results, unchecked
-mutants, and incomplete outcomes. Its timestamp-free JSON report is suitable
-for comparing runs. Pass `--reuse-cache` only when the allowlisted source,
-tests, configuration, runner, and lockfile are unchanged.
+mutants, and incomplete outcomes. It writes a sorted, timestamp-free JSON
+report even when survivor comparison fails. Pass `--reuse-cache` only when
+the allowlisted source, test seams, configuration, runner, and lockfile
+are unchanged.
 
 To inspect existing mutmut metadata without executing mutants:
 
@@ -160,40 +169,30 @@ uv run --frozen --extra dev python scripts/run_mutation_pilot.py \
 
 The reviewed survivor allowlist lives in
 [`tests/mutation/baseline.json`](https://github.com/microsoft/apm/blob/main/tests/mutation/baseline.json).
-Do not update it to make a run green. Inspect surviving diffs with `mutmut show`
-and add behavioral tests for real contract gaps. Use `--update-baseline` only
-when the baseline change itself has been reviewed:
+Do not update it to make a run green. Review every surviving diff with
+`mutmut show` and add behavioral tests for real contract gaps.
+Use `--update-baseline` only when the baseline change itself has been reviewed:
 
 ```bash
 uv run --frozen --extra dev python scripts/run_mutation_pilot.py \
   --update-baseline --output mutation-pilot-report.json
 ```
 
-The repository
-[`CONTRIBUTING.md`](https://github.com/microsoft/apm/blob/main/CONTRIBUTING.md#running-the-bounded-mutation-pilot)
-owns the review policy for baseline changes.
-
 ## Coding Style
 
-This project follows:
-- [PEP 8](https://pep8.org/) for Python style guidelines
-- We use [Ruff](https://docs.astral.sh/ruff/) for linting and formatting
+APM follows [PEP 8](https://pep8.org/) and uses
+[Ruff](https://docs.astral.sh/ruff/) for linting and formatting. Follow the
+canonical [lint contract](https://github.com/microsoft/apm/blob/main/.apm/instructions/linting.instructions.md)
+for local commands, auto-fixes, and common diagnostics. The actual
+[`Lint` job in `ci.yml`](https://github.com/microsoft/apm/blob/main/.github/workflows/ci.yml)
+defines the complete enforced step list; mirror it before pushing or claiming
+green CI.
 
-CI enforces all lint and formatting rules automatically. You can run them locally:
-
-```bash
-uv run --extra dev ruff check src/ tests/         # lint
-uv run --extra dev ruff check --fix src/ tests/   # lint with auto-fix
-uv run --extra dev ruff format src/ tests/        # format
-```
-
-Verify Ruff lint and format before pushing:
-
-```bash
-uv run --extra dev ruff check src/ tests/ && uv run --extra dev ruff format --check src/ tests/
-```
-
-CI also runs repository guardrails from `.github/workflows/ci.yml`, including duplication and auth-boundary checks.
+Ruff lint and format are only part of that job. It also checks YAML I/O,
+file length, portable relative paths, duplication, auth-protocol boundaries,
+and architecture boundaries. Its Python scope includes the architecture-linter
+scripts as well as `src/` and `tests/`. CI checks the PR merge result, so changes
+on `main` can introduce failures even when the branch alone passes.
 
 ### Architecture guardrails
 
@@ -243,6 +242,53 @@ uv run pre-commit install
 
 This is optional -- CI is the authoritative gate. The pre-commit hook rev may lag behind the CI version; check `.pre-commit-config.yaml` against `uv.lock` if you see discrepancies.
 
+## CI and merging
+
+### How merging works
+
+A maintainer adds an approved PR to GitHub's native merge queue. The queue
+builds a tentative merge against the latest `main`, runs checks including the
+integration suite, and merges on success or ejects the PR on failure.
+There is no manual "Update branch" step just to enter the queue. If a real
+failure ejects your PR, push a fix and ask a maintainer to re-queue it.
+
+Fast unit and build checks (Tier 1) run on PR updates. The required Lifecycle
+Smoke check also runs on PRs and merge-queue commits. It selects
+`lifecycle_smoke and not lifecycle_merge_group` contracts with no network,
+credentials, or frozen binary required. See
+[Integration Testing](../integration-testing/) for the bounded selection,
+timeout, prerequisites, and local command.
+The full integration suite (Tier 2) runs in the queue rather than on every
+WIP push.
+
+### Workflow dependency updates
+
+When updating actions in generated `.github/workflows/*.lock.yml` files,
+keep their `gh-aw-manifest` headers, human-readable action lists, and
+`.github/aw/actions-lock.json` entries aligned with the runtime `uses:` pins.
+Dependabot does not update those metadata records. Preserve the compiler
+version and source hashes for dependency-only edits; recompile with
+`gh aw compile` when changing workflow source.
+
+Run `uv run --frozen --extra dev pytest tests/unit/test_triage_panel_lock.py`
+to check setup and app-token action pin consistency across the manifest-bearing
+workflows.
+
+### Code scanning on pull requests and merge queues
+
+The CodeQL workflow runs Python and GitHub Actions analysis on pull requests,
+pushes to `main`, merge-queue `checks_requested` events, and the weekly schedule.
+Keep the workflow path, `analyze` job ID, and language matrix stable: they
+identify the analysis configurations GitHub compares against the base branch.
+PR results do not replace results for the merge queue's separate commit.
+
+If both analysis jobs succeed but Code scanning still reports a missing
+configuration, inspect the CodeQL check summary. An additional `API upload`
+configuration on the base branch belongs to a separate upload producer;
+rerunning this workflow cannot supply that producer's results. Coordinate
+matching PR and queue uploads with its owner rather than deleting findings,
+renaming categories, or weakening the code-scanning ruleset.
+
 ## Documentation
 
 If your changes affect how users interact with the project, update the documentation accordingly.
@@ -256,10 +302,95 @@ npm --prefix docs run build
 uv run --frozen python scripts/check_cli_docs.py docs/dist
 ```
 
-## License
+## Extending APM
 
-By contributing to this project, you agree that your contributions will be licensed under the project's [MIT License](https://github.com/microsoft/apm/blob/main/LICENSE).
+### Adding or modifying an MCP client adapter
 
-## Questions?
+Adapters in `src/apm_cli/adapters/client/` inherit shared utilities from
+`MCPClientAdapter` in `base.py`:
 
-If you have any questions, feel free to open an issue or reach out to the maintainers.
+- Reuse `_apply_pypi_homebrew_generic_config`, `_apply_auth_and_headers_impl`,
+  and `_resolve_env_vars_with_prompting` rather than copying sibling adapters.
+- The pylint R0801 similarity threshold is 10 lines; duplicated blocks fail CI.
+- For marketplace tag parsing, use `marketplace._shared.iter_semver_tags`
+  rather than reimplementing the refs-iteration loop.
+
+### How to add an experimental feature flag
+
+Use an experimental flag for a user-visible behavior change that needs early
+adopter feedback, not a bug fix, internal refactor, or change that should ship
+as the default. Flags are ergonomic/UX toggles only. They MUST NOT gate
+security-critical behavior: content scanning, path validation, lockfile
+integrity, token handling, MCP trust, or collision detection.
+
+1. Register the flag in `src/apm_cli/core/experimental.py`'s `FLAGS` dict with
+   a frozen `ExperimentalFlag(name=..., description=..., default=False, hint=...)`.
+2. Import and call `is_enabled` at function scope to avoid import cycles and
+   config I/O at module import time. For example, the existing `verbose_version`
+   flag can be checked with:
+
+   ```python
+   def show_runtime_details():
+       from apm_cli.core.experimental import is_enabled
+
+       return is_enabled("verbose_version")
+   ```
+
+3. Test both enabled and disabled paths.
+4. Update the [experimental command reference](../../reference/experimental/).
+
+Use `snake_case` in the registry and config, and `kebab-case` for display and
+other user-facing strings. The CLI accepts both forms on input. Persist flag
+state only in `~/.apm/config.json` through `update_config`.
+
+When a flag graduates to the default, remove its gate and `FLAGS` entry in the
+same PR. Add a `CHANGELOG.md` entry under `Changed`, with a migration note if
+the previous default differed.
+
+## Adding or changing a normative requirement (OpenAPM v0.1)
+
+The [OpenAPM v0.1 specification](../../specs/openapm-v0.1/) and APM's
+implementation evolve together. Every normative change MUST include three
+coupled edits in the same PR:
+
+1. **Spec:** add or change a `<a id="req-XXX"></a>` anchor and its prose in
+   `docs/src/content/docs/specs/openapm-v0.1.md`, plus the matching Appendix C row.
+2. **Manifest:** update
+   `docs/src/content/docs/specs/manifests/openapm-v0.1.requirements.yml`
+   to remain a byte-equivalent projection of the canonical anchors.
+3. **Test:** add or extend a `@pytest.mark.req("req-XXX")` test under
+   `tests/spec_conformance/`. If a real assertion is not yet possible, call
+   `waive("...")` from `_helpers.py` with a one-line rationale. The waiver
+   appears in `CONFORMANCE.md` as visible debt, not test coverage.
+
+Regenerate the conformance statement after these edits:
+
+```bash
+uv run --extra dev python -m tests.spec_conformance.gen_statement
+```
+
+Include the resulting root `CONFORMANCE.md` and `CONFORMANCE.json` in the
+same PR; CI requires a clean generated diff.
+
+The workflow distinguishes three modes:
+
+- **Mode A (silent regression):** a code change breaks an assertion bound to
+  a `req-XXX`. The spec-conformance pytest job fails. Fix the code, not the spec.
+- **Mode B (silent extension):** new behavior under a normative critical path
+  lacks a spec citation. The four-way `orphan_check` catches a requirement
+  marker missing its anchor, manifest row, or Appendix C row. The Mode B
+  detector catches substantive critical-path code with no spec artifacts at
+  all. Add the anchor, manifest row, and marker, with the Appendix C row as
+  above. For a true refactor, performance rewrite, or internal cleanup with
+  no observable behavior change, add `apm-spec-waiver: <one-line rationale>`
+  to the PR body or a commit message. The rationale must be at least
+  16 characters; CI echoes the waiver verbatim for reviewer inspection.
+  The critical-path allowlist lives in
+  `tests/spec_conformance/critical_paths.txt`; changes to that list are
+  themselves critical-path edits.
+- **Mode C (stale spec):** the prose misstates intended behavior. Amend the
+  anchor, Appendix C row, and manifest entry, with a test proving the intended
+  behavior in the same PR.
+
+These checks cannot detect every semantic drift. Choosing the appropriate
+mode remains a human decision; the harness exposes the choice, not the answer.


### PR DESCRIPTION
Closes #2953.

APM needs to tell contributors whether work is wanted before they implement it. This establishes the human contribution and governance contract as the first layer of the planned governance/roadmap stack.

- Require a linked issue and explicit human scope approval for substantive work, with a reviewing maintainer. Trivial documentation corrections have standing preapproval; reporting and investigation need no permission.
- Document Daniel and Sergio as project-wide core maintainers, Daniel's lead responsibilities, and Nadav's registry public API ownership with core backup. Add a contribution ladder and continuity/handoff rules.
- Align templates and principles, make agent tools advisory, and explain fair treatment of existing PRs.
- Move technical reference material from CONTRIBUTING.md into the development guide rather than remove it. Retain the root's existing deep-link headings.

No product behavior, CI workflow, GitHub permissions, live labels, roadmap, or backlog changes. Later approved phases cover advisory triage, roadmap management, and eligibility checks; retrospective cleanup comes last. Legacy automated labels do not constitute human approval under this policy.

Local lint and boundary checks passed. All 14 documentation link-checker tests passed. The initial source-link check missed Astro's `openapm-v01` route normalization; the follow-up commit corrects that link.

[Deploy Docs CI now passes](https://github.com/microsoft/apm/actions/runs/34649052885) on `43391a54c8`, including the actual rendered-site link check, CLI page parity, and schema checks. The full build was verified in CI because the local package feed could not supply Astro 7.3.2 already pinned on main. No dependency versions were changed.

This is a draft for the phased rollout; opening it is not approval to merge or to apply the later live migration.