### PR TITLE
fix: honor APM_HOME for global user state

### DIFF
--- a/.apm/architecture/owners/core-runtime.json
+++ b/.apm/architecture/owners/core-runtime.json
@@ -75,6 +75,13 @@
       "owner": "core/project_name.py (resolve_bootstrap_project_name)",
       "selectors": ["src/apm_cli/core/project_name.py"],
       "guards": ["registry-delegation-bootstrap-project-name"]
+    },
+    {
+      "id": "apm-home-resolution",
+      "decision": "APM-owned user metadata root",
+      "owner": "core/scope.py (get_apm_home)",
+      "selectors": ["src/apm_cli/core/scope.py"],
+      "guards": ["registry-delegation-apm-home-resolution"]
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `APM_HOME` now consistently controls global manifests, lockfiles, modules, configuration, lifecycle trust, logs, and command locking while leaving target deployment destinations under their target-specific overrides or the operating-system home. (closes #2884)
 - GitLab `path:` dependencies now preserve the selected SSH transport, username, and port instead of silently using HTTPS; REST fallback requires an executed same-origin HTTPS attempt admitted by the transport policy. (#2938)
 
 ## [0.30.0] - 2026-09-07

--- a/docs/src/content/docs/reference/cli/approve.md
+++ b/docs/src/content/docs/reference/cli/approve.md
@@ -22,13 +22,13 @@ one noun, `executables`, across three layers:
 | Layer | Store | Who manages it | Committed? | Authority |
 |-------|-------|----------------|------------|-----------|
 | Project | `apm.yml` `executables.{allow,deny}` | Maintainer / CI setup (`apm approve`/`apm deny`) | Yes | Admin (shared) |
-| User | `~/.apm/config.json` `executables.{allow,deny}` | `apm approve --user` / `apm deny --user` | No | Lowest; below org/project deny |
+| User | `$APM_HOME/config.json` `executables.{allow,deny}` | `apm approve --user` / `apm deny --user` | No | Lowest; below org/project deny |
 | Org | `apm-policy.yml` `executables:` | Org admin | Yes (policy repo) | Ceiling on deny |
 
 `apm approve` adds a grant; [`apm deny`](../deny/) adds a block. By default,
 both commands write the **project** `apm.yml` (committed, so the whole team
 inherits the decision). `--user` writes your personal
-`~/.apm/config.json` instead -- a machine-local grant with lower authority than
+`$APM_HOME/config.json` instead -- a machine-local grant with lower authority than
 org or project denies. Use `apm deny --user` to narrow trust on one machine.
 
 Text primitives (skills, agents, instructions) are never gated. Local project
@@ -89,7 +89,7 @@ The gate is enabled when any layer opts in: the project declares an
 | `--all` | Approve all currently blocked packages. |
 | `--recommended` | Bulk-accept the org `executables.recommend` set. |
 | `--list` | Show the fleet-level effective trust decision and deciding layer per installed package. |
-| `--user` | Write the grant to `~/.apm/config.json` instead of `apm.yml`. |
+| `--user` | Write the grant to `$APM_HOME/config.json` instead of `apm.yml`. |
 
 ### `apm policy explain`
 
@@ -136,9 +136,9 @@ read as an alias for `executables.allow` for one minor cycle and is migrated to
 `executables.allow`.
 
 The personal store uses the same shape under `executables` in
-`~/.apm/config.json`. The standalone `~/.apm/approvals.yml` file has been
-**removed**; its contents are migrated into `~/.apm/config.json` automatically
-on first read.
+`$APM_HOME/config.json` (default `~/.apm/config.json`). The standalone
+`$APM_HOME/approvals.yml` file has been **removed**; its contents are migrated
+into `$APM_HOME/config.json` automatically on first read.
 
 Ordinary dependency grant keys are package-scoped in v1: a bare `owner/repo`
 key and an `owner/repo#1.2.0` key both match the package name regardless of the

--- a/docs/src/content/docs/reference/cli/compile.md
+++ b/docs/src/content/docs/reference/cli/compile.md
@@ -145,7 +145,7 @@ globally installed instruction packages -- one command, no per-tool setup.
 
 | Flag | Description |
 |------|-------------|
-| `-g, --global` | Compile user-scope root context files from `~/.apm/apm_modules`. Writes targets declared by `target:` or `targets:` in `~/.apm/apm.yml`, or every supported user-scope target when neither field is declared. Not valid with project-output flags such as `--target`, `--all`, `--watch`, `--root`, or `--output`. Exits non-zero if `~/.apm/apm_modules` does not exist. |
+| `-g, --global` | Compile user-scope root context files from `$APM_HOME/apm_modules` (default `~/.apm/apm_modules`). Writes targets declared by `target:` or `targets:` in `$APM_HOME/apm.yml`, or every supported user-scope target when neither field is declared. `APM_HOME` selects the input metadata only; compiled files use each target's home variable or the operating-system home. Not valid with project-output flags such as `--target`, `--all`, `--watch`, `--root`, or `--output`. Exits non-zero if the user-scope modules directory does not exist. |
 
 `apm compile --global` is explicit. `apm install -g` does not run it; instead,
 when global instructions land on a root-context-only target, install prints a
@@ -154,7 +154,7 @@ removing global packages. Hand-authored files (files that do not carry the
 APM-generated marker) are never overwritten.
 
 Because `--target` is rejected alongside `--global`, `target:` or `targets:` in
-`~/.apm/apm.yml` is how you narrow user-scope output. When it declares a target
+`$APM_HOME/apm.yml` is how you narrow user-scope output. When it declares a target
 set, `apm compile -g` writes only those targets. If you install with an explicit
 `apm install -g --target`, update the manifest declaration before compiling;
 the explicit install flag does not replace it. Declare nothing and every
@@ -165,7 +165,7 @@ before any target output is written; fix the reported manifest problem and
 rerun the command.
 
 ```yaml
-# ~/.apm/apm.yml
+# $APM_HOME/apm.yml
 targets: [claude, codex]
 ```
 

--- a/docs/src/content/docs/reference/cli/config.md
+++ b/docs/src/content/docs/reference/cli/config.md
@@ -5,7 +5,8 @@ sidebar:
   order: 10
 ---
 
-Read and write APM CLI configuration stored in `~/.apm/config.json`.
+Read and write APM CLI configuration stored in `$APM_HOME/config.json`
+(default `~/.apm/config.json`).
 
 ## Synopsis
 
@@ -19,10 +20,10 @@ apm config unset KEY             # remove a key
 
 ## Description
 
-`apm config` manages the user-level CLI configuration file at `~/.apm/config.json`. It is independent of `apm.yml`, which describes a project. With no subcommand, `apm config` prints a table that combines:
+`apm config` manages the user-level CLI configuration file at `$APM_HOME/config.json` (default `~/.apm/config.json`). It is independent of `apm.yml`, which describes a project. With no subcommand, `apm config` prints a table that combines:
 
 - **Project** values from `apm.yml` in the current directory (when present): name, version, entrypoint, MCP dependency count, and compilation settings.
-- **Global** values from `~/.apm/config.json`: CLI version, `temp-dir`, and any other set keys.
+- **Global** values from `$APM_HOME/config.json`: CLI version, `temp-dir`, and any other set keys.
 
 Use `get`/`set`/`unset` to manipulate individual keys. Boolean values accept `true`, `false`, `yes`, `no`, `1`, or `0`.
 
@@ -46,7 +47,7 @@ Familiar with `npm config list` or `git config --list`? `apm config list` is the
 
 ### `apm config set KEY VALUE`
 
-Write `KEY` to `~/.apm/config.json`. Validates the value before writing:
+Write `KEY` to `$APM_HOME/config.json`. Validates the value before writing:
 
 - `temp-dir` must be an existing, writable directory. The path is expanded (`~`) and stored absolute.
 - `target` must be a valid install target token (or comma-separated list), using the same validator as `apm install --target`.
@@ -58,7 +59,7 @@ Write `KEY` to `~/.apm/config.json`. Validates the value before writing:
 
 ### `apm config unset KEY`
 
-Remove `KEY` from `~/.apm/config.json`. No-op if the key is not set. Supported unset keys: `target`, `self-update.channel`, `self-update.install-dir`, `temp-dir`, `copilot-cowork-skills-dir`, `prefer-ssh`, `allow-protocol-fallback`, `audit-on-install`, `external.<name>.{llm,args}`, `mcp-registry-url`, and `registry.<name>.{url,token,default}`. After unsetting a key the effective value falls back to the environment variable, then the built-in default. Other boolean keys are reset by `set`-ing them to their default.
+Remove `KEY` from `$APM_HOME/config.json`. No-op if the key is not set. Supported unset keys: `target`, `self-update.channel`, `self-update.install-dir`, `temp-dir`, `copilot-cowork-skills-dir`, `prefer-ssh`, `allow-protocol-fallback`, `audit-on-install`, `external.<name>.{llm,args}`, `mcp-registry-url`, and `registry.<name>.{url,token,default}`. After unsetting a key the effective value falls back to the environment variable, then the built-in default. Other boolean keys are reset by `set`-ing them to their default.
 
 ## Configuration keys
 
@@ -77,7 +78,7 @@ Remove `KEY` from `~/.apm/config.json`. No-op if the key is not set. Supported u
 | `external.<name>.args` | string | unset | Extra scanner CLI flags, stored shlex-split as a list (e.g. `"--model gpt-4o"`). Allowlist-validated per adapter at run time. Overridable per-run with `--external-args`. Requires the `external-scanners` experimental flag. |
 | `mcp-registry-url` | URL | public registry | Persist a private MCP registry endpoint. Accepts `http://` or `https://` URLs. Provides a persistent fallback below `MCP_REGISTRY_URL` and above the built-in default, and applies to every registry lookup: `apm mcp list/search/show`, `apm install --mcp NAME`, and the `dependencies.mcp` entries `apm install` reads from `apm.yml`. |
 | `registry.<name>.url` | URL | unset | Base URL for registry `<name>`. Requires `registries` experimental flag. |
-| `registry.<name>.token` | string | unset | Bearer token for registry `<name>`. Stored in `~/.apm/config.json`; never in repo-tracked files. Requires `registries` experimental flag. |
+| `registry.<name>.token` | string | unset | Bearer token for registry `<name>`. Stored in `$APM_HOME/config.json`; never in repo-tracked files. Requires `registries` experimental flag. |
 | `registry.<name>.default` | boolean | `false` | Mark `<name>` as the user-scoped default registry. Only one registry may be default at a time; setting `true` clears any previous default. Requires `registries` experimental flag. |
 
 ### Resolution order
@@ -85,14 +86,14 @@ Remove `KEY` from `~/.apm/config.json`. No-op if the key is not set. Supported u
 `temp-dir` and `copilot-cowork-skills-dir` are resolved at runtime as:
 
 1. Environment variable (`APM_TEMP_DIR`, `APM_COPILOT_COWORK_SKILLS_DIR`)
-2. Value in `~/.apm/config.json`
+2. Value in `$APM_HOME/config.json`
 3. Built-in default (system temp / platform auto-detection)
 
 `mcp-registry-url` follows a four-layer precedence chain (CLI flag wins):
 
 1. `--registry <url>` flag on `apm mcp install` / `apm install --mcp` (used immediately and persisted on the dependency in `apm.yml`)
 2. `MCP_REGISTRY_URL` environment variable
-3. `mcp-registry-url` value in `~/.apm/config.json`
+3. `mcp-registry-url` value in `$APM_HOME/config.json`
 4. Built-in public default registry
 
 A per-dependency `registry:` URL in `apm.yml` overrides the chain for that entry
@@ -104,26 +105,26 @@ needs no opt-in, since setting it is already the explicit choice.
 
 1. CLI flag (`--allow-protocol-fallback`, `--ssh`) -- highest priority
 2. Environment variable (`APM_ALLOW_PROTOCOL_FALLBACK=1`, `APM_GIT_PROTOCOL=ssh`)
-3. Value in `~/.apm/config.json` (`apm config set ...`)
+3. Value in `$APM_HOME/config.json` (`apm config set ...`)
 4. Built-in default (`false` / no preference)
 
 Registry tokens are resolved as:
 
 1. `APM_REGISTRY_TOKEN_<NAME>` environment variable (uppercase name, `-`/`.` -> `_`)
-2. `registry.<name>.token` in `~/.apm/config.json`
+2. `registry.<name>.token` in `$APM_HOME/config.json`
 3. Unauthenticated (APM surfaces a remediation hint on 401/403)
 
 Registry URLs are merged at install time (highest wins):
 
 1. `apm-policy.yml`
 2. Project `apm.yml` `registries:` block
-3. Workspace `~/.apm/apm.yml`
-4. `registry.<name>.url` in `~/.apm/config.json`
+3. User workspace `$APM_HOME/apm.yml`
+4. `registry.<name>.url` in `$APM_HOME/config.json`
 
 Default registry selection (highest wins):
 
 1. `registries.default` in project `apm.yml`
-2. The registry entry in `~/.apm/config.json` with `"default": true` (set via `registry.<name>.default true`)
+2. The registry entry in `$APM_HOME/config.json` with `"default": true` (set via `registry.<name>.default true`)
 
 `apm self-update` installer inputs resolve as:
 
@@ -244,7 +245,7 @@ See [External scanners](../../../integrations/external-scanners/).
 
 ## Configuration file
 
-- **Location:** `~/.apm/config.json`
+- **Location:** `$APM_HOME/config.json` (default `~/.apm/config.json`)
 - **Format:** JSON object, one entry per stored key.
 - **Created on first read** with `{"default_client": "vscode"}`. Hand-editing is supported but `apm config set` is preferred -- it validates input and normalizes paths.
 

--- a/docs/src/content/docs/reference/cli/deny.md
+++ b/docs/src/content/docs/reference/cli/deny.md
@@ -16,7 +16,7 @@ apm deny [OPTIONS] PACKAGES...
 `apm deny` blocks executable primitives from one or more dependency packages.
 By default, it writes the decision to the project's committed
 `apm.yml` under `executables.deny`. Pass `--user` to write a machine-local
-decision to `~/.apm/config.json` instead. Run the command from an APM project:
+decision to `$APM_HOME/config.json` (default `~/.apm/config.json`) instead. Run the command from an APM project:
 an `apm.yml` file is required for both scopes.
 
 A deny takes precedence over an allow. For the full precedence model and the
@@ -28,7 +28,7 @@ executable types covered by the gate, see
 | Argument or flag | Description |
 |---|---|
 | `PACKAGES...` | One or more package references, such as `owner/repo`. Required. |
-| `--user` | Record the deny in `~/.apm/config.json` instead of `apm.yml`. |
+| `--user` | Record the deny in `$APM_HOME/config.json` (default `~/.apm/config.json`) instead of `apm.yml`. |
 
 For an installed package that declares executable types, APM records those
 types. When no executable declaration is found -- because the package is not

--- a/docs/src/content/docs/reference/cli/deps.md
+++ b/docs/src/content/docs/reference/cli/deps.md
@@ -17,7 +17,7 @@ apm deps SUBCOMMAND [OPTIONS]
 
 `apm deps` is the read-and-maintenance counterpart to [`apm install`](../install/). It reads `apm.lock.yaml` and the `apm_modules/` tree to show what is installed, refresh git refs, or remove the tree entirely. It does not add new packages -- use `apm install <package>` for that.
 
-All subcommands operate on the project scope (`./apm_modules/`) by default. Pass `-g` / `--global` where supported to operate on the user scope (`~/.apm/apm_modules/`).
+All subcommands operate on the project scope (`./apm_modules/`) by default. Pass `-g` / `--global` where supported to operate on `$APM_HOME/apm_modules/` (default `~/.apm/apm_modules/`). `APM_HOME` changes dependency metadata paths, not target deployment destinations.
 
 ## Subcommands
 
@@ -52,7 +52,7 @@ apm deps list [OPTIONS]
 
 | Option | Description |
 |---|---|
-| `-g, --global` | List user-scope dependencies in `~/.apm/` instead of the project. |
+| `-g, --global` | List user-scope dependencies under `$APM_HOME` (default `~/.apm`) instead of the project. |
 | `--all` | Show both project and user-scope dependencies. |
 | `--insecure` | Show only dependencies locked to `http://` sources. Adds an `Origin` column distinguishing `direct` declarations from `via <parent>` transitive pulls. |
 
@@ -71,7 +71,7 @@ apm deps tree [OPTIONS]
 
 | Option | Description |
 |---|---|
-| `-g, --global` | Show the user-scope tree in `~/.apm/`. |
+| `-g, --global` | Show the user-scope tree under `$APM_HOME` (default `~/.apm`). |
 
 ### `apm deps info`
 
@@ -99,7 +99,7 @@ apm deps why PACKAGE [OPTIONS]
 
 | Option | Description |
 |---|---|
-| `-g, --global` | Read the user-scope lockfile at `~/.apm/apm.lock.yaml` instead of the project lockfile. |
+| `-g, --global` | Read `$APM_HOME/apm.lock.yaml` (default `~/.apm/apm.lock.yaml`) instead of the project lockfile. |
 | `--json` | Emit a machine-readable JSON document to stdout. All logs and error payloads are routed to stderr so `apm deps why pkg --json \| jq` is safe. |
 
 Exit codes: `0` on success, `1` when the package is not installed or the query matches multiple packages, `2` when no lockfile exists.
@@ -126,7 +126,7 @@ apm deps update [PACKAGES...] [OPTIONS]
 | `--force` | Overwrite locally-authored files on collision. |
 | `-t, --target` | Force deployment to specific targets. Comma-separated. Values: `agent-skills`, `agents`, `agy`, `all`, `antigravity`, `claude`, `codex`, `copilot`, `cursor`, `gemini`, `grok-build`, `hermes`, `intellij`, `kiro`, `opencode`, `vscode`, `windsurf`. Experimental targets (`copilot-app`, `copilot-cowork`, `grok-cloud`, `openclaw`) are also accepted when their feature flags are enabled. `all` excludes `agent-skills`, `antigravity`, `hermes`, experimental targets, and `intellij`. |
 | `--parallel-downloads N` | Max concurrent downloads. Default `4`. `0` disables parallelism. |
-| `-g, --global` | Update user-scope dependencies in `~/.apm/`. |
+| `-g, --global` | Update user-scope dependencies under `$APM_HOME` (default `~/.apm`). |
 | `--legacy-skill-paths` | Deploy skill files to per-client paths (`.cursor/skills/`, etc.) instead of the shared `.agents/skills/` directory. |
 
 `apm deps update` runs the install pipeline and is gated by org `apm-policy.yml`. There is no `--no-policy` flag; the only escape hatch is `APM_POLICY_DISABLE=1` for the shell session.

--- a/docs/src/content/docs/reference/cli/experimental.md
+++ b/docs/src/content/docs/reference/cli/experimental.md
@@ -1,6 +1,6 @@
 ---
 title: apm experimental
-description: Manage opt-in experimental feature flags stored in ~/.apm/config.json
+description: Manage opt-in experimental feature flags stored in the APM user configuration
 sidebar:
   order: 24
 ---
@@ -23,7 +23,11 @@ apm experimental reset [NAME] [--yes]
 
 ## Description
 
-Experimental flags live under the `experimental` key of `~/.apm/config.json` and default to disabled. Toggling a flag persists the override; `reset` removes it. Flag names are case-insensitive and accept either kebab-case (`verbose-version`) or snake_case (`verbose_version`) on the command line.
+Experimental flags live under the `experimental` key of `$APM_HOME/config.json`
+(default `~/.apm/config.json`) and default to disabled. Toggling a flag persists
+the override; `reset` removes it. Flag names are case-insensitive and accept
+either kebab-case (`verbose-version`) or snake_case (`verbose_version`) on the
+command line.
 
 Flags never gate security-critical behaviour (content scanning, lockfile integrity, token handling, MCP trust checks). Those are always on. See [`apm audit`](../audit/) for the security model.
 
@@ -50,7 +54,7 @@ Disable a flag and persist the override.
 
 ### `apm experimental reset [NAME]`
 
-Reset one flag (when `NAME` is given) or all flags (when omitted) to registry defaults. Bulk reset prompts for confirmation and also removes unknown or malformed entries from `~/.apm/config.json`.
+Reset one flag (when `NAME` is given) or all flags (when omitted) to registry defaults. Bulk reset prompts for confirmation and also removes unknown or malformed entries from `$APM_HOME/config.json`.
 
 | Option | Description |
 | --- | --- |
@@ -71,7 +75,7 @@ Reset one flag (when `NAME` is given) or all flags (when omitted) to registry de
 | `copilot-cowork` | Enables Microsoft 365 Copilot Cowork skill deployment via OneDrive. | `apm install --target copilot-cowork --global` |
 | `copilot-app` | Deploys prompts as workflows into the GitHub Copilot desktop App. Workflows arrive disabled; enable them from the Copilot app's Workflows tab. | `apm install --target copilot-app` |
 | `marketplace-authoring` | Enables marketplace authoring commands (`init`, `build`, `publish`). | `apm marketplace --help` |
-| `registries` | Enables REST-based APM package registries in `apm.yml` and `~/.apm/config.json`. | `apm install` (with `registries:` configured) |
+| `registries` | Enables REST-based APM package registries in `apm.yml` and `$APM_HOME/config.json`. | `apm install` (with `registries:` configured) |
 | `canvas` | Ships Copilot CLI canvas extensions from `.apm/extensions/` bundles. | `apm install` |
 | `external-scanners` | Enables third-party SARIF scanner ingestion in `apm audit` (`--external`, `--external-llm`, `--external-args`), the `external.<name>.{llm,args}` config keys, and `security.audit.scanners` policy governance. | `apm audit --external skillspector` |
 | `openclaw` | Deploys skills to OpenClaw runtime directories. | `apm install --target openclaw` |

--- a/docs/src/content/docs/reference/cli/install.md
+++ b/docs/src/content/docs/reference/cli/install.md
@@ -31,7 +31,7 @@ With no arguments it installs everything from `apm.yml`. With one or more `PACKA
 |---|---|---|
 | `--update` | off | Re-resolve dependencies to the latest version or Git ref allowed by `apm.yml` and rewrite `apm.lock.yaml`. Mutable Git refs must resolve against upstream; APM does not fall back to stale refs from the local bare Git cache. Mutually exclusive with `--frozen`. For interactive use with a confirmation prompt, use [`apm update`](../update/) instead. |
 | `--frozen` | off | Lockfile-only install: refuse to resolve anything new and fail before any project, config, deployment, or cache write if `apm.lock.yaml` is missing or out of sync with `apm.yml`, including MCP state. Mirrors `npm ci`. Mutually exclusive with `--update`, positional package additions, and `--mcp`. |
-| `--dry-run` | off | Print the install plan without deployment writes. Positional packages and ref changes appear in the preview after validation but do not change an existing `apm.yml`. Project auto-bootstrap still keeps its new manifest and any explicit `--target` selection for the next run; global dry-run bootstrap uses temporary preview state and does not create `~/.apm`. The `-g --mcp` path creates no user manifest, lockfile, or runtime configuration. |
+| `--dry-run` | off | Print the install plan without deployment writes. Positional packages and ref changes appear in the preview after validation but do not change an existing `apm.yml`. Project auto-bootstrap still keeps its new manifest and any explicit `--target` selection for the next run; global dry-run bootstrap uses temporary preview state and does not create the APM home (`$APM_HOME`, default `~/.apm`). The `-g --mcp` path creates no user manifest, lockfile, or runtime configuration. |
 | `--force` | off | Overwrite locally-authored files on collision **and** bypass the security scan's critical-finding block. Does **not** suppress general install errors (any reported error still exits `1`, matching npm / pip / cargo) or select ref freshness. Add `--update` or `--refresh` to resolve mutable refs upstream; [`apm update`](../update/) does so with or without `--force`. Use only after independent verification. |
 | `--verbose`, `-v` | off | Show per-file paths and full error context in the diagnostic summary. |
 | `--dev` | off | Add new packages to `devDependencies`. Dev deps install locally but are excluded from `apm pack` output. |
@@ -50,7 +50,7 @@ With no arguments it installs everything from `apm.yml`. With one or more `PACKA
 | `--runtime VALUE` | unset | Legacy alias for `--target` (single value only). Still accepted; prefer `--target`. |
 | `--exclude VALUE` | unset | Skip one runtime from the resolved MCP/LSP target set (explicit selection, manifest, saved config, or auto-detection). |
 | `--only apm\|mcp` | both | Install only APM packages or MCP/LSP service dependencies. Use `--only=apm` to skip service configuration and `--only=mcp` to select MCP and LSP services only. |
-| `-g`, `--global` | off | Install to user scope (`~/.apm/`) instead of the current project. `apm install -g --mcp NAME` creates or updates `~/.apm/apm.yml`, then deploys only to global-capable runtimes, such as Copilot CLI, Claude Code, Codex CLI, Gemini CLI, Antigravity CLI, Hermes, Kiro, Windsurf, and JetBrains Copilot. Mixed selections skip workspace-only targets with a warning. A selection with no global-capable target exits `2` before changing the user manifest, lockfile, or runtime configuration. |
+| `-g`, `--global` | off | Install to user scope under the APM home (`$APM_HOME`, default `~/.apm`) instead of the current project. `apm install -g --mcp NAME` creates or updates `$APM_HOME/apm.yml`, then deploys only to global-capable runtimes, such as Copilot CLI, Claude Code, Codex CLI, Gemini CLI, Antigravity CLI, Hermes, Kiro, Windsurf, and JetBrains Copilot. `APM_HOME` changes metadata paths only; target files still use their target-specific home variables or the operating-system home. Mixed selections skip workspace-only targets with a warning. A selection with no global-capable target exits `2` before changing the user manifest, lockfile, or runtime configuration. |
 | `--legacy-skill-paths` | off | Deploy skills to per-client paths (`.cursor/skills/`, `.github/skills/`, ...) instead of the converged `.agents/skills/`. Env: `APM_LEGACY_SKILL_PATHS=1`. |
 
 File primitives resolve targets in this order: `--target`, manifest
@@ -116,7 +116,7 @@ in `apm.yml`, then run `apm install` again.
 
 ## Behavior
 
-- **Auto-bootstrap.** `apm install <pkg>` with no `apm.yml` creates a minimal one. Its name comes from the current directory (or home directory for global installs) and falls back to `my-project` if that derived name is invalid. `apm install --dry-run -g <pkg>` validates through a temporary manifest when `~/.apm/apm.yml` is absent, reports the real user manifest path, and leaves `~/.apm` uncreated. If `~/.apm/apm.yml` already exists, global dry-run reads it in place without writing changes. Bare `apm install` with no `apm.yml` exits with a hint to run `apm init` or `apm install <org/repo>`.
+- **Auto-bootstrap.** `apm install <pkg>` with no `apm.yml` creates a minimal one. Its name comes from the current directory (or home directory for global installs) and falls back to `my-project` if that derived name is invalid. `apm install --dry-run -g <pkg>` validates through a temporary manifest when `$APM_HOME/apm.yml` is absent (`~/.apm/apm.yml` by default), reports the real user manifest path, and leaves the APM home uncreated. If the user manifest already exists, global dry-run reads it in place without writing changes. Bare `apm install` with no `apm.yml` exits with a hint to run `apm init` or `apm install <org/repo>`.
 - **Target persistence on bootstrap.** When `--target` maps to recognized manifest targets, those target(s) are persisted to the new manifest's `targets:` field so a later bare `apm update` redeploys to the same targets without re-specifying `--target`. For absent user manifests, `apm install --dry-run -g --target ... <pkg>` previews that target field but does not write it.
 - **One effective target.** Package primitives, MCP servers, and LSP servers consume one target decision per invocation: `--target` > `apm.yml targets:` > `apm config set target ...` > auto-detect. A saved target therefore applies to `apm install`, `apm install --mcp`, and later `apm update` runs without another flag.
 - **Claude LSP discovery.** Project installs write the APM-managed plugin at
@@ -168,7 +168,7 @@ in `apm.yml`, then run `apm install` again.
 - **Diagnostic summary.** Output is grouped at the end (collisions, replacements, warnings, errors) instead of inline. Use `--verbose` to expand individual file paths.
 - **Unresolved hook roots.** A hook command that leaves a supported `${PLUGIN_ROOT}` alias unresolved emits a warning naming the package and a concrete repair. Balance quotes around the complete package-relative path, keep it inside the package, then run `apm install` again. See [Hooks and commands](../../../producer/author-primitives/hooks-and-commands/#hooks) for accepted quoting forms.
 - **Declared plugin components.** Every path explicitly listed under a recognized plugin manifest's `agents`, `skills`, `commands`, or `hooks` field must resolve inside that plugin root. A missing or escaping path fails before deployment and lockfile commit; remove the declaration or add the component, then reinstall. Omitted fields and empty lists remain valid.
-- **Default registry routing.** When a default registry is configured (project `registries.default` in `apm.yml` or `registry.<name>.default true` in `~/.apm/config.json`), unscoped `owner/repo#ref` shorthand deps passed to `apm install` route to the registry instead of GitHub. A `#<version>` selector is required; omitting it exits `1`. The selector may be a semver range (`^1.0.0`), an exact version (`1.2.3`), or a non-semver label (`main`, `stable`, `v1.4.2`) -- the registry exact-matches non-semver selectors against its published version list. GitHub probe is skipped for these deps; use the `git:` URL form in `apm.yml` to force the GitHub path (e.g., `- git: https://github.com/owner/repo.git`).
+- **Default registry routing.** When a default registry is configured (project `registries.default` in `apm.yml` or `registry.<name>.default true` in `$APM_HOME/config.json`), unscoped `owner/repo#ref` shorthand deps passed to `apm install` route to the registry instead of GitHub. A `#<version>` selector is required; omitting it exits `1`. The selector may be a semver range (`^1.0.0`), an exact version (`1.2.3`), or a non-semver label (`main`, `stable`, `v1.4.2`) -- the registry exact-matches non-semver selectors against its published version list. GitHub probe is skipped for these deps; use the `git:` URL form in `apm.yml` to force the GitHub path (e.g., `- git: https://github.com/owner/repo.git`).
 
 ## Examples
 
@@ -224,7 +224,7 @@ apm install microsoft/apm-sample-package --dry-run
 apm install -g microsoft/apm-sample-package --dry-run
 ```
 
-With `-g`, an absent `~/.apm` remains uncreated while APM previews the user-scope install.
+With `-g`, an absent APM home (`$APM_HOME`, default `~/.apm`) remains uncreated while APM previews the user-scope install.
 
 ### Redirect writes to a scratch directory
 
@@ -280,7 +280,9 @@ apm install owner/skill-bundle --skill '*'         # reset to all skills
 
 ### Install from a private registry (experimental)
 
-Enable the feature, configure the registry (in `apm.yml` and/or `~/.apm/config.json`), and run install normally. APM resolves registry-sourced deps alongside git deps:
+Enable the feature, configure the registry (in `apm.yml` and/or
+`$APM_HOME/config.json`), and run install normally. APM resolves registry-sourced
+deps alongside git deps:
 
 ```bash
 apm experimental enable registries

--- a/docs/src/content/docs/reference/cli/lifecycle.md
+++ b/docs/src/content/docs/reference/cli/lifecycle.md
@@ -104,7 +104,8 @@ Supported events: `pre-install`, `post-install`, `pre-update`, `post-update`,
 Note: `apm lifecycle test` bypasses the project-script trust gate -- it is an
 explicit developer inspection tool for their own repository.
 
-Script output is written to `~/.apm/logs/scripts.log`.
+Script output is written to `$APM_HOME/logs/scripts.log` (default
+`~/.apm/logs/scripts.log`).
 
 ### `apm lifecycle trust`
 
@@ -118,9 +119,9 @@ apm lifecycle trust
 Trust is bound to the canonical `lifecycle:` subtree (SHA-256). Editing
 other `apm.yml` keys does not revoke trust; editing `lifecycle:` does.
 
-Trust records are stored at `~/.apm/scripts-trust.json` (or
-`$APM_HOME/scripts-trust.json`). To audit or reset trust manually, edit or
-delete that file.
+Trust records are stored at `$APM_HOME/scripts-trust.json` (default
+`~/.apm/scripts-trust.json`). To audit or reset trust manually, edit or delete
+that file.
 
 ### `apm lifecycle untrust`
 
@@ -136,7 +137,7 @@ apm lifecycle untrust
 | Variable | Effect |
 |---|---|
 | `APM_NO_SCRIPTS=1` | Disable all lifecycle scripts for one invocation. Useful in CI and untrusted clone environments. |
-| `APM_HOME` | Override the base directory for user `apm.yml` (`$APM_HOME/apm.yml`) and trust store (`$APM_HOME/scripts-trust.json`). |
+| `APM_HOME` | Override the shared root for user `apm.yml`, global package metadata, configuration, lifecycle trust, and lifecycle logs. It does not redirect target deployment. See the [authoritative path contract](../../environment-variables/#apm_home-path-contract). |
 
 ## Exit codes
 

--- a/docs/src/content/docs/reference/cli/lock.md
+++ b/docs/src/content/docs/reference/cli/lock.md
@@ -33,7 +33,7 @@ This mirrors the ergonomics of `cargo generate-lockfile` and `pnpm lock`.
 | Flag | Default | Description |
 | --- | --- | --- |
 | `--verbose`, `-v` | off | Show per-dependency resolution details. |
-| `--global`, `-g` | off | Operate on `~/.apm/apm.yml` instead of the current project (mirrors `apm install -g`). |
+| `--global`, `-g` | off | Operate on `$APM_HOME/apm.yml` (default `~/.apm/apm.yml`) and write the lockfile beside it instead of using the current project (mirrors `apm install -g`). Target deployment paths are irrelevant because `apm lock` never deploys files. |
 | `--update` | off | Re-resolve deps to their latest matching SHAs from upstream before writing the lockfile. Stale local bare-repository refs are not accepted. |
 | `--no-policy` | off | Skip policy enforcement during resolution. |
 | `--target TARGET`, `-t TARGET` | none | Agent target for policy enforcement during resolution. No files are deployed or deleted regardless of this value. Accepts a single target (`claude`, `copilot`, etc.) or comma-separated list. |
@@ -85,7 +85,7 @@ apm lock export [OPTIONS]
 | --- | --- | --- |
 | `--format FORMAT`, `-f FORMAT` | `cyclonedx` | SBOM output format: `cyclonedx` (1.5) or `spdx` (2.3). |
 | `--output FILE`, `-o FILE` | stdout | Write the SBOM to a file instead of stdout. |
-| `--global`, `-g` | off | Read the user-scope (`~/.apm/`) lockfile instead of the current project. |
+| `--global`, `-g` | off | Read `$APM_HOME/apm.lock.yaml` (default `~/.apm/apm.lock.yaml`) instead of the current project lockfile. |
 | `--timestamp TS` | auto | Pin the SBOM timestamp for reproducible output. The value must be ISO 8601 with a timezone (e.g. `2024-06-01T00:00:00+00:00`); malformed or timezone-naive values fail. Defaults to `SOURCE_DATE_EPOCH`, then the lockfile's legacy `generated_at`, then the Unix epoch. |
 
 Component identity is a Package URL (`pkg:github/<owner>/<repo>@<commit>` for git deps, `pkg:oci/<name>@<digest>` for registry deps, `pkg:generic/<name>@<content_hash>` for local primitives), and the declared license is passed through verbatim (or `NOASSERTION` when undeclared). Output is deterministic -- components sorted by purl with a pinned timestamp -- so two runs are byte-identical. Credentials in recorded URLs are scrubbed. Diagnostics and update notifications route to stderr from process startup, so `apm lock export | jq` stays clean. See [Inventory export (SBOM)](../../../enterprise/security/#inventory-export-sbom) for the full model.

--- a/docs/src/content/docs/reference/cli/mcp.md
+++ b/docs/src/content/docs/reference/cli/mcp.md
@@ -26,9 +26,9 @@ The canonical install path for MCP servers is
 [`apm install --mcp NAME`](../install/#mcp-server-entry-use-only-with---mcp). It
 edits `apm.yml`, resolves the registry entry, and writes the resulting
 `mcpServers` block to your project. With `-g` or `--global`, it creates or
-updates `~/.apm/apm.yml` and writes only to global-capable runtime
-configurations. `apm mcp install` is a forwarder that calls the same code path
--- use whichever spelling you prefer.
+updates `$APM_HOME/apm.yml` (default `~/.apm/apm.yml`) and writes only to
+global-capable runtime configurations. `apm mcp install` is a forwarder that
+calls the same code path -- use whichever spelling you prefer.
 
 For an end-to-end consumer walkthrough (declaring an MCP server in
 `apm.yml`, configuring transport and credentials, deploying to a
@@ -105,7 +105,7 @@ list):
 | `--dev` | Add to `devDependencies`. |
 | `--dry-run` | Resolve and print without writing `apm.yml`. |
 | `--force` | Overwrite an existing entry. |
-| `-g`, `--global` | Install through `~/.apm/apm.yml` into global-capable runtimes. |
+| `-g`, `--global` | Install through `$APM_HOME/apm.yml` (default `~/.apm/apm.yml`) into global-capable runtimes. `APM_HOME` does not redirect runtime configuration. |
 | `--no-policy` | Skip policy checks. |
 | `--verbose`, `-v` | Verbose output. |
 
@@ -150,8 +150,8 @@ Install the same server at user scope:
 apm mcp install fetch -g --target claude -- npx -y @modelcontextprotocol/server-fetch
 ```
 
-This creates or updates `~/.apm/apm.yml` and the selected runtime's user
-configuration.
+This creates or updates `$APM_HOME/apm.yml` (default `~/.apm/apm.yml`) and the
+selected runtime's user configuration.
 
 Install a remote HTTP server:
 

--- a/docs/src/content/docs/reference/cli/outdated.md
+++ b/docs/src/content/docs/reference/cli/outdated.md
@@ -37,7 +37,7 @@ Local dependencies and Artifactory-hosted deps are skipped.
 
 | Option | Description |
 |---|---|
-| `-g, --global` | Check user-scope dependencies in `~/.apm/` instead of the current project. |
+| `-g, --global` | Check user-scope dependencies under `$APM_HOME` (default `~/.apm`) instead of the current project. |
 | `-v, --verbose` | List up to 10 newer Git tags or matching registry versions within the constraint; lockfile-only registry rows list newer versions. |
 | `-j, --parallel-checks N` | Max concurrent remote checks. Default `4`. `0` forces sequential. |
 
@@ -77,7 +77,7 @@ declaration, then run `apm install`.
 
 ### Other checks
 
-Check user-scope deps installed under `~/.apm/`:
+Check user-scope dependencies installed under `$APM_HOME` (default `~/.apm`):
 
 ```bash
 apm outdated --global

--- a/docs/src/content/docs/reference/cli/publish.md
+++ b/docs/src/content/docs/reference/cli/publish.md
@@ -23,7 +23,7 @@ Requires the experimental `registries` feature:
 apm experimental enable registries
 ```
 
-The project's `apm.yml` must declare a `registries:` block with at least one registry URL. Publish credentials resolve via `APM_REGISTRY_TOKEN_{NAME}` or `apm config set registry.<name>.token`. Credentials are sent only when `registry.<name>.url` in `~/.apm/config.json` matches the publish destination.
+The project's `apm.yml` must declare a `registries:` block with at least one registry URL. Publish credentials resolve via `APM_REGISTRY_TOKEN_{NAME}` or `apm config set registry.<name>.token`. Credentials are sent only when `registry.<name>.url` in `$APM_HOME/config.json` (default `~/.apm/config.json`) matches the publish destination.
 
 ## Options
 

--- a/docs/src/content/docs/reference/cli/self-update.md
+++ b/docs/src/content/docs/reference/cli/self-update.md
@@ -116,7 +116,7 @@ When an update is available, APM downloads and runs the platform installer, stre
 
 Recognized Unix bundles retain their launcher/bundle directories whether `self-update.install-dir` is set to the matching launcher directory or left unset. Conflicting overrides fail; this setting does not migrate an installation. See [ownership and migration](../../../getting-started/installation/#unix-install-ownership-and-migration) for bundle recognition, permission checks, administrator updates, and pip fallback restrictions.
 
-On Windows, self-update advances the [stable executable path](../../../getting-started/installation/). Configuration under `~/.apm/` and project files are untouched.
+On Windows, self-update advances the [stable executable path](../../../getting-started/installation/). Configuration under `$APM_HOME` (default `~/.apm`) and project files are untouched.
 
 ## After update
 

--- a/docs/src/content/docs/reference/cli/uninstall.md
+++ b/docs/src/content/docs/reference/cli/uninstall.md
@@ -33,7 +33,7 @@ The command only deletes files tracked in the lockfile's `deployed_files` manife
 |---|---|
 | `--dry-run` | Show the removal plan without writes from the uninstall engine. `pre-uninstall` lifecycle scripts still run and may have side effects. Registry fallback and shared-slot survivor staging are skipped. |
 | `-v, --verbose` | Show detailed removal information. |
-| `-g, --global` | Remove from the user scope (`~/.apm/`) instead of the current project. |
+| `-g, --global` | Remove from the user scope under `$APM_HOME` (default `~/.apm`) instead of the current project. Target deployment cleanup still uses target-specific home variables or the operating-system home. |
 
 ## Examples
 
@@ -160,7 +160,8 @@ ownership conflict. Run `apm install` to reconcile project state, or
 the `apm deps list` row. APM does not reinterpret it as `owner/repo` or rebuild an
 absolute path. If two declared local dependencies have the same portable key,
 selection is ambiguous and exits nonzero without changes. Use one exact path
-already declared in the relevant manifest (`apm.yml` or `~/.apm/apm.yml`); APM
+already declared in the relevant manifest (`apm.yml` or `$APM_HOME/apm.yml`,
+default `~/.apm/apm.yml`); APM
 never removes both or guesses, and diagnostics do not print declared paths.
 When an exact path removes one declaration from a shared local install slot, APM
 validates and stages the survivor before changing the manifest, then activates

--- a/docs/src/content/docs/reference/cli/update.md
+++ b/docs/src/content/docs/reference/cli/update.md
@@ -19,7 +19,7 @@ apm update [OPTIONS] [PACKAGES...]
 
 When every ref is already current but the locked `apm_modules/` cache is empty, `apm update` restores the cache from the same resolved refs without prompting. It uses the normal dependency materialization path without changing `apm.yml` or `apm.lock.yaml`. `--dry-run` remains read-only and does not restore files.
 
-Pass one or more `PACKAGES` to refresh only those dependencies, or `-g/--global` to refresh the user-scope dependencies under `~/.apm/` instead of the current project. With these flags `apm update` is a strict superset of the deprecated [`apm deps update`](../deps/#apm-deps-update).
+Pass one or more `PACKAGES` to refresh only those dependencies, or `-g/--global` to refresh the user-scope dependencies under the APM home (`$APM_HOME`, default `~/.apm`) instead of the current project. This changes APM metadata paths only; target deployment still uses target-specific home variables or the operating-system home. With these flags `apm update` is a strict superset of the deprecated [`apm deps update`](../deps/#apm-deps-update).
 
 This command refreshes dependencies, not the CLI. For CLI upgrades, use your
 package manager (`brew upgrade apm` for Homebrew), or
@@ -44,7 +44,7 @@ For a read-only install that pins to whatever is already in `apm.lock.yaml` -- t
 | `--yes`, `-y` | off | Skip the interactive prompt and accept the plan. Required for non-interactive use. |
 | `--dry-run` | off | Compute and print the plan without prompting and without writing the manifest, lockfile, or filesystem. |
 | `--verbose`, `-v` | off | Show per-dependency resolution detail (old ref, new ref, source) and full error context. |
-| `--global`, `-g` | off | Refresh user-scope dependencies under `~/.apm/` instead of the current project (mirrors `apm install -g`). |
+| `--global`, `-g` | off | Refresh user-scope dependencies under `$APM_HOME` (default `~/.apm`) instead of the current project (mirrors `apm install -g`). |
 | `--force` | off | Overwrite locally-authored files and deploy despite critical security findings. It does not change ref freshness: update still requires current upstream refs. Use only after independent verification. |
 | `--parallel-downloads N` | `4` | Max concurrent package downloads. `0` disables parallelism. |
 | `--target TARGET`, `-t TARGET` | resolution chain | Agent harness(es) to update for. Accepts the same target values and comma-separated lists as [`apm install --target`](../install/#target-selection). Resolution is `--target` > `apm.yml targets:` > `apm config set target ...` > auto-detect. |

--- a/docs/src/content/docs/reference/cli/view.md
+++ b/docs/src/content/docs/reference/cli/view.md
@@ -19,7 +19,7 @@ apm view PACKAGE [FIELD] [OPTIONS]
 
 `apm view` has two modes, selected by the optional `FIELD` argument:
 
-- **No field** -- read installed package metadata from `apm_modules/` (or `~/.apm/apm_modules/` with `-g`). Local-only; the package must be installed.
+- **No field** -- read installed package metadata from `apm_modules/` (or `$APM_HOME/apm_modules/`, default `~/.apm/apm_modules/`, with `-g`). Local-only; the package must be installed.
 - **`versions` field** -- query available versions. Git packages list remote tags and branches without requiring a local install. Registry packages list version and published-timestamp columns. See the `apm view <package> versions` subcommand below for the full registry-routing precedence and escape-hatch details.
 
 When `PACKAGE` matches the `NAME@MARKETPLACE` pattern, `apm view` resolves the plugin against the marketplace manifest and prints its entry (name, version, description, source, tags) instead of a Git repository view. This applies whether or not `versions` is passed.
@@ -51,7 +51,7 @@ For git packages, output is a table with name, type (`tag` or `branch`), and sho
 
 | Option              | Description                                  |
 | ------------------- | -------------------------------------------- |
-| `-g`, `--global`    | Inspect a package installed in user scope (`~/.apm/apm_modules/`) |
+| `-g`, `--global`    | Inspect a package installed in user scope (`$APM_HOME/apm_modules/`, default `~/.apm/apm_modules/`) |
 | `--registry [NAME]` | List versions from a registry. Omit a value to use the lockfile entry or configured default; provide `NAME` to force a specific named registry. Only valid with the `versions` field. |
 
 ## Examples

--- a/docs/src/content/docs/reference/environment-variables.md
+++ b/docs/src/content/docs/reference/environment-variables.md
@@ -77,7 +77,7 @@ APM verifies HTTPS against the operating-system trust store by default. For the 
 | `APM_CACHE_DIR` | Override the APM cache root. | platform default (XDG / `LOCALAPPDATA`) | Must be writable. See [`apm cache`](../cli/cache/). |
 | `APM_NO_CACHE` | `1`/`true`/`yes` disables read and write of the cache for the current invocation. | unset | Equivalent to `--no-cache` on commands that support it. |
 | `APM_TEMP_DIR` | Override the temp directory used by clone and download operations. | system default | Useful on Windows when endpoint security blocks `%TEMP%`. Resolution: env var > `temp_dir` in `~/.apm/config.json` > system default. |
-| `APM_HOME` | Override the APM home directory used for user config and state. | platform default | Must be writable. |
+| `APM_HOME` | Override the root for APM-owned user metadata and configuration. | `~/.apm` | Must be writable. Does not redirect files deployed to agent targets. |
 | `APM_NO_REFLINK` | Any non-empty value disables copy-on-write (reflink) optimisation; APM falls back to plain copies. | unset | Diagnostic / portability escape hatch. |
 | `APM_COPILOT_COWORK_SKILLS_DIR` | Override the destination directory for Copilot cowork skills. | platform auto-detect | Resolution: env var > config > auto-detect. |
 | `APM_COPILOT_APP_DB` | Override the path to the GitHub Copilot desktop App SQLite database used by the `copilot-app` target. | platform auto-detect | Useful for tests or non-standard Copilot installs. Resolution: env var > auto-detect. |
@@ -88,6 +88,44 @@ APM verifies HTTPS against the operating-system trust store by default. For the 
 | `XDG_CACHE_HOME` | Standard XDG base-directory variable APM consults when `APM_CACHE_DIR` is unset (Linux / macOS). | unset | Honoured per the XDG spec. |
 | `LOCALAPPDATA` | Standard Windows variable APM consults when `APM_CACHE_DIR` is unset. | OS-provided | Used to derive the default Windows cache path. |
 | `CLAUDE_CONFIG_DIR` | Override the user-scope destination Claude reads for skills, agents, and MCP config. | Claude default | For MCP config, nonblank values must be absolute. User-scope MCP servers are written to `$CLAUDE_CONFIG_DIR/.claude.json`; when unset or blank, APM uses `~/.claude.json`. |
+
+### `APM_HOME` path contract
+
+`APM_HOME` is the single root for APM-owned user metadata. When it is unset or
+empty, the root is `~/.apm`. When set, global commands and lifecycle processing
+use the same overridden root:
+
+| State | Path |
+|---|---|
+| User manifest | `$APM_HOME/apm.yml` |
+| User lockfile | `$APM_HOME/apm.lock.yaml` |
+| Installed package metadata and content | `$APM_HOME/apm_modules/` |
+| User configuration | `$APM_HOME/config.json` |
+| Lifecycle trust | `$APM_HOME/scripts-trust.json` |
+| Lifecycle logs | `$APM_HOME/logs/` |
+
+This applies to user-scope operations such as `apm install --global`, `apm
+update --global`, `apm lock --global`, `apm deps ... --global`, `apm compile
+--global`, and `apm config`.
+
+`APM_HOME` does **not** redirect target deployment. A target-specific home
+variable, when supported, selects that target's destination (for example,
+`CLAUDE_CONFIG_DIR`, `CODEX_HOME`, or `HERMES_HOME`); otherwise the destination
+is derived from the operating-system home. These settings control different
+path families, so a target-specific variable does not override `APM_HOME`, and
+`APM_HOME` does not act as a fallback for target deployment.
+
+To isolate APM metadata for a temporary global install:
+
+```bash
+export APM_HOME="$(mktemp -d)/apm"
+apm install --global example-org/example-package
+```
+
+The manifest, lockfile, modules, configuration, and lifecycle state remain
+under `$APM_HOME`; deployed target files still go to their normal user-scope
+destinations. For complete filesystem isolation, also run with an isolated
+operating-system home and/or set the selected targets' home variables.
 
 ## Policy
 

--- a/packages/apm-guide/.apm/skills/apm-usage/commands.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/commands.md
@@ -1,5 +1,15 @@
 # CLI Command Reference
 
+## User metadata root
+
+`APM_HOME` is the root for APM-owned user metadata: `apm.yml`,
+`apm.lock.yaml`, `apm_modules/`, `config.json`, lifecycle trust, and lifecycle
+logs. It defaults to `~/.apm`; every `~/.apm` path below describes that
+default. Global package, dependency, lock, compile, lifecycle, and config
+commands honor the override. Target deployments do not: target-specific home
+variables take precedence for their own destinations, with the operating-system
+home as the fallback.
+
 ## Project setup
 
 | Command | Purpose | Key flags |

--- a/packages/apm-guide/.apm/skills/apm-usage/governance.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/governance.md
@@ -16,7 +16,7 @@ repository references with the normal host authentication chain.
 
 ## User config trust boundary
 
-`~/.apm/config.json` is user-scoped state, not org policy. Keep durable config
+`$APM_HOME/config.json` (default `~/.apm/config.json`) is user-scoped state, not org policy. Keep durable config
 additive and narrow: `apm config` may persist non-secret defaults such as
 install targets, transport preferences, and self-update installer preferences
 (`self-update.channel`, `self-update.install-dir`). Do not use self-update

--- a/scripts/architecture_linter/checks/registry_owner_guards.py
+++ b/scripts/architecture_linter/checks/registry_owner_guards.py
@@ -20,6 +20,8 @@ registry-delegation-compiled-output-    AC2 "Compiled output writes must use
 writes                                  CompiledOutputWriter"
 registry-delegation-bootstrap-project-  AC18 ``lint-bootstrap-project-name``
 name                                    (ported semantically)
+registry-delegation-apm-home-resolution APM-owned user metadata must route
+                                        through core/scope.py
 ======================================  ==================================
 
 Every rule check consumes only :class:`FactsProvider` inventory and cached
@@ -150,6 +152,22 @@ _BOOTSTRAP_OWNED_DEFS: tuple[str, ...] = (
 
 
 _RESOLVER_ALT = r"_?resolve_bootstrap_project_name"
+
+
+_APM_HOME_OWNER = "src/apm_cli/core/scope.py"
+
+
+_APM_HOME_CONSUMER_NEEDLES: dict[str, str] = {
+    "src/apm_cli/config.py": "CONFIG_DIR = os.fspath(get_apm_home())",
+    "src/apm_cli/core/lifecycle_scripts.py": 'return get_apm_home() / "apm.yml"',
+    "src/apm_cli/core/script_trust.py": 'return get_apm_home() / "scripts-trust.json"',
+    "src/apm_cli/core/script_executors.py": 'return get_apm_home() / "logs" / "scripts.log"',
+    "src/apm_cli/install/locking.py": "lock_path = get_apm_home() / _LIFECYCLE_LOCK_NAME",
+    "src/apm_cli/deps/registry/config_loader.py": (
+        "workspace_yml = get_manifest_path(InstallScope.USER)"
+    ),
+    "src/apm_cli/security/executables.py": 'return get_apm_home() / "approvals.yml"',
+}
 
 
 def _count_fixed_lines(facts: FileFacts, needle: str) -> int:
@@ -581,6 +599,75 @@ def _check_bootstrap_project_name(provider: FactsProvider) -> Iterable[Violation
     return findings
 
 
+def _check_apm_home_resolution(provider: FactsProvider) -> Iterable[Violation]:
+    """APM-owned user metadata must consume one canonical home resolver."""
+    rule_id = "registry_delegation.apm_home_resolution"
+    required_paths = (_APM_HOME_OWNER, *_APM_HOME_CONSUMER_NEEDLES)
+    facts_by_path, failures = _read_required(provider, rule_id, required_paths)
+    if failures:
+        return failures
+
+    findings: list[Violation] = []
+    definers, def_failures = _defining_files(
+        provider,
+        rule_id,
+        "get_apm_home",
+        kinds=("function",),
+    )
+    findings.extend(def_failures)
+    if definers != frozenset({_APM_HOME_OWNER}):
+        findings.append(
+            violation(
+                rule_id,
+                _APM_HOME_OWNER,
+                "get_apm_home must be defined only by core/scope.py",
+            )
+        )
+
+    owner = facts_by_path[_APM_HOME_OWNER]
+    if _count_fixed_lines(owner, 'os.environ.get("APM_HOME")') != 1:
+        findings.append(
+            violation(
+                rule_id,
+                _APM_HOME_OWNER,
+                "the APM_HOME environment lookup must exist exactly once in its owner",
+            )
+        )
+
+    for path, needle in _APM_HOME_CONSUMER_NEEDLES.items():
+        if not _has_fixed(facts_by_path[path], needle):
+            findings.append(
+                violation(
+                    rule_id,
+                    path,
+                    "APM-owned user metadata path must route through get_apm_home",
+                )
+            )
+
+    for path in _python_paths(provider, under=_SRC):
+        if path == _APM_HOME_OWNER:
+            continue
+        _facts, read_failures = checked_facts(provider, path, rule_id, require_python=True)
+        if read_failures:
+            findings.extend(read_failures)
+            continue
+        index = provider.tree_index(path)
+        if index is None:
+            continue
+        for node in index.nodes:
+            if isinstance(node, ast.Constant) and node.value == "APM_HOME":
+                findings.append(
+                    violation(
+                        rule_id,
+                        path,
+                        "APM_HOME must be read only by core/scope.py::get_apm_home",
+                        line=getattr(node, "lineno", 1),
+                        column=getattr(node, "col_offset", 0) + 1,
+                    )
+                )
+    return findings
+
+
 def _is_name(node: ast.AST | None, name: str) -> bool:
     return isinstance(node, ast.Name) and node.id == name
 
@@ -689,6 +776,13 @@ RULES: tuple[Rule, ...] = (
         guard_ids=("registry-delegation-bootstrap-project-name",),
         description="Bootstrap project names must route through core/project_name.py.",
         check=_check_bootstrap_project_name,
+    ),
+    Rule(
+        id="registry_delegation.apm_home_resolution",
+        group=GROUP,
+        guard_ids=("registry-delegation-apm-home-resolution",),
+        description="APM-owned user metadata paths must share core/scope.py::get_apm_home.",
+        check=_check_apm_home_resolution,
     ),
 )
 

--- a/src/apm_cli/commands/approve.py
+++ b/src/apm_cli/commands/approve.py
@@ -83,7 +83,11 @@ def _save_store(
 
 
 def _store_label(user_scope: bool) -> str:
-    return "~/.apm/config.json" if user_scope else "apm.yml executables block"
+    if user_scope:
+        from .. import config
+
+        return config.CONFIG_FILE
+    return "apm.yml executables block"
 
 
 def _load_org_policy(project_root: Path, logger: CommandLogger | None = None) -> ApmPolicy:
@@ -130,7 +134,7 @@ def load_org_policy(project_root: Path, logger: CommandLogger | None = None) -> 
     "--user",
     "user_scope",
     is_flag=True,
-    help="Persist to your personal ~/.apm/config.json (lowest authority) "
+    help="Persist to your personal APM user config (lowest authority) "
     "instead of the shared project apm.yml.",
 )
 @serialized_lifecycle
@@ -195,7 +199,7 @@ def approve_cmd(
     "--user",
     "user_scope",
     is_flag=True,
-    help="Record the deny in your personal ~/.apm/config.json instead of apm.yml.",
+    help="Record the deny in your personal APM user config instead of apm.yml.",
 )
 @serialized_lifecycle
 def deny_cmd(packages: tuple[str, ...], user_scope: bool) -> None:

--- a/src/apm_cli/commands/compile/cli.py
+++ b/src/apm_cli/commands/compile/cli.py
@@ -467,7 +467,7 @@ def _handle_global_flag(dry_run: bool, logger: CommandLogger) -> int:
             if declared_names == target_names
             else f"{declared_names} -> {target_names}"
         )
-        selection_source = "~/.apm/apm.yml"
+        selection_source = _display_user_path(source_root / APM_YML_FILENAME)
     logger.verbose_detail(f"Global targets from {selection_source}: {provenance}")
 
     results = compile_user_root_contexts(
@@ -1258,7 +1258,7 @@ def _run_compilation(
     default=False,
     help=(
         "Compile user-scope root context files (~/.claude/CLAUDE.md, etc.) "
-        "from ~/.apm/apm_modules, using target(s) from ~/.apm/apm.yml or every "
+        "from the APM user home, using its manifest targets or every "
         "supported target when undeclared. Cannot be combined with project-scoped "
         "output flags such as --target, --all, --watch, --root, or --output; "
         "use with --dry-run to preview changes."

--- a/src/apm_cli/commands/config.py
+++ b/src/apm_cli/commands/config.py
@@ -557,8 +557,10 @@ def set(key, value):  # noqa: F811
     import os as _os
 
     if key == "allow-protocol-fallback" and enabled and _os.environ.get("CI"):
+        from .. import config as config_module
+
         logger.warning(
-            "allow-protocol-fallback is now persisted to ~/.apm/config.json. "
+            f"allow-protocol-fallback is now persisted to {config_module.CONFIG_FILE}. "
             "In CI environments with a shared $HOME this will affect all subsequent "
             "apm install runs on this host. "
             "Prefer APM_ALLOW_PROTOCOL_FALLBACK=1 as an invocation-scoped alternative."

--- a/src/apm_cli/commands/deps/cli.py
+++ b/src/apm_cli/commands/deps/cli.py
@@ -593,7 +593,7 @@ def _show_scope_deps(scope_label, apm_dir, logger, console, has_rich, insecure_o
     "global_",
     is_flag=True,
     default=False,
-    help="List user-scope dependencies (~/.apm/) instead of project",
+    help="List dependencies in the APM user home instead of the project",
 )
 @click.option(
     "--all",
@@ -802,7 +802,7 @@ def _build_dep_tree(apm_dir):
     "global_",
     is_flag=True,
     default=False,
-    help="Show user-scope dependency tree (~/.apm/)",
+    help="Show the dependency tree in the APM user home",
 )
 def tree(global_):
     """Display dependencies in hierarchical tree format using lockfile."""
@@ -993,7 +993,7 @@ def clean(dry_run: bool, yes: bool):
     "global_",
     is_flag=True,
     default=False,
-    help="Update user-scope dependencies (~/.apm/)",
+    help="Update dependencies in the APM user home",
 )
 @click.option(
     "--legacy-skill-paths",
@@ -1055,7 +1055,7 @@ def update(packages, verbose, force, target, parallel_downloads, global_, legacy
     apm_yml_path = project_root / APM_YML_FILENAME
 
     if not apm_yml_path.exists():
-        scope_hint = "~/.apm/" if global_ else "current directory"
+        scope_hint = str(project_root) if global_ else "current directory"
         logger.error(f"No {APM_YML_FILENAME} found in {scope_hint}")
         sys.exit(1)
 

--- a/src/apm_cli/commands/deps/why.py
+++ b/src/apm_cli/commands/deps/why.py
@@ -183,7 +183,7 @@ _HELP = (
     "global_",
     is_flag=True,
     default=False,
-    help="Resolve against the user-scope lockfile (~/.apm/apm.lock.yaml).",
+    help="Resolve against the lockfile in the APM user home.",
 )
 @click.option(
     "--json",

--- a/src/apm_cli/commands/discover.py
+++ b/src/apm_cli/commands/discover.py
@@ -33,7 +33,7 @@ def discover_options(command: Any) -> Any:
                 "-g",
                 "global_",
                 is_flag=True,
-                help="Discover under home and declare packages in ~/.apm/apm.yml",
+                help="Discover under home and declare packages in the APM user manifest",
             ),
         )
     ):

--- a/src/apm_cli/commands/install.py
+++ b/src/apm_cli/commands/install.py
@@ -950,7 +950,7 @@ def _handle_mcp_install(  # noqa: PLR0913
     "global_",
     is_flag=True,
     default=False,
-    help="Install to user scope (~/.apm/) instead of the current project. Direct MCP installs create or update ~/.apm/apm.yml. Mixed selections warn and skip workspace-only runtimes; selections with no global-capable runtime exit 2 before changing the user manifest, lockfile, or runtime configuration. Supported runtimes include Copilot CLI, Claude Code, Codex CLI, Gemini CLI, Antigravity CLI, Hermes, Kiro, Windsurf, and JetBrains Copilot.",
+    help="Install to the APM user home instead of the current project. Direct MCP installs create or update the user manifest. APM_HOME controls metadata but not target deployment. Mixed selections warn and skip workspace-only runtimes; selections with no global-capable runtime exit 2 before changing the user manifest, lockfile, or runtime configuration. Supported runtimes include Copilot CLI, Claude Code, Codex CLI, Gemini CLI, Antigravity CLI, Hermes, Kiro, Windsurf, and JetBrains Copilot.",
 )
 @click.option(
     "--ssh",

--- a/src/apm_cli/commands/lifecycle.py
+++ b/src/apm_cli/commands/lifecycle.py
@@ -181,8 +181,10 @@ def lifecycle_test(event: str, verbose: bool, execute: bool) -> None:
     for t in threads:
         t.join(timeout=15)
 
+    from apm_cli.core.script_executors import _get_scripts_log_path
+
     _rich_success(
-        f"'{event}' event fired. Check ~/.apm/logs/scripts.log for output.",
+        f"'{event}' event fired. Check {_get_scripts_log_path()} for output.",
         symbol="check",
     )
 

--- a/src/apm_cli/commands/lock.py
+++ b/src/apm_cli/commands/lock.py
@@ -26,8 +26,8 @@ What it does
 Flags
 -----
 * ``--verbose``/``-v`` -- show per-dependency resolution details.
-* ``--global``/``-g`` -- operate on ``~/.apm/apm.yml`` instead of the
-  current project (mirrors ``apm install -g``).
+* ``--global``/``-g`` -- operate on ``$APM_HOME/apm.yml`` (default
+  ``~/.apm/apm.yml``) instead of the current project.
 * ``--update`` -- re-resolve refs to their latest SHAs (like
   ``apm install --update``) before writing the lockfile.
 * ``--no-policy`` -- skip policy enforcement during resolution.
@@ -101,7 +101,7 @@ def _handle_lock_error(e: Exception, verbose: bool) -> None:
     "global_",
     is_flag=True,
     default=False,
-    help="Operate on ~/.apm/apm.yml instead of the current project",
+    help="Operate on the APM user manifest instead of the current project",
 )
 @click.option(
     "--update",
@@ -191,7 +191,8 @@ def _run_lock(
         manifest_path = get_apm_dir(scope) / "apm.yml"
         if not manifest_path.is_file():
             _rich_error(
-                "No apm.yml found in ~/.apm/. Run 'apm install -g <org/repo>' to create one."
+                f"No apm.yml found in {manifest_path.parent}. "
+                "Run 'apm install -g <org/repo>' to create one."
             )
             sys.exit(1)
         project_root = manifest_path.parent

--- a/src/apm_cli/commands/mcp.py
+++ b/src/apm_cli/commands/mcp.py
@@ -112,7 +112,7 @@ def mcp():
         "  -t, --target TARGET    Agent target(s) to deploy to\n"
         "  --registry URL         Custom registry URL\n"
         "  --mcp-version VER      Pin registry entry to a specific version\n"
-        "  -g, --global           Install to user scope (~/.apm/)\n"
+        "  -g, --global           Install to the APM user home\n"
         "  --trust-transitive-mcp Trust MCP servers from transitive dependencies\n"
         "  --dev / --dry-run / --force / --verbose / --no-policy"
     ),

--- a/src/apm_cli/commands/outdated.py
+++ b/src/apm_cli/commands/outdated.py
@@ -407,7 +407,7 @@ def _check_one_dep(dep, downloader, verbose, registry_ctx=None):
     "global_",
     is_flag=True,
     default=False,
-    help="Check user-scope dependencies (~/.apm/)",
+    help="Check dependencies in the APM user home",
 )
 @click.option(
     "--verbose",
@@ -450,7 +450,7 @@ def outdated(global_, verbose, parallel_checks):
     lockfile = LockFile.read(lockfile_path)
 
     if lockfile is None:
-        scope_hint = "~/.apm/" if global_ else "current directory"
+        scope_hint = str(project_root) if global_ else "current directory"
         logger.error(f"No lockfile found in {scope_hint}")
         sys.exit(1)
 

--- a/src/apm_cli/commands/uninstall/cli.py
+++ b/src/apm_cli/commands/uninstall/cli.py
@@ -229,7 +229,7 @@ def _report_package_removal_failure(
     "global_",
     is_flag=True,
     default=False,
-    help="Remove from user scope (~/.apm/) instead of the current project",
+    help="Remove from the APM user home instead of the current project",
 )
 @click.pass_context
 @serialized_lifecycle
@@ -283,7 +283,7 @@ def uninstall(ctx, packages, dry_run, verbose, global_):
             sys.exit(1)
 
         if scope is InstallScope.USER:
-            logger.progress("Uninstalling from user scope (~/.apm/)")
+            logger.progress(f"Uninstalling from user scope ({manifest_path.parent}/)")
 
         logger.start(f"Uninstalling {len(packages)} package(s)...")
 

--- a/src/apm_cli/commands/update.py
+++ b/src/apm_cli/commands/update.py
@@ -32,7 +32,7 @@ Flags
 * ``--verbose``/``-v`` -- show unchanged deps in the plan and pipeline
   diagnostics.
 * ``--global``/``-g`` -- refresh user-scope dependencies under
-  ``~/.apm/`` instead of the current project (mirrors
+  ``$APM_HOME`` (default ``~/.apm``) instead of the current project (mirrors
   ``apm install -g``).
 * ``[PACKAGES]...`` -- positional names to refresh only those
   dependencies; omit to refresh everything.
@@ -412,7 +412,7 @@ def _handle_service_only_update(
     "global_",
     is_flag=True,
     default=False,
-    help="Refresh user-scope dependencies (~/.apm/) instead of the current project",
+    help="Refresh dependencies in the APM user home instead of the current project",
 )
 @click.option(
     "--force",
@@ -476,13 +476,14 @@ def update(
     from apm_cli.core.scope import InstallScope, get_apm_dir
 
     if global_:
-        # User scope: operate on ~/.apm/apm.yml. The cwd manifest walk and
+        # User scope: operate on $APM_HOME/apm.yml. The cwd manifest walk and
         # the self-update back-compat shim apply only to project scope.
         scope = InstallScope.USER
         manifest_path = get_apm_dir(scope) / "apm.yml"
         if not manifest_path.is_file():
             _rich_error(
-                "No apm.yml found in ~/.apm/. Run 'apm install -g <org/repo>' to create one."
+                f"No apm.yml found in {manifest_path.parent}. "
+                "Run 'apm install -g <org/repo>' to create one."
             )
             sys.exit(1)
         if check_only:

--- a/src/apm_cli/commands/view.py
+++ b/src/apm_cli/commands/view.py
@@ -678,7 +678,7 @@ _VIEW_HELP = (
     "global_",
     is_flag=True,
     default=False,
-    help="Inspect package from user scope (~/.apm/)",
+    help="Inspect a package from the APM user home",
 )
 @click.option(
     "--registry",

--- a/src/apm_cli/config.py
+++ b/src/apm_cli/config.py
@@ -4,6 +4,8 @@ import contextlib
 import json
 import os
 
+from apm_cli.core.scope import get_apm_home
+
 # ---------------------------------------------------------------------------
 # Public env-var names (re-declared here to avoid a circular import with the
 # transport_selection module which also defines them).
@@ -11,7 +13,7 @@ import os
 _ENV_ALLOW_PROTOCOL_FALLBACK = "APM_ALLOW_PROTOCOL_FALLBACK"
 _ENV_GIT_PROTOCOL = "APM_GIT_PROTOCOL"
 
-CONFIG_DIR = os.path.expanduser("~/.apm")
+CONFIG_DIR = os.fspath(get_apm_home())
 CONFIG_FILE = os.path.join(CONFIG_DIR, "config.json")
 _INSTALL_TARGET_KEY = "install_target"
 _SELF_UPDATE_CHANNEL_KEY = "self_update_channel"

--- a/src/apm_cli/core/lifecycle_scripts.py
+++ b/src/apm_cli/core/lifecycle_scripts.py
@@ -360,10 +360,9 @@ def _get_policy_scripts_dir() -> Path:
 
 def _get_user_apm_yml() -> Path:
     """Return the user-level apm.yml path (~/.apm/apm.yml or $APM_HOME/apm.yml)."""
-    apm_home = os.environ.get("APM_HOME")
-    if apm_home:
-        return Path(apm_home) / "apm.yml"
-    return Path.home() / ".apm" / "apm.yml"
+    from apm_cli.core.scope import get_apm_home
+
+    return get_apm_home() / "apm.yml"
 
 
 def _get_project_apm_yml(project_root: str | None = None) -> Path:

--- a/src/apm_cli/core/scope.py
+++ b/src/apm_cli/core/scope.py
@@ -5,7 +5,8 @@ Defines where packages are deployed based on scope:
 - **project** (default): Deploy to the current working directory.
   Manifest, lockfile, and modules live at the project root.
 - **user**: Deploy to user-level directories (``~/.claude/``, etc.).
-  Manifest, lockfile, and modules live under ``~/.apm/``.
+  Manifest, lockfile, and modules live under ``$APM_HOME`` (default
+  ``~/.apm/``).
 
 User-scope support varies by target -- see ``TargetProfile.user_supported``
 in ``apm_cli.integration.targets`` for the canonical registry.
@@ -29,6 +30,7 @@ deploy root.  Source helpers (:func:`get_source_root`,
 from __future__ import annotations
 
 import contextvars
+import os
 from enum import Enum
 from pathlib import Path
 
@@ -38,6 +40,19 @@ from pathlib import Path
 
 USER_APM_DIR = ".apm"
 """Directory under ``$HOME`` for user-scope metadata."""
+
+
+def get_apm_home() -> Path:
+    """Return the canonical root for APM-owned user metadata.
+
+    ``APM_HOME`` overrides the default ``~/.apm`` location.  An unset or
+    empty value preserves the platform default.  Target deployment roots are
+    deliberately resolved elsewhere and are not affected by this helper.
+    """
+    configured = os.environ.get("APM_HOME")
+    if configured:
+        return Path(configured)
+    return Path.home() / USER_APM_DIR
 
 
 # ---------------------------------------------------------------------------
@@ -146,10 +161,10 @@ def get_apm_dir(scope: InstallScope) -> Path:
     """Return the directory that holds APM metadata (lockfile, modules).
 
     * Project scope: ``<cwd>/`` (the active deploy root)
-    * User scope: ``~/.apm/``
+    * User scope: ``$APM_HOME/`` (default ``~/.apm/``)
     """
     if scope is InstallScope.USER:
-        return Path.home() / USER_APM_DIR
+        return get_apm_home()
     return Path.cwd()
 
 
@@ -198,13 +213,13 @@ def get_lockfile_dir(scope: InstallScope) -> Path:
 
 
 def ensure_user_dirs() -> Path:
-    """Create ``~/.apm/`` and ``~/.apm/apm_modules/`` if they do not exist.
+    """Create the user APM root and its ``apm_modules/`` directory.
 
-    Returns the user APM root (``~/.apm/``).
+    Returns ``$APM_HOME`` when configured, otherwise ``~/.apm/``.
     """
     from ..constants import APM_MODULES_DIR
 
-    user_root = Path.home() / USER_APM_DIR
+    user_root = get_apm_home()
     user_root.mkdir(parents=True, exist_ok=True)
     (user_root / APM_MODULES_DIR).mkdir(exist_ok=True)
     return user_root

--- a/src/apm_cli/core/script_executors.py
+++ b/src/apm_cli/core/script_executors.py
@@ -404,9 +404,9 @@ _CAPTURE_DRAIN_GRACE = 0.5
 
 def _get_scripts_log_path() -> Path:
     """Return the path to the scripts output log file."""
-    apm_home = os.environ.get("APM_HOME")
-    base = Path(apm_home) if apm_home else Path.home() / ".apm"
-    return base / "logs" / "scripts.log"
+    from apm_cli.core.scope import get_apm_home
+
+    return get_apm_home() / "logs" / "scripts.log"
 
 
 _LINE_BREAK_ESCAPES = {

--- a/src/apm_cli/core/script_trust.py
+++ b/src/apm_cli/core/script_trust.py
@@ -68,9 +68,9 @@ _TRUST_STORE_THREAD_LOCK = threading.Lock()
 
 def _trust_store_path() -> Path:
     """Return the path to the script trust store."""
-    apm_home = os.environ.get("APM_HOME")
-    base = Path(apm_home) if apm_home else Path.home() / ".apm"
-    return base / "scripts-trust.json"
+    from apm_cli.core.scope import get_apm_home
+
+    return get_apm_home() / "scripts-trust.json"
 
 
 def script_file_fingerprint(path: Path) -> str | None:

--- a/src/apm_cli/deps/registry/auth.py
+++ b/src/apm_cli/deps/registry/auth.py
@@ -252,10 +252,13 @@ def resolve_for_url(target_url: str, registries: dict[str, str]) -> RegistryAuth
 
 def remediation_message(target_url: str) -> str:
     """The standard 401/403 remediation per §6.2 rule 3."""
+    from ...core.scope import get_apm_home
+
     return (
         f"error: this project depends on a package from\n"
         f"  {target_url}\n"
         f"but no credentials for that registry are configured on this machine.\n"
-        f"Add a registry entry whose URL matches (in apm.yml or ~/.apm/config.json)\n"
+        f"Add a registry entry whose URL matches (in apm.yml or "
+        f"{get_apm_home() / 'config.json'})\n"
         f"and set APM_REGISTRY_TOKEN_<NAME>=<token> in your environment."
     )

--- a/src/apm_cli/deps/registry/config_loader.py
+++ b/src/apm_cli/deps/registry/config_loader.py
@@ -84,8 +84,10 @@ def load_merged_registries(
     # 4. config.json (lowest)
     merged.update(_load_config_json_registries(create_config=create_config))
 
-    # 3. workspace ~/.apm/apm.yml
-    workspace_yml = Path.home() / ".apm" / "apm.yml"
+    # 3. user workspace ($APM_HOME/apm.yml, default ~/.apm/apm.yml)
+    from ...core.scope import InstallScope, get_manifest_path
+
+    workspace_yml = get_manifest_path(InstallScope.USER)
     if workspace_yml.exists():
         merged.update(_load_yaml_registries(workspace_yml))
 

--- a/src/apm_cli/install/locking.py
+++ b/src/apm_cli/install/locking.py
@@ -14,6 +14,7 @@ from typing import Any, TypeVar
 
 from filelock import FileLock, Timeout
 
+from apm_cli.core.scope import get_apm_home
 from apm_cli.utils.path_security import has_symlink_component
 
 LIFECYCLE_LOCK_TIMEOUT = 120.0
@@ -29,9 +30,9 @@ class LifecycleBusyError(RuntimeError):
 
 
 def _validate_lifecycle_lock_path(lock_path: Path) -> None:
-    """Reject lock paths that traverse a symlink below the user's home."""
-    home = Path.home()
-    if has_symlink_component(home, lock_path):
+    """Reject lock paths that traverse a symlink into the APM metadata root."""
+    apm_home = get_apm_home().absolute()
+    if has_symlink_component(apm_home.parent, lock_path.absolute()):
         raise LifecycleBusyError(
             f"Refusing symlinked lifecycle lock path: {lock_path}. "
             "Replace the symlink with a regular directory or file, then retry."
@@ -40,7 +41,7 @@ def _validate_lifecycle_lock_path(lock_path: Path) -> None:
 
 def lifecycle_lock() -> FileLock:
     """Return the process-reentrant OS-user lifecycle lock."""
-    lock_path = Path.home() / ".apm" / _LIFECYCLE_LOCK_NAME
+    lock_path = get_apm_home() / _LIFECYCLE_LOCK_NAME
     _validate_lifecycle_lock_path(lock_path)
     key = (os.getpid(), lock_path)
     with _locks_guard:

--- a/src/apm_cli/install/manifest_helpers.py
+++ b/src/apm_cli/install/manifest_helpers.py
@@ -67,11 +67,14 @@ def _prepare_user_scope_for_install(
     warn_unsupported_user_scope: Callable[[], str | None],
 ) -> None:
     """Prepare user-scope install paths unless the invocation is read-only."""
+    from apm_cli.core.scope import get_apm_home
+
+    scope_label = f"{get_apm_home()}/"
     if not dry_run:
         ensure_user_dirs()
-        logger.progress("Installing to user scope (~/.apm/)")
+        logger.progress(f"Installing to user scope ({scope_label})")
     else:
-        logger.progress("Previewing user-scope install (~/.apm/)")
+        logger.progress(f"Previewing user-scope install ({scope_label})")
     if scope_warning := warn_unsupported_user_scope():
         logger.warning(scope_warning)
 

--- a/src/apm_cli/install/phases/integrate.py
+++ b/src/apm_cli/install/phases/integrate.py
@@ -528,8 +528,10 @@ def _run_executable_approval_prompt(ctx: InstallContext) -> None:
     if updated and updated != allow_exec:
         save_user_executables(updated, deny_exec)
         if ctx.logger:
+            from apm_cli import config
+
             ctx.logger.info(
-                "Updated ~/.apm/config.json. "
+                f"Updated {config.CONFIG_FILE}. "
                 "Run 'apm install' again to deploy approved executables.",
                 symbol="info",
             )

--- a/src/apm_cli/security/executables.py
+++ b/src/apm_cli/security/executables.py
@@ -1261,12 +1261,14 @@ def _user_config_file() -> Path:
 
 
 def _legacy_approvals_path() -> Path:
-    """Return the path to the deprecated ``~/.apm/approvals.yml`` store.
+    """Return the path to the deprecated user ``approvals.yml`` store.
 
-    Read-only: the file is migrated into ``~/.apm/config.json`` on first read
-    and deleted. There is no writer for this path anymore (#1873).
+    Read-only: the file is migrated into the adjacent ``config.json`` on first
+    read and deleted. There is no writer for this path anymore (#1873).
     """
-    return Path.home() / ".apm" / "approvals.yml"
+    from ..core.scope import get_apm_home
+
+    return get_apm_home() / "approvals.yml"
 
 
 def _migrate_legacy_approvals(

--- a/tests/integration/test_architecture_apm_home.py
+++ b/tests/integration/test_architecture_apm_home.py
@@ -1,0 +1,55 @@
+"""Architecture regression for the canonical APM-owned metadata root."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.architecture_linter.runner import run_selected_rules
+
+pytestmark = pytest.mark.component
+
+_ROOT = Path(__file__).resolve().parents[2]
+_RULE_ID = "registry_delegation.apm_home_resolution"
+_SCOPE_PATH = "src/apm_cli/core/scope.py"
+_LIFECYCLE_PATH = "src/apm_cli/core/lifecycle_scripts.py"
+
+
+def test_apm_home_owner_boundary_is_clean() -> None:
+    result = run_selected_rules(_ROOT, {_RULE_ID})
+
+    assert result.failures == ()
+    assert result.violations == ()
+
+
+def test_apm_home_guard_rejects_parallel_environment_lookup() -> None:
+    source = (_ROOT / _LIFECYCLE_PATH).read_text(encoding="utf-8")
+    mutated = source.replace(
+        'return get_apm_home() / "apm.yml"',
+        'return Path(os.environ.get("APM_HOME", "~/.apm")) / "apm.yml"',
+        1,
+    )
+    assert mutated != source
+
+    result = run_selected_rules(
+        _ROOT,
+        {_RULE_ID},
+        source_overrides={_LIFECYCLE_PATH: mutated},
+    )
+
+    assert any("APM_HOME must be read only" in item.message for item in result.violations)
+
+
+def test_apm_home_guard_requires_the_canonical_owner() -> None:
+    source = (_ROOT / _SCOPE_PATH).read_text(encoding="utf-8")
+    mutated = source.replace("def get_apm_home()", "def get_user_metadata_root()", 1)
+    assert mutated != source
+
+    result = run_selected_rules(
+        _ROOT,
+        {_RULE_ID},
+        source_overrides={_SCOPE_PATH: mutated},
+    )
+
+    assert any("get_apm_home must be defined only" in item.message for item in result.violations)

--- a/tests/integration/test_architecture_owner_rule_mutations.py
+++ b/tests/integration/test_architecture_owner_rule_mutations.py
@@ -593,6 +593,22 @@ MUTATIONS: tuple[MutationCase, ...] = (
         intent="Local marketplace version precedence skips the plugin.json fallback read.",
     ),
     MutationCase(
+        guard_id="onboarding-metadata-only",
+        rule_id="onboarding-metadata-only",
+        path="src/apm_cli/adopt/discovery.py",
+        old="admission = validate_apm_package(path, read_only=True)",
+        new="admission = validate_apm_package(path, read_only=False)",
+        intent="Onboarding package admission stops enforcing read-only validation.",
+    ),
+    MutationCase(
+        guard_id="registry-delegation-apm-home-resolution",
+        rule_id="registry_delegation.apm_home_resolution",
+        path="src/apm_cli/core/scope.py",
+        old='configured = os.environ.get("APM_HOME")',
+        new='configured = os.environ.get("APM_ROOT")',
+        intent="APM user metadata stops reading its canonical environment variable.",
+    ),
+    MutationCase(
         guard_id="registry-delegation-bootstrap-project-name",
         rule_id="registry_delegation.bootstrap_project_name",
         path="src/apm_cli/core/project_name.py",

--- a/tests/integration/test_compile_global.py
+++ b/tests/integration/test_compile_global.py
@@ -76,6 +76,53 @@ def test_install_global_supports_claude_config_dir_outside_home(tmp_path, monkey
     assert "[x]" not in result.output
 
 
+def test_apm_home_isolates_metadata_without_redirecting_target_deployment(tmp_path, monkeypatch):
+    """Global install and lifecycle state share APM_HOME; targets do not."""
+    from apm_cli.commands.install import install as install_cmd
+    from apm_cli.core.lifecycle_scripts import _get_user_apm_yml
+    from apm_cli.core.script_executors import _get_scripts_log_path
+    from apm_cli.core.script_trust import _trust_store_path
+    from apm_cli.primitives.discovery import clear_discovery_cache
+
+    home = tmp_path / "home"
+    apm_home = tmp_path / "isolated-metadata"
+    package_dir = tmp_path / "global-package"
+    instruction_dir = package_dir / ".apm" / "instructions"
+    instruction_dir.mkdir(parents=True)
+    (package_dir / "apm.yml").write_text(
+        "name: global-package\nversion: 0.1.0\n",
+        encoding="utf-8",
+    )
+    (instruction_dir / "global.instructions.md").write_text(
+        "---\ndescription: Global install instructions\n---\nUse integration tests.\n",
+        encoding="utf-8",
+    )
+
+    claude_config = tmp_path / "target-config" / "claude"
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("APM_HOME", str(apm_home))
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(claude_config))
+    clear_discovery_cache()
+
+    result = CliRunner().invoke(
+        install_cmd,
+        ["-g", str(package_dir), "--target", "claude"],
+    )
+
+    clear_discovery_cache()
+    assert result.exit_code == 0, result.output
+    assert (apm_home / "apm.yml").is_file()
+    assert (apm_home / "apm.lock.yaml").is_file()
+    assert (apm_home / "apm_modules").is_dir()
+    assert not (home / ".apm").exists()
+    assert (claude_config / "rules" / "global.md").is_file()
+    assert not (apm_home / "rules" / "global.md").exists()
+
+    assert _get_user_apm_yml() == apm_home / "apm.yml"
+    assert _trust_store_path() == apm_home / "scripts-trust.json"
+    assert _get_scripts_log_path() == apm_home / "logs" / "scripts.log"
+
+
 def test_compile_global_writes_claude_md_from_real_fixtures(tmp_path, monkeypatch):
     """Run apm compile --global through real discovery and filesystem writes."""
     from apm_cli.commands.compile.cli import compile as compile_cmd

--- a/tests/unit/compilation/test_compile_global_flag.py
+++ b/tests/unit/compilation/test_compile_global_flag.py
@@ -486,7 +486,7 @@ class TestGlobalCompileHonorsDeclaredTargets:
 
         assert sorted(names) == ["claude", "codex"]
         logger.verbose_detail.assert_called_once_with(
-            "Global targets from ~/.apm/apm.yml: claude, codex"
+            f"Global targets from {source_root / 'apm.yml'}: claude, codex"
         )
 
     def test_declared_target_without_root_output_has_accurate_message(self, tmp_path):
@@ -561,7 +561,7 @@ class TestGlobalCompileHonorsDeclaredTargets:
 
         assert names == ["copilot"]
         logger.verbose_detail.assert_called_once_with(
-            "Global targets from ~/.apm/apm.yml: vscode -> copilot"
+            f"Global targets from {source_root / 'apm.yml'}: vscode -> copilot"
         )
 
     def test_alias_and_canonical_name_collapse_to_one_profile(self, tmp_path):

--- a/tests/unit/core/test_scope.py
+++ b/tests/unit/core/test_scope.py
@@ -11,6 +11,7 @@ from apm_cli.core.scope import (
     InstallScope,
     ensure_user_dirs,
     get_apm_dir,
+    get_apm_home,
     get_deploy_root,
     get_lockfile_dir,
     get_manifest_path,
@@ -81,6 +82,18 @@ class TestGetApmDir:
         with patch.object(Path, "home", return_value=tmp_path):
             assert get_apm_dir(InstallScope.USER) == tmp_path / USER_APM_DIR
 
+    def test_user_honors_apm_home(self, tmp_path, monkeypatch):
+        apm_home = tmp_path / "isolated-apm"
+        monkeypatch.setenv("APM_HOME", str(apm_home))
+
+        assert get_apm_home() == apm_home
+        assert get_apm_dir(InstallScope.USER) == apm_home
+
+    def test_empty_apm_home_uses_default(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("APM_HOME", "")
+        with patch.object(Path, "home", return_value=tmp_path):
+            assert get_apm_home() == tmp_path / USER_APM_DIR
+
 
 # ---------------------------------------------------------------------------
 # get_modules_dir
@@ -97,6 +110,12 @@ class TestGetModulesDir:
     def test_user_modules(self, tmp_path):
         with patch.object(Path, "home", return_value=tmp_path):
             assert get_modules_dir(InstallScope.USER) == tmp_path / ".apm" / "apm_modules"
+
+    def test_user_modules_honor_apm_home(self, tmp_path, monkeypatch):
+        apm_home = tmp_path / "metadata"
+        monkeypatch.setenv("APM_HOME", str(apm_home))
+
+        assert get_modules_dir(InstallScope.USER) == apm_home / "apm_modules"
 
 
 # ---------------------------------------------------------------------------
@@ -115,6 +134,12 @@ class TestGetManifestPath:
         with patch.object(Path, "home", return_value=tmp_path):
             assert get_manifest_path(InstallScope.USER) == tmp_path / ".apm" / "apm.yml"
 
+    def test_user_manifest_honors_apm_home(self, tmp_path, monkeypatch):
+        apm_home = tmp_path / "metadata"
+        monkeypatch.setenv("APM_HOME", str(apm_home))
+
+        assert get_manifest_path(InstallScope.USER) == apm_home / "apm.yml"
+
 
 # ---------------------------------------------------------------------------
 # get_lockfile_dir
@@ -131,6 +156,12 @@ class TestGetLockfileDir:
     def test_user_lockfile(self, tmp_path):
         with patch.object(Path, "home", return_value=tmp_path):
             assert get_lockfile_dir(InstallScope.USER) == tmp_path / ".apm"
+
+    def test_user_lockfile_honors_apm_home(self, tmp_path, monkeypatch):
+        apm_home = tmp_path / "metadata"
+        monkeypatch.setenv("APM_HOME", str(apm_home))
+
+        assert get_lockfile_dir(InstallScope.USER) == apm_home
 
 
 # ---------------------------------------------------------------------------
@@ -153,6 +184,24 @@ class TestEnsureUserDirs:
             ensure_user_dirs()
             ensure_user_dirs()  # Should not raise
             assert (tmp_path / ".apm").is_dir()
+
+    def test_honors_apm_home(self, tmp_path, monkeypatch):
+        apm_home = tmp_path / "metadata"
+        monkeypatch.setenv("APM_HOME", str(apm_home))
+
+        assert ensure_user_dirs() == apm_home
+        assert (apm_home / "apm_modules").is_dir()
+
+
+def test_apm_home_does_not_redirect_target_deployment(tmp_path, monkeypatch):
+    """APM_HOME isolates metadata while target deployment stays under HOME."""
+    apm_home = tmp_path / "metadata"
+    os_home = tmp_path / "home"
+    monkeypatch.setenv("APM_HOME", str(apm_home))
+
+    with patch.object(Path, "home", return_value=os_home):
+        assert get_apm_dir(InstallScope.USER) == apm_home
+        assert get_deploy_root(InstallScope.USER) == os_home
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/install/test_workspace_locking.py
+++ b/tests/unit/install/test_workspace_locking.py
@@ -42,6 +42,17 @@ def test_lifecycle_lock_uses_isolated_windows_home(
         lock.release()
 
 
+def test_lifecycle_lock_honors_apm_home(tmp_path: Path, monkeypatch) -> None:
+    apm_home = tmp_path / "isolated-metadata"
+    monkeypatch.setenv("APM_HOME", str(apm_home))
+
+    lock = acquire_lifecycle_lock()
+    try:
+        assert Path(lock.lock_file) == (apm_home / ".apm-lifecycle.lock").resolve()
+    finally:
+        lock.release()
+
+
 @pytest.mark.skipif(os.name == "nt", reason="symlink creation requires elevated Windows rights")
 def test_lifecycle_lock_rejects_symlink_without_touching_target(
     tmp_path: Path,

--- a/tests/unit/scripts/test_architecture_runner.py
+++ b/tests/unit/scripts/test_architecture_runner.py
@@ -694,6 +694,7 @@ mutation_writes.user_root_scope
 onboarding-metadata-only
 contracts-tooling-root-context-write-eligibility
 registry_delegation.agents_source_attribution
+registry_delegation.apm_home_resolution
 registry_delegation.bootstrap_project_name
 registry_delegation.command_machine_output
 registry_delegation.compile_inventory_authority

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -6,10 +6,55 @@ bugs on Windows when ``open()`` is called without an explicit encoding.
 """
 
 import json
+import os
+import subprocess
+import sys
+from pathlib import Path
 
 import pytest
 
 from apm_cli import config as config_mod
+
+
+def test_apm_home_selects_config_path_in_fresh_process(tmp_path):
+    """Process-level APM_HOME redirects config without touching ~/.apm."""
+    home = tmp_path / "home"
+    apm_home = tmp_path / "isolated-metadata"
+    home.mkdir()
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "HOME": str(home),
+            "USERPROFILE": str(home),
+            "APM_HOME": str(apm_home),
+        }
+    )
+    script = """\
+import json
+from apm_cli import config
+
+config.ensure_config_exists()
+print(json.dumps({"dir": config.CONFIG_DIR, "file": config.CONFIG_FILE}))
+"""
+
+    result = subprocess.run(
+        (sys.executable, "-c", script),
+        cwd=Path(__file__).resolve().parents[2],
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+
+    assert result.returncode == 0, result.stderr
+    paths = json.loads(result.stdout)
+    assert paths == {
+        "dir": str(apm_home),
+        "file": str(apm_home / "config.json"),
+    }
+    assert (apm_home / "config.json").is_file()
+    assert not (home / ".apm").exists()
 
 
 @pytest.fixture

--- a/tests/unit/test_outdated_command.py
+++ b/tests/unit/test_outdated_command.py
@@ -862,7 +862,7 @@ class TestOutdatedCommand:
             result = self.runner.invoke(cli, ["outdated", "--global"])
 
             assert result.exit_code == 1
-            assert "~/.apm/" in result.output
+            assert str(tmp) in result.output
 
     # --- Virtual package deps ---
 


### PR DESCRIPTION
## Summary

- make `APM_HOME` the single canonical root for APM-owned user metadata: the user manifest, lockfile, modules, configuration, lifecycle trust/logs, command lock, registry workspace manifest, and legacy approval migration
- keep target deployment independent, using target-specific overrides such as `CLAUDE_CONFIG_DIR`, `CODEX_HOME`, and `HERMES_HOME`, or the operating-system home
- document the exact path and precedence contract across the environment-variable reference, affected CLI references, and the shipped APM guide

## Architecture and tests

- add an end-to-end global install isolation test with distinct `HOME`, `APM_HOME`, and `CLAUDE_CONFIG_DIR`
- add focused coverage for configuration, scope helpers, lifecycle locking, command diagnostics, and lifecycle path parity
- register a static architecture owner/guard so future APM metadata consumers cannot read `APM_HOME` independently or recreate the split
- complete the existing mutation-matrix entry for the recently added `onboarding-metadata-only` guard while extending that same frozen matrix for the new `APM_HOME` guard

## Validation

- `22461 passed, 42 skipped, 21 xfailed` — full unit suite (`tests/unit tests/test_console.py`, 2 workers)
- `445 passed` — architecture runner, entrypoint, and full owner-guard mutation matrix
- `541 passed` — affected command, compile, and APM_HOME contract suite
- `469 passed` — lifecycle, trust, registry, and executable-security paths
- `281 passed` — red-team suite
- `431 passed, 38 skipped` — Windows compatibility contract
- `206 passed, 2 skipped` — spec conformance suite; orphan and Mode-B gates passed
- `170 passed` — final focused integration regression run
- Ruff lint/format, pylint duplicate-code guard, auth boundary lint, architecture boundary lint, CLI docs contract, rendered CLI registry check, schema ID check, and full Astro docs build all passed
- generated docs link check validated 1,035 relative links

Closes #2884
