### PR TITLE
fix(ci): separate CodeQL merge enforcement from SDL scans

### DIFF
--- a/.github/scripts/ci/codeql_policy.py
+++ b/.github/scripts/ci/codeql_policy.py
@@ -1,0 +1,432 @@
+#!/usr/bin/env python3
+"""Read-only, fail-closed CodeQL policy executed from the trusted base commit."""
+
+import argparse
+import io
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+import zipfile
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlencode
+
+WORKFLOW = ".github/workflows/codeql.yml"
+ANALYSIS_KEY = f"{WORKFLOW}:analyze"
+LANGUAGES = ("python", "actions", "javascript-typescript")
+POLL_SECONDS = 15
+Json = dict[str, Any]
+
+
+class PolicyError(RuntimeError):
+    """Evidence is invalid, inaccessible, or explicitly unsuccessful."""
+
+
+class Pending(PolicyError):
+    """Evidence has not finished arriving; retry within the gate's deadline."""
+
+
+@dataclass(frozen=True)
+class Context:
+    """Immutable event identity; PR analyses belong to the merge, not head, SHA."""
+
+    repository: str
+    event: str
+    sha: str
+    ref: str
+    head_sha: str
+
+    def endpoint(self, resource: str, **query: str) -> str:
+        """Build repository-scoped, read-only API paths."""
+        return f"repos/{self.repository}/{resource}?{urlencode(query | {'per_page': '100'})}"
+
+
+def object_value(value: Any, label: str) -> Json:
+    """Reject malformed API/event objects instead of treating them as empty."""
+    if not isinstance(value, dict):
+        raise PolicyError(f"Invalid {label}: expected an object")
+    return value
+
+
+def commit_sha(value: Any) -> str:
+    """Accept only complete immutable Git commit IDs."""
+    if not isinstance(value, str) or re.fullmatch(r"[0-9a-f]{40}", value) is None:
+        raise PolicyError("Invalid commit SHA in GitHub event")
+    return value
+
+
+def positive_id(value: Any, label: str) -> int:
+    """Validate IDs and counts before using them in API paths or comparisons."""
+    if type(value) is not int or value <= 0:
+        raise PolicyError(f"Invalid {label}: expected a positive integer")
+    return value
+
+
+def load_context(environ: Mapping[str, str]) -> Context:
+    """Read runner-owned event metadata, never a PR-provided policy or artifact."""
+    try:
+        event = object_value(
+            json.loads(Path(environ["GITHUB_EVENT_PATH"]).read_text(encoding="utf-8")),
+            "event",
+        )
+        repo = environ["GITHUB_REPOSITORY"]
+        name = environ["GITHUB_EVENT_NAME"]
+        sha = commit_sha(environ["GITHUB_SHA"])
+        ref = environ["GITHUB_REF"]
+        repository = object_value(event["repository"], "repository")
+        if (
+            re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repo) is None
+            or repository["full_name"] != repo
+            or repository["default_branch"] != "main"
+        ):
+            raise PolicyError("Policy requires the event repository's main branch")
+        if name == "pull_request":
+            pr = object_value(event["pull_request"], "pull request")
+            number = positive_id(event["number"], "PR number")
+            if (
+                ref != f"refs/pull/{number}/merge"
+                or pr["merge_commit_sha"] != sha
+                or pr["base"]["ref"] != "main"
+                or pr["base"]["repo"]["full_name"] != repo
+            ):
+                raise PolicyError("PR merge ref, SHA, or base repository does not match the event")
+            head_sha = commit_sha(pr["head"]["sha"])
+        elif name == "merge_group":
+            group = object_value(event["merge_group"], "merge group")
+            if (
+                group["head_sha"] != sha
+                or group["head_ref"] != ref
+                or not ref.startswith("refs/heads/gh-readonly-queue/main/")
+                or group["base_ref"] != "refs/heads/main"
+            ):
+                raise PolicyError("Merge-queue ref, SHA, or base does not match the event")
+            head_sha = sha
+        else:
+            raise PolicyError(f"Unsupported CodeQL policy event: {name}")
+    except (KeyError, TypeError, OSError, ValueError) as exc:
+        raise PolicyError("Missing or malformed GitHub event metadata") from exc
+    return Context(repo, name, sha, ref, head_sha)
+
+
+class GitHub:
+    """Paginated GET-only transport using the runner's existing gh authentication."""
+
+    def request(self, endpoint: str, *, paginated: bool) -> bytes:
+        """Make a bounded GET request without exposing authentication diagnostics."""
+        executable = shutil.which("gh")
+        if executable is None:
+            raise PolicyError("gh CLI is required for the CodeQL policy")
+        try:
+            command = [
+                executable,
+                "api",
+                "--hostname",
+                "github.com",
+                "--method",
+                "GET",
+                "-H",
+                "Accept: application/vnd.github+json",
+                "-H",
+                "X-GitHub-Api-Version: 2022-11-28",
+                endpoint,
+            ]
+            if paginated:
+                command.extend(["--paginate", "--slurp"])
+            result = subprocess.run(  # noqa: S603 -- fixed executable, argv-only GET requests
+                command,
+                capture_output=True,
+                check=False,
+                timeout=60,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise PolicyError("GitHub API request could not complete; rerun the gate") from exc
+        if result.returncode:
+            raise PolicyError(
+                "GitHub API request failed; verify actions:read and security-events:read "
+                f"permissions and rerun the gate ({endpoint.split('?')[0]})"
+            )
+        return result.stdout
+
+    def pages(self, endpoint: str, key: str | None = None) -> list[Json]:
+        """Read every response page; permission/transport/JSON failures are fatal."""
+        try:
+            pages = json.loads(self.request(endpoint, paginated=True))
+            if not isinstance(pages, list):
+                raise PolicyError("Invalid GitHub API pagination response")
+            records: list[Json] = []
+            for page in pages:
+                items = object_value(page, "API page").get(key) if key else page
+                if not isinstance(items, list):
+                    raise PolicyError("Invalid GitHub API collection response")
+                records.extend(object_value(item, "API record") for item in items)
+            return records
+        except (ValueError, TypeError) as exc:
+            raise PolicyError("Invalid JSON from GitHub API") from exc
+
+    def artifact(self, context: Context, identifier: int, language: str) -> Json:
+        """Read one small JSON entry in memory; never extract or execute artifacts."""
+        payload = self.request(
+            f"repos/{context.repository}/actions/artifacts/{identifier}/zip", paginated=False
+        )
+        if len(payload) > 65536:
+            raise PolicyError("CodeQL evidence artifact is too large")
+        try:
+            with zipfile.ZipFile(io.BytesIO(payload)) as archive:
+                entries = archive.infolist()
+                if (
+                    len(entries) != 1
+                    or entries[0].filename != f"codeql-policy-{language}.json"
+                    or entries[0].file_size > 16384
+                ):
+                    raise PolicyError("Unexpected CodeQL evidence artifact contents")
+                return object_value(json.loads(archive.read(entries[0])), "CodeQL evidence")
+        except (zipfile.BadZipFile, OSError, RuntimeError, ValueError) as exc:
+            raise PolicyError("Unreadable CodeQL evidence artifact; rerun CodeQL") from exc
+
+
+def successful_run(context: Context, api: GitHub) -> tuple[int, int]:
+    """Select the newest matching workflow run, including its current rerun attempt."""
+    runs = api.pages(
+        context.endpoint(
+            f"actions/workflows/{WORKFLOW.rsplit('/', 1)[-1]}/runs",
+            event=context.event,
+            head_sha=context.head_sha,
+        ),
+        "workflow_runs",
+    )
+    matching = [
+        run
+        for run in runs
+        if run.get("path") == WORKFLOW
+        and run.get("event") == context.event
+        and run.get("head_sha") == context.head_sha
+    ]
+    if not matching:
+        raise Pending("CodeQL workflow has not started for this event")
+    run = max(matching, key=lambda item: positive_id(item.get("id"), "workflow run ID"))
+    if run.get("status") != "completed":
+        raise Pending("CodeQL workflow is still running")
+    if run.get("conclusion") != "success":
+        raise PolicyError(f"CodeQL workflow did not succeed: {run.get('conclusion')}")
+    return positive_id(run["id"], "workflow run ID"), positive_id(
+        run.get("run_attempt"), "workflow run attempt"
+    )
+
+
+def successful_jobs(context: Context, api: GitHub, run_id: int) -> None:
+    """A skipped, neutral, removed, or failing language job cannot satisfy policy."""
+    jobs = api.pages(context.endpoint(f"actions/runs/{run_id}/jobs", filter="latest"), "jobs")
+    for language in LANGUAGES:
+        name = f"Analyze ({language})"
+        matching = [job for job in jobs if job.get("name") == name]
+        if not matching:
+            raise Pending(f"Required CodeQL job is missing: {name}")
+        if len(matching) != 1:
+            raise PolicyError(f"Ambiguous CodeQL jobs: {name}")
+        job = matching[0]
+        if job.get("status") != "completed":
+            raise Pending(f"Required CodeQL job is still running: {name}")
+        if job.get("conclusion") != "success":
+            raise PolicyError(f"{name} did not succeed: {job.get('conclusion')}")
+
+
+def configuration_language(record: Json) -> str | None:
+    """Match the workflow's full analysis identity, not merely the CodeQL tool name."""
+    if record.get("analysis_key") != ANALYSIS_KEY:
+        return None
+    for language in LANGUAGES:
+        if record.get("category") == f"{ANALYSIS_KEY}/language:{language}":
+            try:
+                environment = json.loads(record.get("environment", ""))
+            except (ValueError, TypeError) as exc:
+                raise PolicyError(f"Malformed {language} analysis environment") from exc
+            if environment != {"language": language}:
+                raise PolicyError(f"Mismatched {language} analysis environment")
+            return language
+    return None
+
+
+def run_evidence(context: Context, api: GitHub, run: tuple[int, int]) -> dict[str, str]:
+    """Bind every SARIF upload to its exact workflow run, attempt, language, and commit."""
+    artifacts = api.pages(context.endpoint(f"actions/runs/{run[0]}/artifacts"), "artifacts")
+    uploads: dict[str, str] = {}
+    for language in LANGUAGES:
+        name = f"codeql-policy-{language}-{run[1]}"
+        matching = [item for item in artifacts if item.get("name") == name]
+        if not matching:
+            raise Pending(f"Missing current-attempt CodeQL evidence: {language}")
+        if len(matching) != 1 or matching[0].get("expired") is not False:
+            raise PolicyError(f"Ambiguous or expired CodeQL evidence: {language}; rerun CodeQL")
+        identifier = positive_id(matching[0].get("id"), "artifact ID")
+        evidence = api.artifact(context, identifier, language)
+        expected = {
+            "run_id": str(run[0]),
+            "run_attempt": str(run[1]),
+            "language": language,
+            "sha": context.sha,
+            "ref": context.ref,
+        }
+        if any(evidence.get(key) != value for key, value in expected.items()):
+            raise PolicyError(f"CodeQL evidence does not match this execution: {language}")
+        sarif_id = evidence.get("sarif_id")
+        if (
+            not isinstance(sarif_id, str)
+            or re.fullmatch(r"[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}", sarif_id) is None
+        ):
+            raise PolicyError(f"Missing or invalid SARIF upload ID: {language}")
+        uploads[language] = sarif_id
+    return uploads
+
+
+def successful_analyses(context: Context, api: GitHub, uploads: dict[str, str]) -> tuple[int, ...]:
+    """Require processed, nonempty analyses of every language on the exact merge SHA."""
+    analyses = api.pages(
+        context.endpoint("code-scanning/analyses", ref=context.ref, tool_name="CodeQL")
+    )
+    latest: dict[str, Json] = {}
+    for record in analyses:
+        if (
+            record.get("ref") != context.ref
+            or object_value(record.get("tool"), "analysis tool").get("name") != "CodeQL"
+        ):
+            continue
+        language = configuration_language(record)
+        if language is None:
+            continue
+        identifier = positive_id(record.get("id"), "analysis ID")
+        if language not in latest or identifier > latest[language]["id"]:
+            latest[language] = record
+    missing = set(LANGUAGES) - latest.keys()
+    if missing:
+        raise Pending(f"Missing processed CodeQL analyses: {', '.join(sorted(missing))}")
+    for language, record in latest.items():
+        # Alerts describe the moving ref, not a historical analysis snapshot.
+        if record.get("commit_sha") != context.sha:
+            raise Pending(f"Newest CodeQL analysis is for a different commit: {language}")
+        if record.get("sarif_id") != uploads[language]:
+            raise Pending(f"Waiting for the current-attempt SARIF upload: {language}")
+        if record.get("error") != "":
+            raise PolicyError(f"CodeQL analysis has an error for {language}")
+        positive_id(record.get("rules_count"), f"{language} analyzed rule count")
+    return tuple(latest[language]["id"] for language in LANGUAGES)
+
+
+def above_threshold(alert: Json) -> bool:
+    """Preserve the ruleset's high-or-higher security and error alert thresholds."""
+    rule = object_value(alert.get("rule"), "alert rule")
+    if "security_severity_level" not in rule or "severity" not in rule:
+        raise PolicyError("Missing CodeQL alert severity")
+    security = rule["security_severity_level"]
+    severity = rule["severity"]
+    if security not in (None, "low", "medium", "high", "critical") or severity not in (
+        "none",
+        "note",
+        "warning",
+        "error",
+    ):
+        raise PolicyError("Unknown CodeQL alert severity")
+    return security in ("high", "critical") or severity == "error"
+
+
+def open_findings(context: Context, api: GitHub) -> list[int]:
+    """Block all open scoped findings, including pre-existing ones, honoring dismissals."""
+    alerts = api.pages(
+        context.endpoint("code-scanning/alerts", ref=context.ref, tool_name="CodeQL", state="open")
+    )
+    blocked: set[int] = set()
+    for alert in alerts:
+        if alert.get("state") == "dismissed":
+            continue
+        if alert.get("state") not in ("open", "fixed"):
+            raise PolicyError("Unknown CodeQL alert state")
+        if not above_threshold(alert):
+            continue
+        number = positive_id(alert.get("number"), "alert number")
+        instances = api.pages(
+            context.endpoint(f"code-scanning/alerts/{number}/instances", ref=context.ref)
+        )
+        if not instances:
+            raise Pending(f"Missing instances for CodeQL alert {number}")
+        for instance in instances:
+            if instance.get("ref") != context.ref:
+                raise PolicyError(f"Unexpected ref in CodeQL alert {number} response")
+            if instance.get("analysis_key") != ANALYSIS_KEY:
+                continue
+            if configuration_language(instance) is None:
+                raise PolicyError(f"Unknown workflow configuration for CodeQL alert {number}")
+            if instance.get("state") == "fixed":
+                continue
+            if instance.get("state") != "open":
+                raise PolicyError(f"Unknown instance state for CodeQL alert {number}")
+            if instance.get("commit_sha") != context.sha:
+                raise Pending(f"Stale instance for CodeQL alert {number}")
+            blocked.add(number)
+    return sorted(blocked)
+
+
+def evaluate(context: Context, api: GitHub) -> list[int]:
+    """Evaluate a stable completed snapshot; concurrent reruns cannot reuse a pass."""
+    run = successful_run(context, api)
+    successful_jobs(context, api, run[0])
+    uploads = run_evidence(context, api, run)
+    analyses = successful_analyses(context, api, uploads)
+    blocked = open_findings(context, api)
+    if (
+        successful_run(context, api) != run
+        or successful_analyses(context, api, uploads) != analyses
+    ):
+        raise Pending("CodeQL evidence changed during evaluation")
+    return blocked
+
+
+def main() -> int:
+    """Run within the enclosing gate deadline without importing any project code."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--deadline", type=int, required=True, help="Gate deadline as Unix seconds")
+    args = parser.parse_args()
+    try:
+        context = load_context(os.environ)
+        api = GitHub()
+        last_pending = "CodeQL policy has not run"
+        while time.time() < args.deadline:
+            try:
+                blocked = evaluate(context, api)
+            except Pending as exc:
+                last_pending = str(exc)
+                sys.stderr.write(f"[codeql-policy] {last_pending}\n")
+                time.sleep(min(POLL_SECONDS, max(0, args.deadline - time.time())))
+                continue
+            if time.time() >= args.deadline:
+                raise PolicyError("CodeQL policy deadline expired; rerun gate")
+            if blocked:
+                links = [
+                    f"https://github.com/{context.repository}/security/code-scanning/{number}"
+                    for number in blocked
+                ]
+                raise PolicyError(
+                    "Open high/critical or error-level CodeQL findings block merge. "
+                    "Fix or review/dismiss the findings, then rerun gate: " + ", ".join(links)
+                )
+            sys.stdout.write(
+                f"[codeql-policy] Passed for {context.sha}: all language jobs and analyses "
+                "succeeded; no open workflow-scoped findings at blocking severity.\n"
+            )
+            return 0
+        raise PolicyError(
+            f"Timed out: {last_pending}. Rerun CodeQL and gate; re-enqueue merge-queue entries."
+        )
+    except PolicyError as exc:
+        # GitHub workflow-command data must not interpret newlines or percent escapes.
+        message = str(exc).replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+        sys.stderr.write(f"::error title=CodeQL policy failed::{message}\n")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/ci/merge_gate_wait.sh
+++ b/.github/scripts/ci/merge_gate_wait.sh
@@ -16,7 +16,8 @@
 #   "Merge Gate / gate"; this script verifies all underlying checks.
 #
 # Inputs (environment variables):
-#   GH_TOKEN          required. Token with 'checks:read' for the repo.
+#   GH_TOKEN          required. Token with checks, actions, and security-events read.
+#   GITHUB_*          runner-owned event metadata for the trusted CodeQL policy.
 #   REPO              required. owner/repo (e.g. microsoft/apm).
 #   SHA               required. Head SHA to poll (PR head, merge_group temp
 #                     branch head, or workflow_dispatch-resolved PR head).
@@ -85,6 +86,10 @@ done
 deadline=$(( $(date +%s) + TIMEOUT_MIN * 60 ))
 poll_count=0
 
+# This script and the policy are both checked out from the immutable base commit.
+# The first rollout PR therefore keeps the old gate until its implementation lands.
+python3 "$(dirname "$0")/codeql_policy.py" --deadline "$deadline"
+
 echo "[merge-gate] waiting for ${#checks[@]} check(s) on ${REPO}@${SHA}"
 for c in "${checks[@]}"; do
   echo "[merge-gate]   - ${c}"
@@ -143,6 +148,7 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
   done
 
   if [ "$pending_count" -eq 0 ]; then
+    python3 "$(dirname "$0")/codeql_policy.py" --deadline "$deadline"
     echo "[merge-gate] all ${#checks[@]} check(s) completed successfully"
     exit 0
   fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
         src/ tests/
         scripts/lint_architecture_boundaries.py
         scripts/architecture_linter/
+        .github/scripts/ci/codeql_policy.py
 
     - name: Ruff format check
       run: >-
@@ -42,6 +43,7 @@ jobs:
         src/ tests/
         scripts/lint_architecture_boundaries.py
         scripts/architecture_linter/
+        .github/scripts/ci/codeql_policy.py
 
     - name: Check YAML encoding safety
       run: |
@@ -66,7 +68,7 @@ jobs:
         VIOLATIONS=$(
           {
             find src/ scripts/architecture_linter/ -name '*.py' -print0
-            printf '%s\0' scripts/lint_architecture_boundaries.py
+            printf '%s\0' scripts/lint_architecture_boundaries.py .github/scripts/ci/codeql_policy.py
           } | xargs -0 -I{} awk -v max="$MAX_LINES" \
             'END { if (NR > max) printf "%s: %d lines (max %d)\n", FILENAME, NR, max }' {}
         )
@@ -92,7 +94,8 @@ jobs:
           --fail-on=R0801 \
           src/apm_cli/ \
           scripts/lint_architecture_boundaries.py \
-          scripts/architecture_linter/
+          scripts/architecture_linter/ \
+          .github/scripts/ci/codeql_policy.py
 
     - name: Lint - auth-protocol boundary (#1212 anti-regression)
       run: bash scripts/lint-auth-signals.sh

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,11 +19,14 @@ jobs:
     permissions:
       security-events: write
       contents: read
+    env:
+      # The merge policy covers all open findings, not only changed-line alerts.
+      CODEQL_ACTION_DIFF_INFORMED_QUERIES: 'false'
 
     strategy:
       fail-fast: false
       matrix:
-        language: [ python, actions ]
+        language: [ python, actions, javascript-typescript ]
 
     steps:
       - name: Checkout repository
@@ -35,4 +38,40 @@ jobs:
           languages: ${{ matrix.language }}
 
       - name: Perform CodeQL Analysis
+        id: analyze
         uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          # Microsoft CodeQL Central consumes default-branch database uploads
+          # for its separate SDL analysis. Keep local queries and SARIF uploads.
+          upload-database: true
+          wait-for-processing: true
+
+      - name: Record CodeQL upload identity
+        env:
+          LANGUAGE: ${{ matrix.language }}
+          SARIF_ID: ${{ steps.analyze.outputs.sarif-id }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          fields = {
+              "run_id": "GITHUB_RUN_ID", "run_attempt": "GITHUB_RUN_ATTEMPT",
+              "sha": "GITHUB_SHA", "ref": "GITHUB_REF",
+              "language": "LANGUAGE", "sarif_id": "SARIF_ID",
+          }
+          evidence = {key: os.environ[value] for key, value in fields.items()}
+          if not evidence["sarif_id"]:
+              raise SystemExit("CodeQL did not produce a SARIF upload ID")
+          path = Path(os.environ["RUNNER_TEMP"]) / f"codeql-policy-{evidence['language']}.json"
+          path.write_text(json.dumps(evidence) + "\n", encoding="utf-8")
+          PY
+
+      - name: Upload CodeQL policy evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: codeql-policy-${{ matrix.language }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/codeql-policy-${{ matrix.language }}.json
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -59,6 +59,8 @@ permissions:
   contents: read
   checks: read
   pull-requests: read
+  actions: read
+  security-events: read
 
 jobs:
   gate:
@@ -112,6 +114,10 @@ jobs:
           # Keep this in sync with the underlying workflows.
           # NOTE: 'gate' (this job) MUST NOT appear here -- it would
           # deadlock waiting for itself.
+          # CodeQL is evaluated separately inside the trusted base script:
+          # jobs must succeed AND scoped alerts must meet the severity policy.
+          # Do not substitute the tool-wide CodeQL check (SDL API uploads on
+          # main have no matching PR/queue configuration).
           # PR context: only the shard jobs gate. Coverage Combine runs
           # in parallel as a non-required signal so global 80% drift is
           # visible in the PR UI without paying ~3 min of runner-
@@ -146,5 +152,4 @@ jobs:
         run: |
           chmod +x .github/scripts/ci/merge_gate_wait.sh
           .github/scripts/ci/merge_gate_wait.sh
-
 

--- a/docs/src/content/docs/contributing/development-guide.md
+++ b/docs/src/content/docs/contributing/development-guide.md
@@ -363,18 +363,56 @@ workflows.
 
 ### Code scanning on pull requests and merge queues
 
-The CodeQL workflow runs Python and GitHub Actions analysis on pull requests,
-pushes to `main`, merge-queue `checks_requested` events, and the weekly schedule.
-Keep the workflow path, `analyze` job ID, and language matrix stable: they
-identify the analysis configurations GitHub compares against the base branch.
-PR results do not replace results for the merge queue's separate commit.
+`codeql.yml` analyzes `python`, `actions`, and `javascript-typescript` on pull
+requests, pushes to `main`, merge-group `checks_requested` events, and weekly.
+JavaScript adds coverage; preserve stable workflow, job, and category identities.
+Explicit `upload-database: true` and `wait-for-processing: true` retain existing
+defaults; local queries and database uploads remain enabled. Diff-informed
+queries are disabled so PR scans include findings outside changed lines.
 
-If both analysis jobs succeed but Code scanning still reports a missing
-configuration, inspect the CodeQL check summary. An additional `API upload`
-configuration on the base branch belongs to a separate upload producer;
-rerunning this workflow cannot supply that producer's results. Coordinate
-matching PR and queue uploads with its owner rather than deleting findings,
-renaming categories, or weakening the code-scanning ruleset.
+A separate scan producer consumes default-branch database uploads and returns
+the separate `default` API configuration on `main` only. Preserve these uploads
+for compliance; PR and queue workflow analyses do not replace that producer.
+
+`.github/workflows/merge-gate.yml` still requires only the `gate` check and adds
+`actions: read` and `security-events: read`. The base-checked-out
+`merge_gate_wait.sh` unconditionally calls `.github/scripts/ci/codeql_policy.py`
+before polling and immediately before success, within the shared deadline.
+Runner event metadata selects the exact PR merge
+or merge-queue ref and SHA, not the PR head or a moving branch tip.
+
+The policy requires the latest CodeQL workflow run and every `Analyze` job
+(`python`, `actions`, `javascript-typescript`) to succeed. Analyses must match
+the exact ref and commit, full stable workflow key, category, and environment,
+with positive `rules_count`. Small, per-language evidence artifacts bind each
+SARIF upload ID to its workflow run and attempt; older uploads cannot satisfy
+a rerun. These artifacts are parsed as data, never executed. They expire after
+14 days; rerun CodeQL before rerunning `gate` when evidence has expired.
+The policy paginates API results and checks per-alert
+instances. It blocks **all open, undismissed workflow-scoped alerts with
+high/critical security severity or error severity**, including pre-existing
+alerts—not just new findings. GitHub dismissals are honored; the separate
+external `default` API configuration is excluded. API failures, timeouts, and
+stale state fail closed.
+
+**Post-merge rollout (maintainer action):**
+
+1. Keep the native `code_scanning` rule enabled for the initial PR: its gate
+   runs the **old trusted base script**, not the proposed policy.
+2. After merge, verify the new base gate enforces the policy and succeeds on
+   both a fresh PR and a merge-queue run. Verify `main` publishes all three
+   language databases and analyses before changing protection.
+3. Back up `main-protection` (ruleset ID `9294522`) through the GitHub rulesets
+   API. Re-read and compare immediately before updating; abort on concurrent changes.
+4. Only then may a maintainer remove **only CodeQL** from the rule's
+   `parameters.code_scanning_tools`
+   via the API. Retain the rule if other tools remain; remove it only if empty.
+   Preserve `gate` and every other rule, threshold, tool, and bypass setting.
+   Verify the saved ruleset afterward. Neither this PR nor this documentation
+   changes live settings or removes the live blocker.
+
+**Rollback:** Reinstate the prior native code-scanning rule **before** reverting
+the custom gate.
 
 ## Documentation
 

--- a/docs/src/content/docs/contributing/development-guide.md
+++ b/docs/src/content/docs/contributing/development-guide.md
@@ -393,7 +393,8 @@ instances. It blocks **all open, undismissed workflow-scoped alerts with
 high/critical security severity or error severity**, including pre-existing
 alerts—not just new findings. GitHub dismissals are honored; the separate
 external `default` API configuration is excluded. API failures, timeouts, and
-stale state fail closed.
+stale state fail closed. Enabling another language may expose existing findings
+that must be fixed or reviewed before rollout.
 
 **Post-merge rollout (maintainer action):**
 

--- a/scripts/daily-release-smoke-signal.cjs
+++ b/scripts/daily-release-smoke-signal.cjs
@@ -39,8 +39,8 @@ function extractFailedTests(logText) {
   const tests = new Set();
   const cleanLog = stripAnsi(logText);
   const patterns = [
-    /\b(?:FAILED|ERROR)\s+(tests\/[^\s]+(?:::[^\s]+)*)/g,
-    /\b(tests\/[^\s]+(?:::[^\s]+)*)\s+(?:FAILED|ERROR)\b/g,
+    /\b(?:FAILED|ERROR)\s+(tests\/[^\s]+)/g,
+    /\b(tests\/[^\s]+)\s+(?:FAILED|ERROR)\b/g,
   ];
   for (const pattern of patterns) {
     for (const match of cleanLog.matchAll(pattern)) {

--- a/scripts/governance/authority.cjs
+++ b/scripts/governance/authority.cjs
@@ -23,9 +23,13 @@ function readPolicy(markdown) {
   requireValue(blocks.length === 1, 'Expected one governance roster');
   const roster = new Map();
   for (const line of blocks[0][1].split('\n')) {
-    if (!line.includes('https://github.com/')) continue;
+    if (!line.trim()) continue;
     const cells = line.split('|').map(cell => cell.trim());
-    requireValue(cells.length === 6, 'Malformed governance roster row');
+    requireValue(cells.length === 6 && cells[0] === '' && cells[5] === '',
+      'Malformed governance roster row');
+    if (cells[1] === 'Maintainer' || cells.slice(1, 5).every(cell => /^:?-+:?$/.test(cell))) {
+      continue;
+    }
     const link = /^\[[^\]]+\]\(https:\/\/github\.com\/([a-zA-Z0-9-]+)\)$/.exec(cells[1]);
     const remit = /^`([^`]+)`$/.exec(cells[4]);
     requireValue(link && remit && REMITS.has(remit[1]), 'Invalid governance identity or remit');

--- a/tests/scripts/governance_evidence.test.cjs
+++ b/tests/scripts/governance_evidence.test.cjs
@@ -88,6 +88,29 @@ test('roster comes from the governance table and preserves narrow remit', () => 
   assert.throws(() => authority.readPolicy(policyText + '\n<!-- apm-scope-reset-before:2027-01-01T00:00:00Z -->'));
 });
 
+test('every roster row must have an exact GitHub identity, not a matching URL substring', () => {
+  for (const url of [
+    'https://github.com.attacker.invalid/nadav-y',
+    'https://attacker.invalid/https://github.com/nadav-y',
+    'https://attacker.invalid/?next=https://github.com/nadav-y',
+    'https://github.com@attacker.invalid/nadav-y',
+    'http://github.com/nadav-y',
+    'https://github.com/nadav-y?extra=true',
+    'https://github.com/nadav-y#extra',
+  ]) {
+    const changed = policyText.replace('https://github.com/nadav-y', url);
+    assert.throws(() => authority.readPolicy(changed), authority.EvidenceError);
+  }
+  assert.throws(() => authority.readPolicy(
+    policyText.replace('[Nadav](https://github.com/nadav-y)', 'Nadav')), authority.EvidenceError);
+});
+
+test('table whitespace and alignment do not change the governance roster', () => {
+  const changed = policyText.replace('| --- | --- | --- | --- |', '| :--- | ---: | :---: | --- |')
+    .replaceAll('\n|', '\n  |').replaceAll('\n', '\r\n');
+  assert.deepEqual(authority.readPolicy(changed).roster, policy.roster);
+});
+
 test('record presence is never reusable permission', () => {
   const result = evaluate();
   assert.equal(result.state, 'record-present');

--- a/tests/unit/test_codeql_policy.py
+++ b/tests/unit/test_codeql_policy.py
@@ -1,0 +1,543 @@
+"""Behavioral contracts for the trusted, read-only CodeQL merge policy."""
+
+import importlib.util
+import io
+import json
+import os
+import subprocess
+import sys
+import zipfile
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from tests.workflow_contracts import load_workflow, workflow_job
+
+pytestmark = pytest.mark.component
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / ".github/scripts/ci/codeql_policy.py"
+SPEC = importlib.util.spec_from_file_location("codeql_policy", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+policy = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = policy
+SPEC.loader.exec_module(policy)
+
+MERGE_SHA = "a" * 40
+HEAD_SHA = "b" * 40
+BASE_SHA = "c" * 40
+REF = "refs/pull/42/merge"
+REPO = "microsoft/apm"
+
+
+@pytest.fixture
+def context() -> Any:
+    return policy.Context(REPO, "pull_request", MERGE_SHA, REF, HEAD_SHA)
+
+
+def analysis(language: str, **overrides: Any) -> dict[str, Any]:
+    return {
+        "id": 100 + policy.LANGUAGES.index(language),
+        "ref": REF,
+        "commit_sha": MERGE_SHA,
+        "analysis_key": policy.ANALYSIS_KEY,
+        "category": f"{policy.ANALYSIS_KEY}/language:{language}",
+        "environment": json.dumps({"language": language}),
+        "tool": {"name": "CodeQL"},
+        "error": "",
+        "rules_count": 17,
+        "sarif_id": f"00000000-0000-0000-0000-{policy.LANGUAGES.index(language):012d}",
+        **overrides,
+    }
+
+
+def instance(language: str = "python", **overrides: Any) -> dict[str, Any]:
+    record = analysis(language)
+    return {
+        key: record[key] for key in ("ref", "commit_sha", "analysis_key", "category", "environment")
+    } | {"state": "open", **overrides}
+
+
+def alert(
+    number: int = 7, security: Any = "high", level: str = "warning", **overrides: Any
+) -> dict[str, Any]:
+    return {
+        "number": number,
+        "state": "open",
+        "rule": {"security_severity_level": security, "severity": level},
+        **overrides,
+    }
+
+
+class FakeGitHub:
+    def __init__(self) -> None:
+        self.run = {
+            "id": 12,
+            "run_attempt": 1,
+            "path": policy.WORKFLOW,
+            "event": "pull_request",
+            "head_sha": HEAD_SHA,
+            "status": "completed",
+            "conclusion": "success",
+        }
+        self.jobs = [
+            {"name": f"Analyze ({language})", "status": "completed", "conclusion": "success"}
+            for language in policy.LANGUAGES
+        ]
+        self.analyses = [analysis(language) for language in policy.LANGUAGES]
+        self.alerts = []
+        self.instances = {}
+        self.calls = []
+        self.artifacts = [
+            {"id": index + 1, "name": f"codeql-policy-{language}-1", "expired": False}
+            for index, language in enumerate(policy.LANGUAGES)
+        ]
+        self.proofs = {
+            language: {
+                "run_id": "12",
+                "run_attempt": "1",
+                "sha": MERGE_SHA,
+                "ref": REF,
+                "language": language,
+                "sarif_id": analysis(language)["sarif_id"],
+            }
+            for language in policy.LANGUAGES
+        }
+
+    def artifact(self, context: Any, identifier: int, language: str) -> dict[str, Any]:
+        return deepcopy(self.proofs[language])
+
+    def pages(self, path: str, key: str | None = None) -> list[dict[str, Any]]:
+        self.calls.append((path, key))
+        parsed = urlparse(path)
+        query = parse_qs(parsed.query)
+        if parsed.path.endswith("/runs"):
+            assert query["head_sha"] == [HEAD_SHA]
+            return [deepcopy(self.run)]
+        if parsed.path.endswith("/jobs"):
+            assert query["filter"] == ["latest"]
+            return deepcopy(self.jobs)
+        if parsed.path.endswith("/artifacts"):
+            return deepcopy(self.artifacts)
+        if parsed.path.endswith("/analyses"):
+            assert query["ref"] == [REF]
+            return deepcopy(self.analyses)
+        if parsed.path.endswith("/alerts"):
+            assert query["ref"] == [REF]
+            assert query["state"] == ["open"]
+            return deepcopy(self.alerts)
+        if parsed.path.endswith("/instances"):
+            assert query["ref"] == [REF]
+            return deepcopy(self.instances[int(parsed.path.split("/")[-2])])
+        raise AssertionError(f"Unexpected endpoint: {path}")
+
+
+def test_clean_exact_commit_with_no_sdl_pr_upload_passes(context: Any) -> None:
+    api = FakeGitHub()
+    assert policy.evaluate(context, api) == []
+    assert any(urlparse(path).path.endswith("/alerts") for path, _ in api.calls)
+
+
+def test_policy_languages_match_the_workflow_matrix() -> None:
+    workflow = load_workflow(ROOT / ".github/workflows/codeql.yml")
+    assert workflow_job(workflow, "analyze")["strategy"]["matrix"]["language"] == list(
+        policy.LANGUAGES
+    )
+
+
+@pytest.mark.parametrize("language", policy.LANGUAGES)
+def test_each_language_is_mandatory(context: Any, language: str) -> None:
+    api = FakeGitHub()
+    api.analyses = [record for record in api.analyses if record != analysis(language)]
+    with pytest.raises(policy.Pending, match=language):
+        policy.evaluate(context, api)
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"commit_sha": HEAD_SHA},
+        {"ref": "refs/heads/main"},
+        {"analysis_key": "(default)", "category": ""},
+        {"category": "/language:python"},
+        {"environment": '{"language":"actions"}'},
+        {"tool": {"name": "Another scanner"}},
+    ],
+)
+def test_wrong_analysis_cannot_supply_required_python_result(
+    context: Any, overrides: dict[str, Any]
+) -> None:
+    api = FakeGitHub()
+    api.analyses[0] = analysis("python", **overrides)
+    with pytest.raises(policy.PolicyError, match="python"):
+        policy.evaluate(context, api)
+
+
+@pytest.mark.parametrize("overrides", [{"error": "extraction failed"}, {"rules_count": 0}])
+def test_failed_or_empty_analysis_fails_closed(context: Any, overrides: dict[str, Any]) -> None:
+    api = FakeGitHub()
+    api.analyses[0] = analysis("python", **overrides)
+    with pytest.raises(policy.PolicyError, match="python"):
+        policy.evaluate(context, api)
+
+
+@pytest.mark.parametrize("conclusion", ["failure", "cancelled", "skipped", "neutral"])
+def test_workflow_must_succeed_not_merely_finish(context: Any, conclusion: str) -> None:
+    api = FakeGitHub()
+    api.run["conclusion"] = conclusion
+    with pytest.raises(policy.PolicyError, match="workflow"):
+        policy.evaluate(context, api)
+
+
+@pytest.mark.parametrize("conclusion", ["failure", "cancelled", "skipped", "neutral"])
+def test_each_language_job_must_really_run(context: Any, conclusion: str) -> None:
+    api = FakeGitHub()
+    api.jobs[0]["conclusion"] = conclusion
+    with pytest.raises(policy.PolicyError, match="Analyze"):
+        policy.evaluate(context, api)
+
+
+def test_in_progress_and_missing_jobs_wait(context: Any) -> None:
+    api = FakeGitHub()
+    api.jobs.pop()
+    with pytest.raises(policy.Pending, match="javascript-typescript"):
+        policy.evaluate(context, api)
+    api.run["status"] = "in_progress"
+    with pytest.raises(policy.Pending, match="workflow"):
+        policy.evaluate(context, api)
+
+
+@pytest.mark.parametrize(
+    ("security", "level"),
+    [("high", "warning"), ("critical", "note"), (None, "error"), ("low", "error")],
+)
+def test_thresholds_block_all_open_findings_including_existing(
+    context: Any, security: str | None, level: str
+) -> None:
+    api = FakeGitHub()
+    api.alerts = [alert(security=security, level=level, created_at="2020-01-01T00:00:00Z")]
+    api.instances[7] = [instance()]
+    assert policy.evaluate(context, api) == [7]
+
+
+@pytest.mark.parametrize(
+    ("security", "level"),
+    [("medium", "warning"), ("low", "note"), (None, "warning"), (None, "none")],
+)
+def test_below_threshold_findings_do_not_block(
+    context: Any, security: str | None, level: str
+) -> None:
+    api = FakeGitHub()
+    api.alerts = [alert(security=security, level=level)]
+    assert policy.evaluate(context, api) == []
+
+
+def test_dismissed_alert_remains_dismissed(context: Any) -> None:
+    api = FakeGitHub()
+    api.alerts = [alert(state="dismissed")]
+    assert policy.evaluate(context, api) == []
+
+
+def test_sdl_and_old_categories_are_not_premerge_authorities(context: Any) -> None:
+    api = FakeGitHub()
+    api.alerts = [alert()]
+    api.instances[7] = [
+        instance(analysis_key="(default)", category="", environment="{}"),
+        instance(analysis_key="/language:python", category="/language:python", environment="{}"),
+    ]
+    assert policy.evaluate(context, api) == []
+
+
+def test_all_instances_are_inspected_not_only_most_recent(context: Any) -> None:
+    api = FakeGitHub()
+    api.alerts = [alert(most_recent_instance=instance(analysis_key="(default)", category=""))]
+    api.instances[7] = [
+        instance(analysis_key="(default)", category=""),
+        instance(),
+    ]
+    assert policy.evaluate(context, api) == [7]
+
+
+def test_branch_instance_not_default_branch_state_determines_blocking(context: Any) -> None:
+    api = FakeGitHub()
+    api.alerts = [alert(state="fixed")]
+    api.instances[7] = [instance()]
+    assert policy.evaluate(context, api) == [7]
+
+
+def test_fixed_instance_does_not_block(context: Any) -> None:
+    api = FakeGitHub()
+    api.alerts = [alert()]
+    api.instances[7] = [instance(state="fixed", commit_sha=BASE_SHA)]
+    assert policy.evaluate(context, api) == []
+
+
+@pytest.mark.parametrize("records", [[], [instance(commit_sha=BASE_SHA)]])
+def test_missing_or_stale_alert_instances_never_pass(
+    context: Any, records: list[dict[str, Any]]
+) -> None:
+    api = FakeGitHub()
+    api.alerts = [alert()]
+    api.instances[7] = records
+    with pytest.raises(policy.Pending, match="alert"):
+        policy.evaluate(context, api)
+
+
+@pytest.mark.parametrize("bad_value", ["urgent", "", 7])
+def test_unknown_security_severity_fails_closed(context: Any, bad_value: Any) -> None:
+    api = FakeGitHub()
+    api.alerts = [alert(security=bad_value)]
+    with pytest.raises(policy.PolicyError, match="severity"):
+        policy.evaluate(context, api)
+
+
+def test_newer_failed_analysis_does_not_fall_back_to_old_success(context: Any) -> None:
+    api = FakeGitHub()
+    api.analyses.insert(0, analysis("python", id=999, error="failure"))
+    with pytest.raises(policy.PolicyError, match="python"):
+        policy.evaluate(context, api)
+
+
+def test_same_commit_rerun_race_waits(context: Any) -> None:
+    class RerunGitHub(FakeGitHub):
+        def pages(self, path: str, key: str | None = None) -> list[dict[str, Any]]:
+            records = super().pages(path, key)
+            if urlparse(path).path.endswith("/alerts"):
+                self.run["run_attempt"] += 1
+            return records
+
+    with pytest.raises(policy.Pending, match="changed"):
+        policy.evaluate(context, RerunGitHub())
+
+
+def test_api_failure_is_not_treated_as_no_alerts(context: Any) -> None:
+    class BrokenGitHub(FakeGitHub):
+        def pages(self, path: str, key: str | None = None) -> list[dict[str, Any]]:
+            if urlparse(path).path.endswith("/alerts"):
+                raise policy.PolicyError("GitHub API unavailable")
+            return super().pages(path, key)
+
+    with pytest.raises(policy.PolicyError, match="API unavailable"):
+        policy.evaluate(context, BrokenGitHub())
+
+
+@pytest.fixture
+def event_env(tmp_path: Path) -> dict[str, str]:
+    event = {
+        "number": 42,
+        "repository": {"full_name": REPO, "default_branch": "main"},
+        "pull_request": {
+            "merge_commit_sha": MERGE_SHA,
+            "head": {"sha": HEAD_SHA},
+            "base": {"ref": "main", "sha": BASE_SHA, "repo": {"full_name": REPO}},
+        },
+    }
+    path = tmp_path / "event.json"
+    path.write_text(json.dumps(event), encoding="utf-8")
+    return {
+        "GITHUB_EVENT_PATH": str(path),
+        "GITHUB_EVENT_NAME": "pull_request",
+        "GITHUB_REPOSITORY": REPO,
+        "GITHUB_SHA": MERGE_SHA,
+        "GITHUB_REF": REF,
+    }
+
+
+def test_pull_request_context_uses_merge_commit_not_head(
+    event_env: dict[str, str], context: Any
+) -> None:
+    assert policy.load_context(event_env) == context
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [
+        ("GITHUB_EVENT_NAME", "pull_request_target"),
+        ("GITHUB_SHA", HEAD_SHA),
+        ("GITHUB_REF", "refs/heads/main"),
+        ("GITHUB_REPOSITORY", "attacker/repo"),
+    ],
+)
+def test_invalid_event_context_is_rejected(event_env: dict[str, str], key: str, value: str) -> None:
+    event_env[key] = value
+    with pytest.raises(policy.PolicyError):
+        policy.load_context(event_env)
+
+
+def test_queue_context_uses_its_own_commit(event_env: dict[str, str]) -> None:
+    ref = f"refs/heads/gh-readonly-queue/main/pr-42-{HEAD_SHA}"
+    event = {
+        "repository": {"full_name": REPO, "default_branch": "main"},
+        "merge_group": {
+            "head_sha": MERGE_SHA,
+            "head_ref": ref,
+            "base_sha": BASE_SHA,
+            "base_ref": "refs/heads/main",
+        },
+    }
+    Path(event_env["GITHUB_EVENT_PATH"]).write_text(json.dumps(event), encoding="utf-8")
+    event_env.update(GITHUB_EVENT_NAME="merge_group", GITHUB_REF=ref)
+    assert policy.load_context(event_env) == policy.Context(
+        REPO, "merge_group", MERGE_SHA, ref, MERGE_SHA
+    )
+
+
+def test_api_pagination_collects_later_pages(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = []
+
+    def run(command: list[str], **kwargs: Any) -> subprocess.CompletedProcess:
+        calls.append((command, kwargs))
+        return subprocess.CompletedProcess(command, 0, json.dumps([[{"id": 1}], [{"id": 2}]]), "")
+
+    monkeypatch.setattr(policy.subprocess, "run", run)
+    assert policy.GitHub().pages("repos/microsoft/apm/code-scanning/alerts?per_page=100") == [
+        {"id": 1},
+        {"id": 2},
+    ]
+    command, kwargs = calls[0]
+    assert "--paginate" in command
+    assert "--slurp" in command
+    assert command[command.index("--method") + 1] == "GET"
+    assert kwargs["timeout"] > 0
+
+
+@pytest.mark.parametrize("payload", ["not json", '{"message":"denied"}', '[{"wrong":[]}]'])
+def test_malformed_api_response_fails_closed(monkeypatch: pytest.MonkeyPatch, payload: str) -> None:
+    monkeypatch.setattr(
+        policy.subprocess,
+        "run",
+        lambda command, **kwargs: subprocess.CompletedProcess(command, 0, payload, ""),
+    )
+    with pytest.raises(policy.PolicyError):
+        policy.GitHub().pages("repos/microsoft/apm/actions/runs?per_page=100", "workflow_runs")
+
+
+def test_http_failure_is_explicit_and_does_not_leak_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        policy.subprocess,
+        "run",
+        lambda command, **kwargs: subprocess.CompletedProcess(command, 1, "", "secret-token"),
+    )
+    with pytest.raises(policy.PolicyError, match="GitHub API") as failure:
+        policy.GitHub().pages("repos/microsoft/apm/code-scanning/alerts")
+    assert "secret-token" not in str(failure.value)
+
+
+def test_newer_commit_analysis_cannot_use_historical_alert_snapshot(context: Any) -> None:
+    api = FakeGitHub()
+    api.analyses.insert(0, analysis("python", id=999, commit_sha=HEAD_SHA))
+    with pytest.raises(policy.Pending, match="different commit"):
+        policy.evaluate(context, api)
+
+
+def test_completed_rerun_cannot_reuse_previous_attempt_sarif(context: Any) -> None:
+    api = FakeGitHub()
+    api.run["run_attempt"] = 2
+    for artifact in api.artifacts:
+        artifact["name"] = artifact["name"][:-1] + "2"
+    for proof in api.proofs.values():
+        proof["run_attempt"] = "2"
+        proof["sarif_id"] = "11111111-1111-1111-1111-111111111111"
+    with pytest.raises(policy.Pending, match="current-attempt"):
+        policy.evaluate(context, api)
+    for record in api.analyses:
+        record["sarif_id"] = "11111111-1111-1111-1111-111111111111"
+    assert policy.evaluate(context, api) == []
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("run_id", "99"),
+        ("run_attempt", "2"),
+        ("sha", HEAD_SHA),
+        ("language", "ruby"),
+        ("ref", "refs/heads/main"),
+        ("sarif_id", ""),
+    ],
+)
+def test_artifact_cannot_lie_about_its_execution(context: Any, field: str, value: str) -> None:
+    api = FakeGitHub()
+    api.proofs["python"][field] = value
+    with pytest.raises(policy.PolicyError):
+        policy.evaluate(context, api)
+
+
+def test_expired_or_missing_artifacts_fail_closed(context: Any) -> None:
+    api = FakeGitHub()
+    api.artifacts[0]["expired"] = True
+    with pytest.raises(policy.PolicyError, match="expired"):
+        policy.evaluate(context, api)
+    api.artifacts.pop(0)
+    with pytest.raises(policy.Pending, match="evidence"):
+        policy.evaluate(context, api)
+
+
+@pytest.mark.parametrize("filename", ["../outside.json", "wrong.json"])
+def test_artifact_reader_rejects_unexpected_names(
+    context: Any, monkeypatch: pytest.MonkeyPatch, filename: str
+) -> None:
+    payload = io.BytesIO()
+    with zipfile.ZipFile(payload, "w") as archive:
+        archive.writestr(filename, "{}")
+    api = policy.GitHub()
+    monkeypatch.setattr(api, "request", lambda *args, **kwargs: payload.getvalue())
+    with pytest.raises(policy.PolicyError):
+        api.artifact(context, 1, "python")
+
+
+def test_artifact_reader_accepts_bounded_json(
+    context: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    proof = FakeGitHub().proofs["python"]
+    payload = io.BytesIO()
+    with zipfile.ZipFile(payload, "w") as archive:
+        archive.writestr("codeql-policy-python.json", json.dumps(proof))
+    api = policy.GitHub()
+    monkeypatch.setattr(api, "request", lambda *args, **kwargs: payload.getvalue())
+    assert api.artifact(context, 1, "python") == proof
+
+
+@pytest.mark.skipif(os.name != "posix", reason="Exercises the Ubuntu merge-gate Bash runner")
+def test_shell_rechecks_codeql_after_other_checks_finish(tmp_path: Path) -> None:
+    """An initial CodeQL pass must not survive a later failing rerun."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    counter = tmp_path / "calls"
+    helpers = {
+        "python3": f"""#!/bin/sh
+if [ -f "{counter}" ]; then
+  echo "CodeQL rerun failed" >&2
+  exit 1
+fi
+echo first > "{counter}"
+""",
+        "gh": '#!/bin/sh\necho \'{"check_runs":[{"status":"completed",'
+        '"conclusion":"success","started_at":"2026-09-12T00:00:00Z","html_url":""}]}\'\n',
+        "sleep": "#!/bin/sh\nexit 0\n",
+    }
+    for name, content in helpers.items():
+        path = bin_dir / name
+        path.write_text(content, encoding="utf-8")
+        path.chmod(0o755)
+    environment = os.environ | {
+        "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+        "GH_TOKEN": "test-token",
+        "REPO": REPO,
+        "SHA": HEAD_SHA,
+        "EXPECTED_CHECKS": "CI",
+        "TIMEOUT_MIN": "1",
+    }
+    result = subprocess.run(
+        ["bash", str(ROOT / ".github/scripts/ci/merge_gate_wait.sh")],
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    assert result.returncode == 1
+    assert "CodeQL rerun failed" in result.stderr
+    assert "completed successfully" not in result.stdout

--- a/tests/unit/test_daily_release_smoke_signal.py
+++ b/tests/unit/test_daily_release_smoke_signal.py
@@ -1,0 +1,89 @@
+"""Exercise real smoke-report log parsing with mocked GitHub calls."""
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+pytestmark = pytest.mark.component
+
+
+@pytest.mark.parametrize(
+    ("log_text", "expected"),
+    [
+        ("FAILED tests/test_one.py::test_case\n", ["tests/test_one.py::test_case"]),
+        (
+            "\x1b[31mtests/test_one.py::TestSuite::test_case[param] ERROR\x1b[0m\n",
+            ["tests/test_one.py::TestSuite::test_case[param"],
+        ),
+        ("ERROR tests/test_one.py::test_case,\n", ["tests/test_one.py::test_case"]),
+        (
+            "FAILED tests/test_one.py::test_case\n"
+            "tests/test_one.py::test_case FAILED\n"
+            "ERROR tests/test_two.py::test_case\n",
+            ["tests/test_one.py::test_case", "tests/test_two.py::test_case"],
+        ),
+        ("tests/test_one.py::test_case PASSED\n", []),
+        (
+            "\n".join(f"FAILED tests/test_many.py::test_{number}" for number in range(35)),
+            [f"tests/test_many.py::test_{number}" for number in range(30)],
+        ),
+        pytest.param(
+            "FAILED tests/test_real.py::test_failed\ntests/test_slow.py::" + "!::" * 10_000 + "\n",
+            ["tests/test_real.py::test_failed"],
+            id="failure-like-input-cannot-trigger-exponential-backtracking",
+        ),
+    ],
+)
+def test_failure_report_parses_logs_within_deadline(log_text: str, expected: list[str]) -> None:
+    """A child-process deadline catches synchronous regex stalls, not just async delays."""
+    result = subprocess.run(
+        [
+            "node",
+            "-e",
+            """
+const { main } = require('./scripts/daily-release-smoke-signal.cjs');
+const log = JSON.parse(require('node:fs').readFileSync(0, 'utf8'));
+const github = {
+  paginate: async endpoint => endpoint === 'jobs'
+    ? [{id: 1, name: 'Tests', conclusion: 'failure'}] : [],
+  rest: {
+    actions: {
+      listJobsForWorkflowRun: 'jobs',
+      downloadJobLogsForWorkflowRun: async () => ({data: log}),
+    },
+    issues: {
+      getLabel: async () => ({}),
+      listForRepo: 'issues',
+      create: async payload => {
+        console.log(JSON.stringify(payload.body));
+        return {data: {number: 1}};
+      },
+    },
+  },
+};
+main({
+  github,
+  context: {repo: {owner: 'example', repo: 'project'}, runId: 1, runNumber: 1,
+    sha: 'a'.repeat(40), workflow: 'Daily smoke'},
+  core: {info() {}, warning(message) {throw new Error(message);}},
+}).catch(error => { console.error(error); process.exitCode = 1; });
+""",
+        ],
+        input=json.dumps(log_text),
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    body = json.loads(result.stdout)
+    lines = body.split("### Failing tests\n\n", 1)[1].split("\n\n", 1)[0].splitlines()
+    assert lines == (
+        [f"- `{name}`" for name in expected]
+        if expected
+        else ["- Not extractable from failed job logs."]
+    )

--- a/tests/unit/test_security_workflow_contracts.py
+++ b/tests/unit/test_security_workflow_contracts.py
@@ -23,15 +23,36 @@ def test_codeql_covers_merge_queue_with_existing_analysis_configurations() -> No
         assert workflow["on"][event] == {"branches": ["main"]}
 
     analyze = workflow_job(workflow, "analyze")
-    assert analyze["strategy"]["matrix"]["language"] == ["python", "actions"]
+    assert analyze["env"]["CODEQL_ACTION_DIFF_INFORMED_QUERIES"] == "false"
+    assert analyze["strategy"]["matrix"]["language"] == [
+        "python",
+        "actions",
+        "javascript-typescript",
+    ]
     init = workflow_step(analyze, "Initialize CodeQL")
     assert init["with"]["languages"] == "${{ matrix.language }}"
     upload = workflow_step(analyze, "Perform CodeQL Analysis")
     assert upload.get("with", {}).get("upload", True) is True
+    assert upload["with"]["upload-database"] is True
+    assert upload["with"]["wait-for-processing"] is True
+    assert upload["with"].get("skip-queries", False) is False
+    assert "category" not in upload["with"]
+    assert workflow["on"]["schedule"]
+    assert upload["id"] == "analyze"
+    evidence = workflow_step(analyze, "Record CodeQL upload identity")
+    assert evidence["env"]["SARIF_ID"] == "${{ steps.analyze.outputs.sarif-id }}"
+    artifact = workflow_step(analyze, "Upload CodeQL policy evidence")
+    assert (
+        artifact["with"]["name"] == "codeql-policy-${{ matrix.language }}-${{ github.run_attempt }}"
+    )
+    assert artifact["with"]["if-no-files-found"] == "error"
+    assert artifact["with"]["retention-days"] == 14
     for node, label in (
         (analyze, "CodeQL matrix"),
         (init, "CodeQL initialization"),
         (upload, "CodeQL analysis upload"),
+        (evidence, "CodeQL upload identity"),
+        (artifact, "CodeQL evidence artifact"),
     ):
         assert_unconditional(node, label=label)
 
@@ -44,6 +65,18 @@ def test_merge_gate_executes_base_commit_script() -> None:
     assert checkout["with"]["ref"] == "${{ steps.sha.outputs.trusted_sha }}"
     wait = workflow_step(gate, "Wait for all required checks")
     assert wait["env"]["SHA"] == "${{ steps.sha.outputs.target_sha }}"
+    assert workflow["permissions"]["actions"] == "read"
+    assert workflow["permissions"]["security-events"] == "read"
+    script = (ROOT / ".github/scripts/ci/merge_gate_wait.sh").read_text(encoding="utf-8")
+    assert script.count('python3 "$(dirname "$0")/codeql_policy.py" --deadline "$deadline"') == 2
+    assert script.index("codeql_policy.py") < script.index('echo "[merge-gate] waiting')
+
+
+def test_codeql_policy_is_in_the_ci_lint_scope() -> None:
+    workflow = load_workflow(ROOT / ".github/workflows/ci.yml")
+    lint = workflow_job(workflow, "lint")
+    for name in ("Ruff lint", "Ruff format check", "Code duplication guardrail (pylint R0801)"):
+        assert ".github/scripts/ci/codeql_policy.py" in workflow_step(lint, name)["run"]
 
 
 def test_secret_bearing_manual_runs_use_default_branch_dispatch() -> None:


### PR DESCRIPTION
# fix(ci): separate CodeQL merge enforcement from SDL scans

## TL;DR

Add a trusted, workflow-scoped CodeQL policy to the existing required `gate`,
while preserving default-branch database uploads for external SDL scanning.
Extend coverage to JavaScript/TypeScript and require successful full-tree scans,
current-attempt upload evidence, and no open findings at blocking severity.
The native ruleset remains unchanged until the documented post-merge rollout.

> [!IMPORTANT]
> This PR does **not** remove the live `code_scanning` requirement.
> Keep it until the deployed replacement succeeds on a fresh PR and a merge-queue
> run; only then remove CodeQL from that native rule through the API.
> The initial PR still executes the **old trusted base** gate implementation.

Follow-up to #2870 and the maintainer's report of repeated
“Code scanning is still expecting 2 results from CodeQL” messages.

## Problem (WHY)

- [x] The [reported CodeQL check](https://github.com/microsoft/apm/runs/103458081437)
  identifies an additional `API upload / <default>` configuration on `main`,
  despite successful Python and Actions workflow uploads.
- [x] The repository's native rule requires the tool `CodeQL`, not a particular
  workflow configuration. The external default-branch producer cannot be
  satisfied by rerunning the repository's PR analysis.
- [x] The prior workflow omitted JavaScript/TypeScript, although the repository
  contains JavaScript. Existing Python and Actions identities must stay stable.
- [!] Job success alone is insufficient: scans may report vulnerabilities,
  processing can lag, and old analyses can survive a same-commit rerun.
- [x] The first live JavaScript scan exposed two existing findings. With the
  maintainer's approval, this PR also removes ambiguous regex repetition from
  smoke-log parsing and makes every governance roster row undergo validation.

The implementation follows the Agent Skills validation loop:
["do the work, run a validator (a script, a reference checklist, or a self-check), fix any issues, and repeat until validation passes."](https://agentskills.io/skill-creation/best-practices#validation-loops)
The first review identified four gaps—diff filtering, rerun provenance,
moving-ref snapshots, and final-gate freshness—which were fixed before publishing.

## Approach (WHAT)

- Keep the existing `gate` check as the single required status-check authority.
- Execute the policy from the immutable base checkout; never run PR artifacts.
- Require all three language jobs and their processed analyses to succeed.
- Bind each analysis to its real SARIF upload ID, workflow run, attempt, ref, and SHA.
- Block **all open, undismissed** high/critical security or error-level findings
  from this workflow, including pre-existing findings, as approved by the maintainer.
- Leave independent SDL results, database uploads, and the live ruleset intact.

## Implementation (HOW)

| File | Intent |
| :--- | :--- |
| [`.github/scripts/ci/codeql_policy.py`](https://github.com/microsoft/apm/blob/128eb832f3881ca4544acd47bd01dda9880830f7/.github/scripts/ci/codeql_policy.py) | Add GET-only policy evaluation: exact event context, successful jobs, bounded artifact parsing, current SARIF evidence, paginated alert instances, and fail-closed errors. |
| [`.github/scripts/ci/merge_gate_wait.sh`](https://github.com/microsoft/apm/blob/128eb832f3881ca4544acd47bd01dda9880830f7/.github/scripts/ci/merge_gate_wait.sh) | Evaluate CodeQL before polling other checks and immediately before success, using the existing deadline. |
| [`.github/workflows/codeql.yml`](https://github.com/microsoft/apm/blob/128eb832f3881ca4544acd47bd01dda9880830f7/.github/workflows/codeql.yml) | Add JavaScript/TypeScript, disable diff-informed filtering, explicitly retain database uploads and processing waits, and publish small per-language/run-attempt evidence artifacts. |
| [`.github/workflows/merge-gate.yml`](https://github.com/microsoft/apm/blob/128eb832f3881ca4544acd47bd01dda9880830f7/.github/workflows/merge-gate.yml) | Grant only the additional `actions: read` and `security-events: read` permissions needed to inspect evidence. |
| [`.github/workflows/ci.yml`](https://github.com/microsoft/apm/blob/128eb832f3881ca4544acd47bd01dda9880830f7/.github/workflows/ci.yml) | Include the new helper in formatting, lint, duplication, and file-length checks. |
| [`tests/unit/test_codeql_policy.py`](https://github.com/microsoft/apm/blob/128eb832f3881ca4544acd47bd01dda9880830f7/tests/unit/test_codeql_policy.py) | Cover thresholds, dismissals, wrong/missing evidence, reruns, moving refs, pagination, artifact parsing, event identity, and final shell enforcement. |
| [`tests/unit/test_security_workflow_contracts.py`](https://github.com/microsoft/apm/blob/128eb832f3881ca4544acd47bd01dda9880830f7/tests/unit/test_security_workflow_contracts.py) | Lock down full-tree coverage, all language jobs, evidence uploads, trusted-base execution, read-only permissions, and lint integration. |
| [`docs/src/content/docs/contributing/development-guide.md`](https://github.com/microsoft/apm/blob/128eb832f3881ca4544acd47bd01dda9880830f7/docs/src/content/docs/contributing/development-guide.md) | Document the policy, evidence expiry, staged ruleset migration, preservation of other tools/rules, and rollback ordering. |
| [`scripts/daily-release-smoke-signal.cjs`](https://github.com/microsoft/apm/blob/16c1e1443ce7366b97a50e867e9cdd9624170f60/scripts/daily-release-smoke-signal.cjs) | Remove redundant nested regex repetition while preserving failure extraction, ordering, deduplication, and the 30-test limit. |
| [`scripts/governance/authority.cjs`](https://github.com/microsoft/apm/blob/16c1e1443ce7366b97a50e867e9cdd9624170f60/scripts/governance/authority.cjs) | Parse every roster row instead of filtering on a URL substring; retain exact anchored GitHub identity validation and existing remit rules. |
| [`tests/unit/test_daily_release_smoke_signal.py`](https://github.com/microsoft/apm/blob/16c1e1443ce7366b97a50e867e9cdd9624170f60/tests/unit/test_daily_release_smoke_signal.py) | Exercise real Node smoke reporting with mocked GitHub I/O, including adversarial input under a 10-second subprocess deadline. |
| [`tests/scripts/governance_evidence.test.cjs`](https://github.com/microsoft/apm/blob/16c1e1443ce7366b97a50e867e9cdd9624170f60/tests/scripts/governance_evidence.test.cjs) | Reject malformed/foreign roster identities while preserving whitespace, alignment, and the existing governance scenarios. |

No production CLI, dependency manifest, README, or CHANGELOG changes.

## Diagrams

The highlighted interactions add current-run merge enforcement without replacing the independent default-branch SDL feed.

```mermaid
sequenceDiagram
    participant W as codeql.yml Analyze jobs
    participant A as GitHub analyses and artifacts
    participant S as External SDL scanner
    participant G as Trusted merge gate
    participant C as Other required CI
    W->>A: Upload Python, Actions, and JavaScript results
    rect rgb(255, 247, 200)
        W->>A: Record SARIF IDs for this run and attempt
    end
    alt Default branch
        W->>A: Publish CodeQL databases
        A->>S: Databases remain available
        S->>A: Return independent API scan results
    else Pull request or merge queue
        rect rgb(255, 247, 200)
            G->>A: Read exact run, attempt, ref, SHA, and alerts
            A-->>G: Successful scans and matching upload evidence
            G->>G: Reject open blocking findings
        end
        G->>C: Wait for existing required checks
        C-->>G: Checks complete
        rect rgb(255, 247, 200)
            G->>A: Revalidate CodeQL before passing gate
            A-->>G: Stable passing evidence
        end
    end
    Note over G,A: Native scanning rule remains until post-merge rollout
```

## Trade-offs

- **Stricter than new-alerts-only.** All open scoped findings at the existing
  severity thresholds block, including pre-existing ones. Full-tree scans cost
  more than diff-informed queries; dismissals remain a deliberate human action.
- **Bounded evidence retention.** Artifacts expire after 14 days. An old PR may
  need a CodeQL rerun rather than reuse evidence that can no longer be verified.
- **Separate compliance and merge roles.** Private external SDL queries remain
  default-branch compliance scans; this does not claim to run them before merge.
- **Deliberate staged activation.** Hermetic tests and code review do not replace
  deployed GitHub verification. The first PR uses the old base gate; removing
  native protection before fresh PR/queue verification would create a gap.
- **Small standalone CI dependency surface.** The helper uses stdlib and `gh`,
  not APM imports or an editable project install in the trusted gate job.

## Benefits

1. Three language analyses, each with current-run proof, must succeed.
2. Missing, stale, malformed, skipped, or failed evidence cannot produce a pass.
3. External default-branch configurations cannot substitute for—or obstruct—the
   workflow-scoped policy after the ruleset migration.
4. The required `gate` check and existing non-CodeQL protections stay in place.

## Validation

Local validation against `main` at `6f3dd393ce82e4aa3b56d0de292836590af2d59e`.
Remote CI and post-merge activation are not claimed complete.

`uv run --frozen --extra dev pytest -q tests/unit/test_codeql_policy.py tests/unit/test_security_workflow_contracts.py tests/unit/test_daily_release_smoke_signal.py tests/unit/test_governance_evidence.py tests/quality --tb=short`

```text
152 passed in 41.35s
```

The live first scan completed all three languages and uploaded genuine evidence;
the candidate policy correctly rejected two high-severity JavaScript findings.
Before the fixes, the new regex regression exceeded its 10-second deadline and
the roster regression demonstrated a silently skipped malformed identity.
Both now pass without exclusions, alert dismissals, or weaker thresholds.

<details><summary>Type, lint, and guardrail evidence</summary>

`uv run --frozen --extra dev mypy --follow-imports=skip .github/scripts/ci/codeql_policy.py`

```text
Success: no issues found in 1 source file
```

The canonical ruff/format/pylint/auth mirror, including the new helper:

```text
All checks passed!
1869 files already formatted
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)
[+] auth-signal lint clean
```

Remaining CI guards and test-quality checks:

```text
YAML I/O, 2100-line, and portable-path CI guards passed
[+] assertion-quality ratchet clean: AQ001=4, AQ002=12
[+] exact test duplicate ratchet clean: 1228 files, 0 allowed duplicate group(s)
```

Architecture-boundary lint and `git diff --check` exited successfully.
The Mermaid diagram passed `mmdc` and was visually inspected.
Locked dependencies were restored through pip using uv-exported requirements
after uv's package-download transport failed; no dependency files changed.

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
| :---: | :--- | :--- | :--- | :--- |
| 1 | Our scans can pass without an unrelated SDL result on the PR. | Governed by policy | `tests/unit/test_codeql_policy.py::test_clean_exact_commit_with_no_sdl_pr_upload_passes` (regression trap for the reported missing-configuration failure) | unit |
| 2 | Open blocking findings cannot be hidden by job success, age, or another configuration. | Governed by policy | `test_thresholds_block_all_open_findings_including_existing`; `test_all_instances_are_inspected_not_only_most_recent` in `tests/unit/test_codeql_policy.py` | unit |
| 3 | A rerun cannot reuse stale successful results. | Secure by default | `tests/unit/test_codeql_policy.py::test_completed_rerun_cannot_reuse_previous_attempt_sarif`; `test_newer_commit_analysis_cannot_use_historical_alert_snapshot` | unit |
| 4 | Evidence artifacts cannot execute code or escape the parser's expected file shape. | Secure by default | `tests/unit/test_codeql_policy.py::test_artifact_reader_rejects_unexpected_names`; `test_artifact_reader_accepts_bounded_json` | integration |
| 5 | A later CodeQL failure still stops the final merge gate. | Governed by policy | `tests/unit/test_codeql_policy.py::test_shell_rechecks_codeql_after_other_checks_finish` (real Bash orchestration with simulated external checks) | integration |
| 6 | Compliance uploads, complete language coverage, and trusted-base execution remain enabled. | Secure by default; OSS / community-driven | `tests/unit/test_security_workflow_contracts.py::test_codeql_covers_merge_queue_with_existing_analysis_configurations`; `test_merge_gate_executes_base_commit_script` | integration |
| 7 | Newly covered helpers remain safe without suppressing their findings. | Secure by default | `tests/unit/test_daily_release_smoke_signal.py::test_failure_report_parses_logs_within_deadline`; `tests/unit/test_governance_evidence.py::test_governance_node_regressions` | integration |

## How to test

- [ ] Run the focused pytest command above; all 152 cases should pass.
- [ ] Confirm the PR's three `Analyze` jobs succeed and each publishes its current-attempt evidence artifact.
- [ ] After merge, verify the trusted policy logs on a fresh PR and a merge-queue run; verify default-branch database uploads remain available.
- [ ] Only after that verification, back up and re-read ruleset `9294522`, remove only CodeQL from `parameters.code_scanning_tools`, and verify every other rule/tool and required `gate` remain unchanged.
- [ ] For rollback, restore the prior native code-scanning rule before reverting the custom gate.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>